### PR TITLE
Removing projection=full from Blob/Bucket PATCH requests.

### DIFF
--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -127,13 +127,11 @@ class _PropertyMixin(object):
         :rtype: :class:`Bucket`
         :returns: The current bucket.
         """
-        # Pass '?projection=full' here because 'PATCH' documented not
-        # to work properly w/ 'noAcl'.
         update_properties = dict((key, self._properties[key])
                                  for key in self._changes)
         self._properties = self.connection.api_request(
             method='PATCH', path=self.path, data=update_properties,
-            query_params={'projection': 'full'})
+            query_params={'projection': 'noAcl'})
         return self
 
 

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -674,9 +674,10 @@ class Bucket(_PropertyMixin):
         See: https://developers.google.com/storage/docs/website-configuration
 
         .. note::
-          This (apparently) only works
-          if your bucket name is a domain name
-          (and to do that, you need to get approved somehow...).
+          This only works if your bucket name is a domain name
+          (and to do that, you need to get approved). See
+          https://cloud.google.com/storage/docs/bucket-naming#verification
+          to learn more about the process.
 
         If you want this bucket to host a website, just provide the name
         of an index page and a page to use when a blob isn't found::

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -58,7 +58,7 @@ class Test_PropertyMixin(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/path')
         self.assertEqual(kw[0]['data'], {'foo': 'Qux', 'bar': 'Baz'})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_properties_no_fetch(self):
         connection = _Connection({'foo': 'Foo'})
@@ -93,7 +93,7 @@ class Test_PropertyMixin(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/path')
         self.assertEqual(kw[0]['data'], {'foo': 'Foo'})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
 
 class Test_PropertyBatch(unittest2.TestCase):
@@ -162,7 +162,7 @@ class Test_PropertyBatch(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/path')
         self.assertEqual(kw[0]['data'], {'foo': 'Qux', 'bar': 'Baz'})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
 
 class Test__scalar_property(unittest2.TestCase):

--- a/gcloud/storage/test_blob.py
+++ b/gcloud/storage/test_blob.py
@@ -681,7 +681,7 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/b/name/o/%s' % BLOB_NAME)
         self.assertEqual(kw[0]['data'], {'cacheControl': CACHE_CONTROL})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_component_count(self):
         BLOB_NAME = 'blob-name'
@@ -717,7 +717,7 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(kw[0]['path'], '/b/name/o/%s' % BLOB_NAME)
         self.assertEqual(kw[0]['data'],
                          {'contentDisposition': CONTENT_DISPOSITION})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_content_encoding_getter(self):
         BLOB_NAME = 'blob-name'
@@ -744,7 +744,7 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(kw[0]['path'], '/b/name/o/%s' % BLOB_NAME)
         self.assertEqual(kw[0]['data'],
                          {'contentEncoding': CONTENT_ENCODING})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_content_language_getter(self):
         BLOB_NAME = 'blob-name'
@@ -771,7 +771,7 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(kw[0]['path'], '/b/name/o/%s' % BLOB_NAME)
         self.assertEqual(kw[0]['data'],
                          {'contentLanguage': CONTENT_LANGUAGE})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_content_type_getter(self):
         BLOB_NAME = 'blob-name'
@@ -798,7 +798,7 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(kw[0]['path'], '/b/name/o/%s' % BLOB_NAME)
         self.assertEqual(kw[0]['data'],
                          {'contentType': CONTENT_TYPE})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_crc32c_getter(self):
         BLOB_NAME = 'blob-name'
@@ -825,7 +825,7 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(kw[0]['path'], '/b/name/o/%s' % BLOB_NAME)
         self.assertEqual(kw[0]['data'],
                          {'crc32c': CRC32C})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_etag(self):
         BLOB_NAME = 'blob-name'
@@ -879,7 +879,7 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(kw[0]['path'], '/b/name/o/%s' % BLOB_NAME)
         self.assertEqual(kw[0]['data'],
                          {'md5Hash': MD5_HASH})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_media_link(self):
         BLOB_NAME = 'blob-name'
@@ -915,7 +915,7 @@ class Test_Blob(unittest2.TestCase):
         self.assertEqual(kw[0]['path'], '/b/name/o/%s' % BLOB_NAME)
         self.assertEqual(kw[0]['data'],
                          {'metadata': METADATA})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_metageneration(self):
         BLOB_NAME = 'blob-name'

--- a/gcloud/storage/test_bucket.py
+++ b/gcloud/storage/test_bucket.py
@@ -652,7 +652,7 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[0]['data'], after)
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
         entries = bucket.get_cors()
         self.assertEqual(entries, [CORS_ENTRY, {}])
 
@@ -734,7 +734,7 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[0]['data'], after)
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
         entries = bucket.get_lifecycle()
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0]['action']['type'], 'Delete')
@@ -761,7 +761,7 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[0]['data'], {'location': 'AS'})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_get_logging_w_prefix(self):
         NAME = 'name'
@@ -809,7 +809,7 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[1]['method'], 'PATCH')
         self.assertEqual(kw[1]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[1]['data'], resp_to_enable_logging)
-        self.assertEqual(kw[1]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[1]['query_params'], {'projection': 'noAcl'})
         self.assertEqual(kw[2]['method'], 'GET')
         self.assertEqual(kw[2]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[2]['query_params'], {'projection': 'noAcl'})
@@ -840,7 +840,7 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[1]['method'], 'PATCH')
         self.assertEqual(kw[1]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[1]['data'], resp_to_enable_logging)
-        self.assertEqual(kw[1]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[1]['query_params'], {'projection': 'noAcl'})
         self.assertEqual(kw[2]['method'], 'GET')
         self.assertEqual(kw[2]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[2]['query_params'], {'projection': 'noAcl'})
@@ -864,7 +864,7 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[1]['method'], 'PATCH')
         self.assertEqual(kw[1]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[1]['data'], {'logging': None})
-        self.assertEqual(kw[1]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[1]['query_params'], {'projection': 'noAcl'})
         self.assertEqual(kw[2]['method'], 'GET')
         self.assertEqual(kw[2]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[2]['query_params'], {'projection': 'noAcl'})
@@ -942,7 +942,7 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['data'], {'versioning': {'enabled': True}})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_configure_website_defaults(self):
         NAME = 'name'
@@ -957,7 +957,7 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[0]['data'], patched)
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_configure_website_explicit(self):
         NAME = 'name'
@@ -972,7 +972,7 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[0]['data'], patched)
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_disable_website(self):
         NAME = 'name'
@@ -987,7 +987,7 @@ class Test_Bucket(unittest2.TestCase):
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
         self.assertEqual(kw[0]['data'], patched)
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
 
     def test_make_public_defaults(self):
         from gcloud.storage.acl import _ACLEntity


### PR DESCRIPTION
There was a previous comment

> Pass `?projection=full` here because `PATCH` documented not to work properly w/ `noAcl`.

I tested a little with this and it doesn't seem to be an issue.

@thobrla Can you confirm or deny any issues with `projection=full`?
