### PR TITLE
Monitoring Custom Metrics

### DIFF
--- a/docs/monitoring-usage.rst
+++ b/docs/monitoring-usage.rst
@@ -287,22 +287,22 @@ The Stackdriver Monitoring API can be used to write data points to custom metric
 the documentation on `Custom Metrics`_ for more information.
 
 To write a data point to a custom metric, you must provide an instance of
-:class:`~gcloud.monitoring.metric.Metric` specifying the metric type as well as the values for
+:class:`~google.cloud.monitoring.metric.Metric` specifying the metric type as well as the values for
 the metric labels. You will need to have either created the metric descriptor earlier (see the
 `Metric Descriptors`_ section) or rely on metric type auto-creation (see `Auto-creation of
 custom metrics`_).
 
-You will also need to provide a :class:`~gcloud.monitoring.resource.Resource` instance specifying a
-monitored resource type as well as values for all of the monitored resource labels, except for
-``project_id``, which is ignored when it's included in writes to the API. A good choice is to use
-the underlying physical resource where your application code runs – e.g., a monitored resource
-type of ``gce_instance`` or ``aws_ec2_instance``. In some limited circumstances, such as when
-only a single process writes to the custom metric, you may choose to use the ``global`` monitored
-resource type.
+You will also need to provide a :class:`~google.cloud.monitoring.resource.Resource` instance
+specifying a monitored resource type as well as values for all of the monitored resource labels,
+except for ``project_id``, which is ignored when it's included in writes to the API. A good
+choice is to use the underlying physical resource where your application code runs – e.g., a
+monitored resource type of ``gce_instance`` or ``aws_ec2_instance``. In some limited
+circumstances, such as when only a single process writes to the custom metric, you may choose to
+use the ``global`` monitored resource type.
 
-See `Monitored resource types`_ for more information about parcitular monitored resource types.
+See `Monitored resource types`_ for more information about particular monitored resource types.
 
->>> from gcloud import monitoring
+>>> from google.cloud import monitoring
 >>> # Create a Resource object for the desired monitored resource type.
 >>> resource = client.resource('gce_instance', labels={
 ...     'instance_id': '1234567890123456789',
@@ -313,8 +313,8 @@ See `Monitored resource types`_ for more information about parcitular monitored 
 ...      'status': 'successful'
 ... })
 
-With a ``Metric`` and ``Resource`` in hand, the :class:`~gcloud.monitoring.client.Client`
-can be used to write :class:`~gcloud.monitoring.timeseries.Point` values.
+With a ``Metric`` and ``Resource`` in hand, the :class:`~google.cloud.monitoring.client.Client`
+can be used to write :class:`~google.cloud.monitoring.timeseries.Point` values.
 
 When writing points, the Python type of the value must match the *value type* of the metric
 descriptor associated with the metric. For example, a Python float will map to ``ValueType.DOUBLE``.
@@ -345,7 +345,7 @@ In the examples below, the ``end_time`` again defaults to the current time::
     >>> client.write_point(metric, resource, 6, start_time=RESET) # API call
 
 To write multiple ``TimeSeries`` in a single batch, you can use
-:meth:`~gcloud.monitoring.client.write_time_series`::
+:meth:`~google.cloud.monitoring.client.write_time_series`::
 
     >>> ts1 = client.time_series(metric1, resource, 3.14, end_time=end_time)
     >>> ts2 = client.time_series(metric2, resource, 42, end_time=end_time)

--- a/docs/monitoring-usage.rst
+++ b/docs/monitoring-usage.rst
@@ -30,7 +30,7 @@ of the API:
 - Querying of time series.
 - Querying of metric descriptors and monitored resource descriptors.
 - Creation and deletion of metric descriptors for custom metrics.
-- (Writing of custom metric data will be coming soon.)
+- Writing of custom metric data.
 
 .. _Stackdriver Monitoring API: https://cloud.google.com/monitoring/api/v3/
 
@@ -300,8 +300,7 @@ type of ``gce_instance`` or ``aws_ec2_instance``. In some limited circumstances,
 only a single process writes to the custom metric, you may choose to use the ``global`` monitored
 resource type.
 
-See `Monitored resource types`_ for a list of all monitored resource types available in
-Stackdriver Monitoring.
+See `Monitored resource types`_ for more information about parcitular monitored resource types.
 
 >>> from gcloud import monitoring
 >>> # Create a Resource object for the desired monitored resource type.
@@ -314,8 +313,6 @@ Stackdriver Monitoring.
 ...      'status': 'successful'
 ... })
 
-Please refer to the `Metrics`_ documentation for more information.
-
 With a ``Metric`` and ``Resource`` in hand, the :class:`~gcloud.monitoring.client.Client`
 can be used to write :class:`~gcloud.monitoring.timeseries.Point` values.
 
@@ -323,7 +320,7 @@ When writing points, the Python type of the value must match the *value type* of
 descriptor associated with the metric. For example, a Python float will map to ``ValueType.DOUBLE``.
 
 Stackdriver Monitoring supports several *metric kinds*: ``GAUGE``, ``CUMULATIVE``, and ``DELTA``.
-However, ``DELTA`` custom metrics are not supported.
+However, ``DELTA`` is not supported for custom metrics.
 
 ``GAUGE`` metrics represent only a single point in time, so only the ``end_time`` should be
 specified::

--- a/docs/monitoring-usage.rst
+++ b/docs/monitoring-usage.rst
@@ -326,7 +326,7 @@ However, ``DELTA`` is not supported for custom metrics.
 specified::
 
     >>> client.write_point(metric=metric, resource=resource,
-    ... value=3.14, end_time=end_time) # API call
+    ...                    value=3.14, end_time=end_time) # API call
 
 By default, ``end_time`` defaults to :meth:`~datetime.datetime.utcnow()`, so metrics can be written
 to the current time as follows::

--- a/docs/monitoring-usage.rst
+++ b/docs/monitoring-usage.rst
@@ -325,7 +325,8 @@ However, ``DELTA`` is not supported for custom metrics.
 ``GAUGE`` metrics represent only a single point in time, so only the ``end_time`` should be
 specified::
 
-    >>> client.write_point(metric=metric, resource=resource, 3.14, end_time=end) # API call
+    >>> client.write_point(metric=metric, resource=resource,
+    ... value=3.14, end_time=end_time) # API call
 
 By default, ``end_time`` defaults to :meth:`~datetime.datetime.utcnow()`, so metrics can be written
 to the current time as follows::

--- a/google/cloud/monitoring/client.py
+++ b/google/cloud/monitoring/client.py
@@ -548,7 +548,8 @@ class Client(JSONClient):
             >>> client.write_point(metric, resource, 3.14)
 
         :type metric: :class:`~google.cloud.monitoring.metric.Metric`
-        :param metric: A :class:`~google.cloud.monitoring.metric.Metric` object.
+        :param metric: A :class:`~google.cloud.monitoring.metric.Metric`
+                       object.
 
         :type resource: :class:`~google.cloud.monitoring.resource.Resource`
         :param resource: A :class:`~google.cloud.monitoring.resource.Resource`

--- a/google/cloud/monitoring/client.py
+++ b/google/cloud/monitoring/client.py
@@ -547,11 +547,11 @@ class Client(JSONClient):
 
             >>> client.write_point(metric, resource, 3.14)
 
-        :type metric: :class:`~gcloud.monitoring.metric.Metric`
-        :param metric: A :class:`~gcloud.monitoring.metric.Metric` object.
+        :type metric: :class:`~google.cloud.monitoring.metric.Metric`
+        :param metric: A :class:`~google.cloud.monitoring.metric.Metric` object.
 
-        :type resource: :class:`~gcloud.monitoring.resource.Resource`
-        :param resource: A :class:`~gcloud.monitoring.resource.Resource`
+        :type resource: :class:`~google.cloud.monitoring.resource.Resource`
+        :param resource: A :class:`~google.cloud.monitoring.resource.Resource`
                          object.
 
         :type value: bool, int, string, or float

--- a/google/cloud/monitoring/metric.py
+++ b/google/cloud/monitoring/metric.py
@@ -348,3 +348,16 @@ class Metric(collections.namedtuple('Metric', 'type labels')):
             type=info['type'],
             labels=info.get('labels', {}),
         )
+
+    def _to_dict(self):
+        """Build a dictionary ready to be serialized to the JSON format.
+
+        :rtype: dict
+        :returns: A dict representation of the object that can be written to
+                  the API.
+        """
+        info = {
+            'type': self.type,
+            'labels': self.labels,
+        }
+        return info

--- a/google/cloud/monitoring/metric.py
+++ b/google/cloud/monitoring/metric.py
@@ -356,8 +356,7 @@ class Metric(collections.namedtuple('Metric', 'type labels')):
         :returns: A dict representation of the object that can be written to
                   the API.
         """
-        info = {
+        return {
             'type': self.type,
             'labels': self.labels,
         }
-        return info

--- a/google/cloud/monitoring/resource.py
+++ b/google/cloud/monitoring/resource.py
@@ -195,8 +195,7 @@ class Resource(collections.namedtuple('Resource', 'type labels')):
         :returns: A dict representation of the object that can be written to
                   the API.
         """
-        info = {
+        return {
             'type': self.type,
             'labels': self.labels,
         }
-        return info

--- a/google/cloud/monitoring/resource.py
+++ b/google/cloud/monitoring/resource.py
@@ -187,3 +187,16 @@ class Resource(collections.namedtuple('Resource', 'type labels')):
             type=info['type'],
             labels=info.get('labels', {}),
         )
+
+    def _to_dict(self):
+        """Build a dictionary ready to be serialized to the JSON format.
+
+        :rtype: dict
+        :returns: A dict representation of the object that can be written to
+                  the API.
+        """
+        info = {
+            'type': self.type,
+            'labels': self.labels,
+        }
+        return info

--- a/google/cloud/monitoring/timeseries.py
+++ b/google/cloud/monitoring/timeseries.py
@@ -90,6 +90,23 @@ class TimeSeries(collections.namedtuple(
         points = list(points) if points else []
         return self._replace(points=points)
 
+    def _to_dict(self):
+        """Build a dictionary ready to be serialized to the JSON wire format.
+
+        Since this method is used when writing to the API, it excludes
+        output-only fields.
+
+        :rtype: dict
+        :returns: The dictionary representation of the time series object.
+        """
+        info = {
+            'metric': self.metric._to_dict(),
+            'resource': self.resource._to_dict(),
+            'points': [point._to_dict() for point in self.points]
+        }
+
+        return info
+
     @classmethod
     def _from_dict(cls, info):
         """Construct a time series from the parsed JSON representation.
@@ -124,6 +141,41 @@ class TimeSeries(collections.namedtuple(
         )
 
 
+def _make_typed_value(value):
+    """Creates a dict representing TypeValue API object from a value.
+
+    Typed values contain a string representing the type of the
+    value being written, and the value itself. They are used when writing
+    points to time series. This method returns the appropriate string to
+    use when writing typed values based on the Python type of the value.
+
+    This method uses the Python type of the object to infer the correct
+    type to send to the API. For example, a Python float will be sent to the
+    API with "doubleValue" as its key.
+
+    See: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TypedValue
+
+    :type value: bool, int, float, str, or dict
+    :param value: value to infer the typed value of.
+
+    :rtype: dict
+    :returns: A dict
+    """
+    typed_value_map = {
+        bool: "boolValue",
+        int: "int64Value",
+        float: "doubleValue",
+        str: "stringValue",
+        dict: "distributionValue",
+    }
+    type_ = typed_value_map[type(value)]
+    if type_ == "int64Value":
+        value = str(value)
+    return {
+        type_: value
+    }
+
+
 class Point(collections.namedtuple('Point', 'end_time start_time value')):
     """A single point in a time series.
 
@@ -156,3 +208,24 @@ class Point(collections.namedtuple('Point', 'end_time start_time value')):
             value = int(value)  # Convert from string.
 
         return cls(end_time, start_time, value)
+
+    def _to_dict(self):
+        """Build a dictionary ready to be serialized to the JSON wire format.
+
+        This method serializes a point in JSON format to be written
+        to the API.
+
+        :rtype: dict
+        :returns: The dictionary representation of the point object.
+        """
+        info = {
+            'interval': {
+                'endTime': self.end_time
+            },
+            'value': _make_typed_value(self.value)
+        }
+
+        if self.start_time is not None:
+            info['interval']['startTime'] = self.start_time
+
+        return info

--- a/google/cloud/monitoring/timeseries.py
+++ b/google/cloud/monitoring/timeseries.py
@@ -102,7 +102,7 @@ class TimeSeries(collections.namedtuple(
         info = {
             'metric': self.metric._to_dict(),
             'resource': self.resource._to_dict(),
-            'points': [point._to_dict() for point in self.points]
+            'points': [point._to_dict() for point in self.points],
         }
 
         return info

--- a/google/cloud/monitoring/timeseries.py
+++ b/google/cloud/monitoring/timeseries.py
@@ -142,7 +142,7 @@ class TimeSeries(collections.namedtuple(
 
 
 def _make_typed_value(value):
-    """Creates a dict representing a TypedValue API object from a value.
+    """Create a dict representing a TypedValue API object.
 
     Typed values are objects with the value itself as the value, keyed by the
     type of the value. They are used when writing points to time series. This
@@ -170,9 +170,7 @@ def _make_typed_value(value):
     type_ = typed_value_map[type(value)]
     if type_ == "int64Value":
         value = str(value)
-    return {
-        type_: value
-    }
+    return { type_: value }
 
 
 class Point(collections.namedtuple('Point', 'end_time start_time value')):

--- a/google/cloud/monitoring/timeseries.py
+++ b/google/cloud/monitoring/timeseries.py
@@ -142,12 +142,11 @@ class TimeSeries(collections.namedtuple(
 
 
 def _make_typed_value(value):
-    """Creates a dict representing TypeValue API object from a value.
+    """Creates a dict representing a TypeValue API object from a value.
 
-    Typed values contain a string representing the type of the
-    value being written, and the value itself. They are used when writing
-    points to time series. This method returns the appropriate string to
-    use when writing typed values based on the Python type of the value.
+    Typed values are objects with the value itself as the value, keyed by the
+    type of the value. They are used when writing points to time series. This
+    method returns the dict representation for the TypedValue.
 
     This method uses the Python type of the object to infer the correct
     type to send to the API. For example, a Python float will be sent to the

--- a/google/cloud/monitoring/timeseries.py
+++ b/google/cloud/monitoring/timeseries.py
@@ -170,7 +170,7 @@ def _make_typed_value(value):
     type_ = typed_value_map[type(value)]
     if type_ == "int64Value":
         value = str(value)
-    return { type_: value }
+    return {type_: value}
 
 
 class Point(collections.namedtuple('Point', 'end_time start_time value')):

--- a/google/cloud/monitoring/timeseries.py
+++ b/google/cloud/monitoring/timeseries.py
@@ -142,7 +142,7 @@ class TimeSeries(collections.namedtuple(
 
 
 def _make_typed_value(value):
-    """Creates a dict representing a TypeValue API object from a value.
+    """Creates a dict representing a TypedValue API object from a value.
 
     Typed values are objects with the value itself as the value, keyed by the
     type of the value. They are used when writing points to time series. This

--- a/system_tests/monitoring.py
+++ b/system_tests/monitoring.py
@@ -195,12 +195,11 @@ class TestMonitoring(unittest.TestCase):
         )
 
         descriptor.create()
-        retry_404(descriptor._fetch)(client, METRIC_TYPE)
 
         metric = client.metric(METRIC_TYPE, {})
         resource = client.resource('global', {})
 
-        client.write_point(metric, resource, VALUE)
+        retry_500(client.write_point)(metric, resource, VALUE)
 
         def _query_timeseries_with_retries():
             def _has_timeseries(result):

--- a/system_tests/monitoring.py
+++ b/system_tests/monitoring.py
@@ -207,7 +207,6 @@ class TestMonitoring(unittest.TestCase):
                 return len(list(result)) > 0
             retry_result = RetryResult(_has_timeseries, max_tries=7)(
                 client.query)
-            return retry_result
             return RetryErrors(BadRequest)(retry_result)
 
         query = _query_timeseries_with_retries()(METRIC_TYPE, minutes=5)

--- a/unit_tests/monitoring/test_metric.py
+++ b/unit_tests/monitoring/test_metric.py
@@ -530,6 +530,16 @@ class TestMetric(unittest.TestCase):
         self.assertEqual(metric.type, TYPE)
         self.assertEqual(metric.labels, {})
 
+    def test_to_dict(self):
+        TYPE = 'custom.googleapis.com/my_metric'
+        LABELS = {}
+        metric = self._makeOne(TYPE, LABELS)
+        expected_dict = {
+            'type': TYPE,
+            'labels': LABELS
+        }
+        self.assertEquals(metric._to_dict(), expected_dict)
+
 
 class _Connection(object):
 

--- a/unit_tests/monitoring/test_metric.py
+++ b/unit_tests/monitoring/test_metric.py
@@ -536,7 +536,7 @@ class TestMetric(unittest.TestCase):
         metric = self._makeOne(TYPE, LABELS)
         expected_dict = {
             'type': TYPE,
-            'labels': LABELS
+            'labels': LABELS,
         }
         self.assertEquals(metric._to_dict(), expected_dict)
 

--- a/unit_tests/monitoring/test_resource.py
+++ b/unit_tests/monitoring/test_resource.py
@@ -316,6 +316,19 @@ class TestResource(unittest.TestCase):
         self.assertEqual(resource.type, TYPE)
         self.assertEqual(resource.labels, {})
 
+    def test_to_dict(self):
+        TYPE = 'gce_instance'
+        LABELS = {
+            'instance_id': '1234567890123456789',
+            'zone': 'us-central1-a',
+        }
+        resource = self._makeOne(TYPE, LABELS)
+        expected_dict = {
+            'type': TYPE,
+            'labels': LABELS
+        }
+        self.assertEquals(resource._to_dict(), expected_dict)
+
 
 class _Connection(object):
 

--- a/unit_tests/monitoring/test_resource.py
+++ b/unit_tests/monitoring/test_resource.py
@@ -325,7 +325,7 @@ class TestResource(unittest.TestCase):
         resource = self._makeOne(TYPE, LABELS)
         expected_dict = {
             'type': TYPE,
-            'labels': LABELS
+            'labels': LABELS,
         }
         self.assertEquals(resource._to_dict(), expected_dict)
 


### PR DESCRIPTION
This kicks off the PR for #1867 with the usage docs. Implementation is started and will follow this soon.

@rimey is primary reviewer here, largely just took most of his suggestions but some followup comments here:

1) Keyword arguments sounds like a good idea and not too tricky, we can do that now.

2) re: a way to write multiple TimeSeries in one go. I did add the suggested method.

Currently, there is no way to write more than one point in a TimeSeries. The only way we could batch writes is doing something like this: 

https://developers.google.com/api-client-library/python/guide/batch

This might involve some changes to the core client library here, how important do we think this is?

In general, what are the main use cases for writing multiple TimeSeries at once? Is it just batching to reduce network requests? I think the method would currently just be a wrapper around

```
for ts in timeseries_list:
     ts.create()
```

which may be a good wrapper to have, even though users could trivially write that out.

3) I think you want the most common use case to be as simple as possible, which is why I think we want a `write` method that just takes a single value without forcing to pass the metric and resource every time. Since the `timeseries.create()` API call requires a Metric and Resource, we have to have a class that contains that Metric and Resource. We can of course just use the TimeSeries itself, but since you can only write a single point to that TimeSeries, it's not something that makes sense to re-use if we want the local object to map well to the API object. So I instead propose to add a TimeseriesWriter class that can take a Metric and Resource and be re-used to create new TimeSeries with those Metric and Resource. 

```
timeseries_writer = client.get_timeseries_writer(metric, resource)
timeseries_writer.write_point(value) # API call
````

cc @sharbison3 @supriyagarg 
