### PR TITLE
Make all imported module members public.

### DIFF
--- a/gcloud/_helpers.py
+++ b/gcloud/_helpers.py
@@ -45,7 +45,7 @@ from gcloud.environment_vars import PROJECT
 from gcloud.environment_vars import CREDENTIALS
 
 
-_NOW = datetime.datetime.utcnow  # To be replaced by tests.
+NOW = datetime.datetime.utcnow  # To be replaced by tests.
 _RFC3339_MICROS = '%Y-%m-%dT%H:%M:%S.%fZ'
 _RFC3339_NO_FRACTION = '%Y-%m-%dT%H:%M:%S'
 # datetime.strptime cannot handle nanosecond precision:  parse w/ regex
@@ -60,14 +60,14 @@ _RFC3339_NANOS = re.compile(r"""
 DEFAULT_CONFIGURATION_PATH = '~/.config/gcloud/configurations/config_default'
 
 
-class _LocalStack(Local):
+class LocalStack(Local):
     """Manage a thread-local LIFO stack of resources.
 
     Intended for use in :class:`gcloud.datastore.batch.Batch.__enter__`,
     :class:`gcloud.storage.batch.Batch.__enter__`, etc.
     """
     def __init__(self):
-        super(_LocalStack, self).__init__()
+        super(LocalStack, self).__init__()
         self._stack = []
 
     def __iter__(self):
@@ -135,7 +135,7 @@ class _UTC(datetime.tzinfo):
         return self._tzname
 
 
-def _ensure_tuple_or_list(arg_name, tuple_or_list):
+def ensure_tuple_or_list(arg_name, tuple_or_list):
     """Ensures an input is a tuple or list.
 
     This effectively reduces the iterable types allowed to a very short
@@ -251,7 +251,7 @@ def _get_production_project():
     return os.getenv(PROJECT)
 
 
-def _determine_default_project(project=None):
+def determine_default_project(project=None):
     """Determine default project ID explicitly or implicitly as fall-back.
 
     In implicit case, supports three environments. In order of precedence, the
@@ -288,7 +288,7 @@ def _determine_default_project(project=None):
     return project
 
 
-def _millis(when):
+def millis(when):
     """Convert a zone-aware datetime to integer milliseconds.
 
     :type when: :class:`datetime.datetime`
@@ -297,11 +297,11 @@ def _millis(when):
     :rtype: int
     :returns: milliseconds since epoch for ``when``
     """
-    micros = _microseconds_from_datetime(when)
+    micros = microseconds_from_datetime(when)
     return micros // 1000
 
 
-def _datetime_from_microseconds(value):
+def datetime_from_microseconds(value):
     """Convert timestamp to datetime, assuming UTC.
 
     :type value: float
@@ -313,7 +313,7 @@ def _datetime_from_microseconds(value):
     return _EPOCH + datetime.timedelta(microseconds=value)
 
 
-def _microseconds_from_datetime(value):
+def microseconds_from_datetime(value):
     """Convert non-none datetime to microseconds.
 
     :type value: :class:`datetime.datetime`
@@ -330,7 +330,7 @@ def _microseconds_from_datetime(value):
     return int(calendar.timegm(value.timetuple()) * 1e6) + value.microsecond
 
 
-def _millis_from_datetime(value):
+def millis_from_datetime(value):
     """Convert non-none datetime to timestamp, assuming UTC.
 
     :type value: :class:`datetime.datetime`, or None
@@ -340,10 +340,10 @@ def _millis_from_datetime(value):
     :returns: the timestamp, in milliseconds, or None
     """
     if value is not None:
-        return _millis(value)
+        return millis(value)
 
 
-def _rfc3339_to_datetime(dt_str):
+def rfc3339_to_datetime(dt_str):
     """Convert a microsecond-precision timetamp to a native datetime.
 
     :type dt_str: str
@@ -356,7 +356,7 @@ def _rfc3339_to_datetime(dt_str):
         dt_str, _RFC3339_MICROS).replace(tzinfo=UTC)
 
 
-def _rfc3339_nanos_to_datetime(dt_str):
+def rfc3339_nanos_to_datetime(dt_str):
     """Convert a nanosecond-precision timestamp to a native datetime.
 
     .. note::
@@ -386,7 +386,7 @@ def _rfc3339_nanos_to_datetime(dt_str):
     return bare_seconds.replace(microsecond=micros, tzinfo=UTC)
 
 
-def _datetime_to_rfc3339(value, ignore_zone=True):
+def datetime_to_rfc3339(value, ignore_zone=True):
     """Convert a timestamp to a string.
 
     :type value: :class:`datetime.datetime`
@@ -406,7 +406,7 @@ def _datetime_to_rfc3339(value, ignore_zone=True):
     return value.strftime(_RFC3339_MICROS)
 
 
-def _to_bytes(value, encoding='ascii'):
+def to_bytes(value, encoding='ascii'):
     """Converts a string value to bytes, if necessary.
 
     Unfortunately, ``six.b`` is insufficient for this task since in
@@ -436,7 +436,7 @@ def _to_bytes(value, encoding='ascii'):
         raise TypeError('%r could not be converted to bytes' % (value,))
 
 
-def _bytes_to_unicode(value):
+def bytes_to_unicode(value):
     """Converts bytes to a unicode value, if necessary.
 
     :type value: bytes
@@ -456,7 +456,7 @@ def _bytes_to_unicode(value):
         raise ValueError('%r could not be converted to unicode' % (value,))
 
 
-def _pb_timestamp_to_datetime(timestamp_pb):
+def pb_timestamp_to_datetime(timestamp_pb):
     """Convert a Timestamp protobuf to a datetime object.
 
     :type timestamp_pb: :class:`google.protobuf.timestamp_pb2.Timestamp`
@@ -474,7 +474,7 @@ def _pb_timestamp_to_datetime(timestamp_pb):
     )
 
 
-def _pb_timestamp_to_rfc3339(timestamp_pb):
+def pb_timestamp_to_rfc3339(timestamp_pb):
     """Convert a Timestamp protobuf to an RFC 3339 string.
 
     :type timestamp_pb: :class:`google.protobuf.timestamp_pb2.Timestamp`
@@ -483,11 +483,11 @@ def _pb_timestamp_to_rfc3339(timestamp_pb):
     :rtype: string
     :returns: An RFC 3339 formatted timestamp string.
     """
-    timestamp = _pb_timestamp_to_datetime(timestamp_pb)
-    return _datetime_to_rfc3339(timestamp)
+    timestamp = pb_timestamp_to_datetime(timestamp_pb)
+    return datetime_to_rfc3339(timestamp)
 
 
-def _datetime_to_pb_timestamp(when):
+def datetime_to_pb_timestamp(when):
     """Convert a datetime object to a Timestamp protobuf.
 
     :type when: :class:`datetime.datetime`
@@ -496,13 +496,13 @@ def _datetime_to_pb_timestamp(when):
     :rtype: :class:`google.protobuf.timestamp_pb2.Timestamp`
     :returns: A timestamp protobuf corresponding to the object.
     """
-    ms_value = _microseconds_from_datetime(when)
+    ms_value = microseconds_from_datetime(when)
     seconds, micros = divmod(ms_value, 10**6)
     nanos = micros * 10**3
     return timestamp_pb2.Timestamp(seconds=seconds, nanos=nanos)
 
 
-def _name_from_project_path(path, project, template):
+def name_from_project_path(path, project, template):
     """Validate a URI path and get the leaf object's name.
 
     :type path: str

--- a/gcloud/bigquery/_helpers.py
+++ b/gcloud/bigquery/_helpers.py
@@ -14,7 +14,7 @@
 
 """Shared helper functions for BigQuery API classes."""
 
-from gcloud._helpers import _datetime_from_microseconds
+from gcloud._helpers import datetime_from_microseconds
 
 
 def _not_null(value, field):
@@ -44,7 +44,7 @@ def _datetime_from_json(value, field):
     """Coerce 'value' to a datetime, if set or not nullable."""
     if _not_null(value, field):
         # value will be a float in seconds, to microsecond precision, in UTC.
-        return _datetime_from_microseconds(1e6 * float(value))
+        return datetime_from_microseconds(1e6 * float(value))
 
 
 def _record_from_json(value, field):
@@ -76,7 +76,7 @@ _CELLDATA_FROM_JSON = {
 }
 
 
-def _rows_from_json(rows, schema):
+def rows_from_json(rows, schema):
     """Convert JSON row data to rows w/ appropriate types."""
     rows_data = []
     for row in rows:
@@ -126,7 +126,7 @@ class _ConfigurationProperty(object):
         delattr(instance._configuration, self._backing_name)
 
 
-class _TypedProperty(_ConfigurationProperty):
+class TypedProperty(_ConfigurationProperty):
     """Property implementation:  validates based on value type.
 
     :type name: string
@@ -136,7 +136,7 @@ class _TypedProperty(_ConfigurationProperty):
     :param property_type: type to be validated
     """
     def __init__(self, name, property_type):
-        super(_TypedProperty, self).__init__(name)
+        super(TypedProperty, self).__init__(name)
         self.property_type = property_type
 
     def _validate(self, value):
@@ -148,7 +148,7 @@ class _TypedProperty(_ConfigurationProperty):
             raise ValueError('Required type: %s' % (self.property_type,))
 
 
-class _EnumProperty(_ConfigurationProperty):
+class EnumProperty(_ConfigurationProperty):
     """Pseudo-enumeration class.
 
     Subclasses must define ``ALLOWED`` as a class-level constant:  it must

--- a/gcloud/bigquery/dataset.py
+++ b/gcloud/bigquery/dataset.py
@@ -15,7 +15,7 @@
 """Define API Datasets."""
 import six
 
-from gcloud._helpers import _datetime_from_microseconds
+from gcloud._helpers import datetime_from_microseconds
 from gcloud.exceptions import NotFound
 from gcloud.bigquery.table import Table
 
@@ -162,7 +162,7 @@ class Dataset(object):
         creation_time = self._properties.get('creationTime')
         if creation_time is not None:
             # creation_time will be in milliseconds.
-            return _datetime_from_microseconds(1000.0 * creation_time)
+            return datetime_from_microseconds(1000.0 * creation_time)
 
     @property
     def dataset_id(self):
@@ -192,7 +192,7 @@ class Dataset(object):
         modified_time = self._properties.get('lastModifiedTime')
         if modified_time is not None:
             # modified_time will be in milliseconds.
-            return _datetime_from_microseconds(1000.0 * modified_time)
+            return datetime_from_microseconds(1000.0 * modified_time)
 
     @property
     def self_link(self):

--- a/gcloud/bigquery/job.py
+++ b/gcloud/bigquery/job.py
@@ -17,14 +17,14 @@
 import six
 
 from gcloud.exceptions import NotFound
-from gcloud._helpers import _datetime_from_microseconds
+from gcloud._helpers import datetime_from_microseconds
 from gcloud.bigquery.dataset import Dataset
 from gcloud.bigquery.schema import SchemaField
 from gcloud.bigquery.table import Table
-from gcloud.bigquery.table import _build_schema_resource
-from gcloud.bigquery.table import _parse_schema_resource
-from gcloud.bigquery._helpers import _EnumProperty
-from gcloud.bigquery._helpers import _TypedProperty
+from gcloud.bigquery.table import build_schema_resource
+from gcloud.bigquery.table import parse_schema_resource
+from gcloud.bigquery._helpers import EnumProperty
+from gcloud.bigquery._helpers import TypedProperty
 
 
 class UDFResource(object):
@@ -48,7 +48,7 @@ class UDFResource(object):
             self.value == other.value)
 
 
-def _build_udf_resources(resources):
+def build_udf_resources(resources):
     """
     :type resources: sequence of :class:`UDFResource`
     :param resources: fields to be appended.
@@ -81,21 +81,21 @@ class UDFResourcesProperty(object):
         instance._udf_resources = tuple(value)
 
 
-class Compression(_EnumProperty):
+class Compression(EnumProperty):
     """Pseudo-enum for ``compression`` properties."""
     GZIP = 'GZIP'
     NONE = 'NONE'
     ALLOWED = (GZIP, NONE)
 
 
-class CreateDisposition(_EnumProperty):
+class CreateDisposition(EnumProperty):
     """Pseudo-enum for ``create_disposition`` properties."""
     CREATE_IF_NEEDED = 'CREATE_IF_NEEDED'
     CREATE_NEVER = 'CREATE_NEVER'
     ALLOWED = (CREATE_IF_NEEDED, CREATE_NEVER)
 
 
-class DestinationFormat(_EnumProperty):
+class DestinationFormat(EnumProperty):
     """Pseudo-enum for ``destination_format`` properties."""
     CSV = 'CSV'
     NEWLINE_DELIMITED_JSON = 'NEWLINE_DELIMITED_JSON'
@@ -103,21 +103,21 @@ class DestinationFormat(_EnumProperty):
     ALLOWED = (CSV, NEWLINE_DELIMITED_JSON, AVRO)
 
 
-class Encoding(_EnumProperty):
+class Encoding(EnumProperty):
     """Pseudo-enum for ``encoding`` properties."""
     UTF_8 = 'UTF-8'
     ISO_8559_1 = 'ISO-8559-1'
     ALLOWED = (UTF_8, ISO_8559_1)
 
 
-class QueryPriority(_EnumProperty):
+class QueryPriority(EnumProperty):
     """Pseudo-enum for ``QueryJob.priority`` property."""
     INTERACTIVE = 'INTERACTIVE'
     BATCH = 'BATCH'
     ALLOWED = (INTERACTIVE, BATCH)
 
 
-class SourceFormat(_EnumProperty):
+class SourceFormat(EnumProperty):
     """Pseudo-enum for ``source_format`` properties."""
     CSV = 'CSV'
     DATASTORE_BACKUP = 'DATASTORE_BACKUP'
@@ -125,7 +125,7 @@ class SourceFormat(_EnumProperty):
     ALLOWED = (CSV, DATASTORE_BACKUP, NEWLINE_DELIMITED_JSON)
 
 
-class WriteDisposition(_EnumProperty):
+class WriteDisposition(EnumProperty):
     """Pseudo-enum for ``write_disposition`` properties."""
     WRITE_APPEND = 'WRITE_APPEND'
     WRITE_TRUNCATE = 'WRITE_TRUNCATE'
@@ -238,7 +238,7 @@ class _AsyncJob(_BaseJob):
         if statistics is not None:
             millis = statistics.get('creationTime')
             if millis is not None:
-                return _datetime_from_microseconds(millis * 1000.0)
+                return datetime_from_microseconds(millis * 1000.0)
 
     @property
     def started(self):
@@ -251,7 +251,7 @@ class _AsyncJob(_BaseJob):
         if statistics is not None:
             millis = statistics.get('startTime')
             if millis is not None:
-                return _datetime_from_microseconds(millis * 1000.0)
+                return datetime_from_microseconds(millis * 1000.0)
 
     @property
     def ended(self):
@@ -264,7 +264,7 @@ class _AsyncJob(_BaseJob):
         if statistics is not None:
             millis = statistics.get('endTime')
             if millis is not None:
-                return _datetime_from_microseconds(millis * 1000.0)
+                return datetime_from_microseconds(millis * 1000.0)
 
     @property
     def error_result(self):
@@ -537,12 +537,12 @@ class LoadTableFromStorageJob(_AsyncJob):
         if statistics is not None:
             return int(statistics['load']['outputRows'])
 
-    allow_jagged_rows = _TypedProperty('allow_jagged_rows', bool)
+    allow_jagged_rows = TypedProperty('allow_jagged_rows', bool)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.allowJaggedRows
     """
 
-    allow_quoted_newlines = _TypedProperty('allow_quoted_newlines', bool)
+    allow_quoted_newlines = TypedProperty('allow_quoted_newlines', bool)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.allowQuotedNewlines
     """
@@ -557,27 +557,27 @@ class LoadTableFromStorageJob(_AsyncJob):
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.encoding
     """
 
-    field_delimiter = _TypedProperty('field_delimiter', six.string_types)
+    field_delimiter = TypedProperty('field_delimiter', six.string_types)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.fieldDelimiter
     """
 
-    ignore_unknown_values = _TypedProperty('ignore_unknown_values', bool)
+    ignore_unknown_values = TypedProperty('ignore_unknown_values', bool)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.ignoreUnknownValues
     """
 
-    max_bad_records = _TypedProperty('max_bad_records', six.integer_types)
+    max_bad_records = TypedProperty('max_bad_records', six.integer_types)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.maxBadRecords
     """
 
-    quote_character = _TypedProperty('quote_character', six.string_types)
+    quote_character = TypedProperty('quote_character', six.string_types)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.quote
     """
 
-    skip_leading_rows = _TypedProperty('skip_leading_rows', six.integer_types)
+    skip_leading_rows = TypedProperty('skip_leading_rows', six.integer_types)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.skipLeadingRows
     """
@@ -640,14 +640,14 @@ class LoadTableFromStorageJob(_AsyncJob):
 
         if len(self.schema) > 0:
             configuration['schema'] = {
-                'fields': _build_schema_resource(self.schema)}
+                'fields': build_schema_resource(self.schema)}
 
         return resource
 
     def _scrub_local_properties(self, cleaned):
         """Helper:  handle subclass properties in cleaned."""
         schema = cleaned.pop('schema', {'fields': ()})
-        self.schema = _parse_schema_resource(schema)
+        self.schema = parse_schema_resource(schema)
 
     @classmethod
     def from_api_repr(cls, resource, client):
@@ -838,12 +838,12 @@ class ExtractTableToStorageJob(_AsyncJob):
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.extracted.destinationFormat
     """
 
-    field_delimiter = _TypedProperty('field_delimiter', six.string_types)
+    field_delimiter = TypedProperty('field_delimiter', six.string_types)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.extracted.fieldDelimiter
     """
 
-    print_header = _TypedProperty('print_header', bool)
+    print_header = TypedProperty('print_header', bool)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.extracted.printHeader
     """
@@ -957,7 +957,7 @@ class QueryJob(_AsyncJob):
         self.udf_resources = udf_resources
         self._configuration = _AsyncQueryConfiguration()
 
-    allow_large_results = _TypedProperty('allow_large_results', bool)
+    allow_large_results = TypedProperty('allow_large_results', bool)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.query.allowLargeResults
     """
@@ -967,17 +967,17 @@ class QueryJob(_AsyncJob):
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.query.createDisposition
     """
 
-    default_dataset = _TypedProperty('default_dataset', Dataset)
+    default_dataset = TypedProperty('default_dataset', Dataset)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.query.defaultDataset
     """
 
-    destination = _TypedProperty('destination', Table)
+    destination = TypedProperty('destination', Table)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.query.destinationTable
     """
 
-    flatten_results = _TypedProperty('flatten_results', bool)
+    flatten_results = TypedProperty('flatten_results', bool)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.query.flattenResults
     """
@@ -989,12 +989,12 @@ class QueryJob(_AsyncJob):
 
     udf_resources = UDFResourcesProperty()
 
-    use_query_cache = _TypedProperty('use_query_cache', bool)
+    use_query_cache = TypedProperty('use_query_cache', bool)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.query.useQueryCache
     """
 
-    use_legacy_sql = _TypedProperty('use_legacy_sql', bool)
+    use_legacy_sql = TypedProperty('use_legacy_sql', bool)
     """See:
     https://cloud.google.com/bigquery/docs/\
     reference/v2/jobs#configuration.query.useLegacySql
@@ -1043,7 +1043,7 @@ class QueryJob(_AsyncJob):
         if self.write_disposition is not None:
             configuration['writeDisposition'] = self.write_disposition
         if len(self._udf_resources) > 0:
-            configuration[self._UDF_KEY] = _build_udf_resources(
+            configuration[self._UDF_KEY] = build_udf_resources(
                 self._udf_resources)
 
     def _build_resource(self):

--- a/gcloud/bigquery/query.py
+++ b/gcloud/bigquery/query.py
@@ -16,13 +16,13 @@
 
 import six
 
-from gcloud.bigquery._helpers import _TypedProperty
-from gcloud.bigquery._helpers import _rows_from_json
+from gcloud.bigquery._helpers import TypedProperty
+from gcloud.bigquery._helpers import rows_from_json
 from gcloud.bigquery.dataset import Dataset
 from gcloud.bigquery.job import QueryJob
 from gcloud.bigquery.job import UDFResourcesProperty
-from gcloud.bigquery.job import _build_udf_resources
-from gcloud.bigquery.table import _parse_schema_resource
+from gcloud.bigquery.job import build_udf_resources
+from gcloud.bigquery.table import parse_schema_resource
 
 
 class _SyncQueryConfiguration(object):
@@ -201,7 +201,7 @@ class QueryResults(object):
         :rtype: list of tuples of row values, or ``NoneType``
         :returns: fields describing the schema (None until set by the server).
         """
-        return _rows_from_json(self._properties.get('rows', ()), self.schema)
+        return rows_from_json(self._properties.get('rows', ()), self.schema)
 
     @property
     def schema(self):
@@ -213,41 +213,41 @@ class QueryResults(object):
         :rtype: list of :class:`SchemaField`, or ``NoneType``
         :returns: fields describing the schema (None until set by the server).
         """
-        return _parse_schema_resource(self._properties.get('schema', {}))
+        return parse_schema_resource(self._properties.get('schema', {}))
 
-    default_dataset = _TypedProperty('default_dataset', Dataset)
+    default_dataset = TypedProperty('default_dataset', Dataset)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#defaultDataset
     """
 
-    dry_run = _TypedProperty('dry_run', bool)
+    dry_run = TypedProperty('dry_run', bool)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#dryRun
     """
 
-    max_results = _TypedProperty('max_results', six.integer_types)
+    max_results = TypedProperty('max_results', six.integer_types)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#maxResults
     """
 
-    preserve_nulls = _TypedProperty('preserve_nulls', bool)
+    preserve_nulls = TypedProperty('preserve_nulls', bool)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#preserveNulls
     """
 
-    timeout_ms = _TypedProperty('timeout_ms', six.integer_types)
+    timeout_ms = TypedProperty('timeout_ms', six.integer_types)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#timeoutMs
     """
 
     udf_resources = UDFResourcesProperty()
 
-    use_query_cache = _TypedProperty('use_query_cache', bool)
+    use_query_cache = TypedProperty('use_query_cache', bool)
     """See:
     https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#useQueryCache
     """
 
-    use_legacy_sql = _TypedProperty('use_legacy_sql', bool)
+    use_legacy_sql = TypedProperty('use_legacy_sql', bool)
     """See:
     https://cloud.google.com/bigquery/docs/\
     reference/v2/jobs/query#useLegacySql
@@ -291,7 +291,7 @@ class QueryResults(object):
             resource['dryRun'] = self.dry_run
 
         if len(self._udf_resources) > 0:
-            resource[self._UDF_KEY] = _build_udf_resources(self._udf_resources)
+            resource[self._UDF_KEY] = build_udf_resources(self._udf_resources)
 
         return resource
 
@@ -372,6 +372,6 @@ class QueryResults(object):
         if total_rows is not None:
             total_rows = int(total_rows)
         page_token = response.get('pageToken')
-        rows_data = _rows_from_json(response.get('rows', ()), self.schema)
+        rows_data = rows_from_json(response.get('rows', ()), self.schema)
 
         return rows_data, total_rows, page_token

--- a/gcloud/bigquery/test__helpers.py
+++ b/gcloud/bigquery/test__helpers.py
@@ -50,11 +50,11 @@ class Test_ConfigurationProperty(unittest.TestCase):
         self.assertEqual(wrapper._configuration._attr, None)
 
 
-class Test_TypedProperty(unittest.TestCase):
+class TestTypedProperty(unittest.TestCase):
 
     def _getTargetClass(self):
-        from gcloud.bigquery._helpers import _TypedProperty
-        return _TypedProperty
+        from gcloud.bigquery._helpers import TypedProperty
+        return TypedProperty
 
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
@@ -83,11 +83,11 @@ class Test_TypedProperty(unittest.TestCase):
         self.assertEqual(wrapper._configuration._attr, None)
 
 
-class Test_EnumProperty(unittest.TestCase):
+class TestEnumProperty(unittest.TestCase):
 
     def _getTargetClass(self):
-        from gcloud.bigquery._helpers import _EnumProperty
-        return _EnumProperty
+        from gcloud.bigquery._helpers import EnumProperty
+        return EnumProperty
 
     def test_it(self):
 

--- a/gcloud/bigquery/test_job.py
+++ b/gcloud/bigquery/test_job.py
@@ -370,7 +370,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
     def test_props_set_by_server(self):
         import datetime
         from gcloud._helpers import UTC
-        from gcloud._helpers import _millis
+        from gcloud._helpers import millis
 
         CREATED = datetime.datetime(2015, 8, 11, 12, 13, 22, tzinfo=UTC)
         STARTED = datetime.datetime(2015, 8, 11, 13, 47, 15, tzinfo=UTC)
@@ -393,9 +393,9 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         job._properties['user_email'] = EMAIL
 
         statistics = job._properties['statistics'] = {}
-        statistics['creationTime'] = _millis(CREATED)
-        statistics['startTime'] = _millis(STARTED)
-        statistics['endTime'] = _millis(ENDED)
+        statistics['creationTime'] = millis(CREATED)
+        statistics['startTime'] = millis(STARTED)
+        statistics['endTime'] = millis(ENDED)
         load_stats = statistics['load'] = {}
         load_stats['inputFileBytes'] = 12345
         load_stats['inputFiles'] = 1

--- a/gcloud/bigquery/test_table.py
+++ b/gcloud/bigquery/test_table.py
@@ -242,7 +242,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
     def test_props_set_by_server(self):
         import datetime
         from gcloud._helpers import UTC
-        from gcloud._helpers import _millis
+        from gcloud._helpers import millis
 
         CREATED = datetime.datetime(2015, 7, 29, 12, 13, 22, tzinfo=UTC)
         MODIFIED = datetime.datetime(2015, 7, 29, 14, 47, 15, tzinfo=UTC)
@@ -253,9 +253,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
         table = self._makeOne(self.TABLE_NAME, dataset)
-        table._properties['creationTime'] = _millis(CREATED)
+        table._properties['creationTime'] = millis(CREATED)
         table._properties['etag'] = 'ETAG'
-        table._properties['lastModifiedTime'] = _millis(MODIFIED)
+        table._properties['lastModifiedTime'] = millis(MODIFIED)
         table._properties['numBytes'] = 12345
         table._properties['numRows'] = 66
         table._properties['selfLink'] = URL
@@ -629,7 +629,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
     def test_create_w_alternate_client(self):
         import datetime
         from gcloud._helpers import UTC
-        from gcloud._helpers import _millis
+        from gcloud._helpers import millis
         from gcloud.bigquery.table import SchemaField
 
         PATH = 'projects/%s/datasets/%s/tables' % (self.PROJECT, self.DS_NAME)
@@ -641,7 +641,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         RESOURCE['friendlyName'] = TITLE
         self.EXP_TIME = datetime.datetime(2015, 8, 1, 23, 59, 59,
                                           tzinfo=UTC)
-        RESOURCE['expirationTime'] = _millis(self.EXP_TIME)
+        RESOURCE['expirationTime'] = millis(self.EXP_TIME)
         RESOURCE['view'] = {}
         RESOURCE['view']['query'] = QUERY
         RESOURCE['type'] = 'VIEW'
@@ -826,7 +826,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
     def test_patch_w_alternate_client(self):
         import datetime
         from gcloud._helpers import UTC
-        from gcloud._helpers import _millis
+        from gcloud._helpers import millis
         from gcloud.bigquery.table import SchemaField
 
         PATH = 'projects/%s/datasets/%s/tables/%s' % (
@@ -839,7 +839,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         RESOURCE['location'] = LOCATION
         self.EXP_TIME = datetime.datetime(2015, 8, 1, 23, 59, 59,
                                           tzinfo=UTC)
-        RESOURCE['expirationTime'] = _millis(self.EXP_TIME)
+        RESOURCE['expirationTime'] = millis(self.EXP_TIME)
         conn1 = _Connection()
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
@@ -860,7 +860,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         SENT = {
             'view': {'query': QUERY},
             'location': LOCATION,
-            'expirationTime': _millis(self.EXP_TIME),
+            'expirationTime': millis(self.EXP_TIME),
             'schema': {'fields': [
                 {'name': 'full_name', 'type': 'STRING', 'mode': 'REQUIRED'},
                 {'name': 'age', 'type': 'INTEGER', 'mode': 'NULLABLE'}]},
@@ -935,7 +935,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
     def test_update_w_alternate_client(self):
         import datetime
         from gcloud._helpers import UTC
-        from gcloud._helpers import _millis
+        from gcloud._helpers import millis
 
         PATH = 'projects/%s/datasets/%s/tables/%s' % (
             self.PROJECT, self.DS_NAME, self.TABLE_NAME)
@@ -947,7 +947,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         RESOURCE['location'] = LOCATION
         self.EXP_TIME = datetime.datetime(2015, 8, 1, 23, 59, 59,
                                           tzinfo=UTC)
-        RESOURCE['expirationTime'] = _millis(self.EXP_TIME)
+        RESOURCE['expirationTime'] = millis(self.EXP_TIME)
         RESOURCE['view'] = {'query': QUERY}
         RESOURCE['type'] = 'VIEW'
         conn1 = _Connection()
@@ -973,7 +973,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
                 {'projectId': self.PROJECT,
                  'datasetId': self.DS_NAME,
                  'tableId': self.TABLE_NAME},
-            'expirationTime': _millis(self.EXP_TIME),
+            'expirationTime': millis(self.EXP_TIME),
             'location': 'EU',
             'view': {'query': QUERY},
         }
@@ -1251,7 +1251,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
     def test_insert_data_w_bound_client(self):
         import datetime
         from gcloud._helpers import UTC
-        from gcloud._helpers import _microseconds_from_datetime
+        from gcloud._helpers import microseconds_from_datetime
         from gcloud.bigquery.table import SchemaField
 
         WHEN_TS = 1437767599.006
@@ -1277,7 +1277,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         def _row_data(row):
             joined = None
             if row[2] is not None:
-                joined = _microseconds_from_datetime(row[2]) * 1e-6
+                joined = microseconds_from_datetime(row[2]) * 1e-6
             return {'full_name': row[0],
                     'age': row[1],
                     'joined': joined}
@@ -1514,7 +1514,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         import json
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
-        from gcloud._helpers import _to_bytes
+        from gcloud._helpers import to_bytes
         from gcloud.streaming.test_transfer import _email_chunk_parser
 
         requested, PATH, BODY = self._upload_from_file_helper()
@@ -1537,7 +1537,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertTrue(boundary.startswith('boundary="=='))
         self.assertTrue(boundary.endswith('=="'))
 
-        divider = b'--' + _to_bytes(boundary[len('boundary="'):-1])
+        divider = b'--' + to_bytes(boundary[len('boundary="'):-1])
         chunks = req['body'].split(divider)[1:-1]  # discard prolog / epilog
         self.assertEqual(len(chunks), 2)
 
@@ -1654,11 +1654,11 @@ class TestTable(unittest.TestCase, _SchemaBase):
     # pylint: enable=too-many-statements
 
 
-class Test_parse_schema_resource(unittest.TestCase, _SchemaBase):
+class Testparse_schema_resource(unittest.TestCase, _SchemaBase):
 
     def _callFUT(self, resource):
-        from gcloud.bigquery.table import _parse_schema_resource
-        return _parse_schema_resource(resource)
+        from gcloud.bigquery.table import parse_schema_resource
+        return parse_schema_resource(resource)
 
     def _makeResource(self):
         return {
@@ -1668,12 +1668,12 @@ class Test_parse_schema_resource(unittest.TestCase, _SchemaBase):
             ]},
         }
 
-    def test__parse_schema_resource_defaults(self):
+    def test_parse_schema_resource_defaults(self):
         RESOURCE = self._makeResource()
         schema = self._callFUT(RESOURCE['schema'])
         self._verifySchema(schema, RESOURCE)
 
-    def test__parse_schema_resource_subfields(self):
+    def test_parse_schema_resource_subfields(self):
         RESOURCE = self._makeResource()
         RESOURCE['schema']['fields'].append(
             {'name': 'phone',
@@ -1688,7 +1688,7 @@ class Test_parse_schema_resource(unittest.TestCase, _SchemaBase):
         schema = self._callFUT(RESOURCE['schema'])
         self._verifySchema(schema, RESOURCE)
 
-    def test__parse_schema_resource_fields_without_mode(self):
+    def test_parse_schema_resource_fields_without_mode(self):
         RESOURCE = self._makeResource()
         RESOURCE['schema']['fields'].append(
             {'name': 'phone',
@@ -1698,11 +1698,11 @@ class Test_parse_schema_resource(unittest.TestCase, _SchemaBase):
         self._verifySchema(schema, RESOURCE)
 
 
-class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
+class Testbuild_schema_resource(unittest.TestCase, _SchemaBase):
 
     def _callFUT(self, resource):
-        from gcloud.bigquery.table import _build_schema_resource
-        return _build_schema_resource(resource)
+        from gcloud.bigquery.table import build_schema_resource
+        return build_schema_resource(resource)
 
     def test_defaults(self):
         from gcloud.bigquery.table import SchemaField

--- a/gcloud/bigtable/client.py
+++ b/gcloud/bigtable/client.py
@@ -36,9 +36,9 @@ from gcloud.bigtable._generated import bigtable_table_admin_pb2
 from gcloud.bigtable._generated import operations_grpc_pb2
 from gcloud.bigtable.cluster import DEFAULT_SERVE_NODES
 from gcloud.bigtable.instance import Instance
-from gcloud.bigtable.instance import _EXISTING_INSTANCE_LOCATION_ID
-from gcloud.client import _ClientFactoryMixin
-from gcloud.client import _ClientProjectMixin
+from gcloud.bigtable.instance import EXISTING_INSTANCE_LOCATION_ID
+from gcloud.client import ClientFactoryMixin
+from gcloud.client import ClientProjectMixin
 from gcloud.credentials import get_credentials
 
 
@@ -131,7 +131,7 @@ def _make_table_stub(client):
                      TABLE_ADMIN_HOST, TABLE_ADMIN_PORT)
 
 
-class Client(_ClientFactoryMixin, _ClientProjectMixin):
+class Client(ClientFactoryMixin, ClientProjectMixin):
     """Client for interacting with Google Cloud Bigtable API.
 
     .. note::
@@ -175,7 +175,7 @@ class Client(_ClientFactoryMixin, _ClientProjectMixin):
 
     def __init__(self, project=None, credentials=None,
                  read_only=False, admin=False, user_agent=DEFAULT_USER_AGENT):
-        _ClientProjectMixin.__init__(self, project=project)
+        ClientProjectMixin.__init__(self, project=project)
         if credentials is None:
             credentials = get_credentials()
 
@@ -297,7 +297,7 @@ class Client(_ClientFactoryMixin, _ClientProjectMixin):
             raise ValueError('Client is not an admin client.')
         return self._table_stub_internal
 
-    def instance(self, instance_id, location=_EXISTING_INSTANCE_LOCATION_ID,
+    def instance(self, instance_id, location=EXISTING_INSTANCE_LOCATION_ID,
                  display_name=None, serve_nodes=DEFAULT_SERVE_NODES):
         """Factory to create a instance associated with this client.
 

--- a/gcloud/bigtable/cluster.py
+++ b/gcloud/bigtable/cluster.py
@@ -22,8 +22,8 @@ from gcloud.bigtable._generated import (
 from gcloud.bigtable._generated import (
     bigtable_instance_admin_pb2 as messages_v2_pb2)
 from gcloud.operation import Operation
-from gcloud.operation import _compute_type_url
-from gcloud.operation import _register_type_url
+from gcloud.operation import compute_type_url
+from gcloud.operation import register_type_url
 
 
 _CLUSTER_NAME_RE = re.compile(r'^projects/(?P<project>[^/]+)/'
@@ -34,9 +34,9 @@ DEFAULT_SERVE_NODES = 3
 """Default number of nodes to use when creating a cluster."""
 
 
-_UPDATE_CLUSTER_METADATA_URL = _compute_type_url(
+_UPDATE_CLUSTER_METADATA_URL = compute_type_url(
     messages_v2_pb2.UpdateClusterMetadata)
-_register_type_url(
+register_type_url(
     _UPDATE_CLUSTER_METADATA_URL, messages_v2_pb2.UpdateClusterMetadata)
 
 

--- a/gcloud/bigtable/column_family.py
+++ b/gcloud/bigtable/column_family.py
@@ -305,7 +305,7 @@ class ColumnFamily(object):
         client._table_stub.ModifyColumnFamilies(request_pb)
 
 
-def _gc_rule_from_pb(gc_rule_pb):
+def gc_rule_from_pb(gc_rule_pb):
     """Convert a protobuf GC rule to a native object.
 
     :type gc_rule_pb: :class:`.table_v2_pb2.GcRule`
@@ -313,7 +313,7 @@ def _gc_rule_from_pb(gc_rule_pb):
 
     :rtype: :class:`GarbageCollectionRule` or :data:`NoneType <types.NoneType>`
     :returns: An instance of one of the native rules defined
-              in :module:`column_family` or :data:`None` if no values were
+              in :mod:`column_family` or :data:`None` if no values were
               set on the protobuf passed in.
     :raises: :class:`ValueError <exceptions.ValueError>` if the rule name
              is unexpected.
@@ -328,10 +328,10 @@ def _gc_rule_from_pb(gc_rule_pb):
         max_age = _duration_pb_to_timedelta(gc_rule_pb.max_age)
         return MaxAgeGCRule(max_age)
     elif rule_name == 'union':
-        return GCRuleUnion([_gc_rule_from_pb(rule)
+        return GCRuleUnion([gc_rule_from_pb(rule)
                             for rule in gc_rule_pb.union.rules])
     elif rule_name == 'intersection':
-        rules = [_gc_rule_from_pb(rule)
+        rules = [gc_rule_from_pb(rule)
                  for rule in gc_rule_pb.intersection.rules]
         return GCRuleIntersection(rules)
     else:

--- a/gcloud/bigtable/instance.py
+++ b/gcloud/bigtable/instance.py
@@ -27,18 +27,18 @@ from gcloud.bigtable.cluster import Cluster
 from gcloud.bigtable.cluster import DEFAULT_SERVE_NODES
 from gcloud.bigtable.table import Table
 from gcloud.operation import Operation
-from gcloud.operation import _compute_type_url
-from gcloud.operation import _register_type_url
+from gcloud.operation import compute_type_url
+from gcloud.operation import register_type_url
 
 
-_EXISTING_INSTANCE_LOCATION_ID = 'see-existing-cluster'
+EXISTING_INSTANCE_LOCATION_ID = 'see-existing-cluster'
 _INSTANCE_NAME_RE = re.compile(r'^projects/(?P<project>[^/]+)/'
                                r'instances/(?P<instance_id>[a-z][-a-z0-9]*)$')
 
 
-_CREATE_INSTANCE_METADATA_URL = _compute_type_url(
+_CREATE_INSTANCE_METADATA_URL = compute_type_url(
     messages_v2_pb2.CreateInstanceMetadata)
-_register_type_url(
+register_type_url(
     _CREATE_INSTANCE_METADATA_URL, messages_v2_pb2.CreateInstanceMetadata)
 
 
@@ -106,7 +106,7 @@ class Instance(object):
     """
 
     def __init__(self, instance_id, client,
-                 location_id=_EXISTING_INSTANCE_LOCATION_ID,
+                 location_id=EXISTING_INSTANCE_LOCATION_ID,
                  display_name=None,
                  serve_nodes=DEFAULT_SERVE_NODES):
         self.instance_id = instance_id
@@ -151,7 +151,7 @@ class Instance(object):
                              'project ID on the client')
         instance_id = match.group('instance_id')
 
-        result = cls(instance_id, client, _EXISTING_INSTANCE_LOCATION_ID)
+        result = cls(instance_id, client, EXISTING_INSTANCE_LOCATION_ID)
         result._update_from_pb(instance_pb)
         return result
 

--- a/gcloud/bigtable/row.py
+++ b/gcloud/bigtable/row.py
@@ -19,9 +19,9 @@ import struct
 
 import six
 
-from gcloud._helpers import _datetime_from_microseconds
-from gcloud._helpers import _microseconds_from_datetime
-from gcloud._helpers import _to_bytes
+from gcloud._helpers import datetime_from_microseconds
+from gcloud._helpers import microseconds_from_datetime
+from gcloud._helpers import to_bytes
 from gcloud.bigtable._generated import (
     data_pb2 as data_v2_pb2)
 from gcloud.bigtable._generated import (
@@ -52,7 +52,7 @@ class Row(object):
     """
 
     def __init__(self, row_key, table):
-        self._row_key = _to_bytes(row_key)
+        self._row_key = to_bytes(row_key)
         self._table = table
 
 
@@ -122,15 +122,15 @@ class _SetDeleteRow(Row):
         :param state: (Optional) The state that is passed along to
                       :meth:`_get_mutations`.
         """
-        column = _to_bytes(column)
+        column = to_bytes(column)
         if isinstance(value, six.integer_types):
             value = _PACK_I64(value)
-        value = _to_bytes(value)
+        value = to_bytes(value)
         if timestamp is None:
             # Use -1 for current Bigtable server time.
             timestamp_micros = -1
         else:
-            timestamp_micros = _microseconds_from_datetime(timestamp)
+            timestamp_micros = microseconds_from_datetime(timestamp)
             # Truncate to millisecond granularity.
             timestamp_micros -= (timestamp_micros % 1000)
 
@@ -200,7 +200,7 @@ class _SetDeleteRow(Row):
 
             to_append = []
             for column in columns:
-                column = _to_bytes(column)
+                column = to_bytes(column)
                 # time_range will never change if present, but the rest of
                 # delete_kwargs will
                 delete_kwargs.update(
@@ -698,8 +698,8 @@ class AppendRow(Row):
                       the targeted cell is unset, it will be treated as
                       containing the empty string.
         """
-        column = _to_bytes(column)
-        value = _to_bytes(value)
+        column = to_bytes(column)
+        value = to_bytes(value)
         rule_pb = data_v2_pb2.ReadModifyWriteRule(
             family_name=column_family_id,
             column_qualifier=column,
@@ -736,7 +736,7 @@ class AppendRow(Row):
                           big-endian signed integer), or the entire request
                           will fail.
         """
-        column = _to_bytes(column)
+        column = to_bytes(column)
         rule_pb = data_v2_pb2.ReadModifyWriteRule(
             family_name=column_family_id,
             column_qualifier=column,
@@ -880,7 +880,7 @@ def _parse_family_pb(family_pb):
         for cell in column.cells:
             val_pair = (
                 cell.value,
-                _datetime_from_microseconds(cell.timestamp_micros),
+                datetime_from_microseconds(cell.timestamp_micros),
             )
             cells.append(val_pair)
 

--- a/gcloud/bigtable/row_data.py
+++ b/gcloud/bigtable/row_data.py
@@ -18,8 +18,8 @@
 import copy
 import six
 
-from gcloud._helpers import _datetime_from_microseconds
-from gcloud._helpers import _to_bytes
+from gcloud._helpers import datetime_from_microseconds
+from gcloud._helpers import to_bytes
 
 
 class Cell(object):
@@ -50,7 +50,7 @@ class Cell(object):
         :rtype: :class:`Cell`
         :returns: The cell corresponding to the protobuf.
         """
-        timestamp = _datetime_from_microseconds(cell_pb.timestamp_micros)
+        timestamp = datetime_from_microseconds(cell_pb.timestamp_micros)
         if cell_pb.labels:
             return cls(cell_pb.value, timestamp, labels=cell_pb.labels)
         else:
@@ -145,8 +145,8 @@ class PartialRowData(object):
         result = {}
         for column_family_id, columns in six.iteritems(self._cells):
             for column_qual, cells in six.iteritems(columns):
-                key = (_to_bytes(column_family_id) + b':' +
-                       _to_bytes(column_qual))
+                key = (to_bytes(column_family_id) + b':' +
+                       to_bytes(column_qual))
                 result[key] = cells
         return result
 

--- a/gcloud/bigtable/row_filters.py
+++ b/gcloud/bigtable/row_filters.py
@@ -15,8 +15,8 @@
 """Filters for Google Cloud Bigtable Row classes."""
 
 
-from gcloud._helpers import _microseconds_from_datetime
-from gcloud._helpers import _to_bytes
+from gcloud._helpers import microseconds_from_datetime
+from gcloud._helpers import to_bytes
 from gcloud.bigtable._generated import (
     data_pb2 as data_v2_pb2)
 
@@ -120,7 +120,7 @@ class _RegexFilter(RowFilter):
     """
 
     def __init__(self, regex):
-        self.regex = _to_bytes(regex)
+        self.regex = to_bytes(regex)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -273,10 +273,10 @@ class TimestampRange(object):
         timestamp_range_kwargs = {}
         if self.start is not None:
             timestamp_range_kwargs['start_timestamp_micros'] = (
-                _microseconds_from_datetime(self.start))
+                microseconds_from_datetime(self.start))
         if self.end is not None:
             timestamp_range_kwargs['end_timestamp_micros'] = (
-                _microseconds_from_datetime(self.end))
+                microseconds_from_datetime(self.end))
         return data_v2_pb2.TimestampRange(**timestamp_range_kwargs)
 
 
@@ -389,13 +389,13 @@ class ColumnRangeFilter(RowFilter):
                 key = 'start_qualifier_closed'
             else:
                 key = 'start_qualifier_open'
-            column_range_kwargs[key] = _to_bytes(self.start_column)
+            column_range_kwargs[key] = to_bytes(self.start_column)
         if self.end_column is not None:
             if self.inclusive_end:
                 key = 'end_qualifier_closed'
             else:
                 key = 'end_qualifier_open'
-            column_range_kwargs[key] = _to_bytes(self.end_column)
+            column_range_kwargs[key] = to_bytes(self.end_column)
 
         column_range = data_v2_pb2.ColumnRange(**column_range_kwargs)
         return data_v2_pb2.RowFilter(column_range_filter=column_range)
@@ -506,13 +506,13 @@ class ValueRangeFilter(RowFilter):
                 key = 'start_value_closed'
             else:
                 key = 'start_value_open'
-            value_range_kwargs[key] = _to_bytes(self.start_value)
+            value_range_kwargs[key] = to_bytes(self.start_value)
         if self.end_value is not None:
             if self.inclusive_end:
                 key = 'end_value_closed'
             else:
                 key = 'end_value_open'
-            value_range_kwargs[key] = _to_bytes(self.end_value)
+            value_range_kwargs[key] = to_bytes(self.end_value)
 
         value_range = data_v2_pb2.ValueRange(**value_range_kwargs)
         return data_v2_pb2.RowFilter(value_range_filter=value_range)

--- a/gcloud/bigtable/table.py
+++ b/gcloud/bigtable/table.py
@@ -14,14 +14,14 @@
 
 """User friendly container for Google Cloud Bigtable Table."""
 
-from gcloud._helpers import _to_bytes
+from gcloud._helpers import to_bytes
 from gcloud.bigtable._generated import (
     bigtable_pb2 as data_messages_v2_pb2)
 from gcloud.bigtable._generated import (
     bigtable_table_admin_pb2 as table_admin_messages_v2_pb2)
 from gcloud.bigtable._generated import (
     table_pb2 as table_v2_pb2)
-from gcloud.bigtable.column_family import _gc_rule_from_pb
+from gcloud.bigtable.column_family import gc_rule_from_pb
 from gcloud.bigtable.column_family import ColumnFamily
 from gcloud.bigtable.row import AppendRow
 from gcloud.bigtable.row import ConditionalRow
@@ -204,7 +204,7 @@ class Table(object):
 
         result = {}
         for column_family_id, value_pb in table_pb.column_families.items():
-            gc_rule = _gc_rule_from_pb(value_pb.gc_rule)
+            gc_rule = gc_rule_from_pb(value_pb.gc_rule)
             column_family = self.column_family(column_family_id,
                                                gc_rule=gc_rule)
             result[column_family_id] = column_family
@@ -356,9 +356,9 @@ def _create_row_request(table_name, row_key=None, start_key=None, end_key=None,
     range_kwargs = {}
     if start_key is not None or end_key is not None:
         if start_key is not None:
-            range_kwargs['start_key_closed'] = _to_bytes(start_key)
+            range_kwargs['start_key_closed'] = to_bytes(start_key)
         if end_key is not None:
-            range_kwargs['end_key_open'] = _to_bytes(end_key)
+            range_kwargs['end_key_open'] = to_bytes(end_key)
     if filter_ is not None:
         request_kwargs['filter'] = filter_.to_pb()
     if limit is not None:
@@ -367,7 +367,7 @@ def _create_row_request(table_name, row_key=None, start_key=None, end_key=None,
     message = data_messages_v2_pb2.ReadRowsRequest(**request_kwargs)
 
     if row_key is not None:
-        message.rows.row_keys.append(_to_bytes(row_key))
+        message.rows.row_keys.append(to_bytes(row_key))
 
     if range_kwargs:
         message.rows.row_ranges.add(**range_kwargs)

--- a/gcloud/bigtable/test_client.py
+++ b/gcloud/bigtable/test_client.py
@@ -409,7 +409,7 @@ class TestClient(unittest.TestCase):
     def test_instance_factory_defaults(self):
         from gcloud.bigtable.cluster import DEFAULT_SERVE_NODES
         from gcloud.bigtable.instance import Instance
-        from gcloud.bigtable.instance import _EXISTING_INSTANCE_LOCATION_ID
+        from gcloud.bigtable.instance import EXISTING_INSTANCE_LOCATION_ID
 
         PROJECT = 'PROJECT'
         INSTANCE_ID = 'instance-id'
@@ -424,7 +424,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(instance.instance_id, INSTANCE_ID)
         self.assertEqual(instance.display_name, DISPLAY_NAME)
         self.assertEqual(instance._cluster_location_id,
-                         _EXISTING_INSTANCE_LOCATION_ID)
+                         EXISTING_INSTANCE_LOCATION_ID)
         self.assertEqual(instance._cluster_serve_nodes, DEFAULT_SERVE_NODES)
         self.assertTrue(instance._client is client)
 

--- a/gcloud/bigtable/test_cluster.py
+++ b/gcloud/bigtable/test_cluster.py
@@ -276,7 +276,7 @@ class TestCluster(unittest.TestCase):
         from google.longrunning import operations_pb2
         from gcloud.operation import Operation
         from google.protobuf.any_pb2 import Any
-        from gcloud._helpers import _datetime_to_pb_timestamp
+        from gcloud._helpers import datetime_to_pb_timestamp
         from gcloud.bigtable._generated import (
             instance_pb2 as data_v2_pb2)
         from gcloud.bigtable._generated import (
@@ -285,7 +285,7 @@ class TestCluster(unittest.TestCase):
         from gcloud.bigtable.cluster import _UPDATE_CLUSTER_METADATA_URL
 
         NOW = datetime.datetime.utcnow()
-        NOW_PB = _datetime_to_pb_timestamp(NOW)
+        NOW_PB = datetime_to_pb_timestamp(NOW)
 
         SERVE_NODES = 81
 

--- a/gcloud/bigtable/test_column_family.py
+++ b/gcloud/bigtable/test_column_family.py
@@ -566,11 +566,11 @@ class TestColumnFamily(unittest.TestCase):
         )])
 
 
-class Test__gc_rule_from_pb(unittest.TestCase):
+class Test_gc_rule_from_pb(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
-        from gcloud.bigtable.column_family import _gc_rule_from_pb
-        return _gc_rule_from_pb(*args, **kwargs)
+        from gcloud.bigtable.column_family import gc_rule_from_pb
+        return gc_rule_from_pb(*args, **kwargs)
 
     def test_empty(self):
 

--- a/gcloud/bigtable/test_instance.py
+++ b/gcloud/bigtable/test_instance.py
@@ -109,7 +109,7 @@ class TestInstance(unittest.TestCase):
         self.assertEqual(instance.display_name, None)
 
     def test_from_pb_success(self):
-        from gcloud.bigtable.instance import _EXISTING_INSTANCE_LOCATION_ID
+        from gcloud.bigtable.instance import EXISTING_INSTANCE_LOCATION_ID
         from gcloud.bigtable._generated import (
             instance_pb2 as data_v2_pb2)
 
@@ -126,7 +126,7 @@ class TestInstance(unittest.TestCase):
         self.assertEqual(instance._client, client)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
         self.assertEqual(instance._cluster_location_id,
-                         _EXISTING_INSTANCE_LOCATION_ID)
+                         EXISTING_INSTANCE_LOCATION_ID)
 
     def test_from_pb_bad_instance_name(self):
         from gcloud.bigtable._generated import (
@@ -231,14 +231,14 @@ class TestInstance(unittest.TestCase):
         from google.protobuf.any_pb2 import Any
         from gcloud.bigtable._generated import (
             bigtable_instance_admin_pb2 as messages_v2_pb2)
-        from gcloud._helpers import _datetime_to_pb_timestamp
+        from gcloud._helpers import datetime_to_pb_timestamp
         from gcloud.bigtable._testing import _FakeStub
         from gcloud.operation import Operation
         from gcloud.bigtable.cluster import DEFAULT_SERVE_NODES
         from gcloud.bigtable.instance import _CREATE_INSTANCE_METADATA_URL
 
         NOW = datetime.datetime.utcnow()
-        NOW_PB = _datetime_to_pb_timestamp(NOW)
+        NOW_PB = datetime_to_pb_timestamp(NOW)
         client = _Client(self.PROJECT)
         instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID,
                                  display_name=self.DISPLAY_NAME)

--- a/gcloud/bigtable/test_row.py
+++ b/gcloud/bigtable/test_row.py
@@ -666,7 +666,7 @@ class Test__parse_rmw_row_response(unittest.TestCase):
         return _parse_rmw_row_response(row_response)
 
     def test_it(self):
-        from gcloud._helpers import _datetime_from_microseconds
+        from gcloud._helpers import datetime_from_microseconds
         col_fam1 = u'col-fam-id'
         col_fam2 = u'col-fam-id2'
         col_name1 = b'col-name1'
@@ -678,7 +678,7 @@ class Test__parse_rmw_row_response(unittest.TestCase):
         cell_val4 = b'foo'
 
         microseconds = 1000871
-        timestamp = _datetime_from_microseconds(microseconds)
+        timestamp = datetime_from_microseconds(microseconds)
         expected_output = {
             col_fam1: {
                 col_name1: [
@@ -751,7 +751,7 @@ class Test__parse_family_pb(unittest.TestCase):
         return _parse_family_pb(family_pb)
 
     def test_it(self):
-        from gcloud._helpers import _datetime_from_microseconds
+        from gcloud._helpers import datetime_from_microseconds
         col_fam1 = u'col-fam-id'
         col_name1 = b'col-name1'
         col_name2 = b'col-name2'
@@ -760,7 +760,7 @@ class Test__parse_family_pb(unittest.TestCase):
         cell_val3 = b'altcol-cell-val'
 
         microseconds = 5554441037
-        timestamp = _datetime_from_microseconds(microseconds)
+        timestamp = datetime_from_microseconds(microseconds)
         expected_dict = {
             col_name1: [
                 (cell_val1, timestamp),

--- a/gcloud/bigtable/test_row_data.py
+++ b/gcloud/bigtable/test_row_data.py
@@ -637,18 +637,18 @@ class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
 def _flatten_cells(prd):
     # Match results format from JSON testcases.
     # Doesn't handle error cases.
-    from gcloud._helpers import _bytes_to_unicode
-    from gcloud._helpers import _microseconds_from_datetime
+    from gcloud._helpers import bytes_to_unicode
+    from gcloud._helpers import microseconds_from_datetime
     for row_key, row in prd.rows.items():
         for family_name, family in row.cells.items():
             for qualifier, column in family.items():
                 for cell in column:
                     yield {
-                        u'rk': _bytes_to_unicode(row_key),
+                        u'rk': bytes_to_unicode(row_key),
                         u'fm': family_name,
-                        u'qual': _bytes_to_unicode(qualifier),
-                        u'ts': _microseconds_from_datetime(cell.timestamp),
-                        u'value': _bytes_to_unicode(cell.value),
+                        u'qual': bytes_to_unicode(qualifier),
+                        u'ts': microseconds_from_datetime(cell.timestamp),
+                        u'value': bytes_to_unicode(cell.value),
                         u'label': u' '.join(cell.labels),
                         u'error': False,
                     }

--- a/gcloud/bigtable/test_table.py
+++ b/gcloud/bigtable/test_table.py
@@ -133,7 +133,7 @@ class TestTable(unittest.TestCase):
         self.assertNotEqual(table1, table2)
 
     def _create_test_helper(self, initial_split_keys, column_families=()):
-        from gcloud._helpers import _to_bytes
+        from gcloud._helpers import to_bytes
         from gcloud.bigtable._testing import _FakeStub
 
         client = _Client()
@@ -142,7 +142,7 @@ class TestTable(unittest.TestCase):
 
         # Create request_pb
         splits_pb = [
-            _CreateTableRequestSplitPB(key=_to_bytes(key))
+            _CreateTableRequestSplitPB(key=to_bytes(key))
             for key in initial_split_keys or ()]
         table_pb = None
         if column_families:

--- a/gcloud/client.py
+++ b/gcloud/client.py
@@ -17,12 +17,12 @@
 from oauth2client.service_account import ServiceAccountCredentials
 import six
 
-from gcloud._helpers import _determine_default_project
+from gcloud._helpers import determine_default_project
 from gcloud.connection import Connection
 from gcloud.credentials import get_credentials
 
 
-class _ClientFactoryMixin(object):
+class ClientFactoryMixin(object):
     """Mixin to allow factories that create credentials.
 
     .. note::
@@ -96,7 +96,7 @@ class _ClientFactoryMixin(object):
         return cls(*args, **kwargs)
 
 
-class Client(_ClientFactoryMixin):
+class Client(ClientFactoryMixin):
     """Client to bundle configuration needed for API requests.
 
     Assumes that the associated ``_connection_class`` only accepts
@@ -124,7 +124,7 @@ class Client(_ClientFactoryMixin):
             credentials=credentials, http=http)
 
 
-class _ClientProjectMixin(object):
+class ClientProjectMixin(object):
     """Mixin to allow setting the project on the client.
 
     :type project: string
@@ -151,10 +151,10 @@ class _ClientProjectMixin(object):
     @staticmethod
     def _determine_default(project):
         """Helper:  use default project detection."""
-        return _determine_default_project(project)
+        return determine_default_project(project)
 
 
-class JSONClient(Client, _ClientProjectMixin):
+class JSONClient(Client, ClientProjectMixin):
     """Client to for Google JSON-based API.
 
     Assumes such APIs use the ``project`` and the client needs to store this
@@ -182,5 +182,5 @@ class JSONClient(Client, _ClientProjectMixin):
     """
 
     def __init__(self, project=None, credentials=None, http=None):
-        _ClientProjectMixin.__init__(self, project=project)
+        ClientProjectMixin.__init__(self, project=project)
         Client.__init__(self, credentials=credentials, http=http)

--- a/gcloud/credentials.py
+++ b/gcloud/credentials.py
@@ -22,8 +22,8 @@ from six.moves.urllib.parse import urlencode
 from oauth2client import client
 
 from gcloud._helpers import UTC
-from gcloud._helpers import _NOW
-from gcloud._helpers import _microseconds_from_datetime
+from gcloud._helpers import NOW
+from gcloud._helpers import microseconds_from_datetime
 
 
 def get_credentials():
@@ -132,12 +132,12 @@ def _get_expiration_seconds(expiration):
     """
     # If it's a timedelta, add it to `now` in UTC.
     if isinstance(expiration, datetime.timedelta):
-        now = _NOW().replace(tzinfo=UTC)
+        now = NOW().replace(tzinfo=UTC)
         expiration = now + expiration
 
     # If it's a datetime, convert to a timestamp.
     if isinstance(expiration, datetime.datetime):
-        micros = _microseconds_from_datetime(expiration)
+        micros = microseconds_from_datetime(expiration)
         expiration = micros // 10**6
 
     if not isinstance(expiration, six.integer_types):

--- a/gcloud/datastore/client.py
+++ b/gcloud/datastore/client.py
@@ -15,9 +15,9 @@
 
 import os
 
-from gcloud._helpers import _LocalStack
-from gcloud._helpers import _determine_default_project as _base_default_project
-from gcloud.client import _ClientProjectMixin
+from gcloud._helpers import LocalStack
+from gcloud._helpers import determine_default_project as _base_default_project
+from gcloud.client import ClientProjectMixin
 from gcloud.client import Client as _BaseClient
 from gcloud.datastore import helpers
 from gcloud.datastore.connection import Connection
@@ -142,7 +142,7 @@ def _extended_lookup(connection, project, key_pbs,
     return results
 
 
-class Client(_BaseClient, _ClientProjectMixin):
+class Client(_BaseClient, ClientProjectMixin):
     """Convenience wrapper for invoking APIs/factories w/ a project.
 
     :type project: string
@@ -167,9 +167,9 @@ class Client(_BaseClient, _ClientProjectMixin):
 
     def __init__(self, project=None, namespace=None,
                  credentials=None, http=None):
-        _ClientProjectMixin.__init__(self, project=project)
+        ClientProjectMixin.__init__(self, project=project)
         self.namespace = namespace
-        self._batch_stack = _LocalStack()
+        self._batch_stack = LocalStack()
         super(Client, self).__init__(credentials, http)
 
     @staticmethod

--- a/gcloud/datastore/entity.py
+++ b/gcloud/datastore/entity.py
@@ -15,7 +15,7 @@
 """Class for representing a single entity in the Cloud Datastore."""
 
 
-from gcloud._helpers import _ensure_tuple_or_list
+from gcloud._helpers import ensure_tuple_or_list
 
 
 class Entity(dict):
@@ -79,7 +79,7 @@ class Entity(dict):
     def __init__(self, key=None, exclude_from_indexes=()):
         super(Entity, self).__init__()
         self.key = key
-        self._exclude_from_indexes = set(_ensure_tuple_or_list(
+        self._exclude_from_indexes = set(ensure_tuple_or_list(
             'exclude_from_indexes', exclude_from_indexes))
         # NOTE: This will be populated when parsing a protobuf in
         #       gcloud.datastore.helpers.entity_from_protobuf.

--- a/gcloud/datastore/helpers.py
+++ b/gcloud/datastore/helpers.py
@@ -24,8 +24,8 @@ from google.protobuf import struct_pb2
 from google.type import latlng_pb2
 import six
 
-from gcloud._helpers import _datetime_to_pb_timestamp
-from gcloud._helpers import _pb_timestamp_to_datetime
+from gcloud._helpers import datetime_to_pb_timestamp
+from gcloud._helpers import pb_timestamp_to_datetime
 from gcloud.datastore._generated import entity_pb2 as _entity_pb2
 from gcloud.datastore.entity import Entity
 from gcloud.datastore.key import Key
@@ -218,7 +218,7 @@ def entity_to_protobuf(entity):
 
         value_pb = _new_value_pb(entity_pb, name)
         # Set the appropriate value.
-        _set_protobuf_value(value_pb, value)
+        set_protobuf_value(value_pb, value)
 
         # Add index information to protobuf.
         if name in entity.exclude_from_indexes:
@@ -302,7 +302,7 @@ def _pb_attr_value(val):
 
     if isinstance(val, datetime.datetime):
         name = 'timestamp'
-        value = _datetime_to_pb_timestamp(val)
+        value = datetime_to_pb_timestamp(val)
     elif isinstance(val, Key):
         name, value = 'key', val.to_protobuf()
     elif isinstance(val, bool):
@@ -350,7 +350,7 @@ def _get_value_from_value_pb(value_pb):
     value_type = value_pb.WhichOneof('value_type')
 
     if value_type == 'timestamp_value':
-        result = _pb_timestamp_to_datetime(value_pb.timestamp_value)
+        result = pb_timestamp_to_datetime(value_pb.timestamp_value)
 
     elif value_type == 'key_value':
         result = key_from_protobuf(value_pb.key_value)
@@ -390,7 +390,7 @@ def _get_value_from_value_pb(value_pb):
     return result
 
 
-def _set_protobuf_value(value_pb, val):
+def set_protobuf_value(value_pb, val):
     """Assign 'val' to the correct subfield of 'value_pb'.
 
     The Protobuf API uses different attribute names based on value types
@@ -419,7 +419,7 @@ def _set_protobuf_value(value_pb, val):
         l_pb = value_pb.array_value.values
         for item in val:
             i_pb = l_pb.add()
-            _set_protobuf_value(i_pb, item)
+            set_protobuf_value(i_pb, item)
     elif attr == 'geo_point_value':
         value_pb.geo_point_value.CopyFrom(val)
     else:  # scalar, just assign

--- a/gcloud/datastore/query.py
+++ b/gcloud/datastore/query.py
@@ -16,7 +16,7 @@
 
 import base64
 
-from gcloud._helpers import _ensure_tuple_or_list
+from gcloud._helpers import ensure_tuple_or_list
 from gcloud.datastore._generated import query_pb2 as _query_pb2
 from gcloud.datastore import helpers
 from gcloud.datastore.key import Key
@@ -92,9 +92,9 @@ class Query(object):
         # Verify filters passed in.
         for property_name, operator, value in filters:
             self.add_filter(property_name, operator, value)
-        self._projection = _ensure_tuple_or_list('projection', projection)
-        self._order = _ensure_tuple_or_list('order', order)
-        self._distinct_on = _ensure_tuple_or_list('distinct_on', distinct_on)
+        self._projection = ensure_tuple_or_list('projection', projection)
+        self._order = ensure_tuple_or_list('order', order)
+        self._distinct_on = ensure_tuple_or_list('distinct_on', distinct_on)
 
     @property
     def project(self):
@@ -518,7 +518,7 @@ def _pb_from_query(query):
             key_pb = value.to_protobuf()
             property_filter.value.key_value.CopyFrom(key_pb)
         else:
-            helpers._set_protobuf_value(property_filter.value, value)
+            helpers.set_protobuf_value(property_filter.value, value)
 
     if not composite_filter.filters:
         pb.ClearField('filter')

--- a/gcloud/datastore/test_client.py
+++ b/gcloud/datastore/test_client.py
@@ -205,7 +205,7 @@ class TestClient(unittest.TestCase):
         client._push_batch(xact)
         self.assertTrue(client.current_batch is xact)
         self.assertTrue(client.current_transaction is xact)
-        # list(_LocalStack) returns in reverse order.
+        # list(LocalStack) returns in reverse order.
         self.assertEqual(list(client._batch_stack), [xact, batch])
         self.assertTrue(client._pop_batch() is xact)
         self.assertEqual(list(client._batch_stack), [batch])

--- a/gcloud/datastore/test_helpers.py
+++ b/gcloud/datastore/test_helpers.py
@@ -656,9 +656,9 @@ class Test__get_value_from_value_pb(unittest.TestCase):
 class Test_set_protobuf_value(unittest.TestCase):
 
     def _callFUT(self, value_pb, val):
-        from gcloud.datastore.helpers import _set_protobuf_value
+        from gcloud.datastore.helpers import set_protobuf_value
 
-        return _set_protobuf_value(value_pb, val)
+        return set_protobuf_value(value_pb, val)
 
     def _makePB(self):
         from gcloud.datastore._generated import entity_pb2

--- a/gcloud/dns/changes.py
+++ b/gcloud/dns/changes.py
@@ -16,7 +16,7 @@
 
 import six
 
-from gcloud._helpers import _rfc3339_to_datetime
+from gcloud._helpers import rfc3339_to_datetime
 from gcloud.exceptions import NotFound
 from gcloud.dns.resource_record_set import ResourceRecordSet
 
@@ -118,7 +118,7 @@ class Changes(object):
         """
         stamp = self._properties.get('startTime')
         if stamp is not None:
-            return _rfc3339_to_datetime(stamp)
+            return rfc3339_to_datetime(stamp)
 
     @property
     def additions(self):

--- a/gcloud/dns/test_changes.py
+++ b/gcloud/dns/test_changes.py
@@ -29,12 +29,12 @@ class TestChanges(unittest.TestCase):
 
     def _setUpConstants(self):
         from gcloud._helpers import UTC
-        from gcloud._helpers import _NOW
-        self.WHEN = _NOW().replace(tzinfo=UTC)
+        from gcloud._helpers import NOW
+        self.WHEN = NOW().replace(tzinfo=UTC)
 
     def _makeResource(self):
-        from gcloud._helpers import _datetime_to_rfc3339
-        when_str = _datetime_to_rfc3339(self.WHEN)
+        from gcloud._helpers import datetime_to_rfc3339
+        when_str = datetime_to_rfc3339(self.WHEN)
         return {
             'kind': 'dns#change',
             'id': self.CHANGES_NAME,
@@ -55,9 +55,9 @@ class TestChanges(unittest.TestCase):
         }
 
     def _verifyResourceProperties(self, changes, resource, zone):
-        from gcloud._helpers import _rfc3339_to_datetime
+        from gcloud._helpers import rfc3339_to_datetime
         self.assertEqual(changes.name, resource['id'])
-        started = _rfc3339_to_datetime(resource['startTime'])
+        started = rfc3339_to_datetime(resource['startTime'])
         self.assertEqual(changes.started, started)
         self.assertEqual(changes.status, resource['status'])
 

--- a/gcloud/dns/test_zone.py
+++ b/gcloud/dns/test_zone.py
@@ -510,7 +510,7 @@ class TestManagedZone(unittest.TestCase):
                          {'maxResults': 3, 'pageToken': TOKEN})
 
     def test_list_changes_defaults(self):
-        from gcloud._helpers import _datetime_to_rfc3339
+        from gcloud._helpers import datetime_to_rfc3339
         from gcloud.dns.changes import Changes
         from gcloud.dns.resource_record_set import ResourceRecordSet
         self._setUpConstants()
@@ -532,7 +532,7 @@ class TestManagedZone(unittest.TestCase):
                 'kind': 'dns#change',
                 'id': CHANGES_NAME,
                 'status': 'pending',
-                'startTime': _datetime_to_rfc3339(self.WHEN),
+                'startTime': datetime_to_rfc3339(self.WHEN),
                 'additions': [
                     {'kind': 'dns#resourceRecordSet',
                      'name': NAME_1,
@@ -586,7 +586,7 @@ class TestManagedZone(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_changes_explicit(self):
-        from gcloud._helpers import _datetime_to_rfc3339
+        from gcloud._helpers import datetime_to_rfc3339
         from gcloud.dns.changes import Changes
         from gcloud.dns.resource_record_set import ResourceRecordSet
         self._setUpConstants()
@@ -607,7 +607,7 @@ class TestManagedZone(unittest.TestCase):
                 'kind': 'dns#change',
                 'id': CHANGES_NAME,
                 'status': 'pending',
-                'startTime': _datetime_to_rfc3339(self.WHEN),
+                'startTime': datetime_to_rfc3339(self.WHEN),
                 'additions': [
                     {'kind': 'dns#resourceRecordSet',
                      'name': NAME_1,

--- a/gcloud/dns/zone.py
+++ b/gcloud/dns/zone.py
@@ -15,7 +15,7 @@
 """Define API ManagedZones."""
 import six
 
-from gcloud._helpers import _rfc3339_to_datetime
+from gcloud._helpers import rfc3339_to_datetime
 from gcloud.exceptions import NotFound
 from gcloud.dns.changes import Changes
 from gcloud.dns.resource_record_set import ResourceRecordSet
@@ -221,7 +221,7 @@ class ManagedZone(object):
         cleaned = api_response.copy()
         self.dns_name = cleaned.pop('dnsName', None)
         if 'creationTime' in cleaned:
-            cleaned['creationTime'] = _rfc3339_to_datetime(
+            cleaned['creationTime'] = rfc3339_to_datetime(
                 cleaned['creationTime'])
         self._properties.update(cleaned)
 

--- a/gcloud/logging/_gax.py
+++ b/gcloud/logging/_gax.py
@@ -26,14 +26,14 @@ from google.logging.v2.log_entry_pb2 import LogEntry
 from google.protobuf.json_format import Parse
 from grpc import StatusCode
 
-from gcloud._helpers import _datetime_to_pb_timestamp
-from gcloud._helpers import _pb_timestamp_to_rfc3339
+from gcloud._helpers import datetime_to_pb_timestamp
+from gcloud._helpers import pb_timestamp_to_rfc3339
 from gcloud._helpers import exc_to_code
 from gcloud.exceptions import Conflict
 from gcloud.exceptions import NotFound
 
 
-class _LoggingAPI(object):
+class LoggingAPI(object):
     """Helper mapping logging-related APIs.
 
     :type gax_api:
@@ -127,7 +127,7 @@ class _LoggingAPI(object):
             raise
 
 
-class _SinksAPI(object):
+class SinksAPI(object):
     """Helper mapping sink-related APIs.
 
     :type gax_api:
@@ -273,7 +273,7 @@ class _SinksAPI(object):
             raise
 
 
-class _MetricsAPI(object):
+class MetricsAPI(object):
     """Helper mapping sink-related APIs.
 
     :type gax_api:
@@ -486,7 +486,7 @@ def _log_entry_pb_to_mapping(entry_pb):
         'resource': _mon_resource_pb_to_mapping(entry_pb.resource),
         'severity': LogSeverity.Name(entry_pb.severity),
         'insertId': entry_pb.insert_id,
-        'timestamp': _pb_timestamp_to_rfc3339(entry_pb.timestamp),
+        'timestamp': pb_timestamp_to_rfc3339(entry_pb.timestamp),
         'labels': entry_pb.labels,
     }
     if entry_pb.HasField('text_payload'):
@@ -591,7 +591,7 @@ def _log_entry_mapping_to_pb(mapping):
         entry_pb.severity = severity
 
     if 'timestamp' in mapping:
-        timestamp = _datetime_to_pb_timestamp(mapping['timestamp'])
+        timestamp = datetime_to_pb_timestamp(mapping['timestamp'])
         entry_pb.timestamp.CopyFrom(timestamp)
 
     if 'labels' in mapping:

--- a/gcloud/logging/client.py
+++ b/gcloud/logging/client.py
@@ -23,9 +23,9 @@ try:
         LoggingServiceV2Api as GeneratedLoggingAPI)
     from google.cloud.logging.v2.metrics_service_v2_api import (
         MetricsServiceV2Api as GeneratedMetricsAPI)
-    from gcloud.logging._gax import _LoggingAPI as GAXLoggingAPI
-    from gcloud.logging._gax import _MetricsAPI as GAXMetricsAPI
-    from gcloud.logging._gax import _SinksAPI as GAXSinksAPI
+    from gcloud.logging._gax import LoggingAPI as GAXLoggingAPI
+    from gcloud.logging._gax import MetricsAPI as GAXMetricsAPI
+    from gcloud.logging._gax import SinksAPI as GAXSinksAPI
 except ImportError:  # pragma: NO COVER
     _HAVE_GAX = False
     GeneratedLoggingAPI = GAXLoggingAPI = None
@@ -36,9 +36,9 @@ else:
 
 from gcloud.client import JSONClient
 from gcloud.logging.connection import Connection
-from gcloud.logging.connection import _LoggingAPI as JSONLoggingAPI
-from gcloud.logging.connection import _MetricsAPI as JSONMetricsAPI
-from gcloud.logging.connection import _SinksAPI as JSONSinksAPI
+from gcloud.logging.connection import LoggingAPI as JSONLoggingAPI
+from gcloud.logging.connection import MetricsAPI as JSONMetricsAPI
+from gcloud.logging.connection import SinksAPI as JSONSinksAPI
 from gcloud.logging.entries import ProtobufEntry
 from gcloud.logging.entries import StructEntry
 from gcloud.logging.entries import TextEntry

--- a/gcloud/logging/connection.py
+++ b/gcloud/logging/connection.py
@@ -48,7 +48,7 @@ class Connection(base_connection.JSONConnection):
     """The scopes required for authenticating as a Logging consumer."""
 
 
-class _LoggingAPI(object):
+class LoggingAPI(object):
     """Helper mapping logging-related APIs.
 
     See:
@@ -165,7 +165,7 @@ class _LoggingAPI(object):
         self._connection.api_request(method='DELETE', path=path)
 
 
-class _SinksAPI(object):
+class SinksAPI(object):
     """Helper mapping sink-related APIs.
 
     See:
@@ -304,7 +304,7 @@ class _SinksAPI(object):
         self._connection.api_request(method='DELETE', path=target)
 
 
-class _MetricsAPI(object):
+class MetricsAPI(object):
     """Helper mapping sink-related APIs.
 
     See:

--- a/gcloud/logging/entries.py
+++ b/gcloud/logging/entries.py
@@ -19,8 +19,8 @@ import re
 
 from google.protobuf.json_format import Parse
 
-from gcloud._helpers import _name_from_project_path
-from gcloud._helpers import _rfc3339_nanos_to_datetime
+from gcloud._helpers import name_from_project_path
+from gcloud._helpers import rfc3339_nanos_to_datetime
 
 
 _LOGGER_TEMPLATE = re.compile(r"""
@@ -43,7 +43,7 @@ def logger_name_from_path(path):
              the project from the ``path`` does not agree with the
              ``project`` passed in.
     """
-    return _name_from_project_path(path, None, _LOGGER_TEMPLATE)
+    return name_from_project_path(path, None, _LOGGER_TEMPLATE)
 
 
 class _BaseEntry(object):
@@ -112,7 +112,7 @@ class _BaseEntry(object):
         insert_id = resource.get('insertId')
         timestamp = resource.get('timestamp')
         if timestamp is not None:
-            timestamp = _rfc3339_nanos_to_datetime(timestamp)
+            timestamp = rfc3339_nanos_to_datetime(timestamp)
         labels = resource.get('labels')
         severity = resource.get('severity')
         http_request = resource.get('httpRequest')

--- a/gcloud/logging/test__gax.py
+++ b/gcloud/logging/test__gax.py
@@ -224,7 +224,9 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         from datetime import datetime
         from google.logging.type.log_severity_pb2 import WARNING
         from google.logging.v2.log_entry_pb2 import LogEntry
-        from gcloud._helpers import UTC, _pb_timestamp_to_datetime
+        from gcloud._helpers import _pb_timestamp_to_datetime
+        from gcloud._helpers import UTC
+
         NOW = datetime.utcnow().replace(tzinfo=UTC)
         TEXT = 'TEXT'
         LOG_PATH = 'projects/%s/logs/%s' % (self.PROJECT, self.LOG_NAME)
@@ -322,7 +324,9 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         from google.logging.v2.log_entry_pb2 import LogEntry
         from google.protobuf.any_pb2 import Any
         from google.protobuf.struct_pb2 import Struct
-        from gcloud._helpers import _datetime_to_rfc3339, UTC
+        from gcloud._helpers import _datetime_to_rfc3339
+        from gcloud._helpers import UTC
+
         TEXT = 'TEXT'
         NOW = datetime.datetime.utcnow().replace(tzinfo=UTC)
         TIMESTAMP_TYPE_URL = 'type.googleapis.com/google.protobuf.Timestamp'

--- a/gcloud/logging/test__gax.py
+++ b/gcloud/logging/test__gax.py
@@ -37,12 +37,12 @@ class _Base(object):
 
 
 @unittest.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_LoggingAPI(_Base, unittest.TestCase):
+class TestLoggingAPI(_Base, unittest.TestCase):
     LOG_NAME = 'log_name'
 
     def _getTargetClass(self):
-        from gcloud.logging._gax import _LoggingAPI
-        return _LoggingAPI
+        from gcloud.logging._gax import LoggingAPI
+        return LoggingAPI
 
     def test_ctor(self):
         gax_api = _GAXLoggingAPI()
@@ -117,8 +117,8 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         from google.logging.type.log_severity_pb2 import WARNING
         from gcloud._testing import _GAXPageIterator
         from gcloud._helpers import UTC
-        from gcloud._helpers import _datetime_to_rfc3339
-        from gcloud._helpers import _datetime_to_pb_timestamp
+        from gcloud._helpers import datetime_to_rfc3339
+        from gcloud._helpers import datetime_to_pb_timestamp
         NOW = datetime.utcnow().replace(tzinfo=UTC)
         SIZE = 23
         TOKEN = 'TOKEN'
@@ -140,7 +140,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         }
         ENTRY = _LogEntryPB(self.LOG_NAME, proto_payload=PAYLOAD, **EXTRAS)
         ENTRY.resource.labels['foo'] = 'bar'
-        ENTRY.timestamp = _datetime_to_pb_timestamp(NOW)
+        ENTRY.timestamp = datetime_to_pb_timestamp(NOW)
         response = _GAXPageIterator([ENTRY], NEW_TOKEN)
         gax_api = _GAXLoggingAPI(_list_log_entries_response=response)
         api = self._makeOne(gax_api)
@@ -158,7 +158,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         self.assertEqual(entry['severity'], SEVERITY)
         self.assertEqual(entry['labels'], LABELS)
         self.assertEqual(entry['insertId'], IID)
-        self.assertEqual(entry['timestamp'], _datetime_to_rfc3339(NOW))
+        self.assertEqual(entry['timestamp'], datetime_to_rfc3339(NOW))
         EXPECTED_REQUEST = {
             'requestMethod': request.request_method,
             'requestUrl': request.request_url,
@@ -224,7 +224,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         from datetime import datetime
         from google.logging.type.log_severity_pb2 import WARNING
         from google.logging.v2.log_entry_pb2 import LogEntry
-        from gcloud._helpers import _pb_timestamp_to_datetime
+        from gcloud._helpers import pb_timestamp_to_datetime
         from gcloud._helpers import UTC
 
         NOW = datetime.utcnow().replace(tzinfo=UTC)
@@ -290,7 +290,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         self.assertEqual(entry.severity, WARNING)
         self.assertEqual(entry.labels, LABELS)
         self.assertEqual(entry.insert_id, IID)
-        stamp = _pb_timestamp_to_datetime(entry.timestamp)
+        stamp = pb_timestamp_to_datetime(entry.timestamp)
         self.assertEqual(stamp, NOW)
 
         request = entry.http_request
@@ -324,7 +324,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         from google.logging.v2.log_entry_pb2 import LogEntry
         from google.protobuf.any_pb2 import Any
         from google.protobuf.struct_pb2 import Struct
-        from gcloud._helpers import _datetime_to_rfc3339
+        from gcloud._helpers import datetime_to_rfc3339
         from gcloud._helpers import UTC
 
         TEXT = 'TEXT'
@@ -333,7 +333,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         JSON = {'payload': 'PAYLOAD', 'type': 'json'}
         PROTO = {
             '@type': TIMESTAMP_TYPE_URL,
-            'value': _datetime_to_rfc3339(NOW),
+            'value': datetime_to_rfc3339(NOW),
         }
         PRODUCER = 'PRODUCER'
         OPID = 'OPID'
@@ -440,14 +440,14 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
 
 
 @unittest.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_SinksAPI(_Base, unittest.TestCase):
+class TestSinksAPI(_Base, unittest.TestCase):
     SINK_NAME = 'sink_name'
     SINK_PATH = 'projects/%s/sinks/%s' % (_Base.PROJECT, SINK_NAME)
     DESTINATION_URI = 'faux.googleapis.com/destination'
 
     def _getTargetClass(self):
-        from gcloud.logging._gax import _SinksAPI
-        return _SinksAPI
+        from gcloud.logging._gax import SinksAPI
+        return SinksAPI
 
     def test_ctor(self):
         gax_api = _GAXSinksAPI()
@@ -644,14 +644,14 @@ class Test_SinksAPI(_Base, unittest.TestCase):
 
 
 @unittest.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_MetricsAPI(_Base, unittest.TestCase):
+class TestMetricsAPI(_Base, unittest.TestCase):
     METRIC_NAME = 'metric_name'
     METRIC_PATH = 'projects/%s/metrics/%s' % (_Base.PROJECT, METRIC_NAME)
     DESCRIPTION = 'Description'
 
     def _getTargetClass(self):
-        from gcloud.logging._gax import _MetricsAPI
-        return _MetricsAPI
+        from gcloud.logging._gax import MetricsAPI
+        return MetricsAPI
 
     def test_ctor(self):
         gax_api = _GAXMetricsAPI()
@@ -1085,9 +1085,9 @@ class _LogEntryPB(object):
     def _make_timestamp():
         from datetime import datetime
         from gcloud._helpers import UTC
-        from gcloud._helpers import _datetime_to_pb_timestamp
+        from gcloud._helpers import datetime_to_pb_timestamp
         NOW = datetime.utcnow().replace(tzinfo=UTC)
-        return _datetime_to_pb_timestamp(NOW)
+        return datetime_to_pb_timestamp(NOW)
 
 
 class _LogSinkPB(object):

--- a/gcloud/logging/test_client.py
+++ b/gcloud/logging/test_client.py
@@ -39,7 +39,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(client.project, self.PROJECT)
 
     def test_logging_api_wo_gax(self):
-        from gcloud.logging.connection import _LoggingAPI
+        from gcloud.logging.connection import LoggingAPI
         from gcloud.logging import client as MUT
         from gcloud._testing import _Monkey
         client = self._makeOne(self.PROJECT, credentials=_Credentials())
@@ -48,7 +48,7 @@ class TestClient(unittest.TestCase):
         with _Monkey(MUT, _USE_GAX=False):
             api = client.logging_api
 
-        self.assertTrue(isinstance(api, _LoggingAPI))
+        self.assertTrue(isinstance(api, LoggingAPI))
         self.assertTrue(api._connection is conn)
         # API instance is cached
         again = client.logging_api
@@ -86,7 +86,7 @@ class TestClient(unittest.TestCase):
         self.assertTrue(again is api)
 
     def test_sinks_api_wo_gax(self):
-        from gcloud.logging.connection import _SinksAPI
+        from gcloud.logging.connection import SinksAPI
         from gcloud.logging import client as MUT
         from gcloud._testing import _Monkey
         client = self._makeOne(self.PROJECT, credentials=_Credentials())
@@ -95,7 +95,7 @@ class TestClient(unittest.TestCase):
         with _Monkey(MUT, _USE_GAX=False):
             api = client.sinks_api
 
-        self.assertTrue(isinstance(api, _SinksAPI))
+        self.assertTrue(isinstance(api, SinksAPI))
         self.assertTrue(api._connection is conn)
         # API instance is cached
         again = client.sinks_api
@@ -133,7 +133,7 @@ class TestClient(unittest.TestCase):
         self.assertTrue(again is api)
 
     def test_metrics_api_wo_gax(self):
-        from gcloud.logging.connection import _MetricsAPI
+        from gcloud.logging.connection import MetricsAPI
         from gcloud.logging import client as MUT
         from gcloud._testing import _Monkey
         client = self._makeOne(self.PROJECT, credentials=_Credentials())
@@ -142,7 +142,7 @@ class TestClient(unittest.TestCase):
         with _Monkey(MUT, _USE_GAX=False):
             api = client.metrics_api
 
-        self.assertTrue(isinstance(api, _MetricsAPI))
+        self.assertTrue(isinstance(api, MetricsAPI))
         self.assertTrue(api._connection is conn)
         # API instance is cached
         again = client.metrics_api

--- a/gcloud/logging/test_connection.py
+++ b/gcloud/logging/test_connection.py
@@ -34,7 +34,7 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(conn.credentials._scopes, klass.SCOPE)
 
 
-class Test_LoggingAPI(unittest.TestCase):
+class TestLoggingAPI(unittest.TestCase):
 
     PROJECT = 'project'
     LIST_ENTRIES_PATH = 'entries:list'
@@ -43,8 +43,8 @@ class Test_LoggingAPI(unittest.TestCase):
     FILTER = 'logName:syslog AND severity>=ERROR'
 
     def _getTargetClass(self):
-        from gcloud.logging.connection import _LoggingAPI
-        return _LoggingAPI
+        from gcloud.logging.connection import LoggingAPI
+        return LoggingAPI
 
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
@@ -58,9 +58,9 @@ class Test_LoggingAPI(unittest.TestCase):
     def _make_timestamp():
         from datetime import datetime
         from gcloud._helpers import UTC
-        from gcloud.logging.test_entries import _datetime_to_rfc3339_w_nanos
+        from gcloud.logging.test_entries import datetime_to_rfc3339_w_nanos
         NOW = datetime.utcnow().replace(tzinfo=UTC)
-        return _datetime_to_rfc3339_w_nanos(NOW)
+        return datetime_to_rfc3339_w_nanos(NOW)
 
     def test_list_entries_no_paging(self):
         TIMESTAMP = self._make_timestamp()
@@ -217,7 +217,7 @@ class Test_LoggingAPI(unittest.TestCase):
         self.assertEqual(conn._called_with['path'], path)
 
 
-class Test_SinksAPI(unittest.TestCase):
+class TestSinksAPI(unittest.TestCase):
 
     PROJECT = 'project'
     FILTER = 'logName:syslog AND severity>=ERROR'
@@ -227,8 +227,8 @@ class Test_SinksAPI(unittest.TestCase):
     DESTINATION_URI = 'faux.googleapis.com/destination'
 
     def _getTargetClass(self):
-        from gcloud.logging.connection import _SinksAPI
-        return _SinksAPI
+        from gcloud.logging.connection import SinksAPI
+        return SinksAPI
 
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
@@ -412,7 +412,7 @@ class Test_SinksAPI(unittest.TestCase):
         self.assertEqual(conn._called_with['path'], path)
 
 
-class Test_MetricsAPI(unittest.TestCase):
+class TestMetricsAPI(unittest.TestCase):
 
     PROJECT = 'project'
     FILTER = 'logName:syslog AND severity>=ERROR'
@@ -422,8 +422,8 @@ class Test_MetricsAPI(unittest.TestCase):
     DESCRIPTION = 'DESCRIPTION'
 
     def _getTargetClass(self):
-        from gcloud.logging.connection import _MetricsAPI
-        return _MetricsAPI
+        from gcloud.logging.connection import MetricsAPI
+        return MetricsAPI
 
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)

--- a/gcloud/logging/test_entries.py
+++ b/gcloud/logging/test_entries.py
@@ -125,7 +125,7 @@ class Test_BaseEntry(unittest.TestCase):
         SEVERITY = 'CRITICAL'
         IID = 'IID'
         NOW = datetime.utcnow().replace(tzinfo=UTC)
-        TIMESTAMP = _datetime_to_rfc3339_w_nanos(NOW)
+        TIMESTAMP = datetime_to_rfc3339_w_nanos(NOW)
         LOG_NAME = 'projects/%s/logs/%s' % (self.PROJECT, self.LOGGER_NAME)
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         METHOD = 'POST'
@@ -167,7 +167,7 @@ class Test_BaseEntry(unittest.TestCase):
         PAYLOAD = 'PAYLOAD'
         IID = 'IID'
         NOW = datetime.utcnow().replace(tzinfo=UTC)
-        TIMESTAMP = _datetime_to_rfc3339_w_nanos(NOW)
+        TIMESTAMP = datetime_to_rfc3339_w_nanos(NOW)
         LOG_NAME = 'projects/%s/logs/%s' % (self.PROJECT, self.LOGGER_NAME)
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         API_REPR = {
@@ -215,7 +215,7 @@ class TestProtobufEntry(unittest.TestCase):
         self.assertTrue(message.fields['foo'])
 
 
-def _datetime_to_rfc3339_w_nanos(value):
+def datetime_to_rfc3339_w_nanos(value):
     from gcloud._helpers import _RFC3339_NO_FRACTION
     no_fraction = value.strftime(_RFC3339_NO_FRACTION)
     return '%s.%09dZ' % (no_fraction, value.microsecond * 1000)

--- a/gcloud/logging/test_entries.py
+++ b/gcloud/logging/test_entries.py
@@ -203,7 +203,9 @@ class TestProtobufEntry(unittest.TestCase):
     def test_parse_message(self):
         import json
         from google.protobuf.json_format import MessageToJson
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
         LOGGER = object()
         message = Struct(fields={'foo': Value(bool_value=False)})
         with_true = Struct(fields={'foo': Value(bool_value=True)})

--- a/gcloud/logging/test_logger.py
+++ b/gcloud/logging/test_logger.py
@@ -238,7 +238,9 @@ class TestLogger(unittest.TestCase):
     def test_log_proto_w_implicit_client(self):
         import json
         from google.protobuf.json_format import MessageToJson
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
         message = Struct(fields={'foo': Value(bool_value=True)})
         ENTRIES = [{
             'logName': 'projects/%s/logs/%s' % (
@@ -260,7 +262,9 @@ class TestLogger(unittest.TestCase):
     def test_log_proto_w_default_labels(self):
         import json
         from google.protobuf.json_format import MessageToJson
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
         message = Struct(fields={'foo': Value(bool_value=True)})
         DEFAULT_LABELS = {'foo': 'spam'}
         ENTRIES = [{
@@ -285,7 +289,9 @@ class TestLogger(unittest.TestCase):
     def test_log_proto_w_explicit_client_labels_severity_httpreq(self):
         import json
         from google.protobuf.json_format import MessageToJson
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
         message = Struct(fields={'foo': Value(bool_value=True)})
         DEFAULT_LABELS = {'foo': 'spam'}
         LABELS = {'foo': 'bar', 'baz': 'qux'}
@@ -468,7 +474,9 @@ class TestBatch(unittest.TestCase):
                          [('struct', STRUCT, LABELS, IID, SEVERITY, REQUEST)])
 
     def test_log_proto_defaults(self):
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
         message = Struct(fields={'foo': Value(bool_value=True)})
         client = _Client(project=self.PROJECT, connection=object())
         logger = _Logger()
@@ -478,7 +486,9 @@ class TestBatch(unittest.TestCase):
                          [('proto', message, None, None, None, None)])
 
     def test_log_proto_explicit(self):
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
         message = Struct(fields={'foo': Value(bool_value=True)})
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         IID = 'IID'
@@ -510,7 +520,9 @@ class TestBatch(unittest.TestCase):
     def test_commit_w_bound_client(self):
         import json
         from google.protobuf.json_format import MessageToJson
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
         TEXT = 'This is the entry text'
         STRUCT = {'message': TEXT, 'weather': 'partly cloudy'}
         message = Struct(fields={'foo': Value(bool_value=True)})
@@ -543,8 +555,10 @@ class TestBatch(unittest.TestCase):
     def test_commit_w_alternate_client(self):
         import json
         from google.protobuf.json_format import MessageToJson
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
         from gcloud.logging.logger import Logger
+
         TEXT = 'This is the entry text'
         STRUCT = {'message': TEXT, 'weather': 'partly cloudy'}
         message = Struct(fields={'foo': Value(bool_value=True)})
@@ -587,8 +601,10 @@ class TestBatch(unittest.TestCase):
     def test_context_mgr_success(self):
         import json
         from google.protobuf.json_format import MessageToJson
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
         from gcloud.logging.logger import Logger
+
         TEXT = 'This is the entry text'
         STRUCT = {'message': TEXT, 'weather': 'partly cloudy'}
         message = Struct(fields={'foo': Value(bool_value=True)})
@@ -627,7 +643,9 @@ class TestBatch(unittest.TestCase):
                          (ENTRIES, logger.full_name, RESOURCE, DEFAULT_LABELS))
 
     def test_context_mgr_failure(self):
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
         TEXT = 'This is the entry text'
         STRUCT = {'message': TEXT, 'weather': 'partly cloudy'}
         LABELS = {'foo': 'bar', 'baz': 'qux'}

--- a/gcloud/monitoring/_dataframe.py
+++ b/gcloud/monitoring/_dataframe.py
@@ -25,8 +25,8 @@ TOP_RESOURCE_LABELS = (
 )
 
 
-def _build_dataframe(time_series_iterable,
-                     label=None, labels=None):  # pragma: NO COVER
+def build_dataframe(time_series_iterable,
+                    label=None, labels=None):  # pragma: NO COVER
     """Build a :mod:`pandas` dataframe out of time series.
 
     :type time_series_iterable:

--- a/gcloud/monitoring/group.py
+++ b/gcloud/monitoring/group.py
@@ -21,8 +21,8 @@
 
 import re
 
-from gcloud._helpers import _datetime_to_rfc3339
-from gcloud._helpers import _name_from_project_path
+from gcloud._helpers import datetime_to_rfc3339
+from gcloud._helpers import name_from_project_path
 from gcloud.exceptions import NotFound
 from gcloud.monitoring.resource import Resource
 
@@ -51,7 +51,7 @@ def _group_id_from_name(path, project=None):
              the project from the ``path`` does not agree with the
              ``project`` passed in.
     """
-    return _name_from_project_path(path, project, _GROUP_TEMPLATE)
+    return name_from_project_path(path, project, _GROUP_TEMPLATE)
 
 
 def _group_name_from_id(project, group_id):
@@ -336,11 +336,11 @@ class Group(object):
             params['filter'] = filter_string
 
         if end_time is not None:
-            params['interval.endTime'] = _datetime_to_rfc3339(
+            params['interval.endTime'] = datetime_to_rfc3339(
                 end_time, ignore_zone=False)
 
         if start_time is not None:
-            params['interval.startTime'] = _datetime_to_rfc3339(
+            params['interval.startTime'] = datetime_to_rfc3339(
                 start_time, ignore_zone=False)
 
         while True:

--- a/gcloud/monitoring/query.py
+++ b/gcloud/monitoring/query.py
@@ -25,8 +25,8 @@ import itertools
 
 import six
 
-from gcloud._helpers import _datetime_to_rfc3339
-from gcloud.monitoring._dataframe import _build_dataframe
+from gcloud._helpers import datetime_to_rfc3339
+from gcloud.monitoring._dataframe import build_dataframe
 from gcloud.monitoring.timeseries import TimeSeries
 
 _UTCNOW = datetime.datetime.utcnow  # To be replaced by tests.
@@ -499,11 +499,11 @@ class Query(object):
         """
         yield 'filter', self.filter
 
-        yield 'interval.endTime', _datetime_to_rfc3339(
+        yield 'interval.endTime', datetime_to_rfc3339(
             self._end_time, ignore_zone=False)
 
         if self._start_time is not None:
-            yield 'interval.startTime', _datetime_to_rfc3339(
+            yield 'interval.startTime', datetime_to_rfc3339(
                 self._start_time, ignore_zone=False)
 
         if self._per_series_aligner is not None:
@@ -570,7 +570,7 @@ class Query(object):
         :rtype: :class:`pandas.DataFrame`
         :returns: A dataframe where each column represents one time series.
         """
-        return _build_dataframe(self, label, labels)  # pragma: NO COVER
+        return build_dataframe(self, label, labels)  # pragma: NO COVER
 
     def copy(self):
         """Copy the query object.

--- a/gcloud/monitoring/test__dataframe.py
+++ b/gcloud/monitoring/test__dataframe.py
@@ -84,11 +84,11 @@ def generate_query_results():  # pragma: NO COVER
 
 
 @unittest.skipUnless(HAVE_PANDAS, 'No pandas')
-class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
+class Test_build_dataframe(unittest.TestCase):  # pragma: NO COVER
 
     def _callFUT(self, *args, **kwargs):
-        from gcloud.monitoring._dataframe import _build_dataframe
-        return _build_dataframe(*args, **kwargs)
+        from gcloud.monitoring._dataframe import build_dataframe
+        return build_dataframe(*args, **kwargs)
 
     def test_both_label_and_labels_illegal(self):
         with self.assertRaises(ValueError):

--- a/gcloud/monitoring/test_client.py
+++ b/gcloud/monitoring/test_client.py
@@ -28,7 +28,7 @@ class TestClient(unittest.TestCase):
 
     def test_query(self):
         import datetime
-        from gcloud._helpers import _datetime_to_rfc3339
+        from gcloud._helpers import datetime_to_rfc3339
         from gcloud.exceptions import NotFound
 
         START_TIME = datetime.datetime(2016, 4, 6, 22, 5, 0)
@@ -120,8 +120,8 @@ class TestClient(unittest.TestCase):
             'path': '/projects/{project}/timeSeries/'.format(project=PROJECT),
             'query_params': [
                 ('filter', 'metric.type = "{type}"'.format(type=METRIC_TYPE)),
-                ('interval.endTime', _datetime_to_rfc3339(END_TIME)),
-                ('interval.startTime', _datetime_to_rfc3339(START_TIME)),
+                ('interval.endTime', datetime_to_rfc3339(END_TIME)),
+                ('interval.startTime', datetime_to_rfc3339(START_TIME)),
             ],
         }
 

--- a/gcloud/monitoring/test_group.py
+++ b/gcloud/monitoring/test_group.py
@@ -483,7 +483,7 @@ class TestGroup(unittest.TestCase):
 
     def test_list_members_w_all_arguments(self):
         import datetime
-        from gcloud._helpers import _datetime_to_rfc3339
+        from gcloud._helpers import datetime_to_rfc3339
 
         self._setUpResources()
 
@@ -506,8 +506,8 @@ class TestGroup(unittest.TestCase):
         expected_request = {
             'method': 'GET', 'path': '/%s/members' % self.GROUP_NAME,
             'query_params': {
-                'interval.startTime': _datetime_to_rfc3339(T0),
-                'interval.endTime': _datetime_to_rfc3339(T1),
+                'interval.startTime': datetime_to_rfc3339(T0),
+                'interval.endTime': datetime_to_rfc3339(T1),
                 'filter': MEMBER_FILTER,
             },
         }

--- a/gcloud/monitoring/test_query.py
+++ b/gcloud/monitoring/test_query.py
@@ -82,8 +82,8 @@ class TestQuery(unittest.TestCase):
 
     @staticmethod
     def _make_timestamp(value):
-        from gcloud._helpers import _datetime_to_rfc3339
-        return _datetime_to_rfc3339(value)
+        from gcloud._helpers import datetime_to_rfc3339
+        return datetime_to_rfc3339(value)
 
     def test_constructor_minimal(self):
         client = _Client(project=PROJECT, connection=_Connection())

--- a/gcloud/operation.py
+++ b/gcloud/operation.py
@@ -23,7 +23,7 @@ _TYPE_URL_MAP = {
 }
 
 
-def _compute_type_url(klass, prefix=_GOOGLE_APIS_PREFIX):
+def compute_type_url(klass, prefix=_GOOGLE_APIS_PREFIX):
     """Compute a type URL for a klass.
 
     :type klass: type
@@ -39,7 +39,7 @@ def _compute_type_url(klass, prefix=_GOOGLE_APIS_PREFIX):
     return '%s/%s' % (prefix, name)
 
 
-def _register_type_url(type_url, klass):
+def register_type_url(type_url, klass):
     """Register a klass as the factory for a given type URL.
 
     :type type_url: str

--- a/gcloud/pubsub/_gax.py
+++ b/gcloud/pubsub/_gax.py
@@ -21,13 +21,13 @@ from google.pubsub.v1.pubsub_pb2 import PubsubMessage
 from google.pubsub.v1.pubsub_pb2 import PushConfig
 from grpc import StatusCode
 
-from gcloud._helpers import _to_bytes
+from gcloud._helpers import to_bytes
 from gcloud._helpers import exc_to_code
 from gcloud.exceptions import Conflict
 from gcloud.exceptions import NotFound
 
 
-class _PublisherAPI(object):
+class PublisherAPI(object):
     """Helper mapping publisher-related APIs.
 
     :type gax_api: :class:`google.pubsub.v1.publisher_api.PublisherApi`
@@ -204,7 +204,7 @@ class _PublisherAPI(object):
         return subs, token
 
 
-class _SubscriberAPI(object):
+class SubscriberAPI(object):
     """Helper mapping subscriber-related APIs.
 
     :type gax_api: :class:`google.pubsub.v1.publisher_api.SubscriberApi`
@@ -443,12 +443,12 @@ class _SubscriberAPI(object):
 
 
 def _message_pb_from_mapping(message):
-    """Helper for :meth:`_PublisherAPI.topic_publish`.
+    """Helper for :meth:`PublisherAPI.topic_publish`.
 
     Performs "impedance matching" between the protobuf attrs and the keys
     expected in the JSON API.
     """
-    return PubsubMessage(data=_to_bytes(message['data']),
+    return PubsubMessage(data=to_bytes(message['data']),
                          attributes=message['attributes'])
 
 

--- a/gcloud/pubsub/_helpers.py
+++ b/gcloud/pubsub/_helpers.py
@@ -16,7 +16,7 @@
 
 import re
 
-from gcloud._helpers import _name_from_project_path
+from gcloud._helpers import name_from_project_path
 
 
 _TOPIC_TEMPLATE = re.compile(r"""
@@ -51,7 +51,7 @@ def topic_name_from_path(path, project):
              the project from the ``path`` does not agree with the
              ``project`` passed in.
     """
-    return _name_from_project_path(path, project, _TOPIC_TEMPLATE)
+    return name_from_project_path(path, project, _TOPIC_TEMPLATE)
 
 
 def subscription_name_from_path(path, project):
@@ -70,4 +70,4 @@ def subscription_name_from_path(path, project):
              the project from the ``path`` does not agree with the
              ``project`` passed in.
     """
-    return _name_from_project_path(path, project, _SUBSCRIPTION_TEMPLATE)
+    return name_from_project_path(path, project, _SUBSCRIPTION_TEMPLATE)

--- a/gcloud/pubsub/client.py
+++ b/gcloud/pubsub/client.py
@@ -18,9 +18,9 @@ import os
 
 from gcloud.client import JSONClient
 from gcloud.pubsub.connection import Connection
-from gcloud.pubsub.connection import _PublisherAPI as JSONPublisherAPI
-from gcloud.pubsub.connection import _SubscriberAPI as JSONSubscriberAPI
-from gcloud.pubsub.connection import _IAMPolicyAPI
+from gcloud.pubsub.connection import PublisherAPI as JSONPublisherAPI
+from gcloud.pubsub.connection import SubscriberAPI as JSONSubscriberAPI
+from gcloud.pubsub.connection import IAMPolicyAPI
 from gcloud.pubsub.subscription import Subscription
 from gcloud.pubsub.topic import Topic
 
@@ -30,8 +30,8 @@ try:
         PublisherApi as GeneratedPublisherAPI)
     from google.cloud.pubsub.v1.subscriber_api import (
         SubscriberApi as GeneratedSubscriberAPI)
-    from gcloud.pubsub._gax import _PublisherAPI as GAXPublisherAPI
-    from gcloud.pubsub._gax import _SubscriberAPI as GAXSubscriberAPI
+    from gcloud.pubsub._gax import PublisherAPI as GAXPublisherAPI
+    from gcloud.pubsub._gax import SubscriberAPI as GAXSubscriberAPI
 except ImportError:  # pragma: NO COVER
     _HAVE_GAX = False
     GeneratedPublisherAPI = GAXPublisherAPI = None
@@ -95,7 +95,7 @@ class Client(JSONClient):
     def iam_policy_api(self):
         """Helper for IAM policy-related API calls."""
         if self._iam_policy_api is None:
-            self._iam_policy_api = _IAMPolicyAPI(self.connection)
+            self._iam_policy_api = IAMPolicyAPI(self.connection)
         return self._iam_policy_api
 
     def list_topics(self, page_size=None, page_token=None):

--- a/gcloud/pubsub/connection.py
+++ b/gcloud/pubsub/connection.py
@@ -91,7 +91,7 @@ class Connection(base_connection.JSONConnection):
             api_base_url=api_base_url, api_version=api_version)
 
 
-class _PublisherAPI(object):
+class PublisherAPI(object):
     """Helper mapping publisher-related APIs.
 
     :type connection: :class:`Connection`
@@ -243,7 +243,7 @@ class _PublisherAPI(object):
         return resp.get('subscriptions', ()), resp.get('nextPageToken')
 
 
-class _SubscriberAPI(object):
+class SubscriberAPI(object):
     """Helper mapping subscriber-related APIs.
 
     :type connection: :class:`Connection`
@@ -468,7 +468,7 @@ class _SubscriberAPI(object):
         conn.api_request(method='POST', path=path, data=data)
 
 
-class _IAMPolicyAPI(object):
+class IAMPolicyAPI(object):
     """Helper mapping IAM policy-related APIs.
 
     :type connection: :class:`Connection`

--- a/gcloud/pubsub/message.py
+++ b/gcloud/pubsub/message.py
@@ -16,7 +16,7 @@
 
 import base64
 
-from gcloud._helpers import _rfc3339_to_datetime
+from gcloud._helpers import rfc3339_to_datetime
 
 
 class Message(object):
@@ -64,7 +64,7 @@ class Message(object):
         stamp = self.attributes.get('timestamp')
         if stamp is None:
             raise ValueError('No timestamp')
-        return _rfc3339_to_datetime(stamp)
+        return rfc3339_to_datetime(stamp)
 
     @property
     def service_timestamp(self):

--- a/gcloud/pubsub/test__gax.py
+++ b/gcloud/pubsub/test__gax.py
@@ -42,11 +42,11 @@ class _Base(object):
 
 
 @unittest.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_PublisherAPI(_Base, unittest.TestCase):
+class TestPublisherAPI(_Base, unittest.TestCase):
 
     def _getTargetClass(self):
-        from gcloud.pubsub._gax import _PublisherAPI
-        return _PublisherAPI
+        from gcloud.pubsub._gax import PublisherAPI
+        return PublisherAPI
 
     def test_ctor(self):
         gax_api = _GAXPublisherAPI()
@@ -344,13 +344,13 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
 
 @unittest.skipUnless(_HAVE_GAX, 'No gax-python')
-class Test_SubscriberAPI(_Base, unittest.TestCase):
+class TestSubscriberAPI(_Base, unittest.TestCase):
 
     PUSH_ENDPOINT = 'https://api.example.com/push'
 
     def _getTargetClass(self):
-        from gcloud.pubsub._gax import _SubscriberAPI
-        return _SubscriberAPI
+        from gcloud.pubsub._gax import SubscriberAPI
+        return SubscriberAPI
 
     def test_ctor(self):
         gax_api = _GAXSubscriberAPI()

--- a/gcloud/pubsub/test_client.py
+++ b/gcloud/pubsub/test_client.py
@@ -30,7 +30,7 @@ class TestClient(unittest.TestCase):
         return self._getTargetClass()(*args, **kw)
 
     def test_publisher_api_wo_gax(self):
-        from gcloud.pubsub.connection import _PublisherAPI
+        from gcloud.pubsub.connection import PublisherAPI
         from gcloud.pubsub import client as MUT
         from gcloud._testing import _Monkey
         creds = _Credentials()
@@ -40,7 +40,7 @@ class TestClient(unittest.TestCase):
         with _Monkey(MUT, _USE_GAX=False):
             api = client.publisher_api
 
-        self.assertIsInstance(api, _PublisherAPI)
+        self.assertIsInstance(api, PublisherAPI)
         self.assertTrue(api._connection is conn)
         # API instance is cached
         again = client.publisher_api
@@ -78,7 +78,7 @@ class TestClient(unittest.TestCase):
         self.assertTrue(again is api)
 
     def test_subscriber_api_wo_gax(self):
-        from gcloud.pubsub.connection import _SubscriberAPI
+        from gcloud.pubsub.connection import SubscriberAPI
         from gcloud.pubsub import client as MUT
         from gcloud._testing import _Monkey
         creds = _Credentials()
@@ -88,7 +88,7 @@ class TestClient(unittest.TestCase):
         with _Monkey(MUT, _USE_GAX=False):
             api = client.subscriber_api
 
-        self.assertIsInstance(api, _SubscriberAPI)
+        self.assertIsInstance(api, SubscriberAPI)
         self.assertTrue(api._connection is conn)
         # API instance is cached
         again = client.subscriber_api
@@ -126,12 +126,12 @@ class TestClient(unittest.TestCase):
         self.assertTrue(again is api)
 
     def test_iam_policy_api(self):
-        from gcloud.pubsub.connection import _IAMPolicyAPI
+        from gcloud.pubsub.connection import IAMPolicyAPI
         creds = _Credentials()
         client = self._makeOne(project=self.PROJECT, credentials=creds)
         conn = client.connection = object()
         api = client.iam_policy_api
-        self.assertIsInstance(api, _IAMPolicyAPI)
+        self.assertIsInstance(api, IAMPolicyAPI)
         self.assertTrue(api._connection is conn)
         # API instance is cached
         again = client.iam_policy_api

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -640,7 +640,10 @@ class Test_IAMPolicyAPI(_Base):
         self.assertTrue(api._connection is connection)
 
     def test_get_iam_policy(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE
+        from gcloud.pubsub.iam import EDITOR_ROLE
+        from gcloud.pubsub.iam import VIEWER_ROLE
+
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         EDITOR1 = 'domain:google.com'
@@ -667,7 +670,10 @@ class Test_IAMPolicyAPI(_Base):
         self.assertEqual(connection._called_with['path'], path)
 
     def test_set_iam_policy(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE
+        from gcloud.pubsub.iam import EDITOR_ROLE
+        from gcloud.pubsub.iam import VIEWER_ROLE
+
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         EDITOR1 = 'domain:google.com'
@@ -697,7 +703,10 @@ class Test_IAMPolicyAPI(_Base):
                          {'policy': POLICY})
 
     def test_test_iam_permissions(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE
+        from gcloud.pubsub.iam import EDITOR_ROLE
+        from gcloud.pubsub.iam import VIEWER_ROLE
+
         ALL_ROLES = [OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE]
         ALLOWED = ALL_ROLES[1:]
         RETURNED = {'permissions': ALLOWED}
@@ -714,7 +723,10 @@ class Test_IAMPolicyAPI(_Base):
                          {'permissions': ALL_ROLES})
 
     def test_test_iam_permissions_missing_key(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE
+        from gcloud.pubsub.iam import EDITOR_ROLE
+        from gcloud.pubsub.iam import VIEWER_ROLE
+
         ALL_ROLES = [OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE]
         RETURNED = {}
         connection = _Connection(RETURNED)

--- a/gcloud/pubsub/test_connection.py
+++ b/gcloud/pubsub/test_connection.py
@@ -114,11 +114,11 @@ class TestConnection(_Base):
                          URI)
 
 
-class Test_PublisherAPI(_Base):
+class TestPublisherAPI(_Base):
 
     def _getTargetClass(self):
-        from gcloud.pubsub.connection import _PublisherAPI
-        return _PublisherAPI
+        from gcloud.pubsub.connection import PublisherAPI
+        return PublisherAPI
 
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
@@ -375,11 +375,11 @@ class Test_PublisherAPI(_Base):
         self.assertEqual(connection._called_with['query_params'], {})
 
 
-class Test_SubscriberAPI(_Base):
+class TestSubscriberAPI(_Base):
 
     def _getTargetClass(self):
-        from gcloud.pubsub.connection import _SubscriberAPI
-        return _SubscriberAPI
+        from gcloud.pubsub.connection import SubscriberAPI
+        return SubscriberAPI
 
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
@@ -628,11 +628,11 @@ class Test_SubscriberAPI(_Base):
         self.assertEqual(connection._called_with['data'], BODY)
 
 
-class Test_IAMPolicyAPI(_Base):
+class TestIAMPolicyAPI(_Base):
 
     def _getTargetClass(self):
-        from gcloud.pubsub.connection import _IAMPolicyAPI
-        return _IAMPolicyAPI
+        from gcloud.pubsub.connection import IAMPolicyAPI
+        return IAMPolicyAPI
 
     def test_ctor(self):
         connection = _Connection()

--- a/gcloud/pubsub/test_iam.py
+++ b/gcloud/pubsub/test_iam.py
@@ -91,13 +91,12 @@ class TestPolicy(unittest.TestCase):
         self.assertEqual(list(policy.viewers), [])
 
     def test_from_api_repr_complete(self):
-        from gcloud.pubsub.iam import (
-            OWNER_ROLE,
-            EDITOR_ROLE,
-            VIEWER_ROLE,
-            PUBSUB_PUBLISHER_ROLE,
-            PUBSUB_SUBSCRIBER_ROLE,
-        )
+        from gcloud.pubsub.iam import OWNER_ROLE
+        from gcloud.pubsub.iam import EDITOR_ROLE
+        from gcloud.pubsub.iam import VIEWER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_PUBLISHER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_SUBSCRIBER_ROLE
+
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         EDITOR1 = 'domain:google.com'
@@ -150,13 +149,12 @@ class TestPolicy(unittest.TestCase):
         self.assertEqual(policy.to_api_repr(), {'etag': 'DEADBEEF'})
 
     def test_to_api_repr_full(self):
-        from gcloud.pubsub.iam import (
-            PUBSUB_ADMIN_ROLE,
-            PUBSUB_EDITOR_ROLE,
-            PUBSUB_VIEWER_ROLE,
-            PUBSUB_PUBLISHER_ROLE,
-            PUBSUB_SUBSCRIBER_ROLE,
-        )
+        from gcloud.pubsub.iam import PUBSUB_ADMIN_ROLE
+        from gcloud.pubsub.iam import PUBSUB_EDITOR_ROLE
+        from gcloud.pubsub.iam import PUBSUB_VIEWER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_PUBLISHER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_SUBSCRIBER_ROLE
+
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
         EDITOR1 = 'domain:google.com'

--- a/gcloud/pubsub/test_subscription.py
+++ b/gcloud/pubsub/test_subscription.py
@@ -450,13 +450,12 @@ class TestSubscription(unittest.TestCase):
                          (self.SUB_PATH, [ACK_ID1, ACK_ID2], self.DEADLINE))
 
     def test_get_iam_policy_w_bound_client(self):
-        from gcloud.pubsub.iam import (
-            PUBSUB_ADMIN_ROLE,
-            PUBSUB_EDITOR_ROLE,
-            PUBSUB_VIEWER_ROLE,
-            PUBSUB_PUBLISHER_ROLE,
-            PUBSUB_SUBSCRIBER_ROLE,
-        )
+        from gcloud.pubsub.iam import PUBSUB_ADMIN_ROLE
+        from gcloud.pubsub.iam import PUBSUB_EDITOR_ROLE
+        from gcloud.pubsub.iam import PUBSUB_VIEWER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_PUBLISHER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_SUBSCRIBER_ROLE
+
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         EDITOR1 = 'domain:google.com'
@@ -516,13 +515,12 @@ class TestSubscription(unittest.TestCase):
 
     def test_set_iam_policy_w_bound_client(self):
         from gcloud.pubsub.iam import Policy
-        from gcloud.pubsub.iam import (
-            PUBSUB_ADMIN_ROLE,
-            PUBSUB_EDITOR_ROLE,
-            PUBSUB_VIEWER_ROLE,
-            PUBSUB_PUBLISHER_ROLE,
-            PUBSUB_SUBSCRIBER_ROLE,
-        )
+        from gcloud.pubsub.iam import PUBSUB_ADMIN_ROLE
+        from gcloud.pubsub.iam import PUBSUB_EDITOR_ROLE
+        from gcloud.pubsub.iam import PUBSUB_VIEWER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_PUBLISHER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_SUBSCRIBER_ROLE
+
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
         EDITOR1 = 'domain:google.com'
@@ -592,7 +590,10 @@ class TestSubscription(unittest.TestCase):
         self.assertEqual(api._set_iam_policy, (self.SUB_PATH, {}))
 
     def test_check_iam_permissions_w_bound_client(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE
+        from gcloud.pubsub.iam import EDITOR_ROLE
+        from gcloud.pubsub.iam import VIEWER_ROLE
+
         ROLES = [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE]
         client = _Client(project=self.PROJECT)
         api = client.iam_policy_api = _FauxIAMPolicy()
@@ -607,7 +608,10 @@ class TestSubscription(unittest.TestCase):
                          (self.SUB_PATH, ROLES))
 
     def test_check_iam_permissions_w_alternate_client(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE
+        from gcloud.pubsub.iam import EDITOR_ROLE
+        from gcloud.pubsub.iam import VIEWER_ROLE
+
         ROLES = [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE]
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)

--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -160,7 +160,7 @@ class TestTopic(unittest.TestCase):
 
         topic = self._makeOne(self.TOPIC_NAME, client=client1,
                               timestamp_messages=True)
-        with _Monkey(MUT, _NOW=_utcnow):
+        with _Monkey(MUT, NOW=_utcnow):
             msgid = topic.publish(PAYLOAD, client=client2)
 
         self.assertEqual(msgid, MSGID)

--- a/gcloud/pubsub/test_topic.py
+++ b/gcloud/pubsub/test_topic.py
@@ -382,13 +382,12 @@ class TestTopic(unittest.TestCase):
                          (self.TOPIC_PATH, None, None))
 
     def test_get_iam_policy_w_bound_client(self):
-        from gcloud.pubsub.iam import (
-            PUBSUB_ADMIN_ROLE,
-            PUBSUB_EDITOR_ROLE,
-            PUBSUB_VIEWER_ROLE,
-            PUBSUB_PUBLISHER_ROLE,
-            PUBSUB_SUBSCRIBER_ROLE,
-        )
+        from gcloud.pubsub.iam import PUBSUB_ADMIN_ROLE
+        from gcloud.pubsub.iam import PUBSUB_EDITOR_ROLE
+        from gcloud.pubsub.iam import PUBSUB_VIEWER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_PUBLISHER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_SUBSCRIBER_ROLE
+
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         EDITOR1 = 'domain:google.com'
@@ -448,13 +447,12 @@ class TestTopic(unittest.TestCase):
 
     def test_set_iam_policy_w_bound_client(self):
         from gcloud.pubsub.iam import Policy
-        from gcloud.pubsub.iam import (
-            PUBSUB_ADMIN_ROLE,
-            PUBSUB_EDITOR_ROLE,
-            PUBSUB_VIEWER_ROLE,
-            PUBSUB_PUBLISHER_ROLE,
-            PUBSUB_SUBSCRIBER_ROLE,
-        )
+        from gcloud.pubsub.iam import PUBSUB_ADMIN_ROLE
+        from gcloud.pubsub.iam import PUBSUB_EDITOR_ROLE
+        from gcloud.pubsub.iam import PUBSUB_VIEWER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_PUBLISHER_ROLE
+        from gcloud.pubsub.iam import PUBSUB_SUBSCRIBER_ROLE
+
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
         EDITOR1 = 'domain:google.com'
@@ -530,7 +528,10 @@ class TestTopic(unittest.TestCase):
         self.assertEqual(api._set_iam_policy, (self.TOPIC_PATH, {}))
 
     def test_check_iam_permissions_w_bound_client(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE
+        from gcloud.pubsub.iam import EDITOR_ROLE
+        from gcloud.pubsub.iam import VIEWER_ROLE
+
         ROLES = [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE]
         client = _Client(project=self.PROJECT)
         api = client.iam_policy_api = _FauxIAMPolicy()
@@ -544,7 +545,10 @@ class TestTopic(unittest.TestCase):
                          (self.TOPIC_PATH, ROLES))
 
     def test_check_iam_permissions_w_alternate_client(self):
-        from gcloud.pubsub.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        from gcloud.pubsub.iam import OWNER_ROLE
+        from gcloud.pubsub.iam import EDITOR_ROLE
+        from gcloud.pubsub.iam import VIEWER_ROLE
+
         ROLES = [VIEWER_ROLE, EDITOR_ROLE, OWNER_ROLE]
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)

--- a/gcloud/pubsub/topic.py
+++ b/gcloud/pubsub/topic.py
@@ -16,8 +16,8 @@
 
 import base64
 
-from gcloud._helpers import _datetime_to_rfc3339
-from gcloud._helpers import _NOW
+from gcloud._helpers import datetime_to_rfc3339
+from gcloud._helpers import NOW
 from gcloud.exceptions import NotFound
 from gcloud.pubsub._helpers import subscription_name_from_path
 from gcloud.pubsub._helpers import topic_name_from_path
@@ -210,7 +210,7 @@ class Topic(object):
         Helper method for ``publish``/``Batch.publish``.
         """
         if self.timestamp_messages and 'timestamp' not in attrs:
-            attrs['timestamp'] = _datetime_to_rfc3339(_NOW())
+            attrs['timestamp'] = datetime_to_rfc3339(NOW())
 
     def publish(self, message, client=None, **attrs):
         """API call:  publish a message to a topic via a POST request

--- a/gcloud/storage/_helpers.py
+++ b/gcloud/storage/_helpers.py
@@ -21,7 +21,7 @@ import base64
 from hashlib import md5
 
 
-class _PropertyMixin(object):
+class PropertyMixin(object):
     """Abstract mixin for cloud storage classes with associated propertties.
 
     Non-abstract subclasses should implement:
@@ -125,8 +125,8 @@ class _PropertyMixin(object):
         self._set_properties(api_response)
 
 
-def _scalar_property(fieldname):
-    """Create a property descriptor around the :class:`_PropertyMixin` helpers.
+def scalar_property(fieldname):
+    """Create a property descriptor around the :class:`PropertyMixin` helpers.
     """
     def _getter(self):
         """Scalar property getter."""
@@ -160,7 +160,7 @@ def _write_buffer_to_hash(buffer_object, hash_obj, digest_block_size=8192):
         block = buffer_object.read(digest_block_size)
 
 
-def _base64_md5hash(buffer_object):
+def base64_md5hash(buffer_object):
     """Get MD5 hash of bytes (as base64).
 
     :type buffer_object: bytes buffer

--- a/gcloud/storage/blob.py
+++ b/gcloud/storage/blob.py
@@ -28,14 +28,14 @@ import httplib2
 import six
 from six.moves.urllib.parse import quote
 
-from gcloud._helpers import _rfc3339_to_datetime
-from gcloud._helpers import _to_bytes
-from gcloud._helpers import _bytes_to_unicode
+from gcloud._helpers import rfc3339_to_datetime
+from gcloud._helpers import to_bytes
+from gcloud._helpers import bytes_to_unicode
 from gcloud.credentials import generate_signed_url
 from gcloud.exceptions import NotFound
 from gcloud.exceptions import make_exception
-from gcloud.storage._helpers import _PropertyMixin
-from gcloud.storage._helpers import _scalar_property
+from gcloud.storage._helpers import PropertyMixin
+from gcloud.storage._helpers import scalar_property
 from gcloud.storage.acl import ObjectACL
 from gcloud.streaming.http_wrapper import Request
 from gcloud.streaming.http_wrapper import make_api_request
@@ -47,7 +47,7 @@ from gcloud.streaming.transfer import Upload
 _API_ACCESS_ENDPOINT = 'https://storage.googleapis.com'
 
 
-class Blob(_PropertyMixin):
+class Blob(PropertyMixin):
     """A wrapper around Cloud Storage's concept of an ``Object``.
 
     :type name: string
@@ -645,7 +645,7 @@ class Blob(_PropertyMixin):
         self.acl.all().grant_read()
         self.acl.save(client=client)
 
-    cache_control = _scalar_property('cacheControl')
+    cache_control = scalar_property('cacheControl')
     """HTTP 'Cache-Control' header for this object.
 
     See: https://tools.ietf.org/html/rfc7234#section-5.2 and
@@ -656,7 +656,7 @@ class Blob(_PropertyMixin):
     :rtype: string or ``NoneType``
     """
 
-    content_disposition = _scalar_property('contentDisposition')
+    content_disposition = scalar_property('contentDisposition')
     """HTTP 'Content-Disposition' header for this object.
 
     See: https://tools.ietf.org/html/rfc6266 and
@@ -667,7 +667,7 @@ class Blob(_PropertyMixin):
     :rtype: string or ``NoneType``
     """
 
-    content_encoding = _scalar_property('contentEncoding')
+    content_encoding = scalar_property('contentEncoding')
     """HTTP 'Content-Encoding' header for this object.
 
     See: https://tools.ietf.org/html/rfc7231#section-3.1.2.2 and
@@ -678,7 +678,7 @@ class Blob(_PropertyMixin):
     :rtype: string or ``NoneType``
     """
 
-    content_language = _scalar_property('contentLanguage')
+    content_language = scalar_property('contentLanguage')
     """HTTP 'Content-Language' header for this object.
 
     See: http://tools.ietf.org/html/bcp47 and
@@ -689,7 +689,7 @@ class Blob(_PropertyMixin):
     :rtype: string or ``NoneType``
     """
 
-    content_type = _scalar_property('contentType')
+    content_type = scalar_property('contentType')
     """HTTP 'Content-Type' header for this object.
 
     See: https://tools.ietf.org/html/rfc2616#section-14.17 and
@@ -700,7 +700,7 @@ class Blob(_PropertyMixin):
     :rtype: string or ``NoneType``
     """
 
-    crc32c = _scalar_property('crc32c')
+    crc32c = scalar_property('crc32c')
     """CRC32C checksum for this object.
 
     See: http://tools.ietf.org/html/rfc4960#appendix-B and
@@ -764,7 +764,7 @@ class Blob(_PropertyMixin):
         """
         return self._properties.get('id')
 
-    md5_hash = _scalar_property('md5Hash')
+    md5_hash = scalar_property('md5Hash')
     """MD5 hash for this object.
 
     See: http://tools.ietf.org/html/rfc4960#appendix-B and
@@ -889,7 +889,7 @@ class Blob(_PropertyMixin):
         """
         value = self._properties.get('timeDeleted')
         if value is not None:
-            return _rfc3339_to_datetime(value)
+            return rfc3339_to_datetime(value)
 
     @property
     def updated(self):
@@ -903,7 +903,7 @@ class Blob(_PropertyMixin):
         """
         value = self._properties.get('updated')
         if value is not None:
-            return _rfc3339_to_datetime(value)
+            return rfc3339_to_datetime(value)
 
 
 class _UploadConfig(object):
@@ -937,10 +937,10 @@ def _set_encryption_headers(key, headers):
     :type headers: dict
     :param headers: dict of HTTP headers being sent in request.
     """
-    key = _to_bytes(key)
+    key = to_bytes(key)
     sha256_key = hashlib.sha256(key).digest()
     key_hash = base64.b64encode(sha256_key).rstrip()
     encoded_key = base64.b64encode(key).rstrip()
     headers['X-Goog-Encryption-Algorithm'] = 'AES256'
-    headers['X-Goog-Encryption-Key'] = _bytes_to_unicode(encoded_key)
-    headers['X-Goog-Encryption-Key-Sha256'] = _bytes_to_unicode(key_hash)
+    headers['X-Goog-Encryption-Key'] = bytes_to_unicode(encoded_key)
+    headers['X-Goog-Encryption-Key-Sha256'] = bytes_to_unicode(key_hash)

--- a/gcloud/storage/bucket.py
+++ b/gcloud/storage/bucket.py
@@ -18,11 +18,11 @@ import copy
 
 import six
 
-from gcloud._helpers import _rfc3339_to_datetime
+from gcloud._helpers import rfc3339_to_datetime
 from gcloud.exceptions import NotFound
 from gcloud.iterator import Iterator
-from gcloud.storage._helpers import _PropertyMixin
-from gcloud.storage._helpers import _scalar_property
+from gcloud.storage._helpers import PropertyMixin
+from gcloud.storage._helpers import scalar_property
 from gcloud.storage.acl import BucketACL
 from gcloud.storage.acl import DefaultObjectACL
 from gcloud.storage.blob import Blob
@@ -69,7 +69,7 @@ class _BlobIterator(Iterator):
             yield blob
 
 
-class Bucket(_PropertyMixin):
+class Bucket(PropertyMixin):
     """A class representing a Bucket on Cloud Storage.
 
     :type client: :class:`gcloud.storage.client.Client`
@@ -557,7 +557,7 @@ class Bucket(_PropertyMixin):
     def lifecycle_rules(self, rules):
         self._patch_property('lifecycle', {'rule': rules})
 
-    location = _scalar_property('location')
+    location = scalar_property('location')
     """Retrieve location configured for this bucket.
 
     See: https://cloud.google.com/storage/docs/json_api/v1/buckets and
@@ -695,7 +695,7 @@ class Bucket(_PropertyMixin):
         """
         value = self._properties.get('timeCreated')
         if value is not None:
-            return _rfc3339_to_datetime(value)
+            return rfc3339_to_datetime(value)
 
     @property
     def versioning_enabled(self):

--- a/gcloud/storage/client.py
+++ b/gcloud/storage/client.py
@@ -15,7 +15,7 @@
 """Client for interacting with the Google Cloud Storage API."""
 
 
-from gcloud._helpers import _LocalStack
+from gcloud._helpers import LocalStack
 from gcloud.client import JSONClient
 from gcloud.exceptions import NotFound
 from gcloud.iterator import Iterator
@@ -51,7 +51,7 @@ class Client(JSONClient):
         self._connection = None
         super(Client, self).__init__(project=project, credentials=credentials,
                                      http=http)
-        self._batch_stack = _LocalStack()
+        self._batch_stack = LocalStack()
 
     @property
     def connection(self):

--- a/gcloud/storage/test__helpers.py
+++ b/gcloud/storage/test__helpers.py
@@ -15,11 +15,11 @@
 import unittest
 
 
-class Test_PropertyMixin(unittest.TestCase):
+class TestPropertyMixin(unittest.TestCase):
 
     def _getTargetClass(self):
-        from gcloud.storage._helpers import _PropertyMixin
-        return _PropertyMixin
+        from gcloud.storage._helpers import PropertyMixin
+        return PropertyMixin
 
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
@@ -94,11 +94,11 @@ class Test_PropertyMixin(unittest.TestCase):
         self.assertEqual(derived._changes, set())
 
 
-class Test__scalar_property(unittest.TestCase):
+class Test_scalar_property(unittest.TestCase):
 
     def _callFUT(self, fieldName):
-        from gcloud.storage._helpers import _scalar_property
-        return _scalar_property(fieldName)
+        from gcloud.storage._helpers import scalar_property
+        return scalar_property(fieldName)
 
     def test_getter(self):
 
@@ -122,11 +122,11 @@ class Test__scalar_property(unittest.TestCase):
         self.assertEqual(test._patched, ('solfege', 'Latido'))
 
 
-class Test__base64_md5hash(unittest.TestCase):
+class Test_base64_md5hash(unittest.TestCase):
 
     def _callFUT(self, bytes_to_sign):
-        from gcloud.storage._helpers import _base64_md5hash
-        return _base64_md5hash(bytes_to_sign)
+        from gcloud.storage._helpers import base64_md5hash
+        return base64_md5hash(bytes_to_sign)
 
     def test_it(self):
         from io import BytesIO

--- a/gcloud/storage/test_client.py
+++ b/gcloud/storage/test_client.py
@@ -51,7 +51,7 @@ class TestClient(unittest.TestCase):
         self.assertTrue(client.current_batch is batch1)
         client._push_batch(batch2)
         self.assertTrue(client.current_batch is batch2)
-        # list(_LocalStack) returns in reverse order.
+        # list(LocalStack) returns in reverse order.
         self.assertEqual(list(client._batch_stack), [batch2, batch1])
         self.assertTrue(client._pop_batch() is batch2)
         self.assertEqual(list(client._batch_stack), [batch1])

--- a/gcloud/streaming/test_transfer.py
+++ b/gcloud/streaming/test_transfer.py
@@ -1029,7 +1029,7 @@ class Test_Upload(unittest.TestCase):
         self.assertEqual(request.loggable_body, '<media body>')
 
     def test_configure_request_w_simple_w_body(self):
-        from gcloud._helpers import _to_bytes
+        from gcloud._helpers import to_bytes
         from gcloud.streaming.transfer import SIMPLE_UPLOAD
         CONTENT = b'CONTENT'
         BODY = b'BODY'
@@ -1052,7 +1052,7 @@ class Test_Upload(unittest.TestCase):
         self.assertTrue(boundary.startswith('boundary="=='))
         self.assertTrue(boundary.endswith('=="'))
 
-        divider = b'--' + _to_bytes(boundary[len('boundary="'):-1])
+        divider = b'--' + to_bytes(boundary[len('boundary="'):-1])
         chunks = request.body.split(divider)[1:-1]  # discard prolog / epilog
         self.assertEqual(len(chunks), 2)
 

--- a/gcloud/streaming/transfer.py
+++ b/gcloud/streaming/transfer.py
@@ -25,7 +25,7 @@ import os
 import six
 from six.moves import http_client
 
-from gcloud._helpers import _to_bytes
+from gcloud._helpers import to_bytes
 from gcloud.streaming.buffered_stream import BufferedStream
 from gcloud.streaming.exceptions import CommunicationError
 from gcloud.streaming.exceptions import HttpError
@@ -909,7 +909,7 @@ class Upload(_Transfer):
         http_request.headers['content-type'] = (
             'multipart/related; boundary="%s"' % multipart_boundary)
 
-        boundary_bytes = _to_bytes(multipart_boundary)
+        boundary_bytes = to_bytes(multipart_boundary)
         body_components = http_request.body.split(boundary_bytes)
         headers, _, _ = body_components[-2].partition(b'\n\n')
         body_components[-2] = b'\n\n'.join([headers, b'<media body>\n\n--'])

--- a/gcloud/test__helpers.py
+++ b/gcloud/test__helpers.py
@@ -16,12 +16,12 @@ import os
 import unittest
 
 
-class Test__LocalStack(unittest.TestCase):
+class Test_LocalStack(unittest.TestCase):
 
     def _getTargetClass(self):
-        from gcloud._helpers import _LocalStack
+        from gcloud._helpers import LocalStack
 
-        return _LocalStack
+        return LocalStack
 
     def _makeOne(self):
         return self._getTargetClass()()
@@ -97,11 +97,11 @@ class Test__UTC(unittest.TestCase):
         self.assertEqual(str(tz), 'UTC')
 
 
-class Test__ensure_tuple_or_list(unittest.TestCase):
+class Test_ensure_tuple_or_list(unittest.TestCase):
 
     def _callFUT(self, arg_name, tuple_or_list):
-        from gcloud._helpers import _ensure_tuple_or_list
-        return _ensure_tuple_or_list(arg_name, tuple_or_list)
+        from gcloud._helpers import ensure_tuple_or_list
+        return ensure_tuple_or_list(arg_name, tuple_or_list)
 
     def test_valid_tuple(self):
         valid_tuple_or_list = ('a', 'b', 'c', 'd')
@@ -305,11 +305,11 @@ class Test__get_production_project(unittest.TestCase):
             self.assertEqual(project, MOCK_PROJECT)
 
 
-class Test__determine_default_project(unittest.TestCase):
+class Test_determine_default_project(unittest.TestCase):
 
     def _callFUT(self, project=None):
-        from gcloud._helpers import _determine_default_project
-        return _determine_default_project(project=project)
+        from gcloud._helpers import determine_default_project
+        return determine_default_project(project=project)
 
     def _determine_default_helper(self, prod=None, gae=None, gce=None,
                                   file_id=None, srv_id=None, project=None):
@@ -384,11 +384,11 @@ class Test__determine_default_project(unittest.TestCase):
                                    'gae_mock', 'gce_mock'])
 
 
-class Test__millis(unittest.TestCase):
+class Test_millis(unittest.TestCase):
 
     def _callFUT(self, value):
-        from gcloud._helpers import _millis
-        return _millis(value)
+        from gcloud._helpers import millis
+        return millis(value)
 
     def test_one_second_from_epoch(self):
         import datetime
@@ -398,11 +398,11 @@ class Test__millis(unittest.TestCase):
         self.assertEqual(self._callFUT(WHEN), 1000)
 
 
-class Test__microseconds_from_datetime(unittest.TestCase):
+class Test_microseconds_from_datetime(unittest.TestCase):
 
     def _callFUT(self, value):
-        from gcloud._helpers import _microseconds_from_datetime
-        return _microseconds_from_datetime(value)
+        from gcloud._helpers import microseconds_from_datetime
+        return microseconds_from_datetime(value)
 
     def test_it(self):
         import datetime
@@ -415,11 +415,11 @@ class Test__microseconds_from_datetime(unittest.TestCase):
         self.assertEqual(result, microseconds)
 
 
-class Test__millis_from_datetime(unittest.TestCase):
+class Testmillis_from_datetime(unittest.TestCase):
 
     def _callFUT(self, value):
-        from gcloud._helpers import _millis_from_datetime
-        return _millis_from_datetime(value)
+        from gcloud._helpers import millis_from_datetime
+        return millis_from_datetime(value)
 
     def test_w_none(self):
         self.assertTrue(self._callFUT(None) is None)
@@ -428,10 +428,10 @@ class Test__millis_from_datetime(unittest.TestCase):
         import datetime
         import six
         from gcloud._helpers import UTC
-        from gcloud._helpers import _microseconds_from_datetime
+        from gcloud._helpers import microseconds_from_datetime
 
         NOW = datetime.datetime.utcnow().replace(tzinfo=UTC)
-        NOW_MICROS = _microseconds_from_datetime(NOW)
+        NOW_MICROS = microseconds_from_datetime(NOW)
         MILLIS = NOW_MICROS // 1000
         result = self._callFUT(NOW)
         self.assertTrue(isinstance(result, six.integer_types))
@@ -441,7 +441,7 @@ class Test__millis_from_datetime(unittest.TestCase):
         import datetime
         import six
         from gcloud._helpers import _UTC
-        from gcloud._helpers import _microseconds_from_datetime
+        from gcloud._helpers import microseconds_from_datetime
 
         class CET(_UTC):
             _tzname = 'CET'
@@ -449,7 +449,7 @@ class Test__millis_from_datetime(unittest.TestCase):
 
         zone = CET()
         NOW = datetime.datetime(2015, 7, 28, 16, 34, 47, tzinfo=zone)
-        NOW_MICROS = _microseconds_from_datetime(NOW)
+        NOW_MICROS = microseconds_from_datetime(NOW)
         MILLIS = NOW_MICROS // 1000
         result = self._callFUT(NOW)
         self.assertTrue(isinstance(result, six.integer_types))
@@ -459,39 +459,39 @@ class Test__millis_from_datetime(unittest.TestCase):
         import datetime
         import six
         from gcloud._helpers import UTC
-        from gcloud._helpers import _microseconds_from_datetime
+        from gcloud._helpers import microseconds_from_datetime
 
         NOW = datetime.datetime.utcnow()
-        UTC_NOW = NOW.replace(tzinfo=UTC)
-        UTC_NOW_MICROS = _microseconds_from_datetime(UTC_NOW)
-        MILLIS = UTC_NOW_MICROS // 1000
+        UTCNOW = NOW.replace(tzinfo=UTC)
+        UTCNOW_MICROS = microseconds_from_datetime(UTCNOW)
+        MILLIS = UTCNOW_MICROS // 1000
         result = self._callFUT(NOW)
         self.assertTrue(isinstance(result, six.integer_types))
         self.assertEqual(result, MILLIS)
 
 
-class Test__datetime_from_microseconds(unittest.TestCase):
+class Test_datetime_from_microseconds(unittest.TestCase):
 
     def _callFUT(self, value):
-        from gcloud._helpers import _datetime_from_microseconds
-        return _datetime_from_microseconds(value)
+        from gcloud._helpers import datetime_from_microseconds
+        return datetime_from_microseconds(value)
 
     def test_it(self):
         import datetime
         from gcloud._helpers import UTC
-        from gcloud._helpers import _microseconds_from_datetime
+        from gcloud._helpers import microseconds_from_datetime
 
         NOW = datetime.datetime(2015, 7, 29, 17, 45, 21, 123456,
                                 tzinfo=UTC)
-        NOW_MICROS = _microseconds_from_datetime(NOW)
+        NOW_MICROS = microseconds_from_datetime(NOW)
         self.assertEqual(self._callFUT(NOW_MICROS), NOW)
 
 
-class Test__rfc3339_to_datetime(unittest.TestCase):
+class Test_rfc3339_to_datetime(unittest.TestCase):
 
     def _callFUT(self, dt_str):
-        from gcloud._helpers import _rfc3339_to_datetime
-        return _rfc3339_to_datetime(dt_str)
+        from gcloud._helpers import rfc3339_to_datetime
+        return rfc3339_to_datetime(dt_str)
 
     def test_w_bogus_zone(self):
         year = 2009
@@ -541,11 +541,11 @@ class Test__rfc3339_to_datetime(unittest.TestCase):
             self._callFUT(dt_str)
 
 
-class Test__rfc3339_nanos_to_datetime(unittest.TestCase):
+class Test_rfc3339_nanos_to_datetime(unittest.TestCase):
 
     def _callFUT(self, dt_str):
-        from gcloud._helpers import _rfc3339_nanos_to_datetime
-        return _rfc3339_nanos_to_datetime(dt_str)
+        from gcloud._helpers import rfc3339_nanos_to_datetime
+        return rfc3339_nanos_to_datetime(dt_str)
 
     def test_w_bogus_zone(self):
         year = 2009
@@ -611,11 +611,11 @@ class Test__rfc3339_nanos_to_datetime(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
 
-class Test__datetime_to_rfc3339(unittest.TestCase):
+class Test_datetime_to_rfc3339(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
-        from gcloud._helpers import _datetime_to_rfc3339
-        return _datetime_to_rfc3339(*args, **kwargs)
+        from gcloud._helpers import datetime_to_rfc3339
+        return datetime_to_rfc3339(*args, **kwargs)
 
     @staticmethod
     def _make_timezone(offset):
@@ -661,11 +661,11 @@ class Test__datetime_to_rfc3339(unittest.TestCase):
         self.assertEqual(result, '2016-04-05T13:30:00.000000Z')
 
 
-class Test__to_bytes(unittest.TestCase):
+class Test_to_bytes(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
-        from gcloud._helpers import _to_bytes
-        return _to_bytes(*args, **kwargs)
+        from gcloud._helpers import to_bytes
+        return to_bytes(*args, **kwargs)
 
     def test_with_bytes(self):
         value = b'bytes-val'
@@ -688,11 +688,11 @@ class Test__to_bytes(unittest.TestCase):
         self.assertRaises(TypeError, self._callFUT, value)
 
 
-class Test__bytes_to_unicode(unittest.TestCase):
+class Test_bytes_to_unicode(unittest.TestCase):
 
     def _callFUT(self, *args, **kwargs):
-        from gcloud._helpers import _bytes_to_unicode
-        return _bytes_to_unicode(*args, **kwargs)
+        from gcloud._helpers import bytes_to_unicode
+        return bytes_to_unicode(*args, **kwargs)
 
     def test_with_bytes(self):
         value = b'bytes-val'
@@ -709,11 +709,11 @@ class Test__bytes_to_unicode(unittest.TestCase):
         self.assertRaises(ValueError, self._callFUT, value)
 
 
-class Test__pb_timestamp_to_datetime(unittest.TestCase):
+class Test_pb_timestamp_to_datetime(unittest.TestCase):
 
     def _callFUT(self, timestamp):
-        from gcloud._helpers import _pb_timestamp_to_datetime
-        return _pb_timestamp_to_datetime(timestamp)
+        from gcloud._helpers import pb_timestamp_to_datetime
+        return pb_timestamp_to_datetime(timestamp)
 
     def test_it(self):
         import datetime
@@ -730,11 +730,11 @@ class Test__pb_timestamp_to_datetime(unittest.TestCase):
         self.assertEqual(self._callFUT(timestamp), dt_stamp)
 
 
-class Test__pb_timestamp_to_rfc3339(unittest.TestCase):
+class Test_pb_timestamp_to_rfc3339(unittest.TestCase):
 
     def _callFUT(self, timestamp):
-        from gcloud._helpers import _pb_timestamp_to_rfc3339
-        return _pb_timestamp_to_rfc3339(timestamp)
+        from gcloud._helpers import pb_timestamp_to_rfc3339
+        return pb_timestamp_to_rfc3339(timestamp)
 
     def test_it(self):
         from google.protobuf.timestamp_pb2 import Timestamp
@@ -747,11 +747,11 @@ class Test__pb_timestamp_to_rfc3339(unittest.TestCase):
                          '1970-01-01T00:01:01.001234Z')
 
 
-class Test__datetime_to_pb_timestamp(unittest.TestCase):
+class Test_datetime_to_pb_timestamp(unittest.TestCase):
 
     def _callFUT(self, when):
-        from gcloud._helpers import _datetime_to_pb_timestamp
-        return _datetime_to_pb_timestamp(when)
+        from gcloud._helpers import datetime_to_pb_timestamp
+        return datetime_to_pb_timestamp(when)
 
     def test_it(self):
         import datetime
@@ -768,15 +768,15 @@ class Test__datetime_to_pb_timestamp(unittest.TestCase):
         self.assertEqual(self._callFUT(dt_stamp), timestamp)
 
 
-class Test__name_from_project_path(unittest.TestCase):
+class Test_name_from_project_path(unittest.TestCase):
 
     PROJECT = 'PROJECT'
     THING_NAME = 'THING_NAME'
     TEMPLATE = r'projects/(?P<project>\w+)/things/(?P<name>\w+)'
 
     def _callFUT(self, path, project, template):
-        from gcloud._helpers import _name_from_project_path
-        return _name_from_project_path(path, project, template)
+        from gcloud._helpers import name_from_project_path
+        return name_from_project_path(path, project, template)
 
     def test_w_invalid_path_length(self):
         PATH = 'projects/foo'

--- a/gcloud/test_client.py
+++ b/gcloud/test_client.py
@@ -15,11 +15,11 @@
 import unittest
 
 
-class Test_ClientFactoryMixin(unittest.TestCase):
+class TestClientFactoryMixin(unittest.TestCase):
 
     def _getTargetClass(self):
-        from gcloud.client import _ClientFactoryMixin
-        return _ClientFactoryMixin
+        from gcloud.client import ClientFactoryMixin
+        return ClientFactoryMixin
 
     def test_virtual(self):
         klass = self._getTargetClass()
@@ -142,7 +142,7 @@ class TestJSONClient(unittest.TestCase):
         FUNC_CALLS = []
 
         def mock_determine_proj(project):
-            FUNC_CALLS.append((project, '_determine_default_project'))
+            FUNC_CALLS.append((project, 'determine_default_project'))
             return PROJECT
 
         def mock_get_credentials():
@@ -150,7 +150,7 @@ class TestJSONClient(unittest.TestCase):
             return CREDENTIALS
 
         with _Monkey(client, get_credentials=mock_get_credentials,
-                     _determine_default_project=mock_determine_proj):
+                     determine_default_project=mock_determine_proj):
             client_obj = self._makeOne()
 
         self.assertEqual(client_obj.project, PROJECT)
@@ -158,7 +158,7 @@ class TestJSONClient(unittest.TestCase):
         self.assertTrue(client_obj.connection.credentials is CREDENTIALS)
         self.assertEqual(
             FUNC_CALLS,
-            [(None, '_determine_default_project'), 'get_credentials'])
+            [(None, 'determine_default_project'), 'get_credentials'])
 
     def test_ctor_missing_project(self):
         from gcloud._testing import _Monkey
@@ -167,13 +167,13 @@ class TestJSONClient(unittest.TestCase):
         FUNC_CALLS = []
 
         def mock_determine_proj(project):
-            FUNC_CALLS.append((project, '_determine_default_project'))
+            FUNC_CALLS.append((project, 'determine_default_project'))
             return None
 
-        with _Monkey(client, _determine_default_project=mock_determine_proj):
+        with _Monkey(client, determine_default_project=mock_determine_proj):
             self.assertRaises(EnvironmentError, self._makeOne)
 
-        self.assertEqual(FUNC_CALLS, [(None, '_determine_default_project')])
+        self.assertEqual(FUNC_CALLS, [(None, 'determine_default_project')])
 
     def test_ctor_w_invalid_project(self):
         CREDENTIALS = object()

--- a/gcloud/test_credentials.py
+++ b/gcloud/test_credentials.py
@@ -203,7 +203,7 @@ class Test__get_expiration_seconds(unittest.TestCase):
         utc_seconds = self._utc_seconds(dummy_utcnow)
         expiration_as_delta = datetime.timedelta(seconds=10)
 
-        with _Monkey(MUT, _NOW=lambda: dummy_utcnow):
+        with _Monkey(MUT, NOW=lambda: dummy_utcnow):
             result = self._callFUT(expiration_as_delta)
 
         self.assertEqual(result, utc_seconds + 10)
@@ -217,7 +217,7 @@ class Test__get_expiration_seconds(unittest.TestCase):
         utc_seconds = self._utc_seconds(dummy_utcnow)
         expiration_as_delta = datetime.timedelta(days=1)
 
-        with _Monkey(MUT, _NOW=lambda: dummy_utcnow):
+        with _Monkey(MUT, NOW=lambda: dummy_utcnow):
             result = self._callFUT(expiration_as_delta)
 
         self.assertEqual(result, utc_seconds + 86400)

--- a/gcloud/test_operation.py
+++ b/gcloud/test_operation.py
@@ -136,7 +136,9 @@ class OperationTests(unittest.TestCase):
     def test_from_pb_w_unknown_metadata(self):
         from google.longrunning import operations_pb2
         from google.protobuf.any_pb2 import Any
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
         TYPE_URI = 'type.googleapis.com/%s' % (Struct.DESCRIPTOR.full_name,)
 
         client = _Client()
@@ -156,9 +158,11 @@ class OperationTests(unittest.TestCase):
     def test_from_pb_w_metadata_and_kwargs(self):
         from google.longrunning import operations_pb2
         from google.protobuf.any_pb2 import Any
-        from google.protobuf.struct_pb2 import Struct, Value
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
         from gcloud import operation as MUT
         from gcloud._testing import _Monkey
+
         TYPE_URI = 'type.googleapis.com/%s' % (Struct.DESCRIPTOR.full_name,)
         type_url_map = {TYPE_URI: Struct}
 

--- a/gcloud/test_operation.py
+++ b/gcloud/test_operation.py
@@ -15,13 +15,13 @@
 import unittest
 
 
-class Test__compute_type_url(unittest.TestCase):
+class Test_compute_type_url(unittest.TestCase):
 
     def _callFUT(self, klass, prefix=None):
-        from gcloud.operation import _compute_type_url
+        from gcloud.operation import compute_type_url
         if prefix is None:
-            return _compute_type_url(klass)
-        return _compute_type_url(klass, prefix)
+            return compute_type_url(klass)
+        return compute_type_url(klass, prefix)
 
     def test_wo_prefix(self):
         from google.protobuf.struct_pb2 import Struct
@@ -44,11 +44,11 @@ class Test__compute_type_url(unittest.TestCase):
             '%s/%s' % (PREFIX, Struct.DESCRIPTOR.full_name))
 
 
-class Test__register_type_url(unittest.TestCase):
+class Test_register_type_url(unittest.TestCase):
 
     def _callFUT(self, type_url, klass):
-        from gcloud.operation import _register_type_url
-        _register_type_url(type_url, klass)
+        from gcloud.operation import register_type_url
+        register_type_url(type_url, klass)
 
     def test_simple(self):
         from gcloud import operation as MUT

--- a/gcloud/translate/client.py
+++ b/gcloud/translate/client.py
@@ -18,7 +18,7 @@
 import httplib2
 import six
 
-from gcloud._helpers import _to_bytes
+from gcloud._helpers import to_bytes
 from gcloud.translate.connection import Connection
 
 
@@ -115,7 +115,7 @@ class Client(object):
             values = [values]
 
         query_params = [('key', self.api_key)]
-        query_params.extend(('q', _to_bytes(value, 'utf-8'))
+        query_params.extend(('q', to_bytes(value, 'utf-8'))
                             for value in values)
         response = self.connection.api_request(
             method='GET', path='/detect', query_params=query_params)
@@ -200,7 +200,7 @@ class Client(object):
             customization_ids = [customization_ids]
 
         query_params = [('key', self.api_key), ('target', target_language)]
-        query_params.extend(('q', _to_bytes(value, 'utf-8'))
+        query_params.extend(('q', to_bytes(value, 'utf-8'))
                             for value in values)
         query_params.extend(('cid', cid) for cid in customization_ids)
         if format_ is not None:

--- a/gcloud/vision/image.py
+++ b/gcloud/vision/image.py
@@ -17,8 +17,8 @@
 
 from base64 import b64encode
 
-from gcloud._helpers import _to_bytes
-from gcloud._helpers import _bytes_to_unicode
+from gcloud._helpers import to_bytes
+from gcloud._helpers import bytes_to_unicode
 
 
 class Image(object):
@@ -37,10 +37,10 @@ class Image(object):
         self._content = None
         self._source = None
 
-        if _bytes_to_unicode(image_source).startswith('gs://'):
+        if bytes_to_unicode(image_source).startswith('gs://'):
             self._source = image_source
         else:
-            self._content = b64encode(_to_bytes(image_source))
+            self._content = b64encode(to_bytes(image_source))
 
     def as_dict(self):
         """Generate dictionary structure for request"""

--- a/gcloud/vision/test_client.py
+++ b/gcloud/vision/test_client.py
@@ -16,13 +16,13 @@
 import base64
 import unittest
 
-from gcloud._helpers import _to_bytes
+from gcloud._helpers import to_bytes
 
 
 class TestClient(unittest.TestCase):
     PROJECT = 'PROJECT'
     IMAGE_SOURCE = 'gs://some/image.jpg'
-    IMAGE_CONTENT = _to_bytes('/9j/4QNURXhpZgAASUkq')
+    IMAGE_CONTENT = to_bytes('/9j/4QNURXhpZgAASUkq')
     B64_IMAGE_CONTENT = base64.b64encode(IMAGE_CONTENT)
 
     def _getTargetClass(self):
@@ -74,7 +74,7 @@ class TestClient(unittest.TestCase):
 
 
 class TestVisionRequest(unittest.TestCase):
-    _IMAGE_CONTENT = _to_bytes('/9j/4QNURXhpZgAASUkq')
+    _IMAGE_CONTENT = to_bytes('/9j/4QNURXhpZgAASUkq')
 
     def _getTargetClass(self):
         from gcloud.vision.client import VisionRequest

--- a/gcloud/vision/test_client.py
+++ b/gcloud/vision/test_client.py
@@ -39,8 +39,9 @@ class TestClient(unittest.TestCase):
         self.assertTrue('annotate' in dir(client))
 
     def test_face_annotation(self):
-
         from gcloud.vision._fixtures import FACE_DETECTION_RESPONSE as RETURNED
+        from gcloud.vision.feature import Feature
+        from gcloud.vision.feature import FeatureTypes
 
         REQUEST = {
             "requests": [
@@ -60,8 +61,6 @@ class TestClient(unittest.TestCase):
         credentials = _Credentials()
         client = self._makeOne(project=self.PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
-
-        from gcloud.vision.feature import Feature, FeatureTypes
 
         features = [Feature(feature_type=FeatureTypes.FACE_DETECTION,
                             max_results=3)]
@@ -85,7 +84,9 @@ class TestVisionRequest(unittest.TestCase):
         return self._getTargetClass()(*args, **kw)
 
     def test_make_vision_request(self):
-        from gcloud.vision.feature import Feature, FeatureTypes
+        from gcloud.vision.feature import Feature
+        from gcloud.vision.feature import FeatureTypes
+
         feature = Feature(feature_type=FeatureTypes.FACE_DETECTION,
                           max_results=3)
         vision_request = self._makeOne(self._IMAGE_CONTENT, feature)

--- a/gcloud/vision/test_image.py
+++ b/gcloud/vision/test_image.py
@@ -15,12 +15,12 @@
 import unittest
 import base64
 
-from gcloud._helpers import _to_bytes
+from gcloud._helpers import to_bytes
 
 
 class TestVisionImage(unittest.TestCase):
     _IMAGE_SOURCE = 'gs://some/image.jpg'
-    _IMAGE_CONTENT = _to_bytes('/9j/4QNURXhpZgAASUkq')
+    _IMAGE_CONTENT = to_bytes('/9j/4QNURXhpZgAASUkq')
     _B64_IMAGE_CONTENT = base64.b64encode(_IMAGE_CONTENT)
     _CLIENT_MOCK = {'source': ''}
 

--- a/system_tests/bigtable.py
+++ b/system_tests/bigtable.py
@@ -18,8 +18,8 @@ import operator
 import unittest
 
 from gcloud import _helpers
-from gcloud._helpers import _datetime_from_microseconds
-from gcloud._helpers import _microseconds_from_datetime
+from gcloud._helpers import datetime_from_microseconds
+from gcloud._helpers import microseconds_from_datetime
 from gcloud._helpers import UTC
 from gcloud.bigtable.client import Client
 from gcloud.bigtable.column_family import MaxVersionsGCRule
@@ -305,10 +305,10 @@ class TestDataAPI(unittest.TestCase):
 
     def _write_to_row(self, row1=None, row2=None, row3=None, row4=None):
         timestamp1 = datetime.datetime.utcnow().replace(tzinfo=UTC)
-        timestamp1_micros = _microseconds_from_datetime(timestamp1)
+        timestamp1_micros = microseconds_from_datetime(timestamp1)
         # Truncate to millisecond granularity.
         timestamp1_micros -= (timestamp1_micros % 1000)
-        timestamp1 = _datetime_from_microseconds(timestamp1_micros)
+        timestamp1 = datetime_from_microseconds(timestamp1_micros)
         # 1000 microseconds is a millisecond
         timestamp2 = timestamp1 + datetime.timedelta(microseconds=1000)
         timestamp3 = timestamp1 + datetime.timedelta(microseconds=2000)

--- a/system_tests/storage.py
+++ b/system_tests/storage.py
@@ -24,7 +24,7 @@ from gcloud import _helpers
 from gcloud.environment_vars import TESTS_PROJECT
 from gcloud import exceptions
 from gcloud import storage
-from gcloud.storage._helpers import _base64_md5hash
+from gcloud.storage._helpers import base64_md5hash
 
 from system_test_utils import unique_resource_id
 from retry import RetryErrors
@@ -117,7 +117,7 @@ class TestStorageFiles(unittest.TestCase):
         super(TestStorageFiles, cls).setUpClass()
         for file_data in cls.FILES.values():
             with open(file_data['path'], 'rb') as file_obj:
-                file_data['hash'] = _base64_md5hash(file_obj)
+                file_data['hash'] = base64_md5hash(file_obj)
         cls.bucket = Config.TEST_BUCKET
 
     def setUp(self):


### PR DESCRIPTION
Fixes #1735.

Changes made via:

```
git grep -l '_NOW' | xargs sed -i s/'_NOW'/'NOW'/g
git grep -l '_LocalStack' | xargs sed -i s/'_LocalStack'/'LocalStack'/g
git grep -l '_ensure_tuple_or_list' | xargs sed -i s/'_ensure_tuple_or_list'/'ensure_tuple_or_list'/g
git grep -l '_millis_from_datetime' | xargs sed -i s/'_millis_from_datetime'/'millis_from_datetime'/g
git grep -l '_millis' -- gcloud | xargs sed -i s/'_millis'/'millis'/g
git grep -l '_datetime_from_microseconds' | xargs sed -i s/'_datetime_from_microseconds'/'datetime_from_microseconds'/g
git grep -l '_microseconds_from_datetime' | xargs sed -i s/'_microseconds_from_datetime'/'microseconds_from_datetime'/g
git grep -l '_rfc3339_to_datetime' | xargs sed -i s/'_rfc3339_to_datetime'/'rfc3339_to_datetime'/g
git grep -l '_rfc3339_nanos_to_datetime' | xargs sed -i s/'_rfc3339_nanos_to_datetime'/'rfc3339_nanos_to_datetime'/g
git grep -l '_datetime_to_rfc3339' | xargs sed -i s/'_datetime_to_rfc3339'/'datetime_to_rfc3339'/g
git grep -l '_to_bytes' | xargs sed -i s/'_to_bytes'/'to_bytes'/g
git grep -l '_bytes_to_unicode' | xargs sed -i s/'_bytes_to_unicode'/'bytes_to_unicode'/g
git grep -l '_pb_timestamp_to_datetime' | xargs sed -i s/'_pb_timestamp_to_datetime'/'pb_timestamp_to_datetime'/g
git grep -l '_pb_timestamp_to_rfc3339' | xargs sed -i s/'_pb_timestamp_to_rfc3339'/'pb_timestamp_to_rfc3339'/g
git grep -l '_datetime_to_pb_timestamp' | xargs sed -i s/'_datetime_to_pb_timestamp'/'datetime_to_pb_timestamp'/g
git grep -l '_name_from_project_path' | xargs sed -i s/'_name_from_project_path'/'name_from_project_path'/g
git grep -l '_rows_from_json' | xargs sed -i s/'_rows_from_json'/'rows_from_json'/g
git grep -l '_TypedProperty' | xargs sed -i s/'_TypedProperty'/'TypedProperty'/g
git grep -l '_EnumProperty' | xargs sed -i s/'_EnumProperty'/'EnumProperty'/g
git grep -l '_PropertyMixin' | xargs sed -i s/'_PropertyMixin'/'PropertyMixin'/g
git grep -l '_scalar_property' | xargs sed -i s/'_scalar_property'/'scalar_property'/g
git grep -l '_base64_md5hash' | xargs sed -i s/'_base64_md5hash'/'base64_md5hash'/g
git grep -l '_build_udf_resources' | xargs sed -i s/'_build_udf_resources'/'build_udf_resources'/g
git grep -l '_build_schema_resource' | xargs sed -i s/'_build_schema_resource'/'build_schema_resource'/g
git grep -l '_parse_schema_resource' | xargs sed -i s/'_parse_schema_resource'/'parse_schema_resource'/g
git grep -l '_EXISTING_INSTANCE_LOCATION_ID' | xargs sed -i s/'_EXISTING_INSTANCE_LOCATION_ID'/'EXISTING_INSTANCE_LOCATION_ID'/g
git grep -l '_gc_rule_from_pb' | xargs sed -i s/'_gc_rule_from_pb'/'gc_rule_from_pb'/g
git grep -l '_set_protobuf_value' | xargs sed -i s/'_set_protobuf_value'/'set_protobuf_value'/g
git grep -l 'Testset_protobuf_value' | xargs sed -i s/'Testset_protobuf_value'/'Test_set_protobuf_value'/g
git grep -l '_LoggingAPI' | xargs sed -i s/'_LoggingAPI'/'LoggingAPI'/g
git grep -l '_MetricsAPI' | xargs sed -i s/'_MetricsAPI'/'MetricsAPI'/g
git grep -l '_SinksAPI' | xargs sed -i s/'_SinksAPI'/'SinksAPI'/g
git grep -l '_build_dataframe' | xargs sed -i s/'_build_dataframe'/'build_dataframe'/g
git grep -l '_compute_type_url' | xargs sed -i s/'_compute_type_url'/'compute_type_url'/g
git grep -l '_register_type_url' | xargs sed -i s/'_register_type_url'/'register_type_url'/g
git grep -l '_PublisherAPI' | xargs sed -i s/'_PublisherAPI'/'PublisherAPI'/g
git grep -l '_SubscriberAPI' | xargs sed -i s/'_SubscriberAPI'/'SubscriberAPI'/g
git grep -l '_IAMPolicyAPI' | xargs sed -i s/'_IAMPolicyAPI'/'IAMPolicyAPI'/g
git grep -l '_ClientProjectMixin' | xargs sed -i s/'_ClientProjectMixin'/'ClientProjectMixin'/g
git grep -l '_ClientFactoryMixin' | xargs sed -i s/'_ClientFactoryMixin'/'ClientFactoryMixin'/g
```

and a few small edits after the fact.

Also removing commas from imports.

----

@tseaver This is a "dont-merge" for now, but worth considering. LMKWYT. (Some of these renames are not quite right and a little re-org may be a better way to fix.)