### PR TITLE
Add vision label detection

### DIFF
--- a/google/cloud/vision/entity.py
+++ b/google/cloud/vision/entity.py
@@ -55,7 +55,7 @@ class EntityAnnotation(object):
         :rtype: :class:`~google.cloud.vision.entiy.EntityAnnotation`
         :returns: Instance of ``EntityAnnotation``.
         """
-        bounds = Bounds.from_api_repr(response['boundingPoly'])
+        bounds = Bounds.from_api_repr(response.get('boundingPoly'))
         description = response['description']
         locations = [LocationInformation.from_api_repr(location)
                      for location in response.get('locations', [])]

--- a/google/cloud/vision/geometry.py
+++ b/google/cloud/vision/geometry.py
@@ -31,13 +31,14 @@ class BoundsBase(object):
         :type response_vertices: dict
         :param response_vertices: List of vertices.
 
-        :rtype: :class:`~google.cloud.vision.geometry.BoundsBase`
-        :returns: Instance of BoundsBase with populated verticies.
+        :rtype: :class:`~google.cloud.vision.geometry.BoundsBase` or None
+        :returns: Instance of BoundsBase with populated verticies or None.
         """
-        vertices = []
-        for vertex in response_vertices['vertices']:
-            vertices.append(Vertex(vertex.get('x', None),
-                                   vertex.get('y', None)))
+        if not response_vertices:
+            return None
+
+        vertices = [Vertex(vertex.get('x', None), vertex.get('y', None)) for
+                    vertex in response_vertices.get('vertices', [])]
         return cls(vertices)
 
     @property

--- a/google/cloud/vision/image.py
+++ b/google/cloud/vision/image.py
@@ -94,6 +94,7 @@ class Image(object):
                   :class:`~google.cloud.vision.entity.EntityAnnotation`.
         """
         reverse_types = {
+            'LABEL_DETECTION': 'labelAnnotations',
             'LANDMARK_DETECTION': 'landmarkAnnotations',
             'LOGO_DETECTION': 'logoAnnotations',
         }
@@ -121,6 +122,18 @@ class Image(object):
             faces.append(face)
 
         return faces
+
+    def detect_labels(self, limit=10):
+        """Detect labels that describe objects in an image.
+
+        :type limit: int
+        :param limit: The maximum number of labels to try and detect.
+
+        :rtype: list
+        :returns: List of :class:`~google.cloud.vision.entity.EntityAnnotation`
+        """
+        feature = Feature(FeatureTypes.LABEL_DETECTION, limit)
+        return self._detect_annotation(feature)
 
     def detect_landmarks(self, limit=10):
         """Detect landmarks in an image.

--- a/unit_tests/vision/_fixtures.py
+++ b/unit_tests/vision/_fixtures.py
@@ -1,3 +1,28 @@
+LABEL_DETECTION_RESPONSE = {
+    'responses': [
+        {
+            'labelAnnotations': [
+                {
+                    'mid': '/m/0k4j',
+                    'description': 'automobile',
+                    'score': 0.9776855
+                },
+                {
+                    'mid': '/m/07yv9',
+                    'description': 'vehicle',
+                    'score': 0.947987
+                },
+                {
+                    'mid': '/m/07r04',
+                    'description': 'truck',
+                    'score': 0.88429511
+                }
+            ]
+        }
+    ]
+}
+
+
 LANDMARK_DETECTION_RESPONSE = {
     'responses': [
         {

--- a/unit_tests/vision/test_client.py
+++ b/unit_tests/vision/test_client.py
@@ -114,6 +114,27 @@ class TestClient(unittest.TestCase):
                          image_request['image']['content'])
         self.assertEqual(5, image_request['features'][0]['maxResults'])
 
+    def test_label_detection_from_source(self):
+        from google.cloud.vision.entity import EntityAnnotation
+        from unit_tests.vision._fixtures import (LABEL_DETECTION_RESPONSE as
+                                                 RETURNED)
+        credentials = _Credentials()
+        client = self._makeOne(project=self.PROJECT, credentials=credentials)
+        client.connection = _Connection(RETURNED)
+
+        image = client.image(source_uri=_IMAGE_SOURCE)
+        labels = image.detect_labels(limit=3)
+        self.assertEqual(3, len(labels))
+        self.assertTrue(isinstance(labels[0], EntityAnnotation))
+        image_request = client.connection._requested[0]['data']['requests'][0]
+        self.assertEqual(_IMAGE_SOURCE,
+                         image_request['image']['source']['gcs_image_uri'])
+        self.assertEqual(3, image_request['features'][0]['maxResults'])
+        self.assertEqual('automobile', labels[0].description)
+        self.assertEqual('vehicle', labels[1].description)
+        self.assertEqual('/m/0k4j', labels[0].mid)
+        self.assertEqual('/m/07yv9', labels[1].mid)
+
     def test_landmark_detection_from_source(self):
         from google.cloud.vision.entity import EntityAnnotation
         from unit_tests.vision._fixtures import (LANDMARK_DETECTION_RESPONSE as


### PR DESCRIPTION
Based off of #2236.

I was able to DRY up the requests code for the `EntityAnnotation` based detection types.

✅ Waiting for #2236 before rebasing.