### PR TITLE
Updating some Sphinx class links.

### DIFF
--- a/google/cloud/datastore/batch.py
+++ b/google/cloud/datastore/batch.py
@@ -290,7 +290,7 @@ def _assign_entity_to_pb(entity_pb, entity):
 
     Helper method for ``Batch.put``.
 
-    :type entity_pb: :class:`.datastore._generated.entity_pb2.Entity`
+    :type entity_pb: :class:`._generated.entity_pb2.Entity`
     :param entity_pb: The entity owned by a mutation.
 
     :type entity: :class:`google.cloud.datastore.entity.Entity`

--- a/google/cloud/datastore/client.py
+++ b/google/cloud/datastore/client.py
@@ -78,7 +78,7 @@ def _extended_lookup(connection, project, key_pbs,
     :type project: string
     :param project: The project to make the request for.
 
-    :type key_pbs: list of :class:`.datastore._generated.entity_pb2.Key`
+    :type key_pbs: list of :class:`._generated.entity_pb2.Key`
     :param key_pbs: The keys to retrieve from the datastore.
 
     :type missing: list
@@ -100,7 +100,7 @@ def _extended_lookup(connection, project, key_pbs,
                            the given transaction.  Incompatible with
                            ``eventual==True``.
 
-    :rtype: list of :class:`.datastore._generated.entity_pb2.Entity`
+    :rtype: list of :class:`._generated.entity_pb2.Entity`
     :returns: The requested entities.
     :raises: :class:`ValueError` if missing / deferred are not null or
              empty list.
@@ -245,7 +245,7 @@ class Client(_BaseClient, _ClientProjectMixin):
         :param deferred: (Optional) If a list is passed, the keys returned
                          by the backend as "deferred" will be copied into it.
 
-        :type transaction: :class:`~.datastore.transaction.Transaction`
+        :type transaction: :class:`~.transaction.Transaction`
         :param transaction: (Optional) Transaction to use for read consistency.
                             If not passed, uses current transaction, if set.
 
@@ -273,7 +273,7 @@ class Client(_BaseClient, _ClientProjectMixin):
                          by the backend as "deferred" will be copied into it.
                          If the list is not empty, an error will occur.
 
-        :type transaction: :class:`~.datastore.transaction.Transaction`
+        :type transaction: :class:`~.transaction.Transaction`
         :param transaction: (Optional) Transaction to use for read consistency.
                             If not passed, uses current transaction, if set.
 

--- a/google/cloud/streaming/exceptions.py
+++ b/google/cloud/streaming/exceptions.py
@@ -59,7 +59,7 @@ class HttpError(CommunicationError):
     def from_response(cls, http_response):
         """Factory:  construct an exception from a response.
 
-        :type http_response: :class:`~.streaming.http_wrapper.Response`
+        :type http_response: :class:`~.http_wrapper.Response`
         :param http_response: the response which returned the error
 
         :rtype: :class:`HttpError`
@@ -108,7 +108,7 @@ class RetryAfterError(HttpError):
     def from_response(cls, http_response):
         """Factory:  construct an exception from a response.
 
-        :type http_response: :class:`~.streaming.http_wrapper.Response`
+        :type http_response: :class:`~.http_wrapper.Response`
         :param http_response: the response which returned the error.
 
         :rtype: :class:`RetryAfterError`

--- a/google/cloud/streaming/http_wrapper.py
+++ b/google/cloud/streaming/http_wrapper.py
@@ -273,10 +273,9 @@ def _check_response(response):
     :param response: the response to validate
 
     :raises: :exc:`google.cloud.streaming.exceptions.RequestError` if response
-             is None, :exc:`~.streaming.exceptions.BadStatusCodeError` if
-             response status code indicates an error, or
-             :exc:`~.streaming.exceptions.RetryAfterError` if response
-             indicates a retry interval.
+             is None, :exc:`~.exceptions.BadStatusCodeError` if response status
+             code indicates an error, or :exc:`~.exceptions.RetryAfterError`
+             if response indicates a retry interval.
     """
     if response is None:
         # Caller shouldn't call us if the response is None, but handle anyway.


### PR DESCRIPTION
Follow-up to PR #2223. The Sphinx mechanism of using a `.` to mean "go find this class" can be confusing, so we make sure the `.` also is a relative path.