### PR TITLE
Shorten instance ID to match restrictions.

### DIFF
--- a/system_tests/bigtable.py
+++ b/system_tests/bigtable.py
@@ -37,7 +37,7 @@ from system_test_utils import unique_resource_id
 
 
 LOCATION_ID = 'us-central1-c'
-INSTANCE_ID = 'google-cloud' + unique_resource_id('-')
+INSTANCE_ID = 'g-c-p' + unique_resource_id('-')
 TABLE_ID = 'google-cloud-python-test-table'
 COLUMN_FAMILY_ID1 = u'col-fam-id1'
 COLUMN_FAMILY_ID2 = u'col-fam-id2'


### PR DESCRIPTION
Longer instance ID in #2223 breaks creation.

See: https://travis-ci.org/GoogleCloudPlatform/google-cloud-python/builds/158235243#L1292