### PR TITLE
fix README installation command and PyPI links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ Quick Start
 
 ::
 
+    $ pip install --upgrade google-cloud
 
 Example Applications
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Quick Start
 
 ::
 
-    $ pip install -U gcloud
+    $ pip install --upgrade gcloud
 
 Example Applications
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Quick Start
 
 ::
 
-    $ pip install --upgrade google-cloud
+    $ pip install -U gcloud
 
 Example Applications
 --------------------
@@ -328,7 +328,7 @@ Apache 2.0 - See `LICENSE`_ for more information.
    :target: https://travis-ci.org/GoogleCloudPlatform/google-cloud-python
 .. |coverage| image:: https://coveralls.io/repos/GoogleCloudPlatform/google-cloud-python/badge.png?branch=master
    :target: https://coveralls.io/r/GoogleCloudPlatform/google-cloud-python?branch=master
-.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud.svg
-   :target: https://pypi.python.org/pypi/google-cloud
-.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud.svg
-   :target: https://pypi.python.org/pypi/google-cloud
+.. |pypi| image:: https://img.shields.io/pypi/v/gcloud.svg
+   :target: https://pypi.python.org/pypi/gcloud
+.. |versions| image:: https://img.shields.io/pypi/pyversions/gcloud.svg
+   :target: https://pypi.python.org/pypi/gcloud

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,6 @@ Quick Start
 
 ::
 
-    $ pip install --upgrade google-cloud
 
 Example Applications
 --------------------


### PR DESCRIPTION
The current PyPI install command, links, and images point to the wrong package. I suppose this might be due to the new auto-generated documentation platform in use.