### PR TITLE
Cut 0.19.0 release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,12 @@ after_success:
 
 deploy:
   provider: pypi
-  user: silvolu
+  user: gcloudpypi
   password:
-    secure: keSFPLzVj/yAAJ8kw4m+U5kpIiGqubpDqhcHPlGAvMohFMIO4D8ffgCqJdbhQshTtb/wiS5ajK1KNpEzq4BKD/5oRXuj/sIRTMENzX/azUXkT/bADLEGocyfE4/NAGQ9mcDOmHntjt7UUhYN6H87rgex22er4V1vD5tGf5Kc1HU=
+    secure: LR0i9Oeu6kpLTYS5xK/zCng4gmdtPvFfD/XYdQhyY5jBibQkC2WUQU6nJA9bDXRxhBP5bUwXFGkbhOcOJgHNrUfmyPzpDbM8BR29KfY0WfdYv72gsGZOaekqCReFmHbqLE7qOQtHR5U3ey6ivcgw+hZO72Uu6qDCc9B8qwoBfAs=
   on:
     tags: true
     repo: GoogleCloudPlatform/google-cloud-python
-    # until this is fixed: https://github.com/travis-ci/travis-ci/issues/1675
     all_branches: true
   # 'bdist_wheel' builds disabled until #1879 et al. are resolved.
   distributions: "sdist"

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Quick Start
 
 ::
 
-    $ pip install --upgrade gcloud
+    $ pip install --upgrade google-cloud
 
 Example Applications
 --------------------
@@ -328,7 +328,7 @@ Apache 2.0 - See `LICENSE`_ for more information.
    :target: https://travis-ci.org/GoogleCloudPlatform/google-cloud-python
 .. |coverage| image:: https://coveralls.io/repos/GoogleCloudPlatform/google-cloud-python/badge.png?branch=master
    :target: https://coveralls.io/r/GoogleCloudPlatform/google-cloud-python?branch=master
-.. |pypi| image:: https://img.shields.io/pypi/v/gcloud.svg
-   :target: https://pypi.python.org/pypi/gcloud
-.. |versions| image:: https://img.shields.io/pypi/pyversions/gcloud.svg
-   :target: https://pypi.python.org/pypi/gcloud
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud.svg
+   :target: https://pypi.python.org/pypi/google-cloud
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud.svg
+   :target: https://pypi.python.org/pypi/google-cloud

--- a/docs/vision-usage.rst
+++ b/docs/vision-usage.rst
@@ -53,9 +53,9 @@ Annotate multiple images
 .. code-block:: python
 
     >>> import io
-    >>> from gcloud import vision
+    >>> from google.cloud import vision
     >>> client = vision.Client()
-     >>> with io.open('./image.png', 'rb') as image_file:
+    >>> with io.open('./image.png', 'rb') as image_file:
     ...     image_one = client.image(content=image_file.read())
     >>> image_two = client.image(source_uri='gs://my-storage-bucket/image.jpg')
     >>> with client.batch():

--- a/google/cloud/bigquery/client.py
+++ b/google/cloud/bigquery/client.py
@@ -88,8 +88,8 @@ class Client(JSONClient):
                            projects.
 
         :rtype: tuple, (list, str)
-        :returns: list of :class:`gcloud.bigquery.client.Project`, plus a
-                  "next page token" string:  if the token is not None,
+        :returns: list of :class:`~google.cloud.bigquery.client.Project`,
+                  plus a "next page token" string:  if the token is not None,
                   indicates that more projects can be retrieved with another
                   call (pass that value as ``page_token``).
         """

--- a/google/cloud/resource_manager/client.py
+++ b/google/cloud/resource_manager/client.py
@@ -54,7 +54,7 @@ class Client(BaseClient):
         Use :meth:`Project.reload() \
         <google.cloud.resource_manager.project.Project.reload>` to retrieve
         project metadata after creating a
-        :class:`~gcloud.resource_manager.project.Project` instance.
+        :class:`~google.cloud.resource_manager.project.Project` instance.
 
         .. note:
 
@@ -69,9 +69,9 @@ class Client(BaseClient):
         :type labels: dict
         :param labels: A list of labels associated with the project.
 
-        :rtype: :class:`~gcloud.resource_manager.project.Project`
+        :rtype: :class:`~google.cloud.resource_manager.project.Project`
         :returns: A new instance of a
-                  :class:`~gcloud.resource_manager.project.Project`
+                  :class:`~google.cloud.resource_manager.project.Project`
                   **without** any metadata loaded.
         """
         return Project(project_id=project_id,
@@ -88,9 +88,9 @@ class Client(BaseClient):
         :type project_id: str
         :param project_id: The ID for this project.
 
-        :rtype: :class:`~gcloud.resource_manager.project.Project`
-        :returns: A :class:`~gcloud.resource_manager.project.Project` with
-                  metadata fetched from the API.
+        :rtype: :class:`~google.cloud.resource_manager.project.Project`
+        :returns: A :class:`~google.cloud.resource_manager.project.Project`
+                  with metadata fetched from the API.
         """
         project = self.new_project(project_id)
         project.reload()
@@ -145,7 +145,7 @@ class Client(BaseClient):
         :returns: A project iterator. The iterator will make multiple API
                   requests if you continue iterating and there are more
                   pages of results. Each item returned will be a.
-                  :class:`~gcloud.resource_manager.project.Project`.
+                  :class:`~google.cloud.resource_manager.project.Project`.
         """
         extra_params = {}
 
@@ -162,10 +162,10 @@ class _ProjectIterator(Iterator):
     """An iterator over a list of Project resources.
 
     You shouldn't have to use this directly, but instead should use the
-    helper methods on :class:`google.cloud.resource_manager.client.Client`
+    helper methods on :class:`~google.cloud.resource_manager.client.Client`
     objects.
 
-    :type client: :class:`google.cloud.resource_manager.client.Client`
+    :type client: :class:`~google.cloud.resource_manager.client.Client`
     :param client: The client to use for making connections.
 
     :type extra_params: dict

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if RTD_ENV_VAR not in os.environ:
 
 setup(
     name='google-cloud',
-    version='0.18.0',
+    version='0.19.0',
     description='API Client library for Google Cloud',
     author='Google Cloud Platform',
     author_email='jjg+google-cloud-python@google.com',


### PR DESCRIPTION
This is the first release after the rename.

Also updated the account that does deployment from Silvio's to one shared by google-cloud. We'll likely need to ditch the `deploy` section and write a more customized script using `twine` once we deploy versions for each sub-package.

Closes #2264.