### PR TITLE
Reverting user-agent change that came with rename.

### DIFF
--- a/google/cloud/bigtable/client.py
+++ b/google/cloud/bigtable/client.py
@@ -29,8 +29,6 @@ In the hierarchy of API concepts
 
 import os
 
-from pkg_resources import get_distribution
-
 from google.cloud._helpers import make_insecure_stub
 from google.cloud._helpers import make_secure_stub
 from google.cloud.bigtable._generated import bigtable_instance_admin_pb2
@@ -42,6 +40,7 @@ from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable.instance import _EXISTING_INSTANCE_LOCATION_ID
 from google.cloud.client import _ClientFactoryMixin
 from google.cloud.client import _ClientProjectMixin
+from google.cloud.connection import DEFAULT_USER_AGENT
 from google.cloud.credentials import get_credentials
 from google.cloud.environment_vars import BIGTABLE_EMULATOR
 
@@ -63,10 +62,6 @@ DATA_SCOPE = 'https://www.googleapis.com/auth/bigtable.data'
 """Scope for reading and writing table data."""
 READ_ONLY_SCOPE = 'https://www.googleapis.com/auth/bigtable.data.readonly'
 """Scope for reading table data."""
-
-DEFAULT_USER_AGENT = 'google-cloud-python/{0}'.format(
-    get_distribution('google-cloud').version)
-"""The default user agent for API requests."""
 
 
 def _make_data_stub(client):

--- a/google/cloud/connection.py
+++ b/google/cloud/connection.py
@@ -27,6 +27,10 @@ from google.cloud.exceptions import make_exception
 API_BASE_URL = 'https://www.googleapis.com'
 """The base of the API call URL."""
 
+DEFAULT_USER_AGENT = 'gcloud-python/{0}'.format(
+    get_distribution('google-cloud').version)
+"""The user agent for google-cloud-python requests."""
+
 
 class Connection(object):
     """A generic connection to Google Cloud Platform.
@@ -63,9 +67,7 @@ class Connection(object):
     :param http: An optional HTTP object to make requests.
     """
 
-    USER_AGENT = "google-cloud-python/{0}".format(
-        get_distribution('google-cloud').version)
-    """The user agent for google-cloud-python requests."""
+    USER_AGENT = DEFAULT_USER_AGENT
 
     SCOPE = None
     """The scopes required for authenticating with a service.

--- a/unit_tests/test_connection.py
+++ b/unit_tests/test_connection.py
@@ -69,7 +69,7 @@ class TestConnection(unittest.TestCase):
 
     def test_user_agent_format(self):
         from pkg_resources import get_distribution
-        expected_ua = 'google-cloud-python/{0}'.format(
+        expected_ua = 'gcloud-python/{0}'.format(
             get_distribution('google-cloud').version)
         conn = self._makeOne()
         self.assertEqual(conn.USER_AGENT, expected_ua)


### PR DESCRIPTION
Fixes #2271.
    
See https://github.com/GoogleCloudPlatform/gcloud-common/issues/179 for context.

Also moving gRPC user-agent from plugin to channel options. For context on that change, see the comment by @murgatroid99: https://github.com/GoogleCloudPlatform/google-cloud-node/pull/1568/files#r77727186

As for `grpc.primary_user_agent` vs `grpc.secondary_user_agent`, @nathanielmanistaatgoogle said

> That way the user agent as it appears on the wire should be "primarily gRPC, secondarily gcloud" rather than "primarily gcloud <no secondary>".