### PR TITLE
Upgrading gRPC user agent from secondary to primary.

### DIFF
--- a/google/cloud/_helpers.py
+++ b/google/cloud/_helpers.py
@@ -651,7 +651,7 @@ def make_secure_stub(credentials, user_agent, stub_class, host):
         transport_creds, auth_creds)
     target = '%s:%d' % (host, http_client.HTTPS_PORT)
     channel_args = (
-        ('grpc.secondary_user_agent', user_agent),
+        ('grpc.primary_user_agent', user_agent),
     )
     channel = grpc.secure_channel(target, channel_creds,
                                   options=channel_args)

--- a/unit_tests/test__helpers.py
+++ b/unit_tests/test__helpers.py
@@ -975,7 +975,7 @@ class Test_make_secure_stub(unittest.TestCase):
         target = '%s:%d' % (host, http_client.HTTPS_PORT)
         secure_args = (target, COMPOSITE_CREDS)
         secure_kwargs = {
-            'options': (('grpc.secondary_user_agent', user_agent),)
+            'options': (('grpc.primary_user_agent', user_agent),)
         }
         self.assertEqual(grpc_mod.secure_channel_args,
                          (secure_args, secure_kwargs))


### PR DESCRIPTION
Follow on to #2284.

PS I just replaced the only occurrences of `secondary` with `primary`, didn't run tests, so fingers crossed.