### PR TITLE
Stop using a designated tests project ID.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -153,8 +153,6 @@ Running System Tests
   so you'll need to provide some environment variables to facilitate
   authentication to your project:
 
-  - ``GOOGLE_CLOUD_TESTS_PROJECT_ID``: Developers Console project ID (e.g.
-    bamboo-shift-455).
   - ``GOOGLE_APPLICATION_CREDENTIALS``: The path to a JSON key file;
     see ``system_tests/app_credentials.json.sample`` as an example. Such a file
     can be downloaded directly from the developer's console by clicking
@@ -182,12 +180,12 @@ Running System Tests
    $ export CLOUDSDK_PYTHON_SITEPACKAGES=1
 
    # Authenticate the gcloud tool with your account.
-   $ JSON_CREDENTIALS_FILE="path/to/app_credentials.json"
-   $ gcloud auth activate-service-account --key-file=$JSON_CREDENTIALS_FILE
+   $ GOOGLE_APPLICATION_CREDENTIALS="path/to/app_credentials.json"
+   $ gcloud auth activate-service-account \
+   > --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 
    # Create the indexes
-   $ gcloud preview datastore create-indexes system_tests/data/index.yaml \
-   > --project=$GOOGLE_CLOUD_TESTS_PROJECT_ID
+   $ gcloud preview datastore create-indexes system_tests/data/index.yaml
 
    # Restore your environment to its previous state.
    $ unset CLOUDSDK_PYTHON_SITEPACKAGES

--- a/google/cloud/environment_vars.py
+++ b/google/cloud/environment_vars.py
@@ -21,9 +21,6 @@ and tests.
 PROJECT = 'GOOGLE_CLOUD_PROJECT'
 """Environment variable defining default project."""
 
-TESTS_PROJECT = 'GOOGLE_CLOUD_TESTS_PROJECT_ID'
-"""Environment variable defining project for tests."""
-
 GCD_DATASET = 'DATASTORE_DATASET'
 """Environment variable defining default dataset ID under GCD."""
 

--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -16,8 +16,6 @@ import operator
 
 import unittest
 
-from google.cloud import _helpers
-from google.cloud.environment_vars import TESTS_PROJECT
 from google.cloud import bigquery
 from google.cloud.exceptions import Forbidden
 
@@ -52,7 +50,6 @@ class Config(object):
 
 
 def setUpModule():
-    _helpers.PROJECT = TESTS_PROJECT
     Config.CLIENT = bigquery.Client()
 
 

--- a/system_tests/bigtable.py
+++ b/system_tests/bigtable.py
@@ -17,7 +17,6 @@ import operator
 
 import unittest
 
-from google.cloud import _helpers
 from google.cloud._helpers import _datetime_from_microseconds
 from google.cloud._helpers import _microseconds_from_datetime
 from google.cloud._helpers import UTC
@@ -29,7 +28,6 @@ from google.cloud.bigtable.row_filters import RowFilterChain
 from google.cloud.bigtable.row_filters import RowFilterUnion
 from google.cloud.bigtable.row_data import Cell
 from google.cloud.bigtable.row_data import PartialRowData
-from google.cloud.environment_vars import TESTS_PROJECT
 
 from retry import RetryErrors
 from retry import RetryResult
@@ -92,7 +90,6 @@ def _retry_on_unavailable(exc):
 
 def setUpModule():
     from grpc._channel import _Rendezvous
-    _helpers.PROJECT = TESTS_PROJECT
     Config.CLIENT = Client(admin=True)
     Config.INSTANCE = Config.CLIENT.instance(INSTANCE_ID, LOCATION_ID)
     retry = RetryErrors(_Rendezvous, error_predicate=_retry_on_unavailable)

--- a/system_tests/clear_datastore.py
+++ b/system_tests/clear_datastore.py
@@ -21,7 +21,6 @@ import os
 import six
 
 from google.cloud import datastore
-from google.cloud.environment_vars import TESTS_PROJECT
 
 
 FETCH_MAX = 20
@@ -90,7 +89,7 @@ def remove_kind(kind, client):
 def remove_all_entities(client=None):
     if client is None:
         # Get a client that uses the test dataset.
-        client = datastore.Client(project=os.getenv(TESTS_PROJECT))
+        client = datastore.Client()
     for kind in ALL_KINDS:
         remove_kind(kind, client)
 

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -18,12 +18,10 @@ import unittest
 
 import httplib2
 
-from google.cloud import _helpers
 from google.cloud._helpers import UTC
 from google.cloud import datastore
 from google.cloud.datastore.helpers import GeoPoint
 from google.cloud.environment_vars import GCD_DATASET
-from google.cloud.environment_vars import TESTS_PROJECT
 from google.cloud.exceptions import Conflict
 
 import clear_datastore
@@ -55,7 +53,6 @@ def setUpModule():
     # Isolated namespace so concurrent test runs don't collide.
     test_namespace = 'ns' + unique_resource_id()
     if emulator_dataset is None:
-        _helpers.PROJECT = TESTS_PROJECT
         Config.CLIENT = datastore.Client(namespace=test_namespace)
     else:
         credentials = EmulatorCreds()

--- a/system_tests/language.py
+++ b/system_tests/language.py
@@ -14,8 +14,6 @@
 
 import unittest
 
-from google.cloud import _helpers
-from google.cloud.environment_vars import TESTS_PROJECT
 from google.cloud import exceptions
 from google.cloud import language
 from google.cloud import storage
@@ -39,7 +37,6 @@ class Config(object):
 
 
 def setUpModule():
-    _helpers.PROJECT = TESTS_PROJECT
     Config.CLIENT = language.Client()
     # Now create a bucket for GCS stored content.
     storage_client = storage.Client()

--- a/system_tests/local_test_setup.sample
+++ b/system_tests/local_test_setup.sample
@@ -1,4 +1,3 @@
 export GOOGLE_APPLICATION_CREDENTIALS="app_credentials.json.sample"
-export GOOGLE_CLOUD_TESTS_PROJECT_ID="my-project"
 export GOOGLE_CLOUD_REMOTE_FOR_LINT="upstream"
 export GOOGLE_CLOUD_BRANCH_FOR_LINT="master"

--- a/system_tests/logging_.py
+++ b/system_tests/logging_.py
@@ -20,8 +20,6 @@ import google.cloud.logging.handlers.handlers
 from google.cloud.logging.handlers.handlers import CloudLoggingHandler
 from google.cloud.logging.handlers.transports import SyncTransport
 from google.cloud.logging import client
-from google.cloud import _helpers
-from google.cloud.environment_vars import TESTS_PROJECT
 
 from retry import RetryErrors
 from retry import RetryResult
@@ -52,7 +50,6 @@ class Config(object):
 
 
 def setUpModule():
-    _helpers.PROJECT = TESTS_PROJECT
     Config.CLIENT = client.Client()
 
 

--- a/system_tests/monitoring.py
+++ b/system_tests/monitoring.py
@@ -14,8 +14,6 @@
 
 import unittest
 
-from google.cloud import _helpers
-from google.cloud.environment_vars import TESTS_PROJECT
 from google.cloud.exceptions import InternalServerError
 from google.cloud.exceptions import NotFound
 from google.cloud.exceptions import ServiceUnavailable
@@ -28,10 +26,6 @@ retry_404 = RetryErrors(NotFound)
 retry_404_500 = RetryErrors((NotFound, InternalServerError))
 retry_500 = RetryErrors(InternalServerError)
 retry_503 = RetryErrors(ServiceUnavailable)
-
-
-def setUpModule():
-    _helpers.PROJECT = TESTS_PROJECT
 
 
 class TestMonitoring(unittest.TestCase):

--- a/system_tests/populate_datastore.py
+++ b/system_tests/populate_datastore.py
@@ -22,7 +22,6 @@ import os
 import six
 
 from google.cloud import datastore
-from google.cloud.environment_vars import TESTS_PROJECT
 
 
 ANCESTOR = ('Book', 'GoT')
@@ -91,7 +90,7 @@ def print_func(message):
 def add_characters(client=None):
     if client is None:
         # Get a client that uses the test dataset.
-        client = datastore.Client(project=os.getenv(TESTS_PROJECT))
+        client = datastore.Client()
     with client.transaction() as xact:
         for key_path, character in six.moves.zip(KEY_PATHS, CHARACTERS):
             if key_path[-1] != character['name']:

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -23,7 +23,6 @@ import httplib2
 # pylint: disable=ungrouped-imports
 from google.cloud import _helpers
 from google.cloud.environment_vars import PUBSUB_EMULATOR
-from google.cloud.environment_vars import TESTS_PROJECT
 from google.cloud.pubsub import client
 # pylint: enable=ungrouped-imports
 
@@ -51,7 +50,6 @@ class Config(object):
 
 
 def setUpModule():
-    _helpers.PROJECT = TESTS_PROJECT
     if os.getenv(PUBSUB_EMULATOR) is None:
         Config.CLIENT = client.Client()
     else:

--- a/system_tests/storage.py
+++ b/system_tests/storage.py
@@ -20,8 +20,6 @@ import unittest
 import httplib2
 import six
 
-from google.cloud import _helpers
-from google.cloud.environment_vars import TESTS_PROJECT
 from google.cloud import exceptions
 from google.cloud import storage
 from google.cloud.storage._helpers import _base64_md5hash
@@ -33,7 +31,6 @@ from retry import RetryResult
 
 retry_429 = RetryErrors(exceptions.TooManyRequests)
 HTTP = httplib2.Http()
-_helpers.PROJECT = TESTS_PROJECT
 
 
 class Config(object):

--- a/system_tests/system_test_utils.py
+++ b/system_tests/system_test_utils.py
@@ -18,11 +18,9 @@ import sys
 import time
 
 from google.cloud.environment_vars import CREDENTIALS as TEST_CREDENTIALS
-from google.cloud.environment_vars import TESTS_PROJECT
 
 
 # From shell environ. May be None.
-PROJECT_ID = os.getenv(TESTS_PROJECT)
 CREDENTIALS = os.getenv(TEST_CREDENTIALS)
 
 ENVIRON_ERROR_MSG = """\
@@ -44,24 +42,15 @@ class EmulatorCreds(object):
 
 
 def check_environ():
-    missing = []
-    extra = ''
-
-    if PROJECT_ID is None:
-        missing.append(TESTS_PROJECT)
-
+    err_msg = None
     if CREDENTIALS is None:
-        missing.append(TEST_CREDENTIALS)
+        err_msg = '\nMissing variables: ' + TEST_CREDENTIALS
     elif not os.path.isfile(CREDENTIALS):
-        extra = '\nThe %s path %r is not a file.' % (TEST_CREDENTIALS,
-                                                     CREDENTIALS)
+        err_msg = '\nThe %s path %r is not a file.' % (TEST_CREDENTIALS,
+                                                       CREDENTIALS)
 
-    if missing or extra:
-        msg = ENVIRON_ERROR_MSG
-        if missing:
-            msg += '\nMissing variables: ' + ', '.join(missing)
-        if extra:
-            msg += extra
+    if err_msg is not None:
+        msg = ENVIRON_ERROR_MSG + err_msg
         print(msg, file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
This is because the project ID can be determined directly from the file pointed to by `GOOGLE_APPLICATION_CREDENTIALS`.

Fixes #2263.