### PR TITLE
httplib2 Sphinx docs have moved to RTD.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -284,7 +284,7 @@ html_context.update(
 # Refer to the Python standard library and the oauth2client and
 # httplib2 libraries.
 intersphinx_mapping = {
-    'httplib2': ('http://bitworking.org/projects/httplib2/doc/html/', None),
+    'httplib2': ('http://httplib2.readthedocs.io/en/latest/', None),
     'oauth2client': ('http://oauth2client.readthedocs.io/en/latest', None),
     'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
     'python': ('https://docs.python.org/2', None),


### PR DESCRIPTION
The old URL raises a 404, rather than redirecting. :(