### PR TITLE
Making datastore batch/transaction more robust to failure.

### DIFF
--- a/google/cloud/datastore/client.py
+++ b/google/cloud/datastore/client.py
@@ -348,6 +348,7 @@ class Client(_BaseClient, _ClientProjectMixin):
 
         if not in_batch:
             current = self.batch()
+            current.begin()
 
         for entity in entities:
             current.put(entity)
@@ -384,6 +385,7 @@ class Client(_BaseClient, _ClientProjectMixin):
 
         if not in_batch:
             current = self.batch()
+            current.begin()
 
         for key in keys:
             current.delete(key)

--- a/google/cloud/datastore/transaction.py
+++ b/google/cloud/datastore/transaction.py
@@ -90,6 +90,8 @@ class Transaction(Batch):
     :param client: the client used to connect to datastore.
     """
 
+    _status = None
+
     def __init__(self, client):
         super(Transaction, self).__init__(client)
         self._id = None
@@ -125,10 +127,15 @@ class Transaction(Batch):
         statement, however it can be called explicitly if you don't want
         to use a context manager.
 
-        :raises: :class:`ValueError` if the transaction has already begun.
+        :raises: :class:`~exceptions.ValueError` if the transaction has
+                 already begun.
         """
         super(Transaction, self).begin()
-        self._id = self.connection.begin_transaction(self.project)
+        try:
+            self._id = self.connection.begin_transaction(self.project)
+        except:
+            self._status = self._ABORTED
+            raise
 
     def rollback(self):
         """Rolls back the current transaction.

--- a/unit_tests/datastore/test_client.py
+++ b/unit_tests/datastore/test_client.py
@@ -960,6 +960,7 @@ class _NoCommitBatch(object):
         from google.cloud.datastore.batch import Batch
         self._client = client
         self._batch = Batch(client)
+        self._batch.begin()
 
     def __enter__(self):
         self._client._push_batch(self._batch)
@@ -972,10 +973,12 @@ class _NoCommitBatch(object):
 class _NoCommitTransaction(object):
 
     def __init__(self, client, transaction_id='TRANSACTION'):
+        from google.cloud.datastore.batch import Batch
         from google.cloud.datastore.transaction import Transaction
         self._client = client
         xact = self._transaction = Transaction(client)
         xact._id = transaction_id
+        Batch.begin(xact)
 
     def __enter__(self):
         self._client._push_batch(self._transaction)


### PR DESCRIPTION
- Ensuring that `Batch` methods `put()`, `delete()`, `commit()` and `rollback()` are only called when the batch is in progress.
- In `Batch.__enter__()` make sure the batch is only put on the stack after `begin()` succeeds.
- `Client.delete_multi()` and `Client.put_multi()` (and downstream methods) now call `begin()` on new `Batch` (since required to be in progress).
- `Transaction.begin()` if `begin_transaction()` API call fails, make sure to change the status to `ABORTED` before raising the exception from the failure.

Fixes #2297.