### PR TITLE
Remove gRPC/GAX conditional checks.

### DIFF
--- a/appveyor/requirements.txt
+++ b/appveyor/requirements.txt
@@ -3,11 +3,4 @@
 # pip will build them from source using the MSVC compiler matching the
 # target Python version and architecture
 wheel
-pytest
 tox
-cryptography
-grpcio >= 1.0rc1
-grpc-google-pubsub-v1
-grpc-google-logging-v2
-gax-google-pubsub-v1
-gax-google-logging-v2

--- a/google/cloud/bigtable/__init__.py
+++ b/google/cloud/bigtable/__init__.py
@@ -16,23 +16,3 @@
 
 
 from google.cloud.bigtable.client import Client
-
-
-_ERR_MSG = """\
-gRPC is required for using the Cloud Bigtable API, but
-importing the gRPC library (grpcio in PyPI) has failed.
-
-As of June 2016, grpcio is only supported in Python 2.7,
-which unfortunately means the Cloud Bigtable API isn't
-available if you're using Python 3 or Python < 2.7.
-
-If you're using Python 2.7 and importing / installing
-grpcio has failed, this likely means you have a non-standard version
-of Python installed. Check http://grpc.io if you're
-having trouble installing the grpcio package.
-"""
-
-try:
-    import grpc
-except ImportError as exc:  # pragma: NO COVER
-    raise ImportError(_ERR_MSG, exc)

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ import sys
 from setuptools import setup
 from setuptools import find_packages
 
-here = os.path.abspath(os.path.dirname(__file__))
 
+PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(here, 'README.rst')) as f:
-    README = f.read()
+with open(os.path.join(PROJECT_ROOT, 'README.rst')) as file_obj:
+    README = file_obj.read()
 
 
 REQUIREMENTS = [
@@ -19,7 +19,7 @@ REQUIREMENTS = [
     'six',
 ]
 
-GRPC_EXTRAS = [
+GRPC_PACKAGES = [
     'grpcio >= 1.0rc1',
     'google-gax >= 0.12.3, < 0.13dev',
     'gax-google-pubsub-v1 >= 0.8.0, < 0.9dev',
@@ -28,8 +28,9 @@ GRPC_EXTRAS = [
     'grpc-google-logging-v2 >= 0.8.0, < 0.9dev',
 ]
 
-if sys.version_info[:2] == (2, 7) and 'READTHEDOCS' not in os.environ:
-    REQUIREMENTS.extend(GRPC_EXTRAS)
+RTD_ENV_VAR = 'READTHEDOCS'
+if RTD_ENV_VAR not in os.environ:
+    REQUIREMENTS.extend(GRPC_PACKAGES)
 
 setup(
     name='google-cloud',
@@ -52,7 +53,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=REQUIREMENTS,
-    extras_require={'grpc': GRPC_EXTRAS},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/system_tests/attempt_system_tests.py
+++ b/system_tests/attempt_system_tests.py
@@ -56,7 +56,6 @@ from run_system_test import FailedSystemTestModule
 from run_system_test import run_module_tests
 
 
-BIGTABLE_API = 'bigtable'
 MODULES = (  # ordered from most to least stable
     'datastore',
     'storage',
@@ -66,7 +65,7 @@ MODULES = (  # ordered from most to least stable
     'logging',
     'translate',
     'monitoring',
-    BIGTABLE_API,
+    'bigtable',
 )
 
 SCRIPTS_DIR = os.path.dirname(__file__)
@@ -156,8 +155,6 @@ def get_modules():
     args = parser.parse_args()
     if args.packages is ALL_MODULES:
         result = list(MODULES)
-        if sys.version_info[:2] != (2, 7):
-            result.remove(BIGTABLE_API)
     else:
         result = []
         invalid = []
@@ -188,6 +185,7 @@ def main():
             failed_modules += 1
 
     sys.exit(failed_modules)
+
 
 if __name__ == '__main__':
     main()

--- a/tox.ini
+++ b/tox.ini
@@ -12,21 +12,11 @@ covercmd =
       --cov-config {toxinidir}/.coveragerc \
       unit_tests
 
-[grpc]
-deps =
-    grpcio >= 1.0rc1
-    google-gax >= 0.12.3, < 0.13dev
-    gax-google-pubsub-v1 >= 0.8.0, < 0.9dev
-    grpc-google-pubsub-v1 >= 0.8.0, < 0.9dev
-    gax-google-logging-v2 >= 0.8.0, < 0.9dev
-    grpc-google-logging-v2 >= 0.8.0, < 0.9dev
-
 [testenv]
 commands =
     py.test {posargs} unit_tests
 deps =
     {[testing]deps}
-    {[grpc]deps}
 
 [testenv:py27-pandas]
 basepython =


### PR DESCRIPTION
~~Adding support for an environment variable that App Engine users can use to disable installing gRPC packages into their application.~~

Follow-up to #2304.

@jonparrott Can you weigh in here on the GAE env. var. in `setup.py`?