### PR TITLE
Updating .gitignore for JetBrains.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,11 @@ pip-log.txt
 .project
 .pydevproject
 
+# JetBrains
+.idea
+
 # Built documentation
 docs/_build
-docs/_build_rtd
 
 # Virtual environment
 env/


### PR DESCRIPTION
Also removing the `_build_rtd` directory that we no longer use.

H/T to @Ofekmeister for pointing out that we don't `.gitignore` the JetBrains config directory