### PR TITLE
Adding bigtable-emulator tox environment.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -112,23 +112,34 @@ commands =
     python {toxinidir}/system_tests/attempt_system_tests.py {posargs}
 passenv = {[testenv:system-tests]passenv}
 
-[testenv:datastore-emulator]
-basepython =
-    python2.7
-commands =
-    python {toxinidir}/system_tests/run_emulator.py --package=datastore
+[emulator]
+deps =
+    {[testenv]deps}
+    psutil
 setenv =
     GOOGLE_CLOUD_NO_PRINT=true
 passenv =
     GOOGLE_CLOUD_DISABLE_GRPC
-deps =
-    {[testenv]deps}
-    psutil
+emulatorcmd =
+    python {toxinidir}/system_tests/run_emulator.py
+
+[testenv:datastore-emulator]
+commands =
+    {[emulator]emulatorcmd} --package=datastore
+setenv = {[emulator]setenv}
+passenv = {[emulator]passenv}
+deps = {[emulator]deps}
 
 [testenv:pubsub-emulator]
-basepython =
-    python2.7
 commands =
-    python {toxinidir}/system_tests/run_emulator.py --package=pubsub
-passenv = GOOGLE_CLOUD_*
-deps = {[testenv:datastore-emulator]deps}
+    {[emulator]emulatorcmd} --package=pubsub
+setenv = {[emulator]setenv}
+passenv = {[emulator]passenv}
+deps = {[emulator]deps}
+
+[testenv:bigtable-emulator]
+commands =
+    {[emulator]emulatorcmd} --package=bigtable
+setenv = {[emulator]setenv}
+passenv = {[emulator]passenv}
+deps = {[emulator]deps}


### PR DESCRIPTION
Also updating the pubsub system test with similar support for detection of the emulator at run-time rather than import time.

Fixes #2242.

FYI @garye this is the current output:

```
$ tox -e bigtable-emulator
GLOB sdist-make: .../google-cloud-python/setup.py
bigtable-emulator inst-nodeps: .../google-cloud-python/.tox/dist/google-cloud-0.18.0.zip
bigtable-emulator installed: enum34==1.1.6,future==0.15.2,futures==3.0.5,gax-google-logging-v2==0.8.1,gax-google-pubsub-v1==0.8.1,google-cloud==0.18.0,google-gax==0.12.5,googleapis-common-protos==1.3.4,grpc-google-logging-v2==0.8.1,grpc-google-pubsub-v1==0.8.1,grpcio==1.0.0,httplib2==0.9.2,oauth2client==3.0.0,ply==3.8,protobuf==3.0.0,psutil==4.3.1,py==1.4.31,pyasn1==0.1.9,pyasn1-modules==0.0.8,pytest==3.0.2,rsa==3.4.2,six==1.10.0
bigtable-emulator runtests: PYTHONHASHSEED='2409315821'
bigtable-emulator runtests: commands[0] | python .../google-cloud-python/system_tests/run_emulator.py --package=bigtable
test_read_row (bigtable.TestDataAPI) ... ok
test_read_rows (bigtable.TestDataAPI) ... ok
test_read_with_label_applied (bigtable.TestDataAPI) ... skipped 'Labels not supported by Bigtable emulator'
test_create_instance (bigtable.TestInstanceAdminAPI) ... skipped 'Instance Admin API not supported in Bigtable emulator'
test_list_instances (bigtable.TestInstanceAdminAPI) ... skipped 'Instance Admin API not supported in Bigtable emulator'
test_reload (bigtable.TestInstanceAdminAPI) ... skipped 'Instance Admin API not supported in Bigtable emulator'
test_update (bigtable.TestInstanceAdminAPI) ... skipped 'Instance Admin API not supported in Bigtable emulator'
test_create_column_family (bigtable.TestTableAdminAPI) ... ok
test_create_table (bigtable.TestTableAdminAPI) ... ok
test_delete_column_family (bigtable.TestTableAdminAPI) ... ok
test_list_tables (bigtable.TestTableAdminAPI) ... ok
test_update_column_family (bigtable.TestTableAdminAPI) ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.018s

OK (skipped=5)
E0915 09:38:34.312954162    9877 network_status_tracker.c:48] Memory leaked as all network endpoints were not shut down
___________________________________________________________________ summary ___________________________________________________________________
  bigtable-emulator: commands succeeded
  congratulations :)
```