### PR TITLE
Removing pubsub and logging as namespace packages.

### DIFF
--- a/google/cloud/logging/__init__.py
+++ b/google/cloud/logging/__init__.py
@@ -14,9 +14,13 @@
 
 """Google Stackdriver Logging API wrapper."""
 
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+
+from google.cloud.logging.client import Client
+from google.cloud.logging.connection import Connection
+
+
+SCOPE = Connection.SCOPE
+ASCENDING = 'timestamp asc'
+"""Query string to order by ascending timestamps."""
+DESCENDING = 'timestamp desc'
+"""Query string to order by decending timestamps."""

--- a/google/cloud/logging/_gax.py
+++ b/google/cloud/logging/_gax.py
@@ -58,8 +58,8 @@ class _LoggingAPI(object):
                         https://cloud.google.com/logging/docs/view/advanced_filters
 
         :type order_by: str
-        :param order_by: One of :data:`~google.cloud.logging.client.ASCENDING`
-                         or :data:`~google.cloud.logging.client.DESCENDING`.
+        :param order_by: One of :data:`~google.cloud.logging.ASCENDING`
+                         or :data:`~google.cloud.logging.DESCENDING`.
 
         :type page_size: int
         :param page_size: maximum number of entries to return, If not passed,

--- a/google/cloud/logging/client.py
+++ b/google/cloud/logging/client.py
@@ -50,10 +50,6 @@ from google.cloud.logging.sink import Sink
 
 _DISABLE_GAX = os.getenv(DISABLE_GRPC, False)
 _USE_GAX = _HAVE_GAX and not _DISABLE_GAX
-ASCENDING = 'timestamp asc'
-"""Query string to order by ascending timestamps."""
-DESCENDING = 'timestamp desc'
-"""Query string to order by decending timestamps."""
 
 
 class Client(JSONClient):
@@ -177,8 +173,8 @@ class Client(JSONClient):
                         https://cloud.google.com/logging/docs/view/advanced_filters
 
         :type order_by: str
-        :param order_by: One of :data:`~google.cloud.logging.client.ASCENDING`
-                         or :data:`~google.cloud.logging.client.DESCENDING`.
+        :param order_by: One of :data:`~google.cloud.logging.ASCENDING`
+                         or :data:`~google.cloud.logging.DESCENDING`.
 
         :type page_size: int
         :param page_size: maximum number of entries to return, If not passed,

--- a/google/cloud/logging/connection.py
+++ b/google/cloud/logging/connection.py
@@ -77,8 +77,8 @@ class _LoggingAPI(object):
                         https://cloud.google.com/logging/docs/view/advanced_filters
 
         :type order_by: str
-        :param order_by: One of :data:`~google.cloud.logging.client.ASCENDING`
-                         or :data:`~google.cloud.logging.client.DESCENDING`.
+        :param order_by: One of :data:`~google.cloud.logging.ASCENDING`
+                         or :data:`~google.cloud.logging.DESCENDING`.
 
         :type page_size: int
         :param page_size: maximum number of entries to return, If not passed,

--- a/google/cloud/logging/logger.py
+++ b/google/cloud/logging/logger.py
@@ -289,8 +289,8 @@ class Logger(object):
                         https://cloud.google.com/logging/docs/view/advanced_filters
 
         :type order_by: string
-        :param order_by: One of :data:`~google.cloud.logging.client.ASCENDING`
-                         or :data:`~google.cloud.logging.client.DESCENDING`.
+        :param order_by: One of :data:`~google.cloud.logging.ASCENDING`
+                         or :data:`~google.cloud.logging.DESCENDING`.
 
         :type page_size: int
         :param page_size: maximum number of entries to return, If not passed,

--- a/google/cloud/pubsub/__init__.py
+++ b/google/cloud/pubsub/__init__.py
@@ -23,9 +23,11 @@ The main concepts with this API are:
   subscription (either pull or push) to a topic.
 """
 
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+
+from google.cloud.pubsub.client import Client
+from google.cloud.pubsub.connection import Connection
+from google.cloud.pubsub.subscription import Subscription
+from google.cloud.pubsub.topic import Topic
+
+
+SCOPE = Connection.SCOPE

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,6 @@ setup(
     namespace_packages=[
         'google',
         'google.cloud',
-        'google.cloud.logging',
-        'google.cloud.pubsub',
     ],
     packages=find_packages(),
     license='Apache 2.0',

--- a/unit_tests/logging/test__gax.py
+++ b/unit_tests/logging/test__gax.py
@@ -51,8 +51,9 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
 
     def test_list_entries_no_paging(self):
         from google.gax import INITIAL_PAGE
-        from google.cloud.logging.client import DESCENDING
+        from google.cloud.logging import DESCENDING
         from unit_tests._testing import _GAXPageIterator
+
         TOKEN = 'TOKEN'
         TEXT = 'TEXT'
         response = _GAXPageIterator(

--- a/unit_tests/logging/test_client.py
+++ b/unit_tests/logging/test_client.py
@@ -234,10 +234,11 @@ class TestClient(unittest.TestCase):
             ([self.PROJECT], None, None, None, None))
 
     def test_list_entries_explicit(self):
-        from google.cloud.logging.client import DESCENDING
+        from google.cloud.logging import DESCENDING
         from google.cloud.logging.entries import ProtobufEntry
         from google.cloud.logging.entries import StructEntry
         from google.cloud.logging.logger import Logger
+
         PROJECT1 = 'PROJECT1'
         PROJECT2 = 'PROJECT2'
         FILTER = 'logName:LOGNAME'

--- a/unit_tests/logging/test_connection.py
+++ b/unit_tests/logging/test_connection.py
@@ -97,7 +97,8 @@ class Test_LoggingAPI(unittest.TestCase):
         self.assertEqual(conn._called_with['data'], SENT)
 
     def test_list_entries_w_paging(self):
-        from google.cloud.logging.client import DESCENDING
+        from google.cloud.logging import DESCENDING
+
         PROJECT1 = 'PROJECT1'
         PROJECT2 = 'PROJECT2'
         TIMESTAMP = self._make_timestamp()

--- a/unit_tests/logging/test_logger.py
+++ b/unit_tests/logging/test_logger.py
@@ -364,7 +364,8 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(client._listed, LISTED)
 
     def test_list_entries_explicit(self):
-        from google.cloud.logging.client import DESCENDING
+        from google.cloud.logging import DESCENDING
+
         PROJECT1 = 'PROJECT1'
         PROJECT2 = 'PROJECT2'
         FILTER = 'resource.type:global'


### PR DESCRIPTION
Fixes #2258.

See 73d2986b78922930e11258e375cc7f2bb7ce13c8 for the initial commit that removed the original contents of `__init__.py` (from #2223).

/cc @bjwatson 