### PR TITLE
Adding more info about setting up translate test.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -167,6 +167,8 @@ Running System Tests
     `docs <https://cloud.google.com/storage/docs/authentication#generating-a-private-key>`__
     for more details. In order for Logging system tests to work, the Service Account
     will also have to be made a project Owner. This can be changed under "IAM & Admin".
+  - ``GOOGLE_CLOUD_TESTS_API_KEY``: The API key for your project with
+    the Google Translate API (and others) enabled.
 
 - Examples of these can be found in ``system_tests/local_test_setup.sample``. We
   recommend copying this to ``system_tests/local_test_setup``, editing the

--- a/system_tests/local_test_setup.sample
+++ b/system_tests/local_test_setup.sample
@@ -1,3 +1,4 @@
 export GOOGLE_APPLICATION_CREDENTIALS="app_credentials.json.sample"
 export GOOGLE_CLOUD_REMOTE_FOR_LINT="upstream"
 export GOOGLE_CLOUD_BRANCH_FOR_LINT="master"
+export GOOGLE_CLOUD_TESTS_API_KEY="abcd1234"


### PR DESCRIPTION
1. @tseaver Didn't this have an issue somewhere?
1. Should I move the env. var. into the `environment_vars` module? I originally elected not to since it is only used once and is testing only.