### PR TITLE
Fix unicode message in exceptions

### DIFF
--- a/google/cloud/exceptions.py
+++ b/google/cloud/exceptions.py
@@ -21,6 +21,8 @@ import copy
 import json
 import six
 
+from google.cloud._helpers import _to_bytes
+
 _HTTP_CODE_TO_EXCEPTION = {}  # populated at end of module
 
 
@@ -41,7 +43,10 @@ class GoogleCloudError(Exception):
         self._errors = errors
 
     def __str__(self):
-        return '%d %s' % (self.code, self.message)
+        result = u'%d %s' % (self.code, self.message)
+        if six.PY2:
+            result = _to_bytes(result, 'utf-8')
+        return result
 
     @property
     def errors(self):


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/google-cloud-python/issues/2346

@dhermes looking at the magic methods and playing with `__bytes__` and `__unicode__`, the solutions I had felt really hacky. i.e. checking for `six.PY3` in `__str__` and then just calling `self.__bytes__()` instead. 

I'm not sure if it's good form to use `__future__` here but it seems to be a valid way to [solve the issue](http://python-future.org/unicode_literals.html).