### PR TITLE
Ensure that 'QueryResults.from_query_job' copies 'job.name'.

### DIFF
--- a/google/cloud/bigquery/query.py
+++ b/google/cloud/bigquery/query.py
@@ -77,6 +77,8 @@ class QueryResults(object):
         """
         instance = cls(job.query, job._client, job.udf_resources)
         instance._job = job
+        job_ref = instance._properties.setdefault('jobReference', {})
+        job_ref['jobId'] = job.name
         if job.default_dataset is not None:
             instance.default_dataset = job.default_dataset
         if job.use_query_cache is not None:

--- a/unit_tests/bigquery/test_query.py
+++ b/unit_tests/bigquery/test_query.py
@@ -155,6 +155,7 @@ class TestQueryResults(unittest.TestCase):
 
         query = klass.from_query_job(job)
 
+        self.assertEqual(query.name, self.JOB_NAME)
         self.assertEqual(query.query, self.QUERY)
         self.assertIs(query._client, client)
         self.assertIs(query._job, job)


### PR DESCRIPTION
Closes #2368.