### PR TITLE
Raise exception if retry-backoff fails to pass predicate.

### DIFF
--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -356,7 +356,6 @@ class TestBigQuery(unittest.TestCase):
         retry = RetryInstanceState(_job_done, max_tries=8)
         retry(job.reload)()
 
-        self.assertTrue(_job_done(job))
         self.assertEqual(job.output_rows, len(ROWS))
 
         rows, _, _ = table.fetch_data()
@@ -428,8 +427,6 @@ class TestBigQuery(unittest.TestCase):
         # 8 tries -> 1 + 2 + 4 + 8 + 16 + 32 + 64 = 127 seconds
         retry = RetryInstanceState(_job_done, max_tries=8)
         retry(job.reload)()
-
-        self.assertTrue(job.state in ('DONE', 'done'))
 
         rows, _, _ = table.fetch_data()
         by_age = operator.itemgetter(1)

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -221,8 +221,6 @@ class TestPubsub(unittest.TestCase):
         # Retry / backoff up to 7 seconds (1 + 2 + 4)
         retry = RetryResult(lambda result: result, max_tries=4)
         retry(topic.exists)()
-
-        self.assertTrue(topic.exists())
         self.to_delete.append(topic)
 
         if topic.check_iam_permissions([PUBSUB_TOPICS_GET_IAM_POLICY]):
@@ -241,9 +239,8 @@ class TestPubsub(unittest.TestCase):
         # Retry / backoff up to 7 seconds (1 + 2 + 4)
         retry = RetryResult(lambda result: result, max_tries=4)
         retry(topic.exists)()
-
-        self.assertTrue(topic.exists())
         self.to_delete.append(topic)
+
         SUB_NAME = 'test-sub-iam-policy-sub' + unique_resource_id('-')
         subscription = topic.subscription(SUB_NAME)
         subscription.create()
@@ -251,8 +248,6 @@ class TestPubsub(unittest.TestCase):
         # Retry / backoff up to 7 seconds (1 + 2 + 4)
         retry = RetryResult(lambda result: result, max_tries=4)
         retry(subscription.exists)()
-
-        self.assertTrue(subscription.exists())
         self.to_delete.insert(0, subscription)
 
         if subscription.check_iam_permissions(

--- a/system_tests/retry.py
+++ b/system_tests/retry.py
@@ -13,6 +13,10 @@ def _retry_all(_):
     return True
 
 
+class BackoffFailed(Exception):
+    """Retry w/ backoffs did not complete successfully."""
+
+
 class RetryBase(object):
     """Base for retrying calling a decorated function w/ exponential backoff.
 
@@ -134,7 +138,7 @@ class RetryResult(RetryBase):
 
                 time.sleep(delay)
                 tries += 1
-            return to_wrap(*args, **kwargs)
+            raise BackoffFailed()
 
         return wrapped_function
 
@@ -184,6 +188,6 @@ class RetryInstanceState(RetryBase):
 
                 time.sleep(delay)
                 tries += 1
-            return to_wrap(*args, **kwargs)
+            raise BackoffFailed()
 
         return wrapped_function


### PR DESCRIPTION
Closes #2315.

Updates coming to remove redundant tests of assertions after retry.