### PR TITLE
Using dictionary comprehensions in place of dict().

### DIFF
--- a/google/cloud/dns/client.py
+++ b/google/cloud/dns/client.py
@@ -56,8 +56,9 @@ class Client(JSONClient):
         path = '/projects/%s' % (self.project,)
         resp = self.connection.api_request(method='GET', path=path)
 
-        return dict([(key, int(value))
-                     for key, value in resp['quota'].items() if key != 'kind'])
+        return {key: int(value)
+                for key, value in resp['quota'].items()
+                if key != 'kind'}
 
     def list_zones(self, max_results=None, page_token=None):
         """List zones for the project associated with this client.

--- a/google/cloud/logging/_gax.py
+++ b/google/cloud/logging/_gax.py
@@ -472,8 +472,8 @@ def _struct_pb_to_mapping(struct_pb):
     Performs "impedance matching" between the protobuf attrs and the keys
     expected in the JSON API.
     """
-    return dict([(key, _value_pb_to_value(struct_pb.fields[key]))
-                 for key in struct_pb.fields])
+    return {key: _value_pb_to_value(struct_pb.fields[key])
+            for key in struct_pb.fields}
 
 
 def _log_entry_pb_to_mapping(entry_pb):

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -120,8 +120,8 @@ class _PropertyMixin(object):
         client = self._require_client(client)
         # Pass '?projection=full' here because 'PATCH' documented not
         # to work properly w/ 'noAcl'.
-        update_properties = dict((key, self._properties[key])
-                                 for key in self._changes)
+        update_properties = {key: self._properties[key]
+                             for key in self._changes}
         api_response = client.connection.api_request(
             method='PATCH', path=self.path, data=update_properties,
             query_params={'projection': 'full'}, _target_object=self)

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -166,8 +166,7 @@ class Bucket(_PropertyMixin):
         """
         client = self._require_client(client)
         query_params = {'project': client.project}
-        properties = dict(
-            (key, self._properties[key]) for key in self._changes)
+        properties = {key: self._properties[key] for key in self._changes}
         properties['name'] = self.name
         api_response = client.connection.api_request(
             method='POST', path='/b', query_params=query_params,

--- a/system_tests/logging_.py
+++ b/system_tests/logging_.py
@@ -280,7 +280,7 @@ class TestLogging(unittest.TestCase):
         metric.description = NEW_DESCRIPTION
         metric.update()
         after_metrics, _ = Config.CLIENT.list_metrics()
-        after_info = dict((metric.name, metric) for metric in after_metrics)
+        after_info = {metric.name: metric for metric in after_metrics}
         after = after_info[METRIC_NAME]
         self.assertEqual(after.filter_, NEW_FILTER)
         self.assertEqual(after.description, NEW_DESCRIPTION)

--- a/unit_tests/_testing.py
+++ b/unit_tests/_testing.py
@@ -22,7 +22,7 @@ class _Monkey(object):
         self.module = module
         if len(kw) == 0:  # pragma: NO COVER
             raise ValueError('_Monkey was used with nothing to monkey-patch')
-        self.to_restore = dict([(key, getattr(module, key)) for key in kw])
+        self.to_restore = {key: getattr(module, key) for key in kw}
         for key, value in kw.items():
             setattr(module, key, value)
 

--- a/unit_tests/dns/test_client.py
+++ b/unit_tests/dns/test_client.py
@@ -55,8 +55,8 @@ class TestClient(unittest.TestCase):
                 'totalRrdataSizePerChange': str(TOTAL_SIZE),
             }
         }
-        CONVERTED = dict([(key, int(value))
-                          for key, value in DATA['quota'].items()])
+        CONVERTED = {key: int(value)
+                     for key, value in DATA['quota'].items()}
         creds = _Credentials()
         client = self._makeOne(self.PROJECT, creds)
         conn = client.connection = _Connection(DATA)
@@ -88,8 +88,8 @@ class TestClient(unittest.TestCase):
                 'totalRrdataSizePerChange': str(TOTAL_SIZE),
             }
         }
-        CONVERTED = dict([(key, int(value))
-                          for key, value in DATA['quota'].items()])
+        CONVERTED = {key: int(value)
+                     for key, value in DATA['quota'].items()}
         WITH_KIND = {'quota': DATA['quota'].copy()}
         WITH_KIND['quota']['kind'] = 'dns#quota'
         creds = _Credentials()

--- a/unit_tests/logging/test__gax.py
+++ b/unit_tests/logging/test__gax.py
@@ -87,8 +87,9 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         TOKEN = 'TOKEN'
         NEW_TOKEN = 'NEW_TOKEN'
         PAYLOAD = {'message': 'MESSAGE', 'weather': 'sunny'}
-        struct_pb = _StructPB(dict([(key, Value(string_value=value))
-                                    for key, value in PAYLOAD.items()]))
+        struct_pb = _StructPB({
+            key: Value(string_value=value) for key, value in PAYLOAD.items()
+        })
         response = _GAXPageIterator(
             [_LogEntryPB(self.LOG_NAME, json_payload=struct_pb)], NEW_TOKEN)
         gax_api = _GAXLoggingAPI(_list_log_entries_response=response)

--- a/unit_tests/monitoring/test_group.py
+++ b/unit_tests/monitoring/test_group.py
@@ -55,7 +55,7 @@ class TestGroup(unittest.TestCase):
         self.PARENT_NAME = self.PATH + self.PARENT_ID
 
         FILTER_TEMPLATE = 'resource.metadata.tag."color"="%s"'
-        self.FILTER = FILTER_TEMPLATE % 'blue'
+        self.FILTER = FILTER_TEMPLATE % ('blue',)
 
         self.JSON_GROUP = {
             'name': self.GROUP_NAME,
@@ -227,7 +227,7 @@ class TestGroup(unittest.TestCase):
     def test_create(self):
         RESPONSE = self.JSON_GROUP
 
-        REQUEST = dict(RESPONSE)
+        REQUEST = RESPONSE.copy()
         REQUEST.pop('name')
 
         connection = _Connection(RESPONSE)

--- a/unit_tests/monitoring/test_metric.py
+++ b/unit_tests/monitoring/test_metric.py
@@ -254,7 +254,8 @@ class TestMetricDescriptor(unittest.TestCase):
             'valueType': VALUE_TYPE,
             'description': DESCRIPTION,
         }
-        RESPONSE = dict(REQUEST, name=NAME)
+        RESPONSE = REQUEST.copy()
+        RESPONSE['name'] = NAME
 
         connection = _Connection(RESPONSE)
         client = _Client(project=PROJECT, connection=connection)

--- a/unit_tests/storage/test_blob.py
+++ b/unit_tests/storage/test_blob.py
@@ -419,8 +419,8 @@ class Test_Blob(unittest.TestCase):
                 updatedTime = time.mktime(blob.updated.timetuple())
 
         rq = connection.http._requested
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0]['headers'].items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0]['headers'].items()}
         self.assertEqual(headers['X-Goog-Encryption-Algorithm'], 'AES256')
         self.assertEqual(headers['X-Goog-Encryption-Key'], HEADER_KEY_VALUE)
         self.assertEqual(headers['X-Goog-Encryption-Key-Sha256'],
@@ -502,8 +502,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(path, '/b/name/o')
         self.assertEqual(dict(parse_qsl(qs)),
                          {'uploadType': 'media', 'name': BLOB_NAME})
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0]['headers'].items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0]['headers'].items()}
         self.assertEqual(headers['Content-Length'], '6')
         self.assertEqual(headers['Content-Type'], expected_content_type)
 
@@ -558,8 +558,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(len(rq), 3)
 
         # Requested[0]
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0].pop('headers').items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0].pop('headers').items()}
         self.assertEqual(headers['Content-Length'], '0')
         self.assertEqual(headers['X-Upload-Content-Type'],
                          'application/octet-stream')
@@ -579,8 +579,8 @@ class Test_Blob(unittest.TestCase):
         })
 
         # Requested[1]
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[1].pop('headers').items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[1].pop('headers').items()}
         self.assertEqual(headers['Content-Range'], 'bytes 0-4/*')
         self.assertEqual(rq[1], {
             'method': 'PUT',
@@ -591,8 +591,8 @@ class Test_Blob(unittest.TestCase):
         })
 
         # Requested[2]
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[2].pop('headers').items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[2].pop('headers').items()}
         self.assertEqual(headers['Content-Range'], 'bytes */5')
         self.assertEqual(rq[2], {
             'method': 'PUT',
@@ -677,8 +677,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(len(rq), 3)
 
         # Requested[0]
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0].pop('headers').items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0].pop('headers').items()}
         self.assertEqual(headers['X-Upload-Content-Length'], '6')
         self.assertEqual(headers['X-Upload-Content-Type'],
                          'application/octet-stream')
@@ -698,8 +698,8 @@ class Test_Blob(unittest.TestCase):
         })
 
         # Requested[1]
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[1].pop('headers').items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[1].pop('headers').items()}
         self.assertEqual(headers['Content-Range'], 'bytes 0-4/6')
         self.assertEqual(rq[1], {
             'method': 'PUT',
@@ -710,8 +710,8 @@ class Test_Blob(unittest.TestCase):
         })
 
         # Requested[2]
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[2].pop('headers').items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[2].pop('headers').items()}
         self.assertEqual(headers['Content-Range'], 'bytes 5-5/6')
         self.assertEqual(rq[2], {
             'method': 'PUT',
@@ -755,8 +755,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(len(rq), 1)
 
         # Requested[0]
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0].pop('headers').items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0].pop('headers').items()}
         self.assertEqual(headers['X-Upload-Content-Length'], '6')
         self.assertEqual(headers['X-Upload-Content-Type'],
                          'application/octet-stream')
@@ -820,8 +820,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(path, '/b/name/o')
         self.assertEqual(dict(parse_qsl(qs)),
                          {'uploadType': 'media', 'name': 'parent/child'})
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0]['headers'].items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0]['headers'].items()}
         self.assertEqual(headers['Content-Length'], '6')
         self.assertEqual(headers['Content-Type'], 'application/octet-stream')
 
@@ -873,8 +873,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(path, '/b/name/o')
         self.assertEqual(dict(parse_qsl(qs)),
                          {'uploadType': 'media', 'name': BLOB_NAME})
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0]['headers'].items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0]['headers'].items()}
         self.assertEqual(headers['X-Goog-Encryption-Algorithm'], 'AES256')
         self.assertEqual(headers['X-Goog-Encryption-Key'], HEADER_KEY_VALUE)
         self.assertEqual(headers['X-Goog-Encryption-Key-Sha256'],
@@ -926,8 +926,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(path, '/b/name/o')
         self.assertEqual(dict(parse_qsl(qs)),
                          {'uploadType': 'media', 'name': BLOB_NAME})
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0]['headers'].items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0]['headers'].items()}
         self.assertEqual(headers['Content-Length'], '6')
         self.assertEqual(headers['Content-Type'], expected_content_type)
 
@@ -988,8 +988,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(path, '/b/name/o')
         self.assertEqual(dict(parse_qsl(qs)),
                          {'uploadType': 'media', 'name': BLOB_NAME})
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0]['headers'].items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0]['headers'].items()}
         self.assertEqual(headers['Content-Length'], '6')
         self.assertEqual(headers['Content-Type'], 'text/plain')
         self.assertEqual(rq[0]['body'], DATA)
@@ -1028,8 +1028,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(path, '/b/name/o')
         self.assertEqual(dict(parse_qsl(qs)),
                          {'uploadType': 'media', 'name': BLOB_NAME})
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0]['headers'].items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0]['headers'].items()}
         self.assertEqual(headers['Content-Length'], str(len(ENCODED)))
         self.assertEqual(headers['Content-Type'], 'text/plain')
         self.assertEqual(rq[0]['body'], ENCODED)
@@ -1071,8 +1071,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(path, '/b/name/o')
         self.assertEqual(dict(parse_qsl(qs)),
                          {'uploadType': 'media', 'name': BLOB_NAME})
-        headers = dict(
-            [(x.title(), str(y)) for x, y in rq[0]['headers'].items()])
+        headers = {
+            x.title(): str(y) for x, y in rq[0]['headers'].items()}
 
         self.assertEqual(headers['X-Goog-Encryption-Algorithm'], 'AES256')
         self.assertEqual(headers['X-Goog-Encryption-Key'], HEADER_KEY_VALUE)


### PR DESCRIPTION
This is now possible after dropping support for Python 2.6.

Also tweaking a few places `dict(...)` was used to copy a dictionary to just use `.copy()`.

We also have a lot of `dict(parse_qsl(...))` going on, maybe we should use `parse_qs` and just deal with the slightly different output.

Also, we have

```
google/cloud/storage/batch.py:204:        return dict(multi._headers), body
google/cloud/storage/batch.py:319:        msg_headers = dict(sub_message._headers)
```

@tseaver I seem to recall a discussion as to why this wouldn't clobber any repeated headers, but would like some clarification.