### PR TITLE
Fix links to pubsub documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ receivers, Google Cloud Pub/Sub allows developers to communicate between
 independently written applications.
 
 .. _Cloud Pub/Sub: https://cloud.google.com/pubsub/docs
-.. _Pub/Sub API docs: https://cloud.google.com/pubsub/reference/rest/
+.. _Pub/Sub API docs: https://cloud.google.com/pubsub/docs/reference/rest/
 
 See the ``google-cloud-python`` API `Pub/Sub documentation`_ to learn how to connect
 to Cloud Pub/Sub using this Client Library.

--- a/google/cloud/pubsub/_gax.py
+++ b/google/cloud/pubsub/_gax.py
@@ -46,7 +46,7 @@ class _PublisherAPI(object):
         """List topics for the project associated with this API.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/list
 
         :type project: string
         :param project: project ID
@@ -80,7 +80,7 @@ class _PublisherAPI(object):
         """API call:  create a topic
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/create
 
         :type topic_path: string
         :param topic_path: fully-qualified path of the new topic, in format
@@ -103,7 +103,7 @@ class _PublisherAPI(object):
         """API call:  retrieve a topic
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/get
 
         :type topic_path: string
         :param topic_path: fully-qualified path of the topic, in format
@@ -126,7 +126,7 @@ class _PublisherAPI(object):
         """API call:  delete a topic
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/create
 
         :type topic_path: string
         :param topic_path: fully-qualified path of the new topic, in format
@@ -143,7 +143,7 @@ class _PublisherAPI(object):
         """API call:  publish one or more messages to a topic
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/publish
 
         :type topic_path: string
         :param topic_path: fully-qualified path of the topic, in format
@@ -174,7 +174,7 @@ class _PublisherAPI(object):
         """API call:  list subscriptions bound to a topic
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics.subscriptions/list
 
         :type topic_path: string
         :param topic_path: fully-qualified path of the topic, in format
@@ -223,7 +223,7 @@ class _SubscriberAPI(object):
         """List subscriptions for the project associated with this API.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/list
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/list
 
         :type project: string
         :param project: project ID
@@ -259,7 +259,7 @@ class _SubscriberAPI(object):
         """API call:  create a subscription
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the new
@@ -304,7 +304,7 @@ class _SubscriberAPI(object):
         """API call:  retrieve a subscription
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the subscription,
@@ -326,7 +326,7 @@ class _SubscriberAPI(object):
         """API call:  delete a subscription
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/delete
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the subscription,
@@ -345,7 +345,7 @@ class _SubscriberAPI(object):
         """API call:  update push config of a subscription
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the new
@@ -370,7 +370,7 @@ class _SubscriberAPI(object):
         """API call:  retrieve messages for a subscription
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the new
@@ -403,7 +403,7 @@ class _SubscriberAPI(object):
         """API call:  acknowledge retrieved messages
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the new
@@ -425,7 +425,7 @@ class _SubscriberAPI(object):
         """API call:  update ack deadline for retrieved messages
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyAckDeadline
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the new

--- a/google/cloud/pubsub/client.py
+++ b/google/cloud/pubsub/client.py
@@ -103,7 +103,7 @@ class Client(JSONClient):
         """List topics for the project associated with this client.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/list
 
         Example:
 
@@ -137,7 +137,7 @@ class Client(JSONClient):
         """List subscriptions for the project associated with this client.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/list
 
         Example:
 

--- a/google/cloud/pubsub/connection.py
+++ b/google/cloud/pubsub/connection.py
@@ -107,7 +107,7 @@ class _PublisherAPI(object):
         """API call:  list topics for a given project
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/list
 
         :type project: string
         :param project: project ID
@@ -144,7 +144,7 @@ class _PublisherAPI(object):
         """API call:  create a topic
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/create
 
         :type topic_path: string
         :param topic_path: the fully-qualified path of the new topic, in format
@@ -160,7 +160,7 @@ class _PublisherAPI(object):
         """API call:  retrieve a topic
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/get
 
         :type topic_path: string
         :param topic_path: the fully-qualified path of the topic, in format
@@ -176,7 +176,7 @@ class _PublisherAPI(object):
         """API call:  delete a topic
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/delete
 
         :type topic_path: string
         :param topic_path: the fully-qualified path of the topic, in format
@@ -189,7 +189,7 @@ class _PublisherAPI(object):
         """API call:  publish one or more messages to a topic
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/publish
 
         :type topic_path: string
         :param topic_path: the fully-qualified path of the topic, in format
@@ -212,7 +212,7 @@ class _PublisherAPI(object):
         """API call:  list subscriptions bound to a topic
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics.subscriptions/list
 
         :type topic_path: string
         :param topic_path: the fully-qualified path of the topic, in format
@@ -259,7 +259,7 @@ class _SubscriberAPI(object):
         """API call:  list subscriptions for a given project
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/list
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/list
 
         :type project: string
         :param project: project ID
@@ -297,7 +297,7 @@ class _SubscriberAPI(object):
         """API call:  create a subscription
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the new
@@ -337,7 +337,7 @@ class _SubscriberAPI(object):
         """API call:  retrieve a subscription
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the subscription,
@@ -355,7 +355,7 @@ class _SubscriberAPI(object):
         """API call:  delete a subscription
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/delete
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the subscription,
@@ -371,7 +371,7 @@ class _SubscriberAPI(object):
         """API call:  update push config of a subscription
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the new
@@ -393,7 +393,7 @@ class _SubscriberAPI(object):
         """API call:  retrieve messages for a subscription
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the new
@@ -425,7 +425,7 @@ class _SubscriberAPI(object):
         """API call:  acknowledge retrieved messages
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the new
@@ -447,7 +447,7 @@ class _SubscriberAPI(object):
         """API call:  update ack deadline for retrieved messages
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyAckDeadline
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
 
         :type subscription_path: string
         :param subscription_path: the fully-qualified path of the new
@@ -484,8 +484,8 @@ class _IAMPolicyAPI(object):
         """API call:  fetch the IAM policy for the target
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/getIamPolicy
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/getIamPolicy
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/getIamPolicy
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/getIamPolicy
 
         :type target_path: string
         :param target_path: the path of the target object.
@@ -501,8 +501,8 @@ class _IAMPolicyAPI(object):
         """API call:  update the IAM policy for the target
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/setIamPolicy
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/setIamPolicy
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/setIamPolicy
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/setIamPolicy
 
         :type target_path: string
         :param target_path: the path of the target object.
@@ -522,8 +522,8 @@ class _IAMPolicyAPI(object):
         """API call:  test permissions
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/testIamPermissions
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/testIamPermissions
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/testIamPermissions
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/testIamPermissions
 
         :type target_path: string
         :param target_path: the path of the target object.

--- a/google/cloud/pubsub/iam.py
+++ b/google/cloud/pubsub/iam.py
@@ -98,8 +98,8 @@ class Policy(object):
     """Combined IAM Policy / Bindings.
 
     See:
-    https://cloud.google.com/pubsub/reference/rest/Shared.Types/Policy
-    https://cloud.google.com/pubsub/reference/rest/Shared.Types/Binding
+    https://cloud.google.com/pubsub/docs/reference/rest/Shared.Types/Policy
+    https://cloud.google.com/pubsub/docs/reference/rest/Shared.Types/Binding
 
     :type etag: string
     :param etag: ETag used to identify a unique of the policy

--- a/google/cloud/pubsub/message.py
+++ b/google/cloud/pubsub/message.py
@@ -23,7 +23,7 @@ class Message(object):
     """Messages can be published to a topic and received by subscribers.
 
     See:
-    https://cloud.google.com/pubsub/reference/rest/v1/PubsubMessage
+    https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
 
     :type data: bytes
     :param data: the payload of the message.

--- a/google/cloud/pubsub/subscription.py
+++ b/google/cloud/pubsub/subscription.py
@@ -24,7 +24,7 @@ class Subscription(object):
     """Subscriptions receive messages published to their topics.
 
     See:
-    https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions
+    https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions
 
     :type name: string
     :param name: the name of the subscription.
@@ -51,7 +51,7 @@ class Subscription(object):
     """Value of ``projects.subscriptions.topic`` when topic has been deleted.
 
     See:
-    https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions#Subscription.FIELDS.topic
+    https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions#Subscription.FIELDS.topic
     """
 
     def __init__(self, name, topic=None, ack_deadline=None, push_endpoint=None,
@@ -163,7 +163,7 @@ class Subscription(object):
         """API call:  create the subscription via a PUT request
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create
 
         Example:
 
@@ -186,7 +186,7 @@ class Subscription(object):
         """API call:  test existence of the subscription via a GET request
 
         See
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
 
         Example:
 
@@ -215,7 +215,7 @@ class Subscription(object):
         """API call:  sync local subscription configuration via a GET request
 
         See
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/get
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
 
         Example:
 
@@ -239,7 +239,7 @@ class Subscription(object):
         """API call:  delete the subscription via a DELETE request.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/delete
 
         Example:
 
@@ -260,7 +260,7 @@ class Subscription(object):
         """API call:  update the push endpoint for the subscription.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyPushConfig
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         Example:
 
@@ -291,7 +291,7 @@ class Subscription(object):
         """API call:  retrieve messages for the subscription.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/pull
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull
 
         Example:
 
@@ -330,7 +330,7 @@ class Subscription(object):
         """API call:  acknowledge retrieved messages for the subscription.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/acknowledge
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/acknowledge
 
         Example:
 
@@ -354,7 +354,7 @@ class Subscription(object):
         """API call:  update acknowledgement deadline for a retrieved message.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/modifyAckDeadline
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
 
         :type ack_ids: list of string
         :param ack_ids: ack IDs of messages being updated
@@ -376,7 +376,7 @@ class Subscription(object):
         """Fetch the IAM policy for the subscription.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/getIamPolicy
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/getIamPolicy
 
         Example:
 
@@ -402,7 +402,7 @@ class Subscription(object):
         """Update the IAM policy for the subscription.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/setIamPolicy
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/setIamPolicy
 
         Example:
 
@@ -433,7 +433,7 @@ class Subscription(object):
         """Verify permissions allowed for the current user.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/testIamPermissions
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/testIamPermissions
 
         Example:
 

--- a/google/cloud/pubsub/topic.py
+++ b/google/cloud/pubsub/topic.py
@@ -31,7 +31,7 @@ class Topic(object):
     Subscribers then receive those messages.
 
     See:
-    https://cloud.google.com/pubsub/reference/rest/v1/projects.topics
+    https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics
 
     :type name: string
     :param name: the name of the topic
@@ -138,7 +138,7 @@ class Topic(object):
         """API call:  create the topic via a PUT request
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/create
 
         Example:
 
@@ -159,7 +159,7 @@ class Topic(object):
         """API call:  test for the existence of the topic via a GET request
 
         See
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/get
 
         Example:
 
@@ -189,7 +189,7 @@ class Topic(object):
         """API call:  delete the topic via a DELETE request
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/delete
 
         Example:
 
@@ -220,7 +220,7 @@ class Topic(object):
         """API call:  publish a message to a topic via a POST request
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/publish
 
         Example without message attributes:
 
@@ -287,7 +287,7 @@ class Topic(object):
         """List subscriptions for the project associated with this client.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics.subscriptions/list
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics.subscriptions/list
 
         Example:
 
@@ -329,7 +329,7 @@ class Topic(object):
         """Fetch the IAM policy for the topic.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/getIamPolicy
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/getIamPolicy
 
         Example:
 
@@ -355,7 +355,7 @@ class Topic(object):
         """Update the IAM policy for the topic.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/setIamPolicy
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/setIamPolicy
 
         Example:
 
@@ -386,7 +386,7 @@ class Topic(object):
         """Verify permissions allowed for the current user.
 
         See:
-        https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/testIamPermissions
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/testIamPermissions
 
         Example:
 


### PR DESCRIPTION
It appears that the pubsub doc links have changed on us.

Before: https://cloud.google.com/pubsub/reference/rest
After: https://cloud.google.com/pubsub/docs/reference/rest

See: https://github.com/GoogleCloudPlatform/gcloud-common/issues/190
https://github.com/GoogleCloudPlatform/google-cloud-node/issues/1609