### PR TITLE
Tweaking new PyLint config values.

### DIFF
--- a/google/cloud/dns/zone.py
+++ b/google/cloud/dns/zone.py
@@ -332,7 +332,7 @@ class ManagedZone(object):
 
         :rtype: tuple, (list, str)
         :returns: list of
-                  :class:`google.cloud.dns.resource_record_set.ResourceRecordSet`,
+                  :class:`~.resource_record_set.ResourceRecordSet`,
                   plus a "next page token" string:  if the token is not None,
                   indicates that more zones can be retrieved with another
                   call (pass that value as ``page_token``).
@@ -375,7 +375,7 @@ class ManagedZone(object):
 
         :rtype: tuple, (list, str)
         :returns: list of
-                  :class:`google.cloud.dns.resource_record_set.ResourceRecordSet`,
+                  :class:`~.resource_record_set.ResourceRecordSet`,
                   plus a "next page token" string:  if the token is not None,
                   indicates that more zones can be retrieved with another
                   call (pass that value as ``page_token``).

--- a/google/cloud/monitoring/client.py
+++ b/google/cloud/monitoring/client.py
@@ -227,7 +227,7 @@ class Client(JSONClient):
         :type labels: dict
         :param labels: A mapping from label names to values for all labels
                        enumerated in the associated
-                       :class:`~google.cloud.monitoring.metric.MetricDescriptor`.
+                       :class:`~.metric.MetricDescriptor`.
 
         :rtype: :class:`~google.cloud.monitoring.metric.Metric`
         :returns: The metric object.
@@ -254,7 +254,7 @@ class Client(JSONClient):
         :type labels: dict
         :param labels: A mapping from label names to values for all labels
                        enumerated in the associated
-                       :class:`~google.cloud.monitoring.resource.ResourceDescriptor`,
+                       :class:`~.resource.ResourceDescriptor`,
                        except that ``project_id`` can and should be omitted
                        when writing time series data.
 

--- a/google/cloud/pubsub/_gax.py
+++ b/google/cloud/pubsub/_gax.py
@@ -262,9 +262,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the new
-                                  subscription, in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the new subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type topic_path: string
         :param topic_path: the fully-qualified path of the topic being
@@ -307,9 +307,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the subscription,
-                                  in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :rtype: dict
         :returns: ``Subscription`` resource returned from the API.
@@ -329,9 +329,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/delete
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the subscription,
-                                  in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
         """
         try:
             self._gax_api.delete_subscription(subscription_path)
@@ -348,9 +348,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the new
-                                  subscription, in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the new subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type push_endpoint: string, or ``NoneType``
         :param push_endpoint: URL to which messages will be pushed by the
@@ -373,9 +373,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the new
-                                  subscription, in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the new subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type return_immediately: boolean
         :param return_immediately: if True, the back-end returns even if no
@@ -406,9 +406,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the new
-                                  subscription, in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the new subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type ack_ids: list of string
         :param ack_ids: ack IDs of messages being acknowledged
@@ -428,9 +428,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the new
-                                  subscription, in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the new subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type ack_ids: list of string
         :param ack_ids: ack IDs of messages being acknowledged

--- a/google/cloud/pubsub/connection.py
+++ b/google/cloud/pubsub/connection.py
@@ -300,9 +300,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the new
-                                  subscription, in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the new subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type topic_path: string
         :param topic_path: the fully-qualified path of the topic being
@@ -340,9 +340,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the subscription,
-                                  in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :rtype: dict
         :returns: ``Subscription`` resource returned from the API.
@@ -358,9 +358,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/delete
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the subscription,
-                                  in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
         """
         conn = self._connection
         path = '/%s' % (subscription_path,)
@@ -374,9 +374,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the new
-                                  subscription, in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the new subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type push_endpoint: string, or ``NoneType``
         :param push_endpoint: URL to which messages will be pushed by the
@@ -396,9 +396,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the new
-                                  subscription, in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the new subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type return_immediately: boolean
         :param return_immediately: if True, the back-end returns even if no
@@ -428,9 +428,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the new
-                                  subscription, in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the new subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type ack_ids: list of string
         :param ack_ids: ack IDs of messages being acknowledged
@@ -450,9 +450,9 @@ class _SubscriberAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
 
         :type subscription_path: string
-        :param subscription_path: the fully-qualified path of the new
-                                  subscription, in format
-                                  ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
+        :param subscription_path:
+            the fully-qualified path of the new subscription, in format
+            ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type ack_ids: list of string
         :param ack_ids: ack IDs of messages being acknowledged

--- a/scripts/pylintrc_default
+++ b/scripts/pylintrc_default
@@ -370,7 +370,9 @@ ignore-imports=no
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=100
+# DEFAULT: max-line-length=100
+# RATIONALE: PEP8
+max-line-length=80
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$
@@ -404,7 +406,9 @@ indent-string='    '
 indent-after-paren=4
 
 # Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-expected-line-ending-format=
+# DEFAULT:  expected-line-ending-format=
+# RATIONALE:  Uniform UNIX line endings.
+expected-line-ending-format=LF
 
 
 [TYPECHECK]


### PR DESCRIPTION
Reducing the max line length from 80 to 100 revealed several docstrings in violation, so those have been fixed as well.

The other change was restricting to UNIX linefeed.

----

@tseaver mentioned in https://github.com/GoogleCloudPlatform/google-cloud-python/issues/1256#issuecomment-164012842 that the linefeed change may be problematic:

> If we ever get Windows contributors, we'll need to allow them to run the linter without barfing on their own machines.  Maybe do this check only in Travis, and document that they need to use [`core.autocrlf'](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#Formatting-and-Whitespace).
