### PR TITLE
Removing PyPI deploy step from Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,6 @@ script:
 after_success:
   - tox -e coveralls
 
-deploy:
-  provider: pypi
-  user: gcloudpypi
-  password:
-    secure: LR0i9Oeu6kpLTYS5xK/zCng4gmdtPvFfD/XYdQhyY5jBibQkC2WUQU6nJA9bDXRxhBP5bUwXFGkbhOcOJgHNrUfmyPzpDbM8BR29KfY0WfdYv72gsGZOaekqCReFmHbqLE7qOQtHR5U3ey6ivcgw+hZO72Uu6qDCc9B8qwoBfAs=
-  on:
-    tags: true
-    repo: GoogleCloudPlatform/google-cloud-python
-    all_branches: true
-  # 'bdist_wheel' builds disabled until #1879 et al. are resolved.
-  distributions: "sdist"
-
 cache:
   directories:
     - ${HOME}/.cache/pip


### PR DESCRIPTION
As we split out into many packages, Travis won't be able to handle our deploy process, so we'll need to write a custom one.