### PR TITLE
Preserve ACL when copying or renaming blob.

### DIFF
--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -470,11 +470,10 @@ class Bucket(_PropertyMixin):
             new_name = blob.name
         new_blob = Blob(bucket=destination_bucket, name=new_name)
         api_path = blob.path + '/copyTo' + new_blob.path
-        if not preserve_acl:
-            new_blob.acl.reset()
-            new_blob.acl.save()
         copy_result = client.connection.api_request(
             method='POST', path=api_path, _target_object=new_blob)
+        if not preserve_acl:
+            new_blob.acl.save(acl={}, client=client)
         new_blob._set_properties(copy_result)
         return new_blob
 

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -440,7 +440,7 @@ class Bucket(_PropertyMixin):
                     raise
 
     def copy_blob(self, blob, destination_bucket, new_name=None,
-                  client=None, preserve_acl=False):
+                  client=None, preserve_acl=True):
         """Copy the given blob to the given bucket, optionally with a new name.
 
         :type blob: :class:`google.cloud.storage.blob.Blob`
@@ -460,7 +460,7 @@ class Bucket(_PropertyMixin):
 
         :type preserve_acl: bool
         :param preserve_acl: Optional. Copies ACL from old blob to new blob.
-                             Default: False.
+                             Default: True.
 
         :rtype: :class:`google.cloud.storage.blob.Blob`
         :returns: The new Blob.
@@ -470,14 +470,15 @@ class Bucket(_PropertyMixin):
             new_name = blob.name
         new_blob = Blob(bucket=destination_bucket, name=new_name)
         api_path = blob.path + '/copyTo' + new_blob.path
+        if not preserve_acl:
+            new_blob.acl.reset()
+            new_blob.acl.save()
         copy_result = client.connection.api_request(
             method='POST', path=api_path, _target_object=new_blob)
         new_blob._set_properties(copy_result)
-        if preserve_acl:
-            new_blob.acl.save(blob.acl)
         return new_blob
 
-    def rename_blob(self, blob, new_name, client=None, preserve_acl=False):
+    def rename_blob(self, blob, new_name, client=None):
         """Rename the given blob using copy and delete operations.
 
         Effectively, copies blob to the same bucket with a new name, then
@@ -500,15 +501,10 @@ class Bucket(_PropertyMixin):
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the current bucket.
 
-        :type preserve_acl: bool
-        :param preserve_acl: Optional. Copies ACL from old blob to renamed
-                             blob. Default: False.
-
         :rtype: :class:`Blob`
         :returns: The newly-renamed blob.
         """
-        new_blob = self.copy_blob(blob, self, new_name, client=client,
-                                  preserve_acl=preserve_acl)
+        new_blob = self.copy_blob(blob, self, new_name, client=client)
         blob.delete(client=client)
         return new_blob
 

--- a/storage/unit_tests/test_bucket.py
+++ b/storage/unit_tests/test_bucket.py
@@ -543,7 +543,7 @@ class Test_Bucket(unittest.TestCase):
         BLOB_NAME = 'blob-name'
         NEW_NAME = 'new_name'
 
-        def save(self, client):  # pylint: disable=unused-argument
+        def save(self):  # pylint: disable=unused-argument
             return
 
         class _Blob(object):
@@ -552,6 +552,8 @@ class Test_Bucket(unittest.TestCase):
 
             def __init__(self):
                 self.acl = ACL()
+                self.acl.loaded = True
+                self.acl.entity('type', 'id')
 
         connection = _Connection({})
         client = _Client(connection)
@@ -560,10 +562,12 @@ class Test_Bucket(unittest.TestCase):
         blob = _Blob()
         with _Monkey(ACL, save=save):
             new_blob = source.copy_blob(blob, dest, NEW_NAME, client=client,
-                                        preserve_acl=True)
+                                        preserve_acl=False)
             self.assertIs(new_blob.bucket, dest)
             self.assertEqual(new_blob.name, NEW_NAME)
             self.assertIsInstance(new_blob.acl, ObjectACL)
+            self.assertFalse(new_blob.acl.loaded)
+            self.assertEqual(new_blob.acl.entities, {})
 
     def test_copy_blobs_w_name(self):
         SOURCE = 'source'

--- a/storage/unit_tests/test_bucket.py
+++ b/storage/unit_tests/test_bucket.py
@@ -535,39 +535,36 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw['path'], COPY_PATH)
 
     def test_copy_blobs_preserve_acl(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.storage.acl import ACL
         from google.cloud.storage.acl import ObjectACL
         SOURCE = 'source'
         DEST = 'dest'
         BLOB_NAME = 'blob-name'
         NEW_NAME = 'new_name'
-
-        def save(self):  # pylint: disable=unused-argument
-            return
+        BLOB_PATH = '/b/%s/o/%s' % (SOURCE, BLOB_NAME)
+        NEW_BLOB_PATH = '/b/%s/o/%s' % (DEST, NEW_NAME)
+        COPY_PATH = '/b/%s/o/%s/copyTo/b/%s/o/%s' % (SOURCE, BLOB_NAME,
+                                                     DEST, NEW_NAME)
 
         class _Blob(object):
             name = BLOB_NAME
-            path = '/b/%s/o/%s' % (SOURCE, BLOB_NAME)
+            path = BLOB_PATH
 
-            def __init__(self):
-                self.acl = ACL()
-                self.acl.loaded = True
-                self.acl.entity('type', 'id')
-
-        connection = _Connection({})
+        connection = _Connection({}, {})
         client = _Client(connection)
         source = self._makeOne(client=client, name=SOURCE)
         dest = self._makeOne(client=client, name=DEST)
         blob = _Blob()
-        with _Monkey(ACL, save=save):
-            new_blob = source.copy_blob(blob, dest, NEW_NAME, client=client,
-                                        preserve_acl=False)
-            self.assertIs(new_blob.bucket, dest)
-            self.assertEqual(new_blob.name, NEW_NAME)
-            self.assertIsInstance(new_blob.acl, ObjectACL)
-            self.assertFalse(new_blob.acl.loaded)
-            self.assertEqual(new_blob.acl.entities, {})
+        new_blob = source.copy_blob(blob, dest, NEW_NAME, client=client,
+                                    preserve_acl=False)
+        self.assertIs(new_blob.bucket, dest)
+        self.assertEqual(new_blob.name, NEW_NAME)
+        self.assertIsInstance(new_blob.acl, ObjectACL)
+        kw = connection._requested
+        self.assertEqual(len(kw), 2)
+        self.assertEqual(kw[0]['method'], 'POST')
+        self.assertEqual(kw[0]['path'], COPY_PATH)
+        self.assertEqual(kw[1]['method'], 'PATCH')
+        self.assertEqual(kw[1]['path'], NEW_BLOB_PATH)
 
     def test_copy_blobs_w_name(self):
         SOURCE = 'source'


### PR DESCRIPTION
See: #2389

ACL settings are not held when copying a blob or renaming a blob.

Adds `preserve_acl` to `Bucket.copy_blob` and `Bucket.rename_blob`.