### PR TITLE
Attempt to share common setup.py data with sub-packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.egg
 *.egg-info
 dist
+*/setup_base
 build
 eggs
 parts

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Packages
 *.egg
 *.egg-info
+*/setup_base
 dist
 */setup_base
 build

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/dns/setup.py
+++ b/dns/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/language/setup.py
+++ b/language/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/resource_manager/setup.py
+++ b/resource_manager/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -25,29 +25,7 @@ with open(os.path.join(PACKAGE_ROOT, 'README.rst')) as file_obj:
 
 # NOTE: This is duplicated throughout and we should try to
 #       consolidate.
-SETUP_BASE = {
-    'author': 'Google Cloud Platform',
-    'author_email': 'jjg+google-cloud-python@google.com',
-    'scripts': [],
-    'url': 'https://github.com/GoogleCloudPlatform/google-cloud-python',
-    'license': 'Apache 2.0',
-    'platforms': 'Posix; MacOS X; Windows',
-    'include_package_data': True,
-    'zip_safe': False,
-    'classifiers': [
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Topic :: Internet',
-    ],
-}
-
+from setup_base import SETUP_BASE
 
 REQUIREMENTS = [
     'google-cloud-bigquery >= 0.20.0',

--- a/setup_base/base.py
+++ b/setup_base/base.py
@@ -1,0 +1,22 @@
+SETUP_BASE = {
+    'author': 'Google Cloud Platform',
+    'author_email': 'jjg+google-cloud-python@google.com',
+    'scripts': [],
+    'url': 'https://github.com/GoogleCloudPlatform/google-cloud-python',
+    'license': 'Apache 2.0',
+    'platforms': 'Posix; MacOS X; Windows',
+    'include_package_data': True,
+    'zip_safe': False,
+    'classifiers': [
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Topic :: Internet',
+    ],
+}

--- a/storage/MANIFEST.in
+++ b/storage/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
 graft google
+include ../setup_base.py
 graft unit_tests
 global-exclude *.pyc

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -23,6 +23,7 @@ try:
     copytree('../setup_base', './setup_base')
 except:
     pass
+
 from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -17,6 +17,13 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -25,29 +25,7 @@ with open(os.path.join(PACKAGE_ROOT, 'README.rst')) as file_obj:
 
 # NOTE: This is duplicated throughout and we should try to
 #       consolidate.
-SETUP_BASE = {
-    'author': 'Google Cloud Platform',
-    'author_email': 'jjg+google-cloud-python@google.com',
-    'scripts': [],
-    'url': 'https://github.com/GoogleCloudPlatform/google-cloud-python',
-    'license': 'Apache 2.0',
-    'platforms': 'Posix; MacOS X; Windows',
-    'include_package_data': True,
-    'zip_safe': False,
-    'classifiers': [
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Topic :: Internet',
-    ],
-}
-
+from setup_base.base import SETUP_BASE
 
 REQUIREMENTS = [
     'google-cloud-core >= 0.20.0',

--- a/translate/setup.py
+++ b/translate/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -17,6 +17,14 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
+from shutil import copytree
+
+try:
+    copytree('../setup_base', './setup_base')
+except:
+    pass
+
+from setup_base.base import SETUP_BASE
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
See #2395.

I was able to do a `python setup.py sdist` for root as well as `cd storage` and run `python setup.py sdist` from there as well.

`setup_base` was included for the storage sdist.

the naming should probably be changed though.