### PR TITLE
Adding docs/requirements.txt to allow RTD local deps.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,15 @@
+bigquery/
+bigtable/
+core/
+datastore/
+dns/
+error_reporting/
+language/
+logging/
+monitoring/
+pubsub/
+resource_manager/
+speech/
+storage/
+translate/
+vision/


### PR DESCRIPTION
Already updated the settings on RTD:

![screen_shot_001](https://cloud.githubusercontent.com/assets/520669/18882415/e5801f0c-8493-11e6-96a4-e8fc548b3d74.png)

Followed the format suggested for `pip`: https://pip.pypa.io/en/latest/reference/pip_install/#requirements-file-format