### PR TITLE
Removing "install from source" instructions.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -193,15 +193,6 @@ The ``google-cloud`` library is ``pip`` install-able:
 
     $ pip install google-cloud
 
-If you want to install ``google-cloud-python`` from source,
-you can clone the repository from GitHub:
-
-.. code-block:: console
-
-    $ git clone git://github.com/GoogleCloudPlatform/google-cloud-python.git
-    $ cd google-cloud-python
-    $ python setup.py install
-
 ----
 
 Cloud Datastore

--- a/docs/json/json/master/overview.html
+++ b/docs/json/json/master/overview.html
@@ -8,17 +8,6 @@ The <code>google-cloud</code> library is <code>pip</code> install-able:
     $ pip install google-cloud
 </div>
 
-<p>
-If you want to install <code>google-cloud-python</code> from source,
-you can clone the repository from GitHub:
-</p>
-
-<div hljs>
-    $ git clone git://github.com/GoogleCloudPlatform/google-cloud-python.git
-    $ cd google-cloud-python
-    $ python setup.py install
-</div>
-
 <hr>
 
 <h3>Cloud Datastore</h3>


### PR DESCRIPTION
We still have documentation in `CONTRIBUTING` for how one might go about this, it just isn't necessary in the basic user-facing documentation.

Fixes #2437.