### PR TITLE
Monitoring - Look for specific messages in retries

### DIFF
--- a/system_tests/monitoring.py
+++ b/system_tests/monitoring.py
@@ -29,7 +29,6 @@ retry_404_500 = RetryErrors((NotFound, InternalServerError))
 retry_500 = RetryErrors(InternalServerError)
 retry_503 = RetryErrors(ServiceUnavailable)
 
-
 def _has_timeseries(result):
     """Return True if a time series query has non-empty results."""
     return len(list(result)) > 0
@@ -37,11 +36,8 @@ def _has_timeseries(result):
 UNKNOWN_METRIC_ERROR = ('The provided filter doesn\'t refer to any known '
                         'metric.')
 
-
 def _unknown_metric(result):
     """Return True if the error describes writing to an unknown metric.."""
-    import sys
-    sys.stderr.write("WOW %s " % result.args)
     return UNKNOWN_METRIC_ERROR in result.message
 
 

--- a/system_tests/monitoring.py
+++ b/system_tests/monitoring.py
@@ -29,8 +29,6 @@ retry_404_500 = RetryErrors((NotFound, InternalServerError))
 retry_500 = RetryErrors(InternalServerError)
 retry_503 = RetryErrors(ServiceUnavailable)
 
-# Retry predicates
-
 
 def _has_timeseries(result):
     """Return True if a time series query has non-empty results."""
@@ -42,6 +40,8 @@ UNKNOWN_METRIC_ERROR = ('The provided filter doesn\'t refer to any known '
 
 def _unknown_metric(result):
     """Return True if the error describes writing to an unknown metric.."""
+    import sys
+    sys.stderr.write("WOW %s " % result.args)
     return UNKNOWN_METRIC_ERROR in result.message
 
 

--- a/system_tests/monitoring.py
+++ b/system_tests/monitoring.py
@@ -29,12 +29,14 @@ retry_404_500 = RetryErrors((NotFound, InternalServerError))
 retry_500 = RetryErrors(InternalServerError)
 retry_503 = RetryErrors(ServiceUnavailable)
 
+
 def _has_timeseries(result):
     """Return True if a time series query has non-empty results."""
     return len(list(result)) > 0
 
 UNKNOWN_METRIC_ERROR = ('The provided filter doesn\'t refer to any known '
                         'metric.')
+
 
 def _unknown_metric(result):
     """Return True if the error describes writing to an unknown metric.."""

--- a/system_tests/monitoring.py
+++ b/system_tests/monitoring.py
@@ -207,9 +207,14 @@ class TestMonitoring(unittest.TestCase):
             def _has_timeseries(result):
                 return len(list(result)) > 0
 
+            def _unknown_metric(result):
+                return ('The provided filter doesn\'t refer to any known '
+                        'metric.'in result.message)
+
             retry_result = RetryResult(_has_timeseries,
                                        max_tries=MAX_RETRIES)(client.query)
-            return RetryErrors(BadRequest, max_tries=MAX_RETRIES)(retry_result)
+            return RetryErrors(BadRequest, _unknown_metric,
+                               max_tries=MAX_RETRIES)(retry_result)
 
         query = _query_timeseries_with_retries()(METRIC_TYPE, minutes=5)
         timeseries_list = list(query)


### PR DESCRIPTION
This starts to address #2415. 

This was the most obvious check to add. For the other errors, 404s, 500s, and 503s all provide very generic error messages (and really we need the API team to just fix the 500s). 

As far as retry logic, I'm not convinced it can be significantly improved, using a base of 3 makes the jumps too big. Maybe we could start from a higher number, but I think it would complicate the retry logic to save at best a few seconds.

So I am voting to just close #2415 after this is merged but let me know if you disagree.
