### PR TITLE
Updating Bigtable and Datastore autogenerate makefiles.

### DIFF
--- a/Makefile.bigtable_v2
+++ b/Makefile.bigtable_v2
@@ -1,15 +1,15 @@
 GRPCIO_VIRTUALENV=$(shell pwd)/grpc_python_venv
 GENERATED_DIR=$(shell pwd)/generated_python
 GENERATED_SUBDIR=_generated
-BIGTABLE_DIR=$(shell pwd)/google/cloud/bigtable/$(GENERATED_SUBDIR)
+BIGTABLE_DIR=$(shell pwd)/bigtable/google/cloud/bigtable/$(GENERATED_SUBDIR)
 PROTOC_CMD=$(GRPCIO_VIRTUALENV)/bin/python -m grpc.tools.protoc
 GOOGLEAPIS_PROTOS_DIR=$(shell pwd)/googleapis-pb
 
 help:
-	@echo 'Makefile for google-cloud-python Bigtable protos                      '
-	@echo '                                                                '
-	@echo '   make generate                 Generates the protobuf modules '
-	@echo '   make clean                    Clean generated files          '
+	@echo 'Makefile for google-cloud-python Bigtable protos      '
+	@echo '                                                      '
+	@echo '   make generate        Generates the protobuf modules'
+	@echo '   make clean           Clean generated files         '
 
 generate:
 	# Ensure we have a virtualenv w/ up-to-date grpcio/grpcio-tools

--- a/Makefile.datastore
+++ b/Makefile.datastore
@@ -1,14 +1,14 @@
 GRPCIO_VIRTUALENV=$(shell pwd)/grpc_python_venv
 GENERATED_DIR=$(shell pwd)/generated_python
-DATASTORE_DIR=$(shell pwd)/google/cloud/datastore/_generated
+DATASTORE_DIR=$(shell pwd)/datastore/google/cloud/datastore/_generated
 PROTOC_CMD=$(GRPCIO_VIRTUALENV)/bin/python -m grpc.tools.protoc
 GOOGLEAPIS_PROTOS_DIR=$(shell pwd)/googleapis-pb
 
 help:
-	@echo 'Makefile for google-cloud-python Bigtable protos                      '
-	@echo '                                                                '
-	@echo '   make generate                 Generates the protobuf modules '
-	@echo '   make clean                    Clean generated files          '
+	@echo 'Makefile for google-cloud-python Datastore protos     '
+	@echo '                                                      '
+	@echo '   make generate        Generates the protobuf modules'
+	@echo '   make clean           Clean generated files         '
 
 generate:
 	# Ensure we have a virtualenv w/ up-to-date grpcio/grpcio-tools

--- a/bigtable/google/cloud/bigtable/_generated/bigtable_instance_admin_pb2.py
+++ b/bigtable/google/cloud/bigtable/_generated/bigtable_instance_admin_pb2.py
@@ -668,7 +668,7 @@ DESCRIPTOR.has_options = True
 DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\034com.google.bigtable.admin.v2B\032BigtableInstanceAdminProtoP\001'))
 _CREATEINSTANCEREQUEST_CLUSTERSENTRY.has_options = True
 _CREATEINSTANCEREQUEST_CLUSTERSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-
+import grpc
 from grpc.beta import implementations as beta_implementations
 from grpc.beta import interfaces as beta_interfaces
 from grpc.framework.common import cardinality

--- a/bigtable/google/cloud/bigtable/_generated/bigtable_pb2.py
+++ b/bigtable/google/cloud/bigtable/_generated/bigtable_pb2.py
@@ -804,7 +804,7 @@ _sym_db.RegisterMessage(ReadModifyWriteRowResponse)
 
 DESCRIPTOR.has_options = True
 DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\026com.google.bigtable.v2B\rBigtableProtoP\001'))
-
+import grpc
 from grpc.beta import implementations as beta_implementations
 from grpc.beta import interfaces as beta_interfaces
 from grpc.framework.common import cardinality

--- a/bigtable/google/cloud/bigtable/_generated/bigtable_table_admin_pb2.py
+++ b/bigtable/google/cloud/bigtable/_generated/bigtable_table_admin_pb2.py
@@ -504,7 +504,7 @@ _sym_db.RegisterMessage(ModifyColumnFamiliesRequest.Modification)
 
 DESCRIPTOR.has_options = True
 DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\034com.google.bigtable.admin.v2B\027BigtableTableAdminProtoP\001'))
-
+import grpc
 from grpc.beta import implementations as beta_implementations
 from grpc.beta import interfaces as beta_interfaces
 from grpc.framework.common import cardinality

--- a/scripts/make_datastore_grpc.py
+++ b/scripts/make_datastore_grpc.py
@@ -26,7 +26,8 @@ ROOT_DIR = os.path.abspath(
 PROTOS_DIR = os.path.join(ROOT_DIR, 'googleapis-pb')
 PROTO_PATH = os.path.join(PROTOS_DIR, 'google', 'datastore',
                           'v1', 'datastore.proto')
-GRPC_ONLY_FILE = os.path.join(ROOT_DIR, 'google', 'cloud', 'datastore',
+GRPC_ONLY_FILE = os.path.join(ROOT_DIR, 'datastore',
+                              'google', 'cloud', 'datastore',
                               '_generated', 'datastore_grpc_pb2.py')
 GRPCIO_VIRTUALENV = os.getenv('GRPCIO_VIRTUALENV')
 if GRPCIO_VIRTUALENV is None:


### PR DESCRIPTION
In the process, also updating a hardcoded path in make_datastore_grpc.

Also, re-running `make generate` in each of these introduced small changes to the autogenerated bigtable modules.

(This PR needed due to subpackages moving into their own self-contained folders.)