### PR TITLE
Upgrading version of oauth2client due to GAPIC/GAX conflict.

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -52,7 +52,7 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'httplib2 >= 0.9.1',
     'googleapis-common-protos >= 1.3.4',
-    'oauth2client >= 2.0.1, < 3.0.0dev',
+    'oauth2client >= 3.0.0, < 4.0.0dev',
     'protobuf >= 3.0.0',
     'six',
 ]


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/google-cloud-python/issues/2405#issuecomment-250037457 and #2453 for context.