### PR TITLE
Install a fake local `grpc-google-iam-v1` to resolve the version conflict.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,3 +13,4 @@ speech/
 storage/
 translate/
 vision/
+grpc-google-iam-v1-fake/

--- a/grpc-google-iam-v1-fake/README.rst
+++ b/grpc-google-iam-v1-fake/README.rst
@@ -1,0 +1,5 @@
+gRPC library for google-iam-v1
+
+grpc-google-iam-v1 is the IDL-derived library for the google-iam (v1) service in the googleapis_ repository.
+
+.. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/iam/v1

--- a/grpc-google-iam-v1-fake/google/__init__.py
+++ b/grpc-google-iam-v1-fake/google/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/grpc-google-iam-v1-fake/google/iam/__init__.py
+++ b/grpc-google-iam-v1-fake/google/iam/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/grpc-google-iam-v1-fake/setup.py
+++ b/grpc-google-iam-v1-fake/setup.py
@@ -1,0 +1,36 @@
+import setuptools
+
+from setuptools import find_packages
+from setuptools import setup
+
+install_requires = [
+  'grpcio>=1.0.0, <2.0.0',
+  'googleapis-common-protos[grpc]>=1.3.4, <2.0.0'
+]
+
+setuptools.setup(
+  name='grpc-google-iam-v1',
+  version='0.10.0',
+  author='Google Inc',
+  author_email='googleapis-packages@google.com',
+  classifiers=[
+    'Intended Audience :: Developers',
+    'Development Status :: 3 - Alpha',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: Apache Software License',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: Implementation :: CPython',
+  ],
+  description='GRPC library for the google-iam-v1 service',
+  long_description=open('README.rst').read(),
+  install_requires=install_requires,
+  license='Apache-2.0',
+  packages=find_packages(),
+  namespace_packages=['google', 'google.iam', ],
+  url='https://github.com/googleapis/googleapis'
+)

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -33,6 +33,7 @@ import sys
 IGNORED_DIRECTORIES = [
     os.path.join('bigtable', 'google', 'cloud', 'bigtable', '_generated'),
     os.path.join('datastore', 'google', 'cloud', 'datastore', '_generated'),
+    'grpc-google-iam-v1-fake',
 ]
 IGNORED_FILES = [
     os.path.join('docs', 'conf.py'),


### PR DESCRIPTION
See https://readthedocs.org/projects/google-cloud-python/builds/4449660/ for validation of this fact (at 388b9bf2ad9b097ed559cb144bf03357695b5c18). This is a temporary hack to workaround the fact that the latest (0.10.1) `gapic-google-pubsub-v1` relies on `grpc-google-iam-v1` 0.10.0, but they have contradicting bounds on `oauth2client`:

- `'oauth2client>=1.4.11, <2.0.0',` [in `grpc-google-iam-v1`][1]
- `'oauth2client>=3.0.0, <4.0.0dev',` [in `gapic-google-pubsub-v1`][2]

Fixes #2405.

**WORTH NOTING**: I am sending the PR from a branch I created on `GoogleCloudPlatform`. I created it here so I could test if the hack worked on RTD without having to keep behaving badly with premature merges.

/cc @bjwatson 

----

ASIDE: @tseaver @jonparrott Any idea why `pip` is cool with the version conflict but `setuptools` isn't? (Evidence: `python setup.py install` fails at the "Processing dependencies" step with the conflict described above, but `pip` is happy to let it happen.)

[1]: https://github.com/googleapis/api-client-staging/blob/82ffe47ae78e6a23ab02ee9e3de097cec37a5639/generated/python/grpc-google-iam-v1/setup.py#L13
[2]: https://github.com/googleapis/api-client-staging/blob/82ffe47ae78e6a23ab02ee9e3de097cec37a5639/generated/python/gapic-google-pubsub-v1/setup.py#L16