### PR TITLE
General clean-up after rename.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include README.rst
-graft google
 global-exclude *.pyc

--- a/bigquery/google/cloud/__init__.py
+++ b/bigquery/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bigtable/google/cloud/__init__.py
+++ b/bigtable/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/google/cloud/__init__.py
+++ b/core/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/datastore/google/cloud/__init__.py
+++ b/datastore/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dns/google/cloud/__init__.py
+++ b/dns/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -281,17 +281,6 @@ texinfo_documents = [
 # and parameter definitions from the __init__ docstring.
 autoclass_content = 'both'
 
-issue_uri = ('https://github.com/GoogleCloudPlatform/google-cloud-python/issues/'
-             'new?' + urllib.urlencode({'title': '[Documentation Issue] '}))
-issue_uri_template = (
-    issue_uri + '&' + urllib.urlencode({'body': 'Page Name: '}) + '{0}' +
-    urllib.quote('\nRelease: ') + '{1}')
-
-html_context.update(
-    issue_uri=issue_uri,
-    issue_uri_template=issue_uri_template,
-)
-
 # Configuration for intersphinx:
 # Refer to the Python standard library and the oauth2client and
 # httplib2 libraries.

--- a/error_reporting/google/cloud/__init__.py
+++ b/error_reporting/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/language/google/cloud/__init__.py
+++ b/language/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/logging/google/cloud/__init__.py
+++ b/logging/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/monitoring/google/cloud/__init__.py
+++ b/monitoring/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pubsub/google/cloud/__init__.py
+++ b/pubsub/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resource_manager/google/cloud/__init__.py
+++ b/resource_manager/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -16,6 +16,9 @@
 
 set -ev
 
+GH_OWNER="GoogleCloudPlatform"
+GH_PROJECT_NAME="google-cloud-python"
+
 #########################################
 # Only update docs if we are on Travis. #
 #########################################

--- a/scripts/update_json_docs.sh
+++ b/scripts/update_json_docs.sh
@@ -16,6 +16,8 @@
 
 set -ev
 
+GH_OWNER="GoogleCloudPlatform"
+GH_PROJECT_NAME="google-cloud-python"
 
 function buildDocs () {
   echo "Building JSON documentation..."

--- a/scripts/verify_included_modules.py
+++ b/scripts/verify_included_modules.py
@@ -58,7 +58,6 @@ IGNORED_MODULES = frozenset([
     'google.cloud.vision.fixtures',
 ])
 PACKAGES = (
-    '',
     'bigquery',
     'bigtable',
     'core',

--- a/speech/google/cloud/__init__.py
+++ b/speech/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/storage/google/cloud/__init__.py
+++ b/storage/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/system_tests/bigtable.py
+++ b/system_tests/bigtable.py
@@ -68,12 +68,12 @@ class Config(object):
 def _wait_until_complete(operation, max_attempts=5):
     """Wait until an operation has completed.
 
-    :type operation: :class:`google.cloud.bigtable.instance.Operation`
-    :param operation: Operation that has not complete.
+    :type operation: :class:`google.cloud.operation.Operation`
+    :param operation: Operation that has not completed.
 
     :type max_attempts: int
     :param max_attempts: (Optional) The maximum number of times to check if
-                         the operation has complete. Defaults to 5.
+                         the operation has completed. Defaults to 5.
 
     :rtype: bool
     :returns: Boolean indicating if the operation is complete.

--- a/tox.ini
+++ b/tox.ini
@@ -161,9 +161,7 @@ passenv =
     TRAVIS_TAG
     TRAVIS_BRANCH
     TRAVIS_PULL_REQUEST
-    GH_OWNER
     GH_OAUTH_TOKEN
-    GH_PROJECT_NAME
 
 [testenv:docs]
 basepython =
@@ -220,7 +218,7 @@ basepython =
     python2.7
 commands =
     python {toxinidir}/system_tests/attempt_system_tests.py {posargs}
-passenv = GOOGLE_* GOOGLE_CLOUD_* TRAVIS* encrypted_*
+passenv = GOOGLE_* TRAVIS* encrypted_*
 
 [testenv:system-tests3]
 basepython =

--- a/translate/google/cloud/__init__.py
+++ b/translate/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/vision/google/cloud/__init__.py
+++ b/vision/google/cloud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Removing `graft google` from `MANIFEST` for umbrella package. It isn't needed since the umbrella package has no source
- Updating license year on copy-pasted namespace package `__init__.py` files. Done via: https://gist.github.com/dhermes/a0e88f891ffffc3ecea5c9bb2f13e4f5
- Removing unused HTML context from `docs/conf.py`
- Setting `GH_OWNER` and `GH_PROJECT_NAME` (which together make the `REPO_SLUG`) manually in the docs update scripts. This way the env. variables don't need to be set in the Travis UI / CLI. Also updating `tox.ini` to stop passing those variables through
- Removing the root package from `verify_included_modules.py` since it no longer has any source
- Updated a docstring reference to a moved class in the Bigtable system test
- Removing redundant `GOOGLE_CLOUD_*` in `tox` system test `passenv` (already covered by `GOOGLE_*`)