### PR TITLE
Updating docs landing page title to google-cloud-python.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>google-cloud</title>
-    <meta name="description" content="Node idiomatic client for Google Cloud services.">
+    <title>google-cloud-python</title>
+    <meta name="description" content="Python idiomatic client for Google Cloud services.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="https://cloud.google.com/images/gcp-favicon.ico">
     <link rel="stylesheet" href="_landing-page-static/css/normalize.css">


### PR DESCRIPTION
Also changing a meta description to refer to Python, not Node.

Fixes #2470.