### PR TITLE
Collapsing sub-package explosion in Travis config into a script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,53 +5,11 @@ install:
   - pip install --upgrade pip tox
 
 script:
-  - (cd core && tox -e py27)
-  - (cd bigtable && tox -e py27)
-  - (cd storage && tox -e py27)
-  - (cd datastore && tox -e py27)
-  - (cd bigquery && tox -e py27)
-  - (cd pubsub && tox -e py27)
-  - (cd logging && tox -e py27)
-  - (cd dns && tox -e py27)
-  - (cd language && tox -e py27)
-  - (cd error_reporting && tox -e py27)
-  - (cd resource_manager && tox -e py27)
-  - (cd monitoring && tox -e py27)
-  - (cd vision && tox -e py27)
-  - (cd translate && tox -e py27)
-  - (cd speech && tox -e py27)
-  - (cd core && tox -e py34)
-  - (cd bigtable && tox -e py34)
-  - (cd storage && tox -e py34)
-  - (cd datastore && tox -e py34)
-  - (cd bigquery && tox -e py34)
-  - (cd pubsub && tox -e py34)
-  - (cd logging && tox -e py34)
-  - (cd dns && tox -e py34)
-  - (cd language && tox -e py34)
-  - (cd error_reporting && tox -e py34)
-  - (cd resource_manager && tox -e py34)
-  - (cd monitoring && tox -e py34)
-  - (cd vision && tox -e py34)
-  - (cd translate && tox -e py34)
-  - (cd speech && tox -e py34)
+  - tox -e py27
+  - tox -e py34
   - tox -e lint
   - tox -e cover
-  - (cd core && tox -e cover)
-  - (cd bigtable && tox -e cover)
-  - (cd storage && tox -e cover)
-  - (cd datastore && tox -e cover)
-  - (cd bigquery && tox -e cover)
-  - (cd pubsub && tox -e cover)
-  - (cd logging && tox -e cover)
-  - (cd dns && tox -e cover)
-  - (cd language && tox -e cover)
-  - (cd error_reporting && tox -e cover)
-  - (cd resource_manager && tox -e cover)
-  - (cd monitoring && tox -e cover)
-  - (cd vision && tox -e cover)
-  - (cd translate && tox -e cover)
-  - (cd speech && tox -e cover)
+  - tox -e isolated-cover
   - tox -e system-tests
   - tox -e system-tests3
   - scripts/update_docs.sh

--- a/scripts/run_unit_tests.py
+++ b/scripts/run_unit_tests.py
@@ -1,0 +1,151 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Script to run unit tests for the entire project.
+
+This script orchestrates stepping into each sub-package and
+running tests. It also allows running a limited subset of tests
+in cases where such a limited subset can be identified.
+"""
+
+from __future__ import print_function
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..'))
+IGNORED_DIRECTORIES = (
+    'appveyor',
+    'docs',
+    'scripts',
+    'system_tests',
+)
+
+
+def check_output(*args):
+    """Run a command on the operation system.
+
+    :type args: tuple
+    :param args: Keyword arguments to pass to ``subprocess.check_output``.
+
+    :rtype: str
+    :returns: The raw STDOUT from the command (converted from bytes
+              if necessary).
+    """
+    cmd_output = subprocess.check_output(args)
+    # On Python 3, this returns bytes (from STDOUT), so we
+    # convert to a string.
+    cmd_output = cmd_output.decode('utf-8')
+    # Also strip the output since it usually has a trailing newline.
+    return cmd_output.strip()
+
+
+def get_package_directories():
+    """Get a list of directories containing sub-packages.
+
+    :rtype: list
+    :returns: A list of all sub-package directories.
+    """
+    # Run ls-tree with
+    #          -d: For directories only
+    # --name-only: No extra info like the type/hash/permission bits.
+    # --full-name: Give path relative to root, rather than cwd.
+    ls_tree_out = check_output(
+        'git', 'ls-tree',
+        '-d', '--name-only', '--full-name',
+        'HEAD', PROJECT_ROOT)
+    result = []
+    for package in ls_tree_out.split('\n'):
+        if package not in IGNORED_DIRECTORIES:
+            result.append(package)
+    return result
+
+
+def run_package(package, tox_env):
+    """Run tox environment for a given package.
+
+    :type package: str
+    :param package: The name of the subdirectory which holds the sub-package.
+                    This will be a path relative to ``PROJECT_ROOT``.
+
+    :type tox_env: str
+    :param tox_env: The ``tox`` environment(s) to run in each sub-package.
+
+    :rtype: bool
+    :returns: Flag indicating if the test run succeeded.
+    """
+    curr_dir = os.getcwd()
+    package_dir = os.path.join(PROJECT_ROOT, package)
+    try:
+        os.chdir(package_dir)
+        return_code = subprocess.call(['tox', '-e', tox_env])
+        return return_code == 0
+    finally:
+        os.chdir(curr_dir)
+
+
+def get_parser():
+    """Get simple ``argparse`` parser to determine configuration.
+
+    :rtype: :class:`argparse.ArgumentParser`
+    :returns: The parser for this script.
+    """
+    description = 'Run tox environment(s) in all sub-packages.'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        '--tox-env', dest='tox_env', default='py27',
+        help='The tox environment(s) to run in sub-packages.')
+    return parser
+
+
+def get_tox_env():
+    """Get the environment to be used with ``tox``.
+
+    :rtype: str
+    :returns: The current ``tox`` environment to be used, e.g. ``"py27"``.
+    """
+    parser = get_parser()
+    args = parser.parse_args()
+    return args.tox_env
+
+
+def main():
+    """Run all the unit tests that need to be run."""
+    packages_to_run = get_package_directories()
+    if not packages_to_run:
+        print('No tests to run.')
+        return
+
+    tox_env = get_tox_env()
+    failed_packages = []
+    for package in packages_to_run:
+        succeeded = run_package(package, tox_env)
+        if not succeeded:
+            failed_packages.append(package)
+
+    if failed_packages:
+        msg_parts = ['Sub-packages failed:']
+        for package in failed_packages:
+            msg_parts.append('- ' + package)
+        msg = '\n'.join(msg_parts)
+        print(msg, file=sys.stderr)
+        sys.exit(len(failed_packages))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run_unit_tests.py
+++ b/scripts/run_unit_tests.py
@@ -35,6 +35,9 @@ IGNORED_DIRECTORIES = (
     'scripts',
     'system_tests',
 )
+ENV_REMAP = {
+    'isolated-cover': 'cover',
+}
 
 
 def check_output(*args):
@@ -108,8 +111,8 @@ def get_parser():
     description = 'Run tox environment(s) in all sub-packages.'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
-        '--tox-env', dest='tox_env', default='py27',
-        help='The tox environment(s) to run in sub-packages.')
+        '--tox-env-dir', dest='tox_env_dir',
+        help='The current tox environment directory.')
     return parser
 
 
@@ -121,7 +124,10 @@ def get_tox_env():
     """
     parser = get_parser()
     args = parser.parse_args()
-    return args.tox_env
+    env_dir = args.tox_env_dir
+    _, tox_env = os.path.split(env_dir)
+    tox_env = ENV_REMAP.get(tox_env, tox_env)
+    return tox_env
 
 
 def main():

--- a/tox.ini
+++ b/tox.ini
@@ -112,29 +112,18 @@ covercmd =
       speech/unit_tests
     coverage report --show-missing --fail-under=100
 
-[testenv:py27]
+[testenv]
 commands =
-    python {toxinidir}/scripts/run_unit_tests.py --tox-env py27
+    python {toxinidir}/scripts/run_unit_tests.py --tox-env-dir {envdir}
 deps =
-skip_install = True
-
-[testenv:py34]
-commands =
-    python {toxinidir}/scripts/run_unit_tests.py --tox-env py34
-deps =
-skip_install = True
-
-[testenv:py35]
-commands =
-    python {toxinidir}/scripts/run_unit_tests.py --tox-env py35
-deps =
-skip_install = True
+skip_install =
+    py27: True
+    py34: True
+    py35: True
+    isolated-cover: True
 
 [testenv:isolated-cover]
-commands =
-    python {toxinidir}/scripts/run_unit_tests.py --tox-env cover
-deps =
-skip_install = True
+commands = {[testenv]commands}
 
 [testenv:py27-pandas]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -112,17 +112,35 @@ covercmd =
       speech/unit_tests
     coverage report --show-missing --fail-under=100
 
-[testenv]
+[testenv:py27]
 commands =
-    py.test --quiet {posargs} unit_tests
+    python {toxinidir}/scripts/run_unit_tests.py --tox-env py27
 deps =
-    {[testing]deps}
+skip_install = True
+
+[testenv:py34]
+commands =
+    python {toxinidir}/scripts/run_unit_tests.py --tox-env py34
+deps =
+skip_install = True
+
+[testenv:py35]
+commands =
+    python {toxinidir}/scripts/run_unit_tests.py --tox-env py35
+deps =
+skip_install = True
+
+[testenv:isolated-cover]
+commands =
+    python {toxinidir}/scripts/run_unit_tests.py --tox-env cover
+deps =
+skip_install = True
 
 [testenv:py27-pandas]
 basepython =
     python2.7
 deps =
-    {[testenv]deps}
+    {[testing]deps}
     pandas
 
 [testenv:cover]
@@ -131,7 +149,7 @@ basepython =
 commands =
     {[testing]covercmd}
 deps =
-    {[testenv]deps}
+    {[testing]deps}
     coverage
     pytest-cov
 
@@ -174,7 +192,7 @@ commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
     python {toxinidir}/scripts/verify_included_modules.py --build-root _build
 deps =
-    {[testenv]deps}
+    {[testing]deps}
     Sphinx
     sphinx_rtd_theme
 passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE READTHEDOCS
@@ -210,7 +228,7 @@ commands =
     python {toxinidir}/scripts/pycodestyle_on_repo.py
     python {toxinidir}/scripts/run_pylint.py
 deps =
-    {[testenv]deps}
+    {[testing]deps}
     pycodestyle
     pylint >= 1.6.4
 passenv = {[testenv:system-tests]passenv}
@@ -231,7 +249,7 @@ passenv = {[testenv:system-tests]passenv}
 
 [emulator]
 deps =
-    {[testenv]deps}
+    {[testing]deps}
     psutil
 setenv =
     GOOGLE_CLOUD_NO_PRINT=true


### PR DESCRIPTION
This script will be extended a great deal in coming commits.

Note that this doesn't actually make the tests run faster, but it's a minimal change for a PR and I will be sending lots of changes on top of it.

Also, this fixes the current b0rken state of AppVeyor, so that's a plus.

Also, the 2nd commit uses a lesser known feature of `tox`:

- http://tox.readthedocs.io/en/latest/config.html#factors-and-factor-conditional-settings
- http://tox.readthedocs.io/en/latest/config-v2.html