### PR TITLE
Adding flexibility to how run_unit_tests determines what to run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ install:
   - pip install --upgrade pip tox
 
 script:
-  - tox -e py27
-  - tox -e py34
+  - python2.7 scripts/run_unit_tests.py
+  - python3.4 scripts/run_unit_tests.py
   - tox -e lint
   - tox -e cover
-  - tox -e isolated-cover
+  - python scripts/run_unit_tests.py --tox-env cover
   - tox -e system-tests
   - tox -e system-tests3
   - scripts/update_docs.sh

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,16 +8,29 @@ Contributing
 
 Here are some guidelines for hacking on ``google-cloud-python``.
 
+Adding Features
+---------------
+
+In order to add a feature to ``google-cloud-python``:
+
+- The feature must be documented in both the API and narrative
+  documentation (in ``docs/``).
+
+- The feature must work fully on the following CPython versions:  2.7,
+  3.4, and 3.5 on both UNIX and Windows.
+
+- The feature must not add unnecessary dependencies (where
+  "unnecessary" is of course subjective, but new dependencies should
+  be discussed).
+
 Using a Development Checkout
 ----------------------------
 
-You'll have to create a development environment to hack on ``google-cloud-python``,
-using a Git checkout:
+You'll have to create a development environment to hack on
+``google-cloud-python``, using a Git checkout:
 
-- While logged into your GitHub account, navigate to the ``google-cloud-python`` repo
-  on GitHub.
-
-  https://github.com/GoogleCloudPlatform/google-cloud-python
+- While logged into your GitHub account, navigate to the
+  ``google-cloud-python`` `repo`_ on GitHub.
 
 - Fork and clone the ``google-cloud-python`` repository to your GitHub account by
   clicking the "Fork" button.
@@ -41,6 +54,8 @@ repo, from which you can submit a pull request.
 
 To work on the codebase and run the tests, we recommend using ``tox``,
 but you can also use a ``virtualenv`` of your own creation.
+
+.. _repo: https://github.com/GoogleCloudPlatform/google-cloud-python
 
 Using a custom ``virtualenv``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -96,6 +111,19 @@ Using ``tox``
   by the ``tox`` environment, so if you make changes, you'll need
   to again ``--recreate`` the environment.
 
+- To run unit tests on a restricted set of packages::
+
+    $ tox -e py27 -- core datastore
+
+  Alternatively, you can just navigate directly to the package you are
+  currently developing and run tests there::
+
+    $ export GIT_ROOT=$(pwd)
+    $ cd ${GIT_ROOT}/core/
+    $ tox -e py27
+    $ cd ${GIT_ROOT}/datastore/
+    $ tox -e py27
+
 Note on Editable Installs / Develop Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -123,21 +151,6 @@ install ``python-dev`` and try again.
 On Debian/Ubuntu::
 
   $ sudo apt-get install python-dev
-
-Adding Features
----------------
-
-In order to add a feature to ``google-cloud-python``:
-
-- The feature must be documented in both the API and narrative
-  documentation (in ``docs/``).
-
-- The feature must work fully on the following CPython versions:  2.7,
-  3.4, and 3.5 on both UNIX and Windows.
-
-- The feature must not add unnecessary dependencies (where
-  "unnecessary" is of course subjective, but new dependencies should
-  be discussed).
 
 Coding Style
 ------------
@@ -170,20 +183,24 @@ Running Tests
 
 - To run all tests for ``google-cloud-python`` on a single Python version, run
   ``py.test`` from your development virtualenv (See
-  *Using a Development Checkout* above).
+  `Using a Development Checkout`_ above).
+
+.. _Using a Development Checkout: #using-a-development-checkout
 
 - To run the full set of ``google-cloud-python`` tests on all platforms, install
-  ``tox`` (https://testrun.org/tox/) into a system Python.  The ``tox`` console
-  script will be installed into the scripts location for that Python.  While
-  ``cd``'ed to the ``google-cloud-python`` checkout root directory (it contains
-  ``tox.ini``), invoke the ``tox`` console script.  This will read the
-  ``tox.ini`` file and execute the tests on multiple Python versions and
-  platforms; while it runs, it creates a virtualenv for each version/platform
-  combination.  For example::
+  ``tox`` (https://tox.readthedocs.io/en/latest/) into a system Python.  The
+  ``tox`` console script will be installed into the scripts location for that
+  Python.  While ``cd``'-ed to the ``google-cloud-python`` checkout root
+  directory (it contains ``tox.ini``), invoke the ``tox`` console script.
+  This will read the ``tox.ini`` file and execute the tests on multiple
+  Python versions and platforms; while it runs, it creates a ``virtualenv`` for
+  each version/platform combination.  For example::
 
    $ sudo --set-home /usr/bin/pip install tox
    $ cd ${HOME}/hack-on-google-cloud-python/
    $ /usr/bin/tox
+
+.. _Using a Development Checkout: #using-a-development-checkout
 
 Running System Tests
 --------------------

--- a/scripts/run_unit_tests.py
+++ b/scripts/run_unit_tests.py
@@ -150,7 +150,7 @@ def main():
             msg_parts.append('- ' + package)
         msg = '\n'.join(msg_parts)
         print(msg, file=sys.stderr)
-        sys.exit(len(failed_packages))
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -114,7 +114,7 @@ covercmd =
 
 [testenv]
 commands =
-    python {toxinidir}/scripts/run_unit_tests.py
+    python {toxinidir}/scripts/run_unit_tests.py {posargs}
 deps =
 skip_install =
     py27: True
@@ -123,7 +123,8 @@ skip_install =
     isolated-cover: True
 
 [testenv:isolated-cover]
-commands = {[testenv]commands} --tox-env cover
+commands =
+    python {toxinidir}/scripts/run_unit_tests.py {posargs} --tox-env cover
 
 [testenv:py27-pandas]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    cover,docs,lint
+    py27,py34,py35,cover,docs,lint
 
 [testing]
 deps =
@@ -114,7 +114,7 @@ covercmd =
 
 [testenv]
 commands =
-    python {toxinidir}/scripts/run_unit_tests.py --tox-env-dir {envdir}
+    python {toxinidir}/scripts/run_unit_tests.py
 deps =
 skip_install =
     py27: True
@@ -123,7 +123,7 @@ skip_install =
     isolated-cover: True
 
 [testenv:isolated-cover]
-commands = {[testenv]commands}
+commands = {[testenv]commands} --tox-env cover
 
 [testenv:py27-pandas]
 basepython =


### PR DESCRIPTION
- Upgrading the `get_tox_env()` helper to support the `TOXENV` env. var. and the current system Python
- Ditching `tox` on Travis for `py27`, `py34` and `isolated-cover`, this is because those `tox` environments just farm out the work to `tox` environments for each sub-package, so it isn't worth waiting for the extra `tox` env. setup time
- Changing back from `--tox-env-dir` to `--tox-env` flag in `run_unit_tests.py` script (it could always go back but isn't needed. Also could use the `VIRTUAL_ENV` env. var. set by the `activate` script from the `virtualenv` tool)
- Adding `py27,py34,py35` back to the `tox` env. list
- Letting `tox -e py27`, etc. allow the current Python to determine their `tox` env. value
- Allowing a subset of packages to be passed to `run_unit_tests` from the command line
- Some misc. `CONTRIBUTING` doc changes (see 2nd commit)

~~**NOTE**: Has #2473 as diffbase.~~