### PR TITLE
Moving Travis helpers out of run_pylint into shared module.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -151,8 +151,8 @@ Coding Style
 - In order to make ``tox -e lint`` run faster, you can set some environment
   variables::
 
-   export GOOGLE_CLOUD_REMOTE_FOR_LINT="upstream"
-   export GOOGLE_CLOUD_BRANCH_FOR_LINT="master"
+   export GOOGLE_CLOUD_TESTING_REMOTE="upstream"
+   export GOOGLE_CLOUD_TESTING_BRANCH="master"
 
   By doing this, you are specifying the location of the most up-to-date
   version of ``google-cloud-python``. The the suggested remote name ``upstream``

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -29,6 +29,9 @@ import os
 import subprocess
 import sys
 
+from script_utils import LOCAL_BRANCH_ENV
+from script_utils import LOCAL_REMOTE_ENV
+
 
 IGNORED_DIRECTORIES = [
     os.path.join('bigtable', 'google', 'cloud', 'bigtable', '_generated'),
@@ -148,9 +151,9 @@ def get_files_for_linting(allow_limited=True):
     One could potentially use ${TRAVIS_COMMIT_RANGE} to find a diff base but
     this value is not dependable.
 
-    To allow faster local ``tox`` runs, the environment variables
-    ``GOOGLE_CLOUD_REMOTE_FOR_LINT`` and ``GOOGLE_CLOUD_BRANCH_FOR_LINT`` can
-    be set to specify a remote branch to diff against.
+    To allow faster local ``tox`` runs, the local remote and local branch
+    environment variables can be set to specify a remote branch to diff
+    against.
 
     :type allow_limited: bool
     :param allow_limited: Boolean indicating if a reduced set of files can
@@ -168,8 +171,8 @@ def get_files_for_linting(allow_limited=True):
         diff_base = 'origin/master'
     elif os.getenv('TRAVIS') is None:
         # Only allow specified remote and branch in local dev.
-        remote = os.getenv('GOOGLE_CLOUD_REMOTE_FOR_LINT')
-        branch = os.getenv('GOOGLE_CLOUD_BRANCH_FOR_LINT')
+        remote = os.getenv(LOCAL_REMOTE_ENV)
+        branch = os.getenv(LOCAL_BRANCH_ENV)
         if remote is not None and branch is not None:
             diff_base = '%s/%s' % (remote, branch)
 

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -14,6 +14,72 @@
 
 """Common helpers for testing scripts."""
 
+import os
+
 
 LOCAL_REMOTE_ENV = 'GOOGLE_CLOUD_TESTING_REMOTE'
 LOCAL_BRANCH_ENV = 'GOOGLE_CLOUD_TESTING_BRANCH'
+IN_TRAVIS_ENV = 'TRAVIS'
+TRAVIS_PR_ENV = 'TRAVIS_PULL_REQUEST'
+TRAVIS_BRANCH_ENV = 'TRAVIS_BRANCH'
+
+
+def in_travis():
+    """Detect if we are running in Travis.
+
+    .. _Travis env docs: https://docs.travis-ci.com/user/\
+                         environment-variables\
+                         #Default-Environment-Variables
+
+    See `Travis env docs`_.
+
+    :rtype: bool
+    :returns: Flag indicating if we are running on Travis.
+    """
+    return os.getenv(IN_TRAVIS_ENV) == 'true'
+
+
+def in_travis_pr():
+    """Detect if we are running in a pull request on Travis.
+
+    .. _Travis env docs: https://docs.travis-ci.com/user/\
+                         environment-variables\
+                         #Default-Environment-Variables
+
+    See `Travis env docs`_.
+
+    .. note::
+
+        This assumes we already know we are running in Travis.
+
+    :rtype: bool
+    :returns: Flag indicating if we are in a pull request on Travis.
+    """
+    # NOTE: We're a little extra cautious and make sure that the
+    #       PR environment variable is an integer.
+    try:
+        int(os.getenv(TRAVIS_PR_ENV, ''))
+        return True
+    except ValueError:
+        return False
+
+
+def travis_branch():
+    """Get the current branch of the PR.
+
+    .. _Travis env docs: https://docs.travis-ci.com/user/\
+                         environment-variables\
+                         #Default-Environment-Variables
+
+    See `Travis env docs`_.
+
+    .. note::
+
+        This assumes we already know we are running in Travis
+        during a PR.
+
+    :rtype: str
+    :returns: The name of the branch the current pull request is
+              changed against.
+    """
+    return os.getenv(TRAVIS_BRANCH_ENV)

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -1,0 +1,19 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common helpers for testing scripts."""
+
+
+LOCAL_REMOTE_ENV = 'GOOGLE_CLOUD_TESTING_REMOTE'
+LOCAL_BRANCH_ENV = 'GOOGLE_CLOUD_TESTING_BRANCH'

--- a/system_tests/local_test_setup.sample
+++ b/system_tests/local_test_setup.sample
@@ -1,4 +1,4 @@
 export GOOGLE_APPLICATION_CREDENTIALS="app_credentials.json.sample"
-export GOOGLE_CLOUD_REMOTE_FOR_LINT="upstream"
-export GOOGLE_CLOUD_BRANCH_FOR_LINT="master"
+export GOOGLE_CLOUD_TESTING_REMOTE="upstream"
+export GOOGLE_CLOUD_TESTING_BRANCH="master"
 export GOOGLE_CLOUD_TESTS_API_KEY="abcd1234"


### PR DESCRIPTION
This is in preparation to re-use these pieces in other scripts (e.g. the ones for running package-local tests)