### PR TITLE
On Travis, follow package dependency graph to expand package list.

### DIFF
--- a/bigquery/MANIFEST.in
+++ b/bigquery/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/bigquery/requirements.txt
+++ b/bigquery/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-core >= 0.20.0

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -49,9 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-bigquery',

--- a/bigtable/MANIFEST.in
+++ b/bigtable/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/bigtable/requirements.txt
+++ b/bigtable/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-core >= 0.20.0
+grpcio >= 1.0.0, < 2.0dev

--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -49,10 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-    'grpcio >= 1.0.0, < 2.0dev',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-bigtable',

--- a/core/MANIFEST.in
+++ b/core/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,0 +1,5 @@
+httplib2 >= 0.9.1
+googleapis-common-protos >= 1.3.4
+oauth2client >= 3.0.0, < 4.0.0dev
+protobuf >= 3.0.0
+six

--- a/core/setup.py
+++ b/core/setup.py
@@ -49,13 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'httplib2 >= 0.9.1',
-    'googleapis-common-protos >= 1.3.4',
-    'oauth2client >= 3.0.0, < 4.0.0dev',
-    'protobuf >= 3.0.0',
-    'six',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-core',

--- a/datastore/MANIFEST.in
+++ b/datastore/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/datastore/requirements.txt
+++ b/datastore/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-core >= 0.20.0
+grpcio >= 1.0.0, < 2.0dev

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -49,10 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-    'grpcio >= 1.0.0, < 2.0dev',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-datastore',

--- a/dns/MANIFEST.in
+++ b/dns/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/dns/requirements.txt
+++ b/dns/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-core >= 0.20.0

--- a/dns/setup.py
+++ b/dns/setup.py
@@ -49,9 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-dns',

--- a/error_reporting/MANIFEST.in
+++ b/error_reporting/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/error_reporting/requirements.txt
+++ b/error_reporting/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-core >= 0.20.0
+google-cloud-logging >= 0.20.0

--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -49,10 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-    'google-cloud-logging >= 0.20.0',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-error-reporting',

--- a/language/MANIFEST.in
+++ b/language/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/language/requirements.txt
+++ b/language/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-core >= 0.20.0

--- a/language/setup.py
+++ b/language/setup.py
@@ -49,9 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-language',

--- a/logging/MANIFEST.in
+++ b/logging/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/logging/requirements.txt
+++ b/logging/requirements.txt
@@ -1,0 +1,5 @@
+google-cloud-core >= 0.20.0
+grpcio >= 1.0.0, < 2.0dev
+google-gax >= 0.14.1, < 0.15dev
+gapic-google-logging-v2 >= 0.10.1, < 0.11dev
+grpc-google-logging-v2 >= 0.10.1, < 0.11dev

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -49,13 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-    'grpcio >= 1.0.0, < 2.0dev',
-    'google-gax >= 0.14.1, < 0.15dev',
-    'gapic-google-logging-v2 >= 0.10.1, < 0.11dev',
-    'grpc-google-logging-v2 >= 0.10.1, < 0.11dev',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-logging',

--- a/monitoring/MANIFEST.in
+++ b/monitoring/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/monitoring/requirements.txt
+++ b/monitoring/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-core >= 0.20.0

--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -49,9 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-monitoring',

--- a/pubsub/MANIFEST.in
+++ b/pubsub/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/pubsub/requirements.txt
+++ b/pubsub/requirements.txt
@@ -1,0 +1,5 @@
+google-cloud-core >= 0.20.0
+grpcio >= 1.0.0, < 2.0dev
+google-gax >= 0.14.1, < 0.15dev
+gapic-google-pubsub-v1 >= 0.10.1, < 0.11dev
+grpc-google-pubsub-v1 >= 0.10.1, < 0.11dev

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -49,13 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-    'grpcio >= 1.0.0, < 2.0dev',
-    'google-gax >= 0.14.1, < 0.15dev',
-    'gapic-google-pubsub-v1 >= 0.10.1, < 0.11dev',
-    'grpc-google-pubsub-v1 >= 0.10.1, < 0.11dev',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-pubsub',

--- a/resource_manager/MANIFEST.in
+++ b/resource_manager/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/resource_manager/requirements.txt
+++ b/resource_manager/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-core >= 0.20.0

--- a/resource_manager/setup.py
+++ b/resource_manager/setup.py
@@ -49,9 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-resource-manager',

--- a/scripts/generate_json_docs.py
+++ b/scripts/generate_json_docs.py
@@ -26,6 +26,7 @@ from parinx.parser import parse_docstring
 from parinx.errors import MethodParsingException
 import six
 
+from script_utils import PROJECT_ROOT
 from verify_included_modules import get_public_modules
 
 
@@ -601,7 +602,7 @@ def main():
     parser.add_argument('--tag', help='The version of the documentation.',
                         default='master')
     parser.add_argument('--basepath', help='Path to the library.',
-                        default=os.path.join(os.path.dirname(__file__), '..'))
+                        default=PROJECT_ROOT)
     parser.add_argument('--show-toc', help='Prints partial table of contents',
                         default=False)
     args = parser.parse_args()
@@ -635,10 +636,9 @@ def main():
         }
     }
 
-    BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-    BASE_JSON_DOCS_DIR = os.path.join(BASE_DIR, 'docs', 'json')
+    BASE_JSON_DOCS_DIR = os.path.join(PROJECT_ROOT, 'docs', 'json')
 
-    DOCS_BUILD_DIR = os.path.join(BASE_DIR, 'docs', '_build')
+    DOCS_BUILD_DIR = os.path.join(PROJECT_ROOT, 'docs', '_build')
     JSON_DOCS_DIR = os.path.join(DOCS_BUILD_DIR, 'json', args.tag)
     LIB_DIR = os.path.abspath(args.basepath)
 
@@ -646,7 +646,7 @@ def main():
     public_mods = get_public_modules(library_dir,
                                      base_package='google.cloud')
 
-    generate_module_docs(public_mods, JSON_DOCS_DIR, BASE_DIR, toc)
+    generate_module_docs(public_mods, JSON_DOCS_DIR, PROJECT_ROOT, toc)
     generate_doc_types_json(public_mods,
                             os.path.join(JSON_DOCS_DIR, 'types.json'))
     package_files(JSON_DOCS_DIR, DOCS_BUILD_DIR, BASE_JSON_DOCS_DIR)

--- a/scripts/make_datastore_grpc.py
+++ b/scripts/make_datastore_grpc.py
@@ -20,13 +20,13 @@ import subprocess
 import sys
 import tempfile
 
+from script_utils import PROJECT_ROOT
 
-ROOT_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '..'))
-PROTOS_DIR = os.path.join(ROOT_DIR, 'googleapis-pb')
+
+PROTOS_DIR = os.path.join(PROJECT_ROOT, 'googleapis-pb')
 PROTO_PATH = os.path.join(PROTOS_DIR, 'google', 'datastore',
                           'v1', 'datastore.proto')
-GRPC_ONLY_FILE = os.path.join(ROOT_DIR, 'datastore',
+GRPC_ONLY_FILE = os.path.join(PROJECT_ROOT, 'datastore',
                               'google', 'cloud', 'datastore',
                               '_generated', 'datastore_grpc_pb2.py')
 GRPCIO_VIRTUALENV = os.getenv('GRPCIO_VIRTUALENV')

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -30,6 +30,7 @@ import subprocess
 import sys
 
 from script_utils import get_affected_files
+from script_utils import PROJECT_ROOT
 
 
 IGNORED_DIRECTORIES = [
@@ -44,7 +45,7 @@ IGNORED_POSTFIXES = [
     os.path.join('google', 'cloud', '__init__.py'),
     'setup.py',
 ]
-SCRIPTS_DIR = os.path.abspath(os.path.dirname(__file__))
+SCRIPTS_DIR = os.path.join(PROJECT_ROOT, 'scripts')
 PRODUCTION_RC = os.path.join(SCRIPTS_DIR, 'pylintrc_default')
 TEST_RC = os.path.join(SCRIPTS_DIR, 'pylintrc_reduced')
 TEST_DISABLED_MESSAGES = [

--- a/scripts/verify_included_modules.py
+++ b/scripts/verify_included_modules.py
@@ -24,10 +24,10 @@ import warnings
 
 from sphinx.ext.intersphinx import fetch_inventory
 
+from script_utils import PROJECT_ROOT
 
-BASE_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '..'))
-DOCS_DIR = os.path.join(BASE_DIR, 'docs')
+
+DOCS_DIR = os.path.join(PROJECT_ROOT, 'docs')
 IGNORED_PREFIXES = ('test_', '_')
 IGNORED_MODULES = frozenset([
     'google.cloud.__init__',
@@ -153,7 +153,7 @@ def verify_modules(build_root='_build'):
 
     public_mods = set()
     for package in PACKAGES:
-        library_dir = os.path.join(BASE_DIR, package, 'google', 'cloud')
+        library_dir = os.path.join(PROJECT_ROOT, package, 'google', 'cloud')
         package_mods = get_public_modules(library_dir,
                                           base_package='google.cloud')
         public_mods.update(package_mods)

--- a/speech/MANIFEST.in
+++ b/speech/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/speech/requirements.txt
+++ b/speech/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-core >= 0.20.0

--- a/speech/setup.py
+++ b/speech/setup.py
@@ -49,9 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-speech',

--- a/storage/MANIFEST.in
+++ b/storage/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/storage/requirements.txt
+++ b/storage/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-core >= 0.20.0

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -49,9 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-storage',

--- a/translate/MANIFEST.in
+++ b/translate/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/translate/requirements.txt
+++ b/translate/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-core >= 0.20.0

--- a/translate/setup.py
+++ b/translate/setup.py
@@ -49,9 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-translate',

--- a/vision/MANIFEST.in
+++ b/vision/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include requirements.txt
 graft google
 graft unit_tests
 global-exclude *.pyc

--- a/vision/requirements.txt
+++ b/vision/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-core >= 0.20.0

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -49,9 +49,12 @@ SETUP_BASE = {
 }
 
 
-REQUIREMENTS = [
-    'google-cloud-core >= 0.20.0',
-]
+# NOTE: This assumes that no comments or other extra text
+#       is in the requirements.txt file.
+with open(os.path.join(PACKAGE_ROOT, 'requirements.txt')) as file_obj:
+    REQUIREMENTS = file_obj.read()
+    REQUIREMENTS = REQUIREMENTS.strip().split('\n')
+
 
 setup(
     name='google-cloud-vision',


### PR DESCRIPTION
To make computing the dependency graph easier I moved the requirements of each package into a `requirements.txt` file.

I'm happy to instead write a custom `setup.py` parser but decided that the route of less code was "better" in some sense.