### PR TITLE
Follow package dependency graph from changed packages.

### DIFF
--- a/scripts/generate_json_docs.py
+++ b/scripts/generate_json_docs.py
@@ -26,6 +26,7 @@ from parinx.parser import parse_docstring
 from parinx.errors import MethodParsingException
 import six
 
+from script_utils import PROJECT_ROOT
 from verify_included_modules import get_public_modules
 
 
@@ -601,7 +602,7 @@ def main():
     parser.add_argument('--tag', help='The version of the documentation.',
                         default='master')
     parser.add_argument('--basepath', help='Path to the library.',
-                        default=os.path.join(os.path.dirname(__file__), '..'))
+                        default=PROJECT_ROOT)
     parser.add_argument('--show-toc', help='Prints partial table of contents',
                         default=False)
     args = parser.parse_args()
@@ -635,10 +636,9 @@ def main():
         }
     }
 
-    BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-    BASE_JSON_DOCS_DIR = os.path.join(BASE_DIR, 'docs', 'json')
+    BASE_JSON_DOCS_DIR = os.path.join(PROJECT_ROOT, 'docs', 'json')
 
-    DOCS_BUILD_DIR = os.path.join(BASE_DIR, 'docs', '_build')
+    DOCS_BUILD_DIR = os.path.join(PROJECT_ROOT, 'docs', '_build')
     JSON_DOCS_DIR = os.path.join(DOCS_BUILD_DIR, 'json', args.tag)
     LIB_DIR = os.path.abspath(args.basepath)
 
@@ -646,7 +646,7 @@ def main():
     public_mods = get_public_modules(library_dir,
                                      base_package='google.cloud')
 
-    generate_module_docs(public_mods, JSON_DOCS_DIR, BASE_DIR, toc)
+    generate_module_docs(public_mods, JSON_DOCS_DIR, PROJECT_ROOT, toc)
     generate_doc_types_json(public_mods,
                             os.path.join(JSON_DOCS_DIR, 'types.json'))
     package_files(JSON_DOCS_DIR, DOCS_BUILD_DIR, BASE_JSON_DOCS_DIR)

--- a/scripts/make_datastore_grpc.py
+++ b/scripts/make_datastore_grpc.py
@@ -20,13 +20,13 @@ import subprocess
 import sys
 import tempfile
 
+from script_utils import PROJECT_ROOT
 
-ROOT_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '..'))
-PROTOS_DIR = os.path.join(ROOT_DIR, 'googleapis-pb')
+
+PROTOS_DIR = os.path.join(PROJECT_ROOT, 'googleapis-pb')
 PROTO_PATH = os.path.join(PROTOS_DIR, 'google', 'datastore',
                           'v1', 'datastore.proto')
-GRPC_ONLY_FILE = os.path.join(ROOT_DIR, 'datastore',
+GRPC_ONLY_FILE = os.path.join(PROJECT_ROOT, 'datastore',
                               'google', 'cloud', 'datastore',
                               '_generated', 'datastore_grpc_pb2.py')
 GRPCIO_VIRTUALENV = os.getenv('GRPCIO_VIRTUALENV')

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -30,6 +30,7 @@ import subprocess
 import sys
 
 from script_utils import get_affected_files
+from script_utils import PROJECT_ROOT
 
 
 IGNORED_DIRECTORIES = [
@@ -44,7 +45,7 @@ IGNORED_POSTFIXES = [
     os.path.join('google', 'cloud', '__init__.py'),
     'setup.py',
 ]
-SCRIPTS_DIR = os.path.abspath(os.path.dirname(__file__))
+SCRIPTS_DIR = os.path.join(PROJECT_ROOT, 'scripts')
 PRODUCTION_RC = os.path.join(SCRIPTS_DIR, 'pylintrc_default')
 TEST_RC = os.path.join(SCRIPTS_DIR, 'pylintrc_reduced')
 TEST_DISABLED_MESSAGES = [

--- a/scripts/run_unit_tests.py
+++ b/scripts/run_unit_tests.py
@@ -31,11 +31,10 @@ from script_utils import get_changed_packages
 from script_utils import in_travis
 from script_utils import in_travis_pr
 from script_utils import local_diff_branch
+from script_utils import PROJECT_ROOT
 from script_utils import travis_branch
 
 
-PROJECT_ROOT = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '..'))
 IGNORED_DIRECTORIES = (
     'appveyor',
     'docs',

--- a/scripts/run_unit_tests.py
+++ b/scripts/run_unit_tests.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 
 from script_utils import check_output
+from script_utils import follow_dependencies
 from script_utils import get_changed_packages
 from script_utils import in_travis
 from script_utils import in_travis_pr
@@ -126,6 +127,12 @@ def get_test_packages():
       any filtering)
     * Just use all packages
 
+    An additional check is done for the cases when a diff is computed (i.e.
+    using local remote and local branch environment variables, and on Travis).
+    Once the filtered list of **changed** packages is found, the package
+    dependency graph is used to add any additional packages which depend on
+    the changed packages.
+
     :rtype: list
     :returns: A list of all package directories where tests
               need be run.
@@ -139,9 +146,12 @@ def get_test_packages():
         verify_packages(args.packages, all_packages)
         return sorted(args.packages)
     elif local_diff is not None:
-        return get_changed_packages('HEAD', local_diff, all_packages)
+        changed_packages = get_changed_packages(
+            'HEAD', local_diff, all_packages)
+        return follow_dependencies(changed_packages, all_packages)
     elif in_travis():
-        return get_travis_directories(all_packages)
+        changed_packages = get_travis_directories(all_packages)
+        return follow_dependencies(changed_packages, all_packages)
     else:
         return all_packages
 

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -20,6 +20,8 @@ import os
 import subprocess
 
 
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..'))
 LOCAL_REMOTE_ENV = 'GOOGLE_CLOUD_TESTING_REMOTE'
 LOCAL_BRANCH_ENV = 'GOOGLE_CLOUD_TESTING_BRANCH'
 IN_TRAVIS_ENV = 'TRAVIS'

--- a/scripts/verify_included_modules.py
+++ b/scripts/verify_included_modules.py
@@ -24,10 +24,10 @@ import warnings
 
 from sphinx.ext.intersphinx import fetch_inventory
 
+from script_utils import PROJECT_ROOT
 
-BASE_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '..'))
-DOCS_DIR = os.path.join(BASE_DIR, 'docs')
+
+DOCS_DIR = os.path.join(PROJECT_ROOT, 'docs')
 IGNORED_PREFIXES = ('test_', '_')
 IGNORED_MODULES = frozenset([
     'google.cloud.__init__',
@@ -153,7 +153,7 @@ def verify_modules(build_root='_build'):
 
     public_mods = set()
     for package in PACKAGES:
-        library_dir = os.path.join(BASE_DIR, package, 'google', 'cloud')
+        library_dir = os.path.join(PROJECT_ROOT, package, 'google', 'cloud')
         package_mods = get_public_modules(library_dir,
                                           base_package='google.cloud')
         public_mods.update(package_mods)


### PR DESCRIPTION
Alternative approach to #2487

This may expand the list, for example if `core` is among the changed packages then all downstream packages need to be tested.

Also in the process, moving `PROJECT_ROOT` variable into `script_utils` and using it in all `scripts/`.
