### PR TITLE
Allow passing extra headers to 'Connection.api_request'.

### DIFF
--- a/core/google/cloud/connection.py
+++ b/core/google/cloud/connection.py
@@ -303,7 +303,7 @@ class JSONConnection(Connection):
         :param content_type: The proper MIME type of the data provided. Default
                              is None.
 
-        :type headers: dist
+        :type headers: dict
         :param headers: extra HTTP headers to be sent with the request.
 
         :type api_base_url: string

--- a/core/google/cloud/connection.py
+++ b/core/google/cloud/connection.py
@@ -273,7 +273,7 @@ class JSONConnection(Connection):
                                  body=data)
 
     def api_request(self, method, path, query_params=None,
-                    data=None, content_type=None,
+                    data=None, content_type=None, headers=None,
                     api_base_url=None, api_version=None,
                     expect_json=True, _target_object=None):
         """Make a request over the HTTP transport to the API.
@@ -302,6 +302,9 @@ class JSONConnection(Connection):
         :type content_type: string
         :param content_type: The proper MIME type of the data provided. Default
                              is None.
+
+        :type headers: dist
+        :param headers: extra HTTP headers to be sent with the request.
 
         :type api_base_url: string
         :param api_base_url: The base URL for the API endpoint.
@@ -343,7 +346,7 @@ class JSONConnection(Connection):
 
         response, content = self._make_request(
             method=method, url=url, data=data, content_type=content_type,
-            target_object=_target_object)
+            headers=headers, target_object=_target_object)
 
         if not 200 <= response.status < 300:
             raise make_exception(response, content,

--- a/core/unit_tests/test_connection.py
+++ b/core/unit_tests/test_connection.py
@@ -318,6 +318,37 @@ class TestJSONConnection(unittest.TestCase):
         }
         self.assertEqual(http._called_with['headers'], expected_headers)
 
+    def test_api_request_w_headers(self):
+        from six.moves.urllib.parse import urlsplit
+        conn = self._makeMockOne()
+        http = conn._http = _Http(
+            {'status': '200', 'content-type': 'application/json'},
+            b'{}',
+        )
+        self.assertEqual(
+            conn.api_request('GET', '/', headers={'X-Foo': 'bar'}), {})
+        self.assertEqual(http._called_with['method'], 'GET')
+        uri = http._called_with['uri']
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)
+        # Intended to emulate self.mock_template
+        PATH = '/'.join([
+            '',
+            'mock',
+            conn.API_VERSION,
+            '',
+        ])
+        self.assertEqual(path, PATH)
+        self.assertEqual(qs, '')
+        self.assertIsNone(http._called_with['body'])
+        expected_headers = {
+            'Accept-Encoding': 'gzip',
+            'Content-Length': '0',
+            'User-Agent': conn.USER_AGENT,
+            'X-Foo': 'bar',
+        }
+        self.assertEqual(http._called_with['headers'], expected_headers)
+
     def test_api_request_w_data(self):
         import json
         DATA = {'foo': 'bar'}


### PR DESCRIPTION
Needed to support oddball out-of-band encryption headers for `Blob.rewrite`.