### PR TITLE
Restricting when the umbrella cover runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - scripts/update_docs.sh
 
 after_success:
-  - tox -e coveralls
+  - scripts/travis_coveralls.sh
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ install:
 script:
   - python2.7 scripts/run_unit_tests.py
   - python3.4 scripts/run_unit_tests.py
-  - tox -e lint
-  - tox -e cover
   - python scripts/run_unit_tests.py --tox-env cover
+  - tox -e lint
   - tox -e system-tests
   - tox -e system-tests3
   - scripts/update_docs.sh

--- a/scripts/travis_coveralls.sh
+++ b/scripts/travis_coveralls.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ev
+
+##################################################
+# Only run coveralls during a Travis push build. #
+##################################################
+if [[ "${TRAVIS_BRANCH}" == "master" ]] && \
+       [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
+  echo "Sending coverage report on a merge to master."
+  tox -e coveralls
+else
+  echo "Not on a push build for master, skipping coveralls."
+  exit
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -120,14 +120,14 @@ skip_install =
     py27: True
     py34: True
     py35: True
-    isolated-cover: True
+    cover: True
 passenv = TRAVIS* GOOGLE_CLOUD_*
 
-[testenv:isolated-cover]
+[testenv:cover]
 commands =
     python {toxinidir}/scripts/run_unit_tests.py {posargs} --tox-env cover
 
-[testenv:cover]
+[testenv:umbrella-cover]
 basepython =
     python2.7
 commands =
@@ -138,13 +138,13 @@ deps =
     pytest-cov
 
 [testenv:coveralls]
-basepython = {[testenv:cover]basepython}
+basepython = {[testenv:umbrella-cover]basepython}
 commands =
     {[testing]covercmd}
     coveralls
 ignore_errors = True
 deps =
-    {[testenv:cover]deps}
+    {[testenv:umbrella-cover]deps}
     coveralls
 passenv = {[testenv:system-tests]passenv}
 


### PR DESCRIPTION
First, swapping the cover envs. in the umbrella tox config:

```
isolated-cover --> cover
         cover --> umbrella-cover
```

and dropping the (now redunant) `tox -e cover` from `.travis.yml`. Finally, wrapping the `after_success:` Travis call to `tox -e coveralls` in a check to make sure it only runs on push builds (to speed up PR builds).

**NOTE**: This means that Coveralls will no longer be a check on PRs.