### PR TITLE
Tighten Speech Asynchronous encoding support.

### DIFF
--- a/docs/speech-usage.rst
+++ b/docs/speech-usage.rst
@@ -41,7 +41,7 @@ audio data of any duration up to 80 minutes.
 
 .. note::
 
-    Only the LINEAR16 encoding type is supported by asynchronous recognition.
+    Only the `LINEAR16`_ encoding type is supported by asynchronous recognition.
 
 See: `Speech Asynchronous Recognize`_
 
@@ -144,6 +144,6 @@ words to the vocabulary of the recognizer.
     transcript: Hello, this is a test
     confidence: 0.81
 
-
+.. _LINEAR16: https://cloud.google.com/speech/reference/rpc/google.cloud.speech.v1beta1#audioencoding
 .. _sync_recognize: https://cloud.google.com/speech/reference/rest/v1beta1/speech/syncrecognize
 .. _Speech Asynchronous Recognize: https://cloud.google.com/speech/reference/rest/v1beta1/speech/asyncrecognize

--- a/docs/speech-usage.rst
+++ b/docs/speech-usage.rst
@@ -41,7 +41,8 @@ audio data of any duration up to 80 minutes.
 
 .. note::
 
-    Only the `LINEAR16`_ encoding type is supported by asynchronous recognition.
+    Only the :attr:`Encoding.LINEAR16` encoding type is supported by
+    asynchronous recognition.
 
 See: `Speech Asynchronous Recognize`_
 
@@ -144,6 +145,5 @@ words to the vocabulary of the recognizer.
     transcript: Hello, this is a test
     confidence: 0.81
 
-.. _LINEAR16: https://cloud.google.com/speech/reference/rpc/google.cloud.speech.v1beta1#audioencoding
 .. _sync_recognize: https://cloud.google.com/speech/reference/rest/v1beta1/speech/syncrecognize
 .. _Speech Asynchronous Recognize: https://cloud.google.com/speech/reference/rest/v1beta1/speech/asyncrecognize

--- a/docs/speech-usage.rst
+++ b/docs/speech-usage.rst
@@ -39,6 +39,10 @@ Speech API and initiates a Long Running Operation. Using this operation, you
 can periodically poll for recognition results. Use asynchronous requests for
 audio data of any duration up to 80 minutes.
 
+.. note::
+
+    Only the LINEAR16 encoding type is supported by asynchronous recognition.
+
 See: `Speech Asynchronous Recognize`_
 
 
@@ -49,7 +53,7 @@ See: `Speech Asynchronous Recognize`_
     >>> from google.cloud.speech.encoding import Encoding
     >>> client = speech.Client()
     >>> sample = client.sample(source_uri='gs://my-bucket/recording.flac',
-    ...                        encoding=Encoding.FLAC,
+    ...                        encoding=Encoding.LINEAR16,
     ...                        sample_rate=44100)
     >>> operation = client.async_recognize(sample, max_alternatives=2)
     >>> retry_count = 100

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -19,6 +19,7 @@ from base64 import b64encode
 from google.cloud._helpers import _to_bytes
 from google.cloud import client as client_module
 from google.cloud.speech.connection import Connection
+from google.cloud.speech.encoding import Encoding
 from google.cloud.speech.operation import Operation
 from google.cloud.speech.sample import Sample
 
@@ -89,6 +90,9 @@ class Client(client_module.Client):
         :rtype: `~google.cloud.speech.operation.Operation`
         :returns: ``Operation`` for asynchronous request to Google Speech API.
         """
+        if sample.encoding is not Encoding.LINEAR16:
+            raise ValueError('Only LINEAR16 encoding is supported by '
+                             'asynchronous speech requests.')
 
         data = _build_request_data(sample, language_code, max_alternatives,
                                    profanity_filter, speech_context)

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -160,6 +160,20 @@ class TestClient(unittest.TestCase):
                             sample_rate=self.SAMPLE_RATE)
             client.sync_recognize(sample)
 
+    def test_async_supported_encodings(self):
+        from google.cloud.speech.encoding import Encoding
+        from google.cloud.speech.sample import Sample
+
+        credentials = _Credentials()
+        client = self._makeOne(credentials=credentials)
+        client.connection = _Connection({})
+
+        sample = Sample(source_uri=self.AUDIO_SOURCE_URI,
+                        encoding=Encoding.FLAC,
+                        sample_rate=self.SAMPLE_RATE)
+        with self.assertRaises(ValueError):
+            client.async_recognize(sample)
+
     def test_async_recognize(self):
         from unit_tests._fixtures import ASYNC_RECOGNIZE_RESPONSE
         from google.cloud.speech.encoding import Encoding
@@ -172,7 +186,7 @@ class TestClient(unittest.TestCase):
         client.connection = _Connection(RETURNED)
 
         sample = Sample(source_uri=self.AUDIO_SOURCE_URI,
-                        encoding=Encoding.FLAC,
+                        encoding=Encoding.LINEAR16,
                         sample_rate=self.SAMPLE_RATE)
         operation = client.async_recognize(sample)
         self.assertIsInstance(operation, Operation)


### PR DESCRIPTION
This adds an exception if any encoding other than `LINEAR16` is used for asyn recognition.


> Uncompressed 16-bit signed little-endian samples. This is the only encoding that may be used by AsyncRecognize.

See: https://cloud.google.com/speech/reference/rpc/google.cloud.speech.v1beta1#audioencoding 