### PR TITLE
Speech Python 3.5 encoding content - 'not JSON serializable'

### DIFF
--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -17,6 +17,7 @@
 from base64 import b64encode
 
 from google.cloud._helpers import _to_bytes
+from google.cloud._helpers import _bytes_to_unicode
 from google.cloud import client as client_module
 from google.cloud.speech.connection import Connection
 from google.cloud.speech.encoding import Encoding
@@ -238,7 +239,7 @@ def _build_request_data(sample, language_code=None, max_alternatives=None,
     """
     if sample.content is not None:
         audio = {'content':
-                 b64encode(_to_bytes(sample.content)).decode('ascii')}
+                 _bytes_to_unicode(b64encode(_to_bytes(sample.content)))}
     else:
         audio = {'uri': sample.source_uri}
 

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -237,7 +237,8 @@ def _build_request_data(sample, language_code=None, max_alternatives=None,
     :returns: Dictionary with required data for Google Speech API.
     """
     if sample.content is not None:
-        audio = {'content': b64encode(_to_bytes(sample.content))}
+        audio = {'content':
+                 b64encode(_to_bytes(sample.content)).decode('ascii')}
     else:
         audio = {'uri': sample.source_uri}
 

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -67,7 +67,8 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.sample import Sample
         from unit_tests._fixtures import SYNC_RECOGNIZE_RESPONSE
 
-        _B64_AUDIO_CONTENT = base64.b64encode(_to_bytes(self.AUDIO_CONTENT))
+        _B64_AUDIO_CONTENT = (base64.b64encode(_to_bytes(self.AUDIO_CONTENT))
+                              .decode('ascii'))
         RETURNED = SYNC_RECOGNIZE_RESPONSE
         REQUEST = {
             'config': {

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -61,14 +61,15 @@ class TestClient(unittest.TestCase):
         self.assertEqual(content_sample.encoding, Encoding.FLAC)
 
     def test_sync_recognize_content_with_optional_parameters(self):
-        import base64
+        from base64 import b64encode
         from google.cloud._helpers import _to_bytes
+        from google.cloud._helpers import _bytes_to_unicode
+
         from google.cloud.speech.encoding import Encoding
         from google.cloud.speech.sample import Sample
         from unit_tests._fixtures import SYNC_RECOGNIZE_RESPONSE
-
-        _B64_AUDIO_CONTENT = (base64.b64encode(_to_bytes(self.AUDIO_CONTENT))
-                              .decode('ascii'))
+        _AUDIO_CONTENT = _to_bytes(self.AUDIO_CONTENT)
+        _B64_AUDIO_CONTENT = _bytes_to_unicode(b64encode(_AUDIO_CONTENT))
         RETURNED = SYNC_RECOGNIZE_RESPONSE
         REQUEST = {
             'config': {


### PR DESCRIPTION
Handling bytes when encoding the request content was failing in Python 3.5.

Closes #2519.