### PR TITLE
Moving to iterators in DNS.

### DIFF
--- a/dns/unit_tests/test_client.py
+++ b/dns/unit_tests/test_client.py
@@ -132,7 +132,10 @@ class TestClient(unittest.TestCase):
         client = self._makeOne(self.PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
-        zones, token = client.list_zones()
+        iterator = client.list_zones()
+        iterator.update_page()
+        zones = list(iterator.page)
+        token = iterator.next_page_token
 
         self.assertEqual(len(zones), len(DATA['managedZones']))
         for found, expected in zip(zones, DATA['managedZones']):
@@ -173,7 +176,10 @@ class TestClient(unittest.TestCase):
         client = self._makeOne(self.PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
-        zones, token = client.list_zones(max_results=3, page_token=TOKEN)
+        iterator = client.list_zones(max_results=3, page_token=TOKEN)
+        iterator.update_page()
+        zones = list(iterator.page)
+        token = iterator.next_page_token
 
         self.assertEqual(len(zones), len(DATA['managedZones']))
         for found, expected in zip(zones, DATA['managedZones']):

--- a/dns/unit_tests/test_zone.py
+++ b/dns/unit_tests/test_zone.py
@@ -440,7 +440,10 @@ class TestManagedZone(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=conn)
         zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
 
-        rrsets, token = zone.list_resource_record_sets()
+        iterator = zone.list_resource_record_sets()
+        iterator.update_page()
+        rrsets = list(iterator.page)
+        token = iterator.next_page_token
 
         self.assertEqual(len(rrsets), len(DATA['rrsets']))
         for found, expected in zip(rrsets, DATA['rrsets']):
@@ -489,8 +492,11 @@ class TestManagedZone(unittest.TestCase):
         client2 = _Client(project=self.PROJECT, connection=conn2)
         zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client1)
 
-        rrsets, token = zone.list_resource_record_sets(
+        iterator = zone.list_resource_record_sets(
             max_results=3, page_token=TOKEN, client=client2)
+        iterator.update_page()
+        rrsets = list(iterator.page)
+        token = iterator.next_page_token
 
         self.assertEqual(len(rrsets), len(DATA['rrsets']))
         for found, expected in zip(rrsets, DATA['rrsets']):
@@ -551,7 +557,10 @@ class TestManagedZone(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=conn)
         zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
 
-        changes, token = zone.list_changes()
+        iterator = zone.list_changes()
+        iterator.update_page()
+        changes = list(iterator.page)
+        token = iterator.next_page_token
 
         self.assertEqual(len(changes), len(DATA['changes']))
         for found, expected in zip(changes, DATA['changes']):
@@ -628,8 +637,11 @@ class TestManagedZone(unittest.TestCase):
         client2 = _Client(project=self.PROJECT, connection=conn2)
         zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client1)
 
-        changes, token = zone.list_changes(
+        iterator = zone.list_changes(
             max_results=3, page_token=TOKEN, client=client2)
+        iterator.update_page()
+        changes = list(iterator.page)
+        token = iterator.next_page_token
 
         self.assertEqual(len(changes), len(DATA['changes']))
         for found, expected in zip(changes, DATA['changes']):


### PR DESCRIPTION
~~**NOTE**: Has #2531 as diffbase.~~

~~In doing this, I realized it's a bit tedious to have to write two classes (page and iterator) for each method. It may be more user-friendly to collapse back into one class. I think I could do it mostly by just making anything that is accessed via `self.page.foo` as `self.page_foo`.~~