### PR TITLE
Use correct 'publishTime' field name for server-set message timestamp.

### DIFF
--- a/pubsub/google/cloud/pubsub/message.py
+++ b/pubsub/google/cloud/pubsub/message.py
@@ -89,5 +89,5 @@ class Message(object):
         instance = cls(
             data=data, message_id=api_repr['messageId'],
             attributes=api_repr.get('attributes'))
-        instance._service_timestamp = api_repr.get('publishTimestamp')
+        instance._service_timestamp = api_repr.get('publishTime')
         return instance

--- a/pubsub/unit_tests/test_message.py
+++ b/pubsub/unit_tests/test_message.py
@@ -98,7 +98,7 @@ class TestMessage(unittest.TestCase):
         api_repr = {
             'data': B64_DATA,
             'messageId': MESSAGE_ID,
-            'publishTimestamp': TIMESTAMP,
+            'publishTime': TIMESTAMP,
         }
         message = self._getTargetClass().from_api_repr(api_repr)
         self.assertEqual(message.data, DATA)
@@ -116,7 +116,7 @@ class TestMessage(unittest.TestCase):
         api_repr = {
             'data': B64_DATA,
             'messageId': MESSAGE_ID,
-            'publishTimestamp': TIMESTAMP,
+            'publishTime': TIMESTAMP,
             'attributes': ATTRS,
         }
         message = self._getTargetClass().from_api_repr(api_repr)

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -198,10 +198,14 @@ class TestPubsub(unittest.TestCase):
 
         message1, message2 = sorted(hoover.received,
                                     key=operator.attrgetter('timestamp'))
+
         self.assertEqual(message1.data, MESSAGE_1)
         self.assertEqual(message1.attributes['extra'], EXTRA_1)
+        self.assertIsNotNone(message1.service_timestamp)
+
         self.assertEqual(message2.data, MESSAGE_2)
         self.assertEqual(message2.attributes['extra'], EXTRA_2)
+        self.assertIsNotNone(message2.service_timestamp)
 
     def _maybe_emulator_skip(self):
         # NOTE: This method is necessary because ``Config.IN_EMULATOR``


### PR DESCRIPTION
Closes #2529.