### PR TITLE
Moving backend specific behavior from Page to Iterator.

### DIFF
--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -273,7 +273,7 @@ class Iterator(object):
         # NOTE: This assumes Page.remaining can never go below 0.
         page_empty = self._page is _UNSET or self._page.remaining == 0
         if page_empty:
-            if self.has_next_page():
+            if self._has_next_page():
                 response = self._get_next_page_response()
                 self._page = self._PAGE_CLASS(self, response, self.ITEMS_KEY)
             else:
@@ -307,7 +307,7 @@ class Iterator(object):
     # Alias needed for Python 2/3 support.
     __next__ = next
 
-    def has_next_page(self):
+    def _has_next_page(self):
         """Determines whether or not there are more pages with results.
 
         :rtype: boolean

--- a/core/unit_tests/test_iterator.py
+++ b/core/unit_tests/test_iterator.py
@@ -229,22 +229,22 @@ class TestIterator(unittest.TestCase):
         self.assertEqual(kw['path'], path)
         self.assertEqual(kw['query_params'], {})
 
-    def test_has_next_page_new(self):
+    def test__has_next_page_new(self):
         connection = _Connection()
         client = _Client(connection)
         path = '/foo'
         iterator = self._makeOne(client, path=path)
-        self.assertTrue(iterator.has_next_page())
+        self.assertTrue(iterator._has_next_page())
 
-    def test_has_next_page_w_number_no_token(self):
+    def test__has_next_page_w_number_no_token(self):
         connection = _Connection()
         client = _Client(connection)
         path = '/foo'
         iterator = self._makeOne(client, path=path)
         iterator.page_number = 1
-        self.assertFalse(iterator.has_next_page())
+        self.assertFalse(iterator._has_next_page())
 
-    def test_has_next_page_w_number_w_token(self):
+    def test__has_next_page_w_number_w_token(self):
         connection = _Connection()
         client = _Client(connection)
         path = '/foo'
@@ -252,20 +252,20 @@ class TestIterator(unittest.TestCase):
         iterator = self._makeOne(client, path=path)
         iterator.page_number = 1
         iterator.next_page_token = token
-        self.assertTrue(iterator.has_next_page())
+        self.assertTrue(iterator._has_next_page())
 
-    def test_has_next_page_w_max_results_not_done(self):
+    def test__has_next_page_w_max_results_not_done(self):
         iterator = self._makeOne(None, path=None, max_results=3,
                                  page_token='definitely-not-none')
         iterator.page_number = 1
         self.assertLess(iterator.num_results, iterator.max_results)
-        self.assertTrue(iterator.has_next_page())
+        self.assertTrue(iterator._has_next_page())
 
-    def test_has_next_page_w_max_results_done(self):
+    def test__has_next_page_w_max_results_done(self):
         iterator = self._makeOne(None, None, max_results=3)
         iterator.page_number = 1
         iterator.num_results = iterator.max_results
-        self.assertFalse(iterator.has_next_page())
+        self.assertFalse(iterator._has_next_page())
 
     def test__get_query_params_no_token(self):
         connection = _Connection()

--- a/resource_manager/google/cloud/resource_manager/client.py
+++ b/resource_manager/google/cloud/resource_manager/client.py
@@ -17,7 +17,6 @@
 
 from google.cloud.client import Client as BaseClient
 from google.cloud.iterator import Iterator
-from google.cloud.iterator import Page
 from google.cloud.resource_manager.connection import Connection
 from google.cloud.resource_manager.project import Project
 
@@ -159,30 +158,6 @@ class Client(BaseClient):
         return _ProjectIterator(self, extra_params=extra_params)
 
 
-class _ProjectPage(Page):
-    """Iterator for a single page of results.
-
-    :type parent: :class:`_ProjectIterator`
-    :param parent: The iterator that owns the current page.
-
-    :type response: dict
-    :param response: The JSON API response for a page of projects.
-    """
-
-    ITEMS_KEY = 'projects'
-
-    def _item_to_value(self, resource):
-        """Convert a JSON project to the native object.
-
-        :type resource: dict
-        :param resource: An resource to be converted to a project.
-
-        :rtype: :class:`.Project`
-        :returns: The next project in the page.
-        """
-        return Project.from_api_repr(resource, client=self._parent.client)
-
-
 class _ProjectIterator(Iterator):
     """An iterator over a list of Project resources.
 
@@ -204,5 +179,16 @@ class _ProjectIterator(Iterator):
                          the API call.
     """
 
-    PAGE_CLASS = _ProjectPage
     PATH = '/projects'
+    ITEMS_KEY = 'projects'
+
+    def _item_to_value(self, resource):
+        """Convert a JSON project to the native object.
+
+        :type resource: dict
+        :param resource: An resource to be converted to a project.
+
+        :rtype: :class:`.Project`
+        :returns: The next project in the page.
+        """
+        return Project.from_api_repr(resource, client=self.client)

--- a/resource_manager/unit_tests/test_client.py
+++ b/resource_manager/unit_tests/test_client.py
@@ -68,6 +68,7 @@ class Test__ProjectIterator(unittest.TestCase):
         iterator = self._makeOne(client)
         iterator._get_next_page_response = dummy_response
 
+        iterator.next_page()
         page = iterator.page
         self.assertEqual(page.num_items, 1)
         project = iterator.next()

--- a/resource_manager/unit_tests/test_client.py
+++ b/resource_manager/unit_tests/test_client.py
@@ -68,7 +68,7 @@ class Test__ProjectIterator(unittest.TestCase):
         iterator = self._makeOne(client)
         iterator._get_next_page_response = dummy_response
 
-        iterator.next_page()
+        iterator.update_page()
         page = iterator.page
         self.assertEqual(page.num_items, 1)
         project = iterator.next()

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -19,7 +19,6 @@ from google.cloud._helpers import _LocalStack
 from google.cloud.client import JSONClient
 from google.cloud.exceptions import NotFound
 from google.cloud.iterator import Iterator
-from google.cloud.iterator import Page
 from google.cloud.storage.batch import Batch
 from google.cloud.storage.bucket import Bucket
 from google.cloud.storage.connection import Connection
@@ -272,39 +271,14 @@ class Client(JSONClient):
         return result
 
 
-class _BucketPage(Page):
-    """Iterator for a single page of results.
-
-    :type parent: :class:`_BucketIterator`
-    :param parent: The iterator that owns the current page.
-
-    :type response: dict
-    :param response: The JSON API response for a page of buckets.
-    """
-
-    def _item_to_value(self, item):
-        """Convert a JSON bucket to the native object.
-
-        :type item: dict
-        :param item: An item to be converted to a bucket.
-
-        :rtype: :class:`.Bucket`
-        :returns: The next bucket in the page.
-        """
-        name = item.get('name')
-        bucket = Bucket(self._parent.client, name)
-        bucket._set_properties(item)
-        return bucket
-
-
 class _BucketIterator(Iterator):
     """An iterator listing all buckets.
 
     You shouldn't have to use this directly, but instead should use the
-    helper methods on :class:`google.cloud.storage.connection.Connection`
+    helper methods on :class:`~google.cloud.storage.connection.Connection`
     objects.
 
-    :type client: :class:`google.cloud.storage.client.Client`
+    :type client: :class:`~google.cloud.storage.client.Client`
     :param client: The client to use for making connections.
 
     :type page_token: str
@@ -317,5 +291,18 @@ class _BucketIterator(Iterator):
     :param extra_params: Extra query string parameters for the API call.
     """
 
-    PAGE_CLASS = _BucketPage
     PATH = '/b'
+
+    def _item_to_value(self, item):
+        """Convert a JSON bucket to the native object.
+
+        :type item: dict
+        :param item: An item to be converted to a bucket.
+
+        :rtype: :class:`.Bucket`
+        :returns: The next bucket in the page.
+        """
+        name = item.get('name')
+        bucket = Bucket(self.client, name)
+        bucket._set_properties(item)
+        return bucket

--- a/storage/unit_tests/test_bucket.py
+++ b/storage/unit_tests/test_bucket.py
@@ -64,6 +64,7 @@ class Test__BlobIterator(unittest.TestCase):
         iterator = self._makeOne(bucket, client=client)
         iterator._get_next_page_response = dummy_response
 
+        iterator.next_page()
         page = iterator.page
         self.assertEqual(page.prefixes, ('foo',))
         self.assertEqual(page.num_items, 1)
@@ -97,6 +98,7 @@ class Test__BlobIterator(unittest.TestCase):
         iterator._get_next_page_response = dummy_response
 
         # Parse first response.
+        iterator.next_page()
         page1 = iterator.page
         self.assertEqual(page1.prefixes, ('foo',))
         self.assertEqual(page1.num_items, 1)
@@ -106,6 +108,7 @@ class Test__BlobIterator(unittest.TestCase):
         self.assertEqual(blob.name, BLOB_NAME)
         self.assertEqual(iterator.prefixes, set(['foo']))
         # Parse second response.
+        iterator.next_page()
         page2 = iterator.page
         self.assertEqual(page2.prefixes, ('bar',))
         self.assertEqual(page2.num_items, 0)

--- a/storage/unit_tests/test_bucket.py
+++ b/storage/unit_tests/test_bucket.py
@@ -64,7 +64,7 @@ class Test__BlobIterator(unittest.TestCase):
         iterator = self._makeOne(bucket, client=client)
         iterator._get_next_page_response = dummy_response
 
-        iterator.next_page()
+        iterator.update_page()
         page = iterator.page
         self.assertEqual(page.prefixes, ('foo',))
         self.assertEqual(page.num_items, 1)
@@ -98,7 +98,7 @@ class Test__BlobIterator(unittest.TestCase):
         iterator._get_next_page_response = dummy_response
 
         # Parse first response.
-        iterator.next_page()
+        iterator.update_page()
         page1 = iterator.page
         self.assertEqual(page1.prefixes, ('foo',))
         self.assertEqual(page1.num_items, 1)
@@ -108,7 +108,7 @@ class Test__BlobIterator(unittest.TestCase):
         self.assertEqual(blob.name, BLOB_NAME)
         self.assertEqual(iterator.prefixes, set(['foo']))
         # Parse second response.
-        iterator.next_page()
+        iterator.update_page()
         page2 = iterator.page
         self.assertEqual(page2.prefixes, ('bar',))
         self.assertEqual(page2.num_items, 0)

--- a/storage/unit_tests/test_client.py
+++ b/storage/unit_tests/test_client.py
@@ -370,41 +370,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(parse_qs(uri_parts.query), EXPECTED_QUERY)
 
 
-class Test__BucketPage(unittest.TestCase):
-
-    def _getTargetClass(self):
-        from google.cloud.storage.client import _BucketPage
-        return _BucketPage
-
-    def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
-
-    def test_empty_response(self):
-        from google.cloud.storage.client import _BucketIterator
-
-        connection = object()
-        client = _Client(connection)
-        iterator = _BucketIterator(client)
-        page = self._makeOne(iterator, {})
-        self.assertEqual(list(page), [])
-
-    def test_non_empty_response(self):
-        from google.cloud.storage.bucket import Bucket
-        from google.cloud.storage.client import _BucketIterator
-
-        BLOB_NAME = 'blob-name'
-        response = {'items': [{'name': BLOB_NAME}]}
-        connection = object()
-        client = _Client(connection)
-        iterator = _BucketIterator(client)
-        page = self._makeOne(iterator, response)
-        self.assertEqual(page.num_items, 1)
-        bucket = page.next()
-        self.assertEqual(page.remaining, 0)
-        self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BLOB_NAME)
-
-
 class Test__BucketIterator(unittest.TestCase):
 
     def _getTargetClass(self):
@@ -422,6 +387,37 @@ class Test__BucketIterator(unittest.TestCase):
         self.assertEqual(iterator.page_number, 0)
         self.assertIsNone(iterator.next_page_token)
         self.assertIs(iterator.client, client)
+
+    def test_page_empty_response(self):
+        from google.cloud.iterator import Page
+
+        connection = object()
+        client = _Client(connection)
+        iterator = self._makeOne(client)
+        page = Page(iterator, {}, iterator.ITEMS_KEY)
+        iterator._page = page
+        self.assertEqual(list(page), [])
+
+    def test_page_non_empty_response(self):
+        from google.cloud.storage.bucket import Bucket
+
+        BLOB_NAME = 'blob-name'
+        response = {'items': [{'name': BLOB_NAME}]}
+        connection = object()
+        client = _Client(connection)
+
+        def dummy_response():
+            return response
+
+        iterator = self._makeOne(client)
+        iterator._get_next_page_response = dummy_response
+
+        page = iterator.page
+        self.assertEqual(page.num_items, 1)
+        bucket = iterator.next()
+        self.assertEqual(page.remaining, 0)
+        self.assertIsInstance(bucket, Bucket)
+        self.assertEqual(bucket.name, BLOB_NAME)
 
 
 class _Credentials(object):

--- a/storage/unit_tests/test_client.py
+++ b/storage/unit_tests/test_client.py
@@ -412,6 +412,7 @@ class Test__BucketIterator(unittest.TestCase):
         iterator = self._makeOne(client)
         iterator._get_next_page_response = dummy_response
 
+        iterator.next_page()
         page = iterator.page
         self.assertEqual(page.num_items, 1)
         bucket = iterator.next()

--- a/storage/unit_tests/test_client.py
+++ b/storage/unit_tests/test_client.py
@@ -412,7 +412,7 @@ class Test__BucketIterator(unittest.TestCase):
         iterator = self._makeOne(client)
         iterator._get_next_page_response = dummy_response
 
-        iterator.next_page()
+        iterator.update_page()
         page = iterator.page
         self.assertEqual(page.num_items, 1)
         bucket = iterator.next()

--- a/system_tests/storage.py
+++ b/system_tests/storage.py
@@ -257,12 +257,12 @@ class TestStorageListFiles(TestStorageFiles):
         truncation_size = 1
         count = len(self.FILENAMES) - truncation_size
         iterator = self.bucket.list_blobs(max_results=count)
-        iterator._update_page()
+        iterator.next_page()
         blobs = list(iterator.page)
         self.assertEqual(len(blobs), count)
         self.assertIsNotNone(iterator.next_page_token)
 
-        iterator._update_page()
+        iterator.next_page()
         last_blobs = list(iterator.page)
         self.assertEqual(len(last_blobs), truncation_size)
 
@@ -301,7 +301,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
     @RetryErrors(unittest.TestCase.failureException)
     def test_root_level_w_delimiter(self):
         iterator = self.bucket.list_blobs(delimiter='/')
-        iterator._update_page()
+        iterator.next_page()
         blobs = list(iterator.page)
         self.assertEqual([blob.name for blob in blobs], ['file01.txt'])
         self.assertIsNone(iterator.next_page_token)
@@ -310,7 +310,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
     @RetryErrors(unittest.TestCase.failureException)
     def test_first_level(self):
         iterator = self.bucket.list_blobs(delimiter='/', prefix='parent/')
-        iterator._update_page()
+        iterator.next_page()
         blobs = list(iterator.page)
         self.assertEqual([blob.name for blob in blobs], ['parent/file11.txt'])
         self.assertIsNone(iterator.next_page_token)
@@ -325,7 +325,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
 
         iterator = self.bucket.list_blobs(delimiter='/',
                                           prefix='parent/child/')
-        iterator._update_page()
+        iterator.next_page()
         blobs = list(iterator.page)
         self.assertEqual([blob.name for blob in blobs],
                          expected_names)
@@ -341,7 +341,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
         # Exercise a layer deeper to illustrate this.
         iterator = self.bucket.list_blobs(delimiter='/',
                                           prefix='parent/child/grand/')
-        iterator._update_page()
+        iterator.next_page()
         blobs = list(iterator.page)
         self.assertEqual([blob.name for blob in blobs],
                          ['parent/child/grand/file31.txt'])

--- a/system_tests/storage.py
+++ b/system_tests/storage.py
@@ -257,12 +257,12 @@ class TestStorageListFiles(TestStorageFiles):
         truncation_size = 1
         count = len(self.FILENAMES) - truncation_size
         iterator = self.bucket.list_blobs(max_results=count)
-        iterator.next_page()
+        iterator.update_page()
         blobs = list(iterator.page)
         self.assertEqual(len(blobs), count)
         self.assertIsNotNone(iterator.next_page_token)
 
-        iterator.next_page()
+        iterator.update_page()
         last_blobs = list(iterator.page)
         self.assertEqual(len(last_blobs), truncation_size)
 
@@ -301,7 +301,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
     @RetryErrors(unittest.TestCase.failureException)
     def test_root_level_w_delimiter(self):
         iterator = self.bucket.list_blobs(delimiter='/')
-        iterator.next_page()
+        iterator.update_page()
         blobs = list(iterator.page)
         self.assertEqual([blob.name for blob in blobs], ['file01.txt'])
         self.assertIsNone(iterator.next_page_token)
@@ -310,7 +310,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
     @RetryErrors(unittest.TestCase.failureException)
     def test_first_level(self):
         iterator = self.bucket.list_blobs(delimiter='/', prefix='parent/')
-        iterator.next_page()
+        iterator.update_page()
         blobs = list(iterator.page)
         self.assertEqual([blob.name for blob in blobs], ['parent/file11.txt'])
         self.assertIsNone(iterator.next_page_token)
@@ -325,7 +325,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
 
         iterator = self.bucket.list_blobs(delimiter='/',
                                           prefix='parent/child/')
-        iterator.next_page()
+        iterator.update_page()
         blobs = list(iterator.page)
         self.assertEqual([blob.name for blob in blobs],
                          expected_names)
@@ -341,7 +341,7 @@ class TestStoragePseudoHierarchy(TestStorageFiles):
         # Exercise a layer deeper to illustrate this.
         iterator = self.bucket.list_blobs(delimiter='/',
                                           prefix='parent/child/grand/')
-        iterator.next_page()
+        iterator.update_page()
         blobs = list(iterator.page)
         self.assertEqual([blob.name for blob in blobs],
                          ['parent/child/grand/file31.txt'])


### PR DESCRIPTION
This is to lower the burden on implementers. The previous approach (requiring a `Page` and `Iterator` subclass) ended up causing lots of copy-pasta docstrings that were just a distraction.

Follow up to #2531.