### PR TITLE
Allows Explicitly Enabling/Disabling GAX for Logging/Pubsub

### DIFF
--- a/error_reporting/google/cloud/error_reporting/client.py
+++ b/error_reporting/google/cloud/error_reporting/client.py
@@ -106,7 +106,7 @@ class Client(object):
                  service=None,
                  version=None):
         self.logging_client = google.cloud.logging.client.Client(
-            project=project, credentials=credentials, http=http, use_gax=False)
+            project, credentials, http)
         self.service = service if service else self.DEFAULT_SERVICE
         self.version = version
 

--- a/error_reporting/google/cloud/error_reporting/client.py
+++ b/error_reporting/google/cloud/error_reporting/client.py
@@ -106,7 +106,7 @@ class Client(object):
                  service=None,
                  version=None):
         self.logging_client = google.cloud.logging.client.Client(
-            project, credentials, http)
+            project=project, credentials=credentials, http=http, use_gax=False)
         self.service = service if service else self.DEFAULT_SERVICE
         self.version = version
 

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -73,8 +73,10 @@ class Client(JSONClient):
                  ``credentials`` for the current object.
 
     :type use_gax: bool
-    :param use_gax: An optional parameter that explicitly specifies whether
-                    to use the gRPC transport (via GAX) or HTTP
+    :param use_gax: (Optional) Explicitly specifies whether
+                    to use the gRPC transport (via GAX) or HTTP. If unset,
+                    falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
+                    variable
     """
 
     _connection_class = Connection

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -71,15 +71,22 @@ class Client(JSONClient):
     :param http: An optional HTTP object to make requests. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
+
+    :type use_gax: bool or :class:`NoneType`
+    :param use_gax: An optional parameter that explicitly specifies whether
+                    to use the gRPC transport (gax) or HTTP
     """
 
     _connection_class = Connection
     _logging_api = _sinks_api = _metrics_api = None
 
     def __init__(self, project=None, credentials=None,
-                 http=None, use_gax=True):
+                 http=None, use_gax=None):
         super(Client, self).__init__(project, credentials, http)
-        self.use_gax = use_gax
+        if use_gax is None:
+            self._use_gax = _USE_GAX
+        else:
+            self._use_gax = use_gax
 
     @property
     def logging_api(self):
@@ -90,7 +97,7 @@ class Client(JSONClient):
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.logs
         """
         if self._logging_api is None:
-            if _USE_GAX and self.use_gax:
+            if self._use_gax:
                 generated = GeneratedLoggingAPI()
                 self._logging_api = GAXLoggingAPI(generated)
             else:

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -72,9 +72,9 @@ class Client(JSONClient):
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
 
-    :type use_gax: bool or :class:`NoneType`
+    :type use_gax: bool
     :param use_gax: An optional parameter that explicitly specifies whether
-                    to use the gRPC transport (gax) or HTTP
+                    to use the gRPC transport (via GAX) or HTTP
     """
 
     _connection_class = Connection

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -76,6 +76,11 @@ class Client(JSONClient):
     _connection_class = Connection
     _logging_api = _sinks_api = _metrics_api = None
 
+    def __init__(self, project=None, credentials=None,
+                 http=None, use_gax=True):
+        super(Client, self).__init__(project, credentials, http)
+        self.use_gax = use_gax
+
     @property
     def logging_api(self):
         """Helper for logging-related API calls.
@@ -85,7 +90,7 @@ class Client(JSONClient):
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.logs
         """
         if self._logging_api is None:
-            if _USE_GAX:
+            if _USE_GAX and self.use_gax:
                 generated = GeneratedLoggingAPI()
                 self._logging_api = GAXLoggingAPI(generated)
             else:

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -16,6 +16,7 @@ import unittest
 
 
 class TestClient(unittest.TestCase):
+
     PROJECT = 'PROJECT'
     LOGGER_NAME = 'LOGGER_NAME'
     SINK_NAME = 'SINK_NAME'
@@ -65,6 +66,7 @@ class TestClient(unittest.TestCase):
             return wrapped
 
         class _GaxLoggingAPI(object):
+
             def __init__(self, _wrapped):
                 self._wrapped = _wrapped
 

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -86,13 +86,12 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
     def test_no_gax_ctor(self):
-        from google.cloud.logging.connection import _LoggingAPI
-        from google.cloud.logging import client as MUT
         from google.cloud._testing import _Monkey
+        from google.cloud.logging import client as MUT
+        from google.cloud.logging.connection import _LoggingAPI
 
         creds = _Credentials()
-        with _Monkey(MUT,
-                     _USE_GAX=True):
+        with _Monkey(MUT, _USE_GAX=True):
             client = self._makeOne(project=self.PROJECT, credentials=creds,
                                    use_gax=False)
 

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -39,14 +39,14 @@ class TestClient(unittest.TestCase):
         self.assertEqual(client.project, self.PROJECT)
 
     def test_logging_api_wo_gax(self):
-        from google.cloud.logging.connection import _LoggingAPI
-        from google.cloud.logging import client as MUT
         from google.cloud._testing import _Monkey
+        from google.cloud.logging import client as MUT
+        from google.cloud.logging.connection import _LoggingAPI
 
         with _Monkey(MUT, _USE_GAX=False):
             client = self._makeOne(self.PROJECT, credentials=_Credentials())
-            conn = client.connection = object()
-            api = client.logging_api
+        conn = client.connection = object()
+        api = client.logging_api
 
         self.assertIsInstance(api, _LoggingAPI)
         self.assertIs(api._connection, conn)

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -16,7 +16,6 @@ import unittest
 
 
 class TestClient(unittest.TestCase):
-
     PROJECT = 'PROJECT'
     LOGGER_NAME = 'LOGGER_NAME'
     SINK_NAME = 'SINK_NAME'
@@ -42,10 +41,10 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging.connection import _LoggingAPI
         from google.cloud.logging import client as MUT
         from google.cloud._testing import _Monkey
-        client = self._makeOne(self.PROJECT, credentials=_Credentials())
-        conn = client.connection = object()
 
         with _Monkey(MUT, _USE_GAX=False):
+            client = self._makeOne(self.PROJECT, credentials=_Credentials())
+            conn = client.connection = object()
             api = client.logging_api
 
         self.assertIsInstance(api, _LoggingAPI)
@@ -66,7 +65,6 @@ class TestClient(unittest.TestCase):
             return wrapped
 
         class _GaxLoggingAPI(object):
-
             def __init__(self, _wrapped):
                 self._wrapped = _wrapped
 
@@ -84,6 +82,20 @@ class TestClient(unittest.TestCase):
         # API instance is cached
         again = client.logging_api
         self.assertIs(again, api)
+
+    def test_no_gax_ctor(self):
+        from google.cloud.logging.connection import _LoggingAPI
+        from google.cloud.logging import client as MUT
+        from google.cloud._testing import _Monkey
+
+        creds = _Credentials()
+        with _Monkey(MUT,
+                     _USE_GAX=True):
+            client = self._makeOne(project=self.PROJECT, credentials=creds,
+                                   use_gax=False)
+
+        api = client.logging_api
+        self.assertIsInstance(api, _LoggingAPI)
 
     def test_sinks_api_wo_gax(self):
         from google.cloud.logging.connection import _SinksAPI

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -65,8 +65,10 @@ class Client(JSONClient):
                  ``credentials`` for the current object.
 
     :type use_gax: bool
-    :param use_gax: An optional parameter that explicitly specifies whether
-                    to use the gRPC transport (via GAX) or HTTP
+    :param use_gax: (Optional) Explicitly specifies whether
+                    to use the gRPC transport (via GAX) or HTTP. If unset,
+                    falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
+                    variable
     """
     def __init__(self, project=None, credentials=None,
                  http=None, use_gax=None):

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -63,7 +63,18 @@ class Client(JSONClient):
     :param http: An optional HTTP object to make requests. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
+
+    :type use_gax: bool or :class:`NoneType`
+    :param use_gax: An optional parameter that explicitly specifies whether
+                    to use the gRPC transport (gax) or HTTP
     """
+    def __init__(self, project=None, credentials=None,
+                 http=None, use_gax=None):
+        super(Client, self).__init__(project, credentials, http)
+        if use_gax is None:
+            self._use_gax = _USE_GAX
+        else:
+            self._use_gax = use_gax
 
     _connection_class = Connection
     _publisher_api = _subscriber_api = _iam_policy_api = None
@@ -72,7 +83,7 @@ class Client(JSONClient):
     def publisher_api(self):
         """Helper for publisher-related API calls."""
         if self._publisher_api is None:
-            if _USE_GAX:
+            if self._use_gax:
                 generated = make_gax_publisher_api(self.connection)
                 self._publisher_api = GAXPublisherAPI(generated)
             else:
@@ -83,7 +94,7 @@ class Client(JSONClient):
     def subscriber_api(self):
         """Helper for subscriber-related API calls."""
         if self._subscriber_api is None:
-            if _USE_GAX:
+            if self._use_gax:
                 generated = make_gax_subscriber_api(self.connection)
                 self._subscriber_api = GAXSubscriberAPI(generated)
             else:

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -64,9 +64,9 @@ class Client(JSONClient):
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
 
-    :type use_gax: bool or :class:`NoneType`
+    :type use_gax: bool
     :param use_gax: An optional parameter that explicitly specifies whether
-                    to use the gRPC transport (gax) or HTTP
+                    to use the gRPC transport (via GAX) or HTTP
     """
     def __init__(self, project=None, credentials=None,
                  http=None, use_gax=None):

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -37,8 +37,9 @@ class TestClient(unittest.TestCase):
 
         with _Monkey(MUT, _USE_GAX=False):
             client = self._makeOne(project=self.PROJECT, credentials=creds)
-            conn = client.connection = object()
-            api = client.publisher_api
+
+        conn = client.connection = object()
+        api = client.publisher_api
 
         self.assertIsInstance(api, _PublisherAPI)
         self.assertIs(api._connection, conn)
@@ -59,7 +60,6 @@ class TestClient(unittest.TestCase):
         self.assertFalse(client._use_gax)
         api = client.publisher_api
         self.assertIsInstance(api, _PublisherAPI)
-
 
     def test_publisher_api_w_gax(self):
         from google.cloud.pubsub import client as MUT
@@ -102,8 +102,9 @@ class TestClient(unittest.TestCase):
 
         with _Monkey(MUT, _USE_GAX=False):
             client = self._makeOne(project=self.PROJECT, credentials=creds)
-            conn = client.connection = object()
-            api = client.subscriber_api
+
+        conn = client.connection = object()
+        api = client.subscriber_api
 
         self.assertIsInstance(api, _SubscriberAPI)
         self.assertIs(api._connection, conn)

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -48,9 +48,9 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
     def test_no_gax_ctor(self):
-        from google.cloud.pubsub import client as MUT
-        from google.cloud.pubsub.connection import _PublisherAPI
         from google.cloud._testing import _Monkey
+        from google.cloud.pubsub.connection import _PublisherAPI
+        from google.cloud.pubsub import client as MUT
 
         creds = _Credentials()
         with _Monkey(MUT, _USE_GAX=True):

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -34,10 +34,10 @@ class TestClient(unittest.TestCase):
         from google.cloud.pubsub import client as MUT
         from google.cloud._testing import _Monkey
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds)
-        conn = client.connection = object()
 
         with _Monkey(MUT, _USE_GAX=False):
+            client = self._makeOne(project=self.PROJECT, credentials=creds)
+            conn = client.connection = object()
             api = client.publisher_api
 
         self.assertIsInstance(api, _PublisherAPI)
@@ -45,6 +45,21 @@ class TestClient(unittest.TestCase):
         # API instance is cached
         again = client.publisher_api
         self.assertIs(again, api)
+
+    def test_no_gax_ctor(self):
+        from google.cloud.pubsub import client as MUT
+        from google.cloud.pubsub.connection import _PublisherAPI
+        from google.cloud._testing import _Monkey
+
+        creds = _Credentials()
+        with _Monkey(MUT, _USE_GAX=True):
+            client = self._makeOne(project=self.PROJECT, credentials=creds,
+                                   use_gax=False)
+
+        self.assertFalse(client._use_gax)
+        api = client.publisher_api
+        self.assertIsInstance(api, _PublisherAPI)
+
 
     def test_publisher_api_w_gax(self):
         from google.cloud.pubsub import client as MUT
@@ -84,10 +99,10 @@ class TestClient(unittest.TestCase):
         from google.cloud.pubsub import client as MUT
         from google.cloud._testing import _Monkey
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds)
-        conn = client.connection = object()
 
         with _Monkey(MUT, _USE_GAX=False):
+            client = self._makeOne(project=self.PROJECT, credentials=creds)
+            conn = client.connection = object()
             api = client.subscriber_api
 
         self.assertIsInstance(api, _SubscriberAPI)


### PR DESCRIPTION
Currently gax can’t log nested structs, so this is a workaround to allow forced HTTP logging.

Workaround to resolve #2521 until #2552 is resolved.