### PR TITLE
Removing Iterator and Page subclasses.

### DIFF
--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -17,29 +17,27 @@
 These iterators simplify the process of paging through API responses
 where the response is a list of results with a ``nextPageToken``.
 
-To make an iterator work, you may need to override the
-``ITEMS_KEY`` class attribute so that a given response (containing a page of
-results) can be parsed into an iterable page of the actual objects you want::
+To make an iterator work, you'll need to provide a way to convert a JSON
+item returned from the API into the object of your choice (via
+``item_to_value``). You also may need to specify a custom ``items_key`` so
+that a given response (containing a page of results) can be parsed into an
+iterable page of the actual objects you want. You then can use this to get
+**all** the results from a resource::
 
-  class MyIterator(Iterator):
-
-      ITEMS_KEY = 'blocks'
-
-      def _item_to_value(self, item):
-          my_item = MyItemClass(other_arg=True)
-          my_item._set_properties(item)
-          return my_item
-
-You then can use this to get **all** the results from a resource::
-
-    >>> iterator = MyIterator(...)
+    >>> def item_to_value(iterator, item):
+    ...     my_item = MyItemClass(iterator.client, other_arg=True)
+    ...     my_item._set_properties(item)
+    ...     return my_item
+    ...
+    >>> iterator = Iterator(..., items_key='blocks',
+    ...                     item_to_value=item_to_value)
     >>> list(iterator)  # Convert to a list (consumes all values).
 
 Or you can walk your way through items and call off the search early if
 you find what you're looking for (resulting in possibly fewer
 requests)::
 
-    >>> for my_item in MyIterator(...):
+    >>> for my_item in Iterator(...):
     ...     print(my_item.name)
     ...     if not my_item.is_valid:
     ...         break
@@ -47,7 +45,7 @@ requests)::
 When iterating, not every new item will send a request to the server.
 To monitor these requests, track the current page of the iterator::
 
-    >>> iterator = MyIterator(...)
+    >>> iterator = Iterator(...)
     >>> iterator.page_number
     0
     >>> next(iterator)
@@ -58,6 +56,8 @@ To monitor these requests, track the current page of the iterator::
     1
     >>> next(iterator)
     <MyItemClass at 0x7f1d3cccfe90>
+    >>> iterator.page_number
+    1
     >>> iterator.page.remaining
     0
     >>> next(iterator)
@@ -70,7 +70,7 @@ To monitor these requests, track the current page of the iterator::
 It's also possible to consume an entire page and handle the paging process
 manually::
 
-    >>> iterator = MyIterator(...)
+    >>> iterator = Iterator(...)
     >>> # Manually pull down the first page.
     >>> iterator.update_page()
     >>> items = list(iterator.page)
@@ -96,6 +96,8 @@ manually::
     ]
     >>>
     >>> # When there are no more results
+    >>> iterator.next_page_token is None
+    True
     >>> iterator.update_page()
     >>> iterator.page is None
     True
@@ -113,6 +115,43 @@ _UNSTARTED_ERR = (
 _PAGE_ERR_TEMPLATE = (
     'Tried to update the page while current page (%r) still has %d '
     'items remaining.')
+DEFAULT_ITEMS_KEY = 'items'
+"""The dictionary key used to retrieve items from each response."""
+
+
+# pylint: disable=unused-argument
+def _not_implemented_item_to_value(iterator, item):
+    """Helper to convert an item into the native object.
+
+    This is a virtual stand-in as the default value, effectively
+    causing callers to pass in their own callable.
+
+    :type iterator: :class:`Iterator`
+    :param iterator: An iterator that holds some request info.
+
+    :type item: dict
+    :param item: A JSON object to be converted into a native object.
+
+    :raises NotImplementedError: Always.
+    """
+    raise NotImplementedError
+
+
+def _do_nothing_page_start(iterator, page, response):
+    """Helper to provide custom behavior after a :class:`Page` is started.
+
+    This is a do-nothing stand-in as the default value.
+
+    :type iterator: :class:`Iterator`
+    :param iterator: An iterator that holds some request info.
+
+    :type page: :class:`Page`
+    :param page: The page that was just created.
+
+    :type response: dict
+    :param response: The JSON API response for a page.
+    """
+# pylint: enable=unused-argument
 
 
 class Page(object):
@@ -127,15 +166,21 @@ class Page(object):
     :type items_key: str
     :param items_key: The dictionary key used to retrieve items
                       from the response.
+
+    :type item_to_value: callable
+    :param item_to_value: Callable to convert an item from JSON
+                          into the native object. Assumed signature
+                          takes an :class:`Iterator` and a dictionary
+                          holding a single item.
     """
 
-    def __init__(self, parent, response, items_key):
+    def __init__(self, parent, response, items_key, item_to_value):
         self._parent = parent
         items = response.get(items_key, ())
         self._num_items = len(items)
         self._remaining = self._num_items
         self._item_iter = iter(items)
-        self.response = response
+        self._item_to_value = item_to_value
 
     @property
     def num_items(self):
@@ -162,7 +207,7 @@ class Page(object):
     def next(self):
         """Get the next value in the page."""
         item = six.next(self._item_iter)
-        result = self._parent._item_to_value(item)
+        result = self._item_to_value(self._parent, item)
         # Since we've successfully got the next value from the
         # iterator, we update the number of remaining.
         self._remaining -= 1
@@ -175,11 +220,22 @@ class Page(object):
 class Iterator(object):
     """A generic class for iterating through Cloud JSON APIs list responses.
 
-    Sub-classes need to over-write :attr:`ITEMS_KEY` and to define
-    :meth:`_item_to_value`.
-
     :type client: :class:`~google.cloud.client.Client`
     :param client: The client, which owns a connection to make requests.
+
+    :type path: str
+    :param path: The path to query for the list of items. Defaults
+                 to :attr:`PATH` on the current iterator class.
+
+    :type items_key: str
+    :param items_key: The key used to grab retrieved items from an API
+                      response. Defaults to :data:`DEFAULT_ITEMS_KEY`.
+
+    :type item_to_value: callable
+    :param item_to_value: (Optional) Callable to convert an item from JSON
+                          into the native object. Assumed signature
+                          takes an :class:`Iterator` and a dictionary
+                          holding a single item.
 
     :type page_token: str
     :param page_token: (Optional) A token identifying a page in a result set.
@@ -191,26 +247,32 @@ class Iterator(object):
     :param extra_params: (Optional) Extra query string parameters for the
                          API call.
 
-    :type path: str
-    :param path: (Optional) The path to query for the list of items. Defaults
-                 to :attr:`PATH` on the current iterator class.
+    :type page_start: callable
+    :param page_start: (Optional) Callable to provide any special behavior
+                       after a new page has been created. Assumed signature
+                       takes the :class:`Iterator` that started the page,
+                       the :class:`Page` that was started and the dictionary
+                       containing the page response.
     """
 
-    PAGE_TOKEN = 'pageToken'
-    MAX_RESULTS = 'maxResults'
-    RESERVED_PARAMS = frozenset([PAGE_TOKEN, MAX_RESULTS])
-    PATH = None
-    ITEMS_KEY = 'items'
-    """The dictionary key used to retrieve items from each response."""
-    _PAGE_CLASS = Page
+    _PAGE_TOKEN = 'pageToken'
+    _MAX_RESULTS = 'maxResults'
+    _RESERVED_PARAMS = frozenset([_PAGE_TOKEN, _MAX_RESULTS])
 
-    def __init__(self, client, page_token=None, max_results=None,
-                 extra_params=None, path=None):
-        self.extra_params = extra_params or {}
-        self._verify_params()
-        self.max_results = max_results
+    def __init__(self, client, path, items_key=DEFAULT_ITEMS_KEY,
+                 item_to_value=_not_implemented_item_to_value,
+                 page_token=None, max_results=None, extra_params=None,
+                 page_start=_do_nothing_page_start):
         self.client = client
-        self.path = path or self.PATH
+        self.path = path
+        self._items_key = items_key
+        self._item_to_value = item_to_value
+        self.max_results = max_results
+        self.extra_params = extra_params
+        self._page_start = page_start
+        if self.extra_params is None:
+            self.extra_params = {}
+        self._verify_params()
         # The attributes below will change over the life of the iterator.
         self.page_number = 0
         self.next_page_token = page_token
@@ -222,7 +284,7 @@ class Iterator(object):
 
         :raises ValueError: If a reserved parameter is used.
         """
-        reserved_in_use = self.RESERVED_PARAMS.intersection(
+        reserved_in_use = self._RESERVED_PARAMS.intersection(
             self.extra_params)
         if reserved_in_use:
             raise ValueError('Using a reserved parameter',
@@ -275,25 +337,15 @@ class Iterator(object):
         if page_empty:
             if self._has_next_page():
                 response = self._get_next_page_response()
-                self._page = self._PAGE_CLASS(self, response, self.ITEMS_KEY)
+                self._page = Page(self, response, self._items_key,
+                                  self._item_to_value)
+                self._page_start(self, self._page, response)
             else:
                 self._page = None
         else:
             if require_empty:
                 msg = _PAGE_ERR_TEMPLATE % (self._page, self.page.remaining)
                 raise ValueError(msg)
-
-    def _item_to_value(self, item):
-        """Get the next item in the page.
-
-        Subclasses will need to implement this method.
-
-        :type item: dict
-        :param item: An item to be converted to a native object.
-
-        :raises NotImplementedError: Always
-        """
-        raise NotImplementedError
 
     def next(self):
         """Get the next item from the request."""
@@ -330,9 +382,9 @@ class Iterator(object):
         """
         result = {}
         if self.next_page_token is not None:
-            result[self.PAGE_TOKEN] = self.next_page_token
+            result[self._PAGE_TOKEN] = self.next_page_token
         if self.max_results is not None:
-            result[self.MAX_RESULTS] = self.max_results - self.num_results
+            result[self._MAX_RESULTS] = self.max_results - self.num_results
         result.update(self.extra_params)
         return result
 

--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -120,23 +120,6 @@ DEFAULT_ITEMS_KEY = 'items'
 
 
 # pylint: disable=unused-argument
-def _not_implemented_item_to_value(iterator, item):
-    """Helper to convert an item into the native object.
-
-    This is a virtual stand-in as the default value, effectively
-    causing callers to pass in their own callable.
-
-    :type iterator: :class:`Iterator`
-    :param iterator: An iterator that holds some request info.
-
-    :type item: dict
-    :param item: A JSON object to be converted into a native object.
-
-    :raises NotImplementedError: Always.
-    """
-    raise NotImplementedError
-
-
 def _do_nothing_page_start(iterator, page, response):
     """Helper to provide custom behavior after a :class:`Page` is started.
 
@@ -227,15 +210,15 @@ class Iterator(object):
     :param path: The path to query for the list of items. Defaults
                  to :attr:`PATH` on the current iterator class.
 
-    :type items_key: str
-    :param items_key: The key used to grab retrieved items from an API
-                      response. Defaults to :data:`DEFAULT_ITEMS_KEY`.
-
     :type item_to_value: callable
-    :param item_to_value: (Optional) Callable to convert an item from JSON
+    :param item_to_value: Callable to convert an item from JSON
                           into the native object. Assumed signature
                           takes an :class:`Iterator` and a dictionary
                           holding a single item.
+
+    :type items_key: str
+    :param items_key: (Optional) The key used to grab retrieved items from an
+                      API response. Defaults to :data:`DEFAULT_ITEMS_KEY`.
 
     :type page_token: str
     :param page_token: (Optional) A token identifying a page in a result set.
@@ -259,8 +242,8 @@ class Iterator(object):
     _MAX_RESULTS = 'maxResults'
     _RESERVED_PARAMS = frozenset([_PAGE_TOKEN, _MAX_RESULTS])
 
-    def __init__(self, client, path, items_key=DEFAULT_ITEMS_KEY,
-                 item_to_value=_not_implemented_item_to_value,
+    def __init__(self, client, path, item_to_value,
+                 items_key=DEFAULT_ITEMS_KEY,
                  page_token=None, max_results=None, extra_params=None,
                  page_start=_do_nothing_page_start):
         self.client = client

--- a/core/unit_tests/test_iterator.py
+++ b/core/unit_tests/test_iterator.py
@@ -15,6 +15,28 @@
 import unittest
 
 
+class Test__not_implemented_item_to_value(unittest.TestCase):
+
+    def _callFUT(self, iterator, item):
+        from google.cloud.iterator import _not_implemented_item_to_value
+        return _not_implemented_item_to_value(iterator, item)
+
+    def test_virtual(self):
+        with self.assertRaises(NotImplementedError):
+            self._callFUT(None, None)
+
+
+class Test__do_nothing_page_start(unittest.TestCase):
+
+    def _callFUT(self, iterator, page, response):
+        from google.cloud.iterator import _do_nothing_page_start
+        return _do_nothing_page_start(iterator, page, response)
+
+    def test_do_nothing(self):
+        result = self._callFUT(None, None, None)
+        self.assertIsNone(result)
+
+
 class TestPage(unittest.TestCase):
 
     def _getTargetClass(self):
@@ -28,25 +50,25 @@ class TestPage(unittest.TestCase):
         parent = object()
         items_key = 'potatoes'
         response = {items_key: (1, 2, 3)}
-        page = self._makeOne(parent, response, items_key)
+        page = self._makeOne(parent, response, items_key, None)
         self.assertIs(page._parent, parent)
         self.assertEqual(page._num_items, 3)
         self.assertEqual(page._remaining, 3)
 
     def test_num_items_property(self):
-        page = self._makeOne(None, {}, '')
+        page = self._makeOne(None, {}, '', None)
         num_items = 42
         page._num_items = num_items
         self.assertEqual(page.num_items, num_items)
 
     def test_remaining_property(self):
-        page = self._makeOne(None, {}, '')
+        page = self._makeOne(None, {}, '', None)
         remaining = 1337
         page._remaining = remaining
         self.assertEqual(page.remaining, remaining)
 
     def test___iter__(self):
-        page = self._makeOne(None, {}, '')
+        page = self._makeOne(None, {}, '', None)
         self.assertIs(iter(page), page)
 
     def test_iterator_calls__item_to_value(self):
@@ -55,16 +77,16 @@ class TestPage(unittest.TestCase):
         class Parent(object):
 
             calls = 0
-            values = None
 
-            def _item_to_value(self, item):
+            def item_to_value(self, item):
                 self.calls += 1
                 return item
 
         items_key = 'turkeys'
         response = {items_key: [10, 11, 12]}
         parent = Parent()
-        page = self._makeOne(parent, response, items_key)
+        page = self._makeOne(parent, response, items_key,
+                             Parent.item_to_value)
         page._remaining = 100
 
         self.assertEqual(parent.calls, 0)
@@ -93,23 +115,9 @@ class TestIterator(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         path = '/foo'
-        iterator = self._makeOne(client, path=path)
+        iterator = self._makeOne(client, path)
         self.assertIs(iterator.client, client)
         self.assertEqual(iterator.path, path)
-        self.assertEqual(iterator.page_number, 0)
-        self.assertIsNone(iterator.next_page_token)
-
-    def test_constructor_default_path(self):
-        klass = self._getTargetClass()
-
-        class WithPath(klass):
-            PATH = '/path'
-
-        connection = _Connection()
-        client = _Client(connection)
-        iterator = WithPath(client)
-        self.assertIs(iterator.client, client)
-        self.assertEqual(iterator.path, WithPath.PATH)
         self.assertEqual(iterator.page_number, 0)
         self.assertIsNone(iterator.next_page_token)
 
@@ -122,7 +130,7 @@ class TestIterator(unittest.TestCase):
             self._makeOne(client, path=path, extra_params=extra_params)
 
     def test_page_property(self):
-        iterator = self._makeOne(None)
+        iterator = self._makeOne(None, None)
         page = object()
         iterator._page = page
         self.assertIs(iterator.page, page)
@@ -130,13 +138,13 @@ class TestIterator(unittest.TestCase):
     def test_page_property_unset(self):
         from google.cloud.iterator import _UNSET
 
-        iterator = self._makeOne(None)
+        iterator = self._makeOne(None, None)
         self.assertIs(iterator._page, _UNSET)
         with self.assertRaises(AttributeError):
             getattr(iterator, 'page')
 
     def test_update_page_no_more(self):
-        iterator = self._makeOne(None)
+        iterator = self._makeOne(None, None)
         iterator._page = None
         with self.assertRaises(ValueError):
             iterator.update_page()
@@ -144,8 +152,8 @@ class TestIterator(unittest.TestCase):
     def test_update_page_not_empty_success(self):
         from google.cloud.iterator import Page
 
-        iterator = self._makeOne(None)
-        page = Page(None, {}, '')
+        iterator = self._makeOne(None, None)
+        page = Page(None, {}, '', None)
         iterator._page = page
         iterator._page._remaining = 1
         iterator.update_page(require_empty=False)
@@ -154,14 +162,14 @@ class TestIterator(unittest.TestCase):
     def test_update_page_not_empty_fail(self):
         from google.cloud.iterator import Page
 
-        iterator = self._makeOne(None)
-        iterator._page = Page(None, {}, '')
+        iterator = self._makeOne(None, None)
+        iterator._page = Page(None, {}, '', None)
         iterator._page._remaining = 1
         with self.assertRaises(ValueError):
             iterator.update_page(require_empty=True)
 
     def test_update_page_empty_then_no_more(self):
-        iterator = self._makeOne(None)
+        iterator = self._makeOne(None, None)
         # Fake that there are no more pages.
         iterator.page_number = 1
         iterator.next_page_token = None
@@ -169,7 +177,11 @@ class TestIterator(unittest.TestCase):
         self.assertIsNone(iterator.page)
 
     def test_update_page_empty_then_another(self):
-        iterator = self._makeOne(None)
+        from google.cloud._testing import _Monkey
+        from google.cloud import iterator as MUT
+
+        items_key = 'its-key'
+        iterator = self._makeOne(None, None, items_key=items_key)
         # Fake the next page class.
         fake_page = object()
         page_args = []
@@ -182,10 +194,11 @@ class TestIterator(unittest.TestCase):
             return fake_page
 
         iterator._get_next_page_response = dummy_response
-        iterator._PAGE_CLASS = dummy_page_class
-        iterator.update_page()
+        with _Monkey(MUT, Page=dummy_page_class):
+            iterator.update_page()
         self.assertIs(iterator.page, fake_page)
-        self.assertEqual(page_args, [(iterator, {}, iterator.ITEMS_KEY)])
+        self.assertEqual(
+            page_args, [(iterator, {}, items_key, iterator._item_to_value)])
 
     def test___iter__(self):
         iterator = self._makeOne(None, None)
@@ -200,17 +213,14 @@ class TestIterator(unittest.TestCase):
         item1, item2 = object(), object()
         ITEMS = {key1: item1, key2: item2}
 
-        klass = self._getTargetClass()
-
-        class WithItemToValue(klass):
-
-            def _item_to_value(self, item):
-                return ITEMS[item['name']]
+        def item_to_value(iterator, item):  # pylint: disable=unused-argument
+            return ITEMS[item['name']]
 
         connection = _Connection(
             {'items': [{'name': key1}, {'name': key2}]})
         client = _Client(connection)
-        iterator = WithItemToValue(client, path=path)
+        iterator = self._makeOne(client, path=path,
+                                 item_to_value=item_to_value)
         self.assertEqual(iterator.num_results, 0)
 
         val1 = six.next(iterator)
@@ -334,11 +344,6 @@ class TestIterator(unittest.TestCase):
         self.assertEqual(kw['method'], 'GET')
         self.assertEqual(kw['path'], path)
         self.assertEqual(kw['query_params'], {})
-
-    def test__item_to_value_virtual(self):
-        iterator = self._makeOne(None)
-        with self.assertRaises(NotImplementedError):
-            iterator._item_to_value({})
 
     def test_reset(self):
         from google.cloud.iterator import _UNSET

--- a/resource_manager/google/cloud/resource_manager/client.py
+++ b/resource_manager/google/cloud/resource_manager/client.py
@@ -155,8 +155,8 @@ class Client(BaseClient):
             extra_params['filter'] = filter_params
 
         return Iterator(
-            client=self, items_key='projects', path='/projects',
-            item_to_value=_item_to_project, extra_params=extra_params)
+            client=self, path='/projects', item_to_value=_item_to_project,
+            items_key='projects', extra_params=extra_params)
 
 
 def _item_to_project(iterator, resource):

--- a/resource_manager/google/cloud/resource_manager/client.py
+++ b/resource_manager/google/cloud/resource_manager/client.py
@@ -141,11 +141,10 @@ class Client(BaseClient):
                           single page. If not passed, defaults to a value set
                           by the API.
 
-        :rtype: :class:`_ProjectIterator`
-        :returns: A project iterator. The iterator will make multiple API
-                  requests if you continue iterating and there are more
-                  pages of results. Each item returned will be a.
+        :rtype: :class:`~google.cloud.iterator.Iterator`
+        :returns: Iterator of all
                   :class:`~google.cloud.resource_manager.project.Project`.
+                  that the current user has access to.
         """
         extra_params = {}
 
@@ -155,40 +154,21 @@ class Client(BaseClient):
         if filter_params is not None:
             extra_params['filter'] = filter_params
 
-        return _ProjectIterator(self, extra_params=extra_params)
+        return Iterator(
+            client=self, items_key='projects', path='/projects',
+            item_to_value=_item_to_project, extra_params=extra_params)
 
 
-class _ProjectIterator(Iterator):
-    """An iterator over a list of Project resources.
+def _item_to_project(iterator, resource):
+    """Convert a JSON project to the native object.
 
-    You shouldn't have to use this directly, but instead should use the
-    helper methods on :class:`~google.cloud.resource_manager.client.Client`
-    objects.
+    :type iterator: :class:`~google.cloud.iterator.Iterator`
+    :param iterator: The iterator that has retrieved the item.
 
-    :type client: :class:`~google.cloud.resource_manager.client.Client`
-    :param client: The client to use for making connections.
+    :type resource: dict
+    :param resource: A resource to be converted to a project.
 
-    :type page_token: str
-    :param page_token: (Optional) A token identifying a page in a result set.
-
-    :type max_results: int
-    :param max_results: (Optional) The maximum number of results to fetch.
-
-    :type extra_params: dict
-    :param extra_params: (Optional) Extra query string parameters for
-                         the API call.
+    :rtype: :class:`.Project`
+    :returns: The next project in the page.
     """
-
-    PATH = '/projects'
-    ITEMS_KEY = 'projects'
-
-    def _item_to_value(self, resource):
-        """Convert a JSON project to the native object.
-
-        :type resource: dict
-        :param resource: An resource to be converted to a project.
-
-        :rtype: :class:`.Project`
-        :returns: The next project in the page.
-        """
-        return Project.from_api_repr(resource, client=self.client)
+    return Project.from_api_repr(resource, client=iterator.client)


### PR DESCRIPTION
Instead require `Iterator` takes:
- a well-formed path for the request
- a callable to convert a JSON item to native obj.
- (optional) the key in a response holding all items
- (optional) a `page_start` (acts as proxy for `Page.__init__`)