### PR TITLE
Move BigQuery list_ methods to use iterators

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -86,20 +86,34 @@ _CELLDATA_FROM_JSON = {
 }
 
 
+def _row_from_json(row, schema):
+    """Convert JSON row data to row w/ appropriate types.
+
+    :type row: dict
+    :param row:
+
+    :type schema: tuple
+    :param schema: A tuple of
+                   :class:`~google.cloud.bigquery.schema.SchemaField`.
+
+    :rtype: tuple
+    :returns: A tuple of data converted to native types.
+    """
+    row_data = []
+    for field, cell in zip(schema, row['f']):
+        converter = _CELLDATA_FROM_JSON[field.field_type]
+        if field.mode == 'REPEATED':
+            row_data.append([converter(item, field)
+                             for item in cell['v']])
+        else:
+            row_data.append(converter(cell['v'], field))
+
+    return tuple(row_data)
+
+
 def _rows_from_json(rows, schema):
     """Convert JSON row data to rows w/ appropriate types."""
-    rows_data = []
-    for row in rows:
-        row_data = []
-        for field, cell in zip(schema, row['f']):
-            converter = _CELLDATA_FROM_JSON[field.field_type]
-            if field.mode == 'REPEATED':
-                row_data.append([converter(item, field)
-                                 for item in cell['v']])
-            else:
-                row_data.append(converter(cell['v'], field))
-        rows_data.append(tuple(row_data))
-    return rows_data
+    return [_row_from_json(row, schema) for row in rows]
 
 
 class _ConfigurationProperty(object):

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -87,10 +87,10 @@ _CELLDATA_FROM_JSON = {
 
 
 def _row_from_json(row, schema):
-    """Convert JSON row data to row w/ appropriate types.
+    """Convert JSON row data to row with appropriate types.
 
     :type row: dict
-    :param row:
+    :param row: A JSON response row to be converted.
 
     :type schema: tuple
     :param schema: A tuple of
@@ -112,7 +112,7 @@ def _row_from_json(row, schema):
 
 
 def _rows_from_json(rows, schema):
-    """Convert JSON row data to rows w/ appropriate types."""
+    """Convert JSON row data to rows with appropriate types."""
     return [_row_from_json(row, schema) for row in rows]
 
 

--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -18,7 +18,7 @@ import six
 from google.cloud._helpers import _datetime_from_microseconds
 from google.cloud.exceptions import NotFound
 from google.cloud.bigquery.table import Table
-from google.cloud.iterator import Iterator
+from google.cloud.iterator import HTTPIterator
 
 
 class AccessGrant(object):
@@ -556,9 +556,9 @@ class Dataset(object):
                   contained within the current dataset.
         """
         path = '/projects/%s/datasets/%s/tables' % (self.project, self.name)
-        result = Iterator(client=self._client, path=path,
-                          item_to_value=_item_to_table, items_key='tables',
-                          page_token=page_token, max_results=max_results)
+        result = HTTPIterator(client=self._client, path=path,
+                              item_to_value=_item_to_table, items_key='tables',
+                              page_token=page_token, max_results=max_results)
         result.dataset = self
         return result
 

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -668,7 +668,7 @@ class Table(object):
                        back to the ``client`` stored on the current dataset.
 
         :rtype: :class:`~google.cloud.iterator.Iterator`
-        :returns: Iterator of row data :class:`tuple`s. Each page in the
+        :returns: Iterator of row data :class:`tuple`s. During each page, the
                   iterator will have the ``total_rows`` attribute set,
                   which counts the total number of rows **in the table**
                   (this is distinct from the total number of rows in the
@@ -1109,7 +1109,8 @@ def _rows_page_start(iterator, page, response):
     """
     total_rows = response.get('totalRows')
     if total_rows is not None:
-        page.total_rows = int(total_rows)
+        total_rows = int(total_rows)
+    iterator.total_rows = total_rows
 # pylint: enable=unused-argument
 
 

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -33,7 +33,7 @@ from google.cloud.streaming.transfer import RESUMABLE_UPLOAD
 from google.cloud.streaming.transfer import Upload
 from google.cloud.bigquery.schema import SchemaField
 from google.cloud.bigquery._helpers import _row_from_json
-from google.cloud.iterator import Iterator
+from google.cloud.iterator import HTTPIterator
 
 
 _TABLE_HAS_NO_SCHEMA = "Table has no schema:  call 'table.reload()'"
@@ -676,10 +676,10 @@ class Table(object):
         """
         client = self._require_client(client)
         path = '%s/data' % (self.path,)
-        iterator = Iterator(client=client, path=path,
-                            item_to_value=_item_to_row, items_key='rows',
-                            page_token=page_token, max_results=max_results,
-                            page_start=_rows_page_start)
+        iterator = HTTPIterator(client=client, path=path,
+                                item_to_value=_item_to_row, items_key='rows',
+                                page_token=page_token, max_results=max_results,
+                                page_start=_rows_page_start)
         iterator.schema = self._schema
         # Over-ride the key used to retrieve the next page token.
         iterator._NEXT_TOKEN = 'pageToken'

--- a/bigquery/unit_tests/test_dataset.py
+++ b/bigquery/unit_tests/test_dataset.py
@@ -639,7 +639,13 @@ class TestDataset(unittest.TestCase):
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = self._makeOne(self.DS_NAME, client=client)
-        tables, token = dataset.list_tables()
+
+        iterator = dataset.list_tables()
+        self.assertIs(iterator.dataset, dataset)
+        iterator.update_page()
+        tables = list(iterator.page)
+        token = iterator.next_page_token
+
         self.assertEqual(tables, [])
         self.assertIsNone(token)
         self.assertEqual(len(conn._requested), 1)
@@ -677,7 +683,11 @@ class TestDataset(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = self._makeOne(self.DS_NAME, client=client)
 
-        tables, token = dataset.list_tables()
+        iterator = dataset.list_tables()
+        self.assertIs(iterator.dataset, dataset)
+        iterator.update_page()
+        tables = list(iterator.page)
+        token = iterator.next_page_token
 
         self.assertEqual(len(tables), len(DATA['tables']))
         for found, expected in zip(tables, DATA['tables']):
@@ -719,7 +729,11 @@ class TestDataset(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = self._makeOne(self.DS_NAME, client=client)
 
-        tables, token = dataset.list_tables(max_results=3, page_token=TOKEN)
+        iterator = dataset.list_tables(max_results=3, page_token=TOKEN)
+        self.assertIs(iterator.dataset, dataset)
+        iterator.update_page()
+        tables = list(iterator.page)
+        token = iterator.next_page_token
 
         self.assertEqual(len(tables), len(DATA['tables']))
         for found, expected in zip(tables, DATA['tables']):

--- a/bigquery/unit_tests/test_dataset.py
+++ b/bigquery/unit_tests/test_dataset.py
@@ -636,14 +636,16 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_tables_empty(self):
+        import six
+
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = self._makeOne(self.DS_NAME, client=client)
 
         iterator = dataset.list_tables()
         self.assertIs(iterator.dataset, dataset)
-        iterator.update_page()
-        tables = list(iterator.page)
+        page = six.next(iterator.pages)
+        tables = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(tables, [])
@@ -655,6 +657,7 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_tables_defaults(self):
+        import six
         from google.cloud.bigquery.table import Table
 
         TABLE_1 = 'table_one'
@@ -685,8 +688,8 @@ class TestDataset(unittest.TestCase):
 
         iterator = dataset.list_tables()
         self.assertIs(iterator.dataset, dataset)
-        iterator.update_page()
-        tables = list(iterator.page)
+        page = six.next(iterator.pages)
+        tables = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(tables), len(DATA['tables']))
@@ -702,6 +705,7 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_tables_explicit(self):
+        import six
         from google.cloud.bigquery.table import Table
 
         TABLE_1 = 'table_one'
@@ -731,8 +735,8 @@ class TestDataset(unittest.TestCase):
 
         iterator = dataset.list_tables(max_results=3, page_token=TOKEN)
         self.assertIs(iterator.dataset, dataset)
-        iterator.update_page()
-        tables = list(iterator.page)
+        page = six.next(iterator.pages)
+        tables = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(tables), len(DATA['tables']))

--- a/bigquery/unit_tests/test_table.py
+++ b/bigquery/unit_tests/test_table.py
@@ -1015,6 +1015,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
 
     def test_fetch_data_w_bound_client(self):
         import datetime
+        import six
         from google.cloud._helpers import UTC
         from google.cloud.bigquery.table import SchemaField
 
@@ -1069,9 +1070,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
                               schema=[full_name, age, joined])
 
         iterator = table.fetch_data()
-        iterator.update_page()
-        rows = list(iterator.page)
-        total_rows = iterator.page.total_rows
+        page = six.next(iterator.pages)
+        rows = list(page)
+        total_rows = page.total_rows
         page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 4)
@@ -1088,7 +1089,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_fetch_data_w_alternate_client(self):
+        import six
         from google.cloud.bigquery.table import SchemaField
+
         PATH = 'projects/%s/datasets/%s/tables/%s/data' % (
             self.PROJECT, self.DS_NAME, self.TABLE_NAME)
         MAX = 10
@@ -1135,9 +1138,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
 
         iterator = table.fetch_data(
             client=client2, max_results=MAX, page_token=TOKEN)
-        iterator.update_page()
-        rows = list(iterator.page)
-        total_rows = getattr(iterator.page, 'total_rows', None)
+        page = six.next(iterator.pages)
+        rows = list(page)
+        total_rows = getattr(page, 'total_rows', None)
         page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 4)
@@ -1157,7 +1160,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
                          {'maxResults': MAX, 'pageToken': TOKEN})
 
     def test_fetch_data_w_repeated_fields(self):
+        import six
         from google.cloud.bigquery.table import SchemaField
+
         PATH = 'projects/%s/datasets/%s/tables/%s/data' % (
             self.PROJECT, self.DS_NAME, self.TABLE_NAME)
         ROWS = 1234
@@ -1185,9 +1190,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
                               schema=[full_name, struct])
 
         iterator = table.fetch_data()
-        iterator.update_page()
-        rows = list(iterator.page)
-        total_rows = iterator.page.total_rows
+        page = six.next(iterator.pages)
+        rows = list(page)
+        total_rows = page.total_rows
         page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 1)
@@ -1203,7 +1208,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_fetch_data_w_record_schema(self):
+        import six
         from google.cloud.bigquery.table import SchemaField
+
         PATH = 'projects/%s/datasets/%s/tables/%s/data' % (
             self.PROJECT, self.DS_NAME, self.TABLE_NAME)
         ROWS = 1234
@@ -1239,9 +1246,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
                               schema=[full_name, phone])
 
         iterator = table.fetch_data()
-        iterator.update_page()
-        rows = list(iterator.page)
-        total_rows = iterator.page.total_rows
+        page = six.next(iterator.pages)
+        rows = list(page)
+        total_rows = page.total_rows
         page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 3)

--- a/bigquery/unit_tests/test_table.py
+++ b/bigquery/unit_tests/test_table.py
@@ -1072,7 +1072,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         iterator = table.fetch_data()
         page = six.next(iterator.pages)
         rows = list(page)
-        total_rows = page.total_rows
+        total_rows = iterator.total_rows
         page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 4)
@@ -1140,7 +1140,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
             client=client2, max_results=MAX, page_token=TOKEN)
         page = six.next(iterator.pages)
         rows = list(page)
-        total_rows = getattr(page, 'total_rows', None)
+        total_rows = iterator.total_rows
         page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 4)
@@ -1192,7 +1192,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         iterator = table.fetch_data()
         page = six.next(iterator.pages)
         rows = list(page)
-        total_rows = page.total_rows
+        total_rows = iterator.total_rows
         page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 1)
@@ -1248,7 +1248,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         iterator = table.fetch_data()
         page = six.next(iterator.pages)
         rows = list(page)
-        total_rows = page.total_rows
+        total_rows = iterator.total_rows
         page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 3)

--- a/bigquery/unit_tests/test_table.py
+++ b/bigquery/unit_tests/test_table.py
@@ -1068,7 +1068,11 @@ class TestTable(unittest.TestCase, _SchemaBase):
         table = self._makeOne(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, joined])
 
-        rows, total_rows, page_token = table.fetch_data()
+        iterator = table.fetch_data()
+        iterator.update_page()
+        rows = list(iterator.page)
+        total_rows = iterator.page.total_rows
+        page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 4)
         self.assertEqual(rows[0], ('Phred Phlyntstone', 32, WHEN))
@@ -1129,9 +1133,12 @@ class TestTable(unittest.TestCase, _SchemaBase):
         table = self._makeOne(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, voter, score])
 
-        rows, total_rows, page_token = table.fetch_data(client=client2,
-                                                        max_results=MAX,
-                                                        page_token=TOKEN)
+        iterator = table.fetch_data(
+            client=client2, max_results=MAX, page_token=TOKEN)
+        iterator.update_page()
+        rows = list(iterator.page)
+        total_rows = getattr(iterator.page, 'total_rows', None)
+        page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 4)
         self.assertEqual(rows[0], ('Phred Phlyntstone', 32, True, 3.1415926))
@@ -1177,7 +1184,11 @@ class TestTable(unittest.TestCase, _SchemaBase):
         table = self._makeOne(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, struct])
 
-        rows, total_rows, page_token = table.fetch_data()
+        iterator = table.fetch_data()
+        iterator.update_page()
+        rows = list(iterator.page)
+        total_rows = iterator.page.total_rows
+        page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0][0], ['red', 'green'])
@@ -1227,7 +1238,11 @@ class TestTable(unittest.TestCase, _SchemaBase):
         table = self._makeOne(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, phone])
 
-        rows, total_rows, page_token = table.fetch_data()
+        iterator = table.fetch_data()
+        iterator.update_page()
+        rows = list(iterator.page)
+        total_rows = iterator.page.total_rows
+        page_token = iterator.next_page_token
 
         self.assertEqual(len(rows), 3)
         self.assertEqual(rows[0][0], 'Phred Phlyntstone')

--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -297,6 +297,7 @@ class HTTPIterator(Iterator):
 
     _PAGE_TOKEN = 'pageToken'
     _MAX_RESULTS = 'maxResults'
+    _NEXT_TOKEN = 'nextPageToken'
     _RESERVED_PARAMS = frozenset([_PAGE_TOKEN, _MAX_RESULTS])
     _HTTP_METHOD = 'GET'
 

--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -340,7 +340,7 @@ class HTTPIterator(Iterator):
             items = response.get(self._items_key, ())
             page = Page(self, items, self._item_to_value)
             self._page_start(self, page, response)
-            self.next_page_token = response.get('nextPageToken')
+            self.next_page_token = response.get(self._NEXT_TOKEN)
             return page
         else:
             return None

--- a/docs/bigquery-usage.rst
+++ b/docs/bigquery-usage.rst
@@ -209,8 +209,9 @@ Run a query which can be expected to complete within bounded time:
    :start-after: [START client_run_sync_query]
    :end-before: [END client_run_sync_query]
 
-If the rows returned by the query do not fit into the inital response,
-then we need to fetch the remaining rows via ``fetch_data``:
+If the rows returned by the query do not fit into the initial response,
+then we need to fetch the remaining rows via
+:meth:`~google.cloud.bigquery.query.QueryResults.fetch_data`:
 
 .. literalinclude:: bigquery_snippets.py
    :start-after: [START client_run_sync_query_paged]
@@ -218,7 +219,7 @@ then we need to fetch the remaining rows via ``fetch_data``:
 
 If the query takes longer than the timeout allowed, ``query.complete``
 will be ``False``.  In that case, we need to poll the associated job until
-it is done, and then fetch the reuslts:
+it is done, and then fetch the results:
 
 .. literalinclude:: bigquery_snippets.py
    :start-after: [START client_run_sync_query_timeout]

--- a/docs/bigquery_snippets.py
+++ b/docs/bigquery_snippets.py
@@ -26,6 +26,8 @@ need to be deleted during teardown.
 import operator
 import time
 
+import six
+
 from google.cloud.bigquery import SchemaField
 from google.cloud.bigquery.client import Client
 
@@ -342,8 +344,8 @@ def _warm_up_inserted_table_data(table):
     while len(rows) == 0 and counter > 0:
         counter -= 1
         iterator = table.fetch_data()
-        iterator.update_page()
-        rows = list(iterator.page)
+        page = six.next(iterator.pages)
+        rows = list(page)
         if len(rows) == 0:
             time.sleep(5)
 
@@ -422,9 +424,9 @@ def table_upload_from_file(client, to_delete):
     _warm_up_inserted_table_data(table)
 
     iterator = table.fetch_data()
-    iterator.update_page()
-    rows = list(iterator.page)
-    total = iterator.page.total_rows
+    page = six.next(iterator.pages)
+    rows = list(page)
+    total = page.total_rows
     token = iterator.next_page_token
 
     assert len(rows) == total == 2

--- a/docs/bigquery_snippets.py
+++ b/docs/bigquery_snippets.py
@@ -341,7 +341,9 @@ def _warm_up_inserted_table_data(table):
 
     while len(rows) == 0 and counter > 0:
         counter -= 1
-        rows, _, _ = table.fetch_data()
+        iterator = table.fetch_data()
+        iterator.update_page()
+        rows = list(iterator.page)
         if len(rows) == 0:
             time.sleep(5)
 
@@ -376,13 +378,8 @@ def table_insert_fetch_data(client, to_delete):
         found_rows.append(row)
 
     # [START table_fetch_data]
-    rows, _, token = table.fetch_data()
-    while True:
-        for row in rows:
-            do_something(row)
-        if token is None:
-            break
-        rows, _, token = table.fetch_data(page_token=token)
+    for row in table.fetch_data():
+        do_something(row)
     # [END table_fetch_data]
 
     assert len(found_rows) == len(ROWS_TO_INSERT)
@@ -424,7 +421,11 @@ def table_upload_from_file(client, to_delete):
 
     _warm_up_inserted_table_data(table)
 
-    rows, total, token = table.fetch_data()
+    iterator = table.fetch_data()
+    iterator.update_page()
+    rows = list(iterator.page)
+    total = iterator.page.total_rows
+    token = iterator.next_page_token
 
     assert len(rows) == total == 2
     assert token is None

--- a/docs/bigquery_snippets.py
+++ b/docs/bigquery_snippets.py
@@ -426,7 +426,7 @@ def table_upload_from_file(client, to_delete):
     iterator = table.fetch_data()
     page = six.next(iterator.pages)
     rows = list(page)
-    total = page.total_rows
+    total = iterator.total_rows
     token = iterator.next_page_token
 
     assert len(rows) == total == 2

--- a/docs/bigquery_snippets.py
+++ b/docs/bigquery_snippets.py
@@ -200,13 +200,12 @@ def dataset_list_tables(client, to_delete):
     to_delete.append(dataset)
 
     # [START dataset_list_tables]
-    tables, token = dataset.list_tables()   # API request
+    tables = list(dataset.list_tables())  # API request(s)
     assert len(tables) == 0
-    assert token is None
     table = dataset.table(TABLE_NAME)
     table.view_query = QUERY
     table.create()                          # API request
-    tables, token = dataset.list_tables()   # API request
+    tables = list(dataset.list_tables())  # API request(s)
     assert len(tables) == 1
     assert tables[0].name == TABLE_NAME
     # [END dataset_list_tables]

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -72,7 +72,7 @@ TEST_RC_ADDITIONS = {
 }
 TEST_RC_REPLACEMENTS = {
     'FORMAT': {
-        'max-module-lines': 1960,
+        'max-module-lines': 2000,
     },
 }
 

--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -265,9 +265,11 @@ class TestBigQuery(unittest.TestCase):
 
     @staticmethod
     def _fetch_single_page(table):
+        import six
+
         iterator = table.fetch_data()
-        iterator.update_page()
-        return list(iterator.page)
+        page = six.next(iterator.pages)
+        return list(page)
 
     def test_insert_data_then_dump_table(self):
         import datetime

--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -25,6 +25,10 @@ from retry import RetryResult
 from system_test_utils import unique_resource_id
 
 
+def _has_rows(result):
+    return len(result) > 0
+
+
 def _make_dataset_name(prefix):
     return '%s%s' % (prefix, unique_resource_id())
 
@@ -307,9 +311,6 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(len(errors), 0)
 
         rows = ()
-
-        def _has_rows(result):
-            return len(result[0]) > 0
 
         # Allow for "warm up" before rows visible.  See:
         # https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataavailability

--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -186,9 +186,10 @@ class TestBigQuery(unittest.TestCase):
         self.to_delete.append(dataset)
 
         # Retrieve tables before any are created for the dataset.
-        all_tables, token = dataset.list_tables()
+        iterator = dataset.list_tables()
+        all_tables = list(iterator)
         self.assertEqual(all_tables, [])
-        self.assertIsNone(token)
+        self.assertIsNone(iterator.next_page_token)
 
         # Insert some tables to be listed.
         tables_to_create = [
@@ -205,8 +206,9 @@ class TestBigQuery(unittest.TestCase):
             self.to_delete.insert(0, table)
 
         # Retrieve the tables.
-        all_tables, token = dataset.list_tables()
-        self.assertIsNone(token)
+        iterator = dataset.list_tables()
+        all_tables = list(iterator)
+        self.assertIsNone(iterator.next_page_token)
         created = [table for table in all_tables
                    if (table.name in tables_to_create and
                        table.dataset_name == DATASET_NAME)]


### PR DESCRIPTION
Follow up to #2561. This only covers `Dataset.list_tables()` and `Table.fetch_data()`. It may also be "correct" to use an Iterator in
- `QueryResults.fetch_data`
- `QueryResults.run` (via `QueryResults._build_resource`)

but I wanted to get eyes on this change first / opinion from the original author (@tseaver) before moving forward.
