### PR TITLE
Do not encode pubsub message for gRPC requests. 

### DIFF
--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -85,10 +85,6 @@ Test permissions allowed by the current IAM policy on a topic:
 Publish messages to a topic
 ---------------------------
 
-.. note::
-    If you're publishing a message from console.cloud.google.com, you will need
-    to base64 encode the message first.
-
 Publish a single message to a topic, without attributes:
 
 .. literalinclude:: pubsub_snippets.py

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -14,6 +14,7 @@
 
 """Create / interact with Google Cloud Pub/Sub connections."""
 
+import base64
 import os
 
 from google.cloud import connection as base_connection
@@ -201,6 +202,7 @@ class _PublisherAPI(object):
         :rtype: list of string
         :returns: list of opaque IDs for published messages.
         """
+        _transform_messages_base64(messages, _base64_unicode)
         conn = self._connection
         data = {'messages': messages}
         response = conn.api_request(
@@ -419,7 +421,9 @@ class _SubscriberAPI(object):
             'maxMessages': max_messages,
         }
         response = conn.api_request(method='POST', path=path, data=data)
-        return response.get('receivedMessages', ())
+        messages = response.get('receivedMessages', ())
+        _transform_messages_base64(messages, base64.b64decode, 'message')
+        return messages
 
     def subscription_acknowledge(self, subscription_path, ack_ids):
         """API call:  acknowledge retrieved messages
@@ -539,3 +543,35 @@ class _IAMPolicyAPI(object):
         path = '/%s:testIamPermissions' % (target_path,)
         resp = conn.api_request(method='POST', path=path, data=wrapped)
         return resp.get('permissions', [])
+
+
+def _base64_unicode(value):
+    """Helper to base64 encode and make JSON serializable.
+
+    :type value: str
+    :param value: String value to be base64 encoded and made serializable.
+
+    :rtype: str
+    :returns: Base64 encoded string/unicode value.
+    """
+    as_bytes = base64.b64encode(value)
+    return as_bytes.decode('ascii')
+
+
+def _transform_messages_base64(messages, transform, key=None):
+    """Helper for base64 encoding and decoding messages.
+
+    :type messages: list
+    :param messages: List of dictionaries with message data.
+
+    :type transform: :class:`~types.FunctionType`
+    :param transform: Function to encode/decode the message data.
+
+    :type key: str
+    :param key: Index to access messages.
+    """
+    for message in messages:
+        if key is not None:
+            message = message[key]
+        if 'data' in message:
+            message['data'] = transform(message['data'])

--- a/pubsub/google/cloud/pubsub/message.py
+++ b/pubsub/google/cloud/pubsub/message.py
@@ -14,9 +14,6 @@
 
 """Define API Topics."""
 
-import base64
-import binascii
-
 from google.cloud._helpers import _rfc3339_to_datetime
 
 
@@ -86,14 +83,7 @@ class Message(object):
         :rtype: :class:`Message`
         :returns: The message created from the response.
         """
-        raw_data = api_repr.get('data', b'')
-        try:
-            data = base64.b64decode(raw_data)
-        except (binascii.Error, TypeError):
-            to_pad = (- len(raw_data)) % 4
-            padded_data = raw_data + b'=' * to_pad
-            data = base64.b64decode(padded_data)
-
+        data = api_repr.get('data', b'')
         instance = cls(
             data=data, message_id=api_repr['messageId'],
             attributes=api_repr.get('attributes'))

--- a/pubsub/google/cloud/pubsub/topic.py
+++ b/pubsub/google/cloud/pubsub/topic.py
@@ -14,8 +14,6 @@
 
 """Define API Topics."""
 
-import base64
-
 from google.cloud._helpers import _datetime_to_rfc3339
 from google.cloud._helpers import _NOW
 from google.cloud.exceptions import NotFound
@@ -252,8 +250,7 @@ class Topic(object):
         api = client.publisher_api
 
         self._timestamp_message(attrs)
-        message_b = base64.b64encode(message).decode('ascii')
-        message_data = {'data': message_b, 'attributes': attrs}
+        message_data = {'data': message, 'attributes': attrs}
         message_ids = api.topic_publish(self.full_name, [message_data])
         return message_ids[0]
 
@@ -449,7 +446,7 @@ class Batch(object):
         """
         self.topic._timestamp_message(attrs)
         self.messages.append(
-            {'data': base64.b64encode(message).decode('ascii'),
+            {'data': message,
              'attributes': attrs})
 
     def commit(self, client=None):

--- a/pubsub/unit_tests/test_message.py
+++ b/pubsub/unit_tests/test_message.py
@@ -89,27 +89,12 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message.attributes, {})
         self.assertIsNone(message.service_timestamp)
 
-    def test_from_api_repr_bad_b64_data(self):
-        DATA = b'wefwefw'
-        BAD_B64_DATA = b'd2Vmd2Vmdw='
-        MESSAGE_ID = '12345'
-        TIMESTAMP = '2016-03-18-19:38:22.001393427Z'
-        api_repr = {
-            'data': BAD_B64_DATA,
-            'messageId': MESSAGE_ID,
-            'publishTimestamp': TIMESTAMP,
-        }
-        message = self._getTargetClass().from_api_repr(api_repr)
-        self.assertEqual(message.data, DATA)
-
     def test_from_api_repr_no_attributes(self):
-        from base64 import b64encode as b64
         DATA = b'DEADBEEF'
-        B64_DATA = b64(DATA)
         MESSAGE_ID = '12345'
         TIMESTAMP = '2016-03-18-19:38:22.001393427Z'
         api_repr = {
-            'data': B64_DATA,
+            'data': DATA,
             'messageId': MESSAGE_ID,
             'publishTime': TIMESTAMP,
         }
@@ -120,14 +105,12 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message.service_timestamp, TIMESTAMP)
 
     def test_from_api_repr_w_attributes(self):
-        from base64 import b64encode as b64
         DATA = b'DEADBEEF'
-        B64_DATA = b64(DATA)
         MESSAGE_ID = '12345'
         ATTRS = {'a': 'b'}
         TIMESTAMP = '2016-03-18-19:38:22.001393427Z'
         api_repr = {
-            'data': B64_DATA,
+            'data': DATA,
             'messageId': MESSAGE_ID,
             'publishTime': TIMESTAMP,
             'attributes': ATTRS,

--- a/pubsub/unit_tests/test_subscription.py
+++ b/pubsub/unit_tests/test_subscription.py
@@ -322,13 +322,11 @@ class TestSubscription(unittest.TestCase):
                          (self.SUB_PATH, None))
 
     def test_pull_wo_return_immediately_max_messages_w_bound_client(self):
-        import base64
         from google.cloud.pubsub.message import Message
         ACK_ID = 'DEADBEEF'
         MSG_ID = 'BEADCAFE'
         PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD)
-        MESSAGE = {'messageId': MSG_ID, 'data': B64}
+        MESSAGE = {'messageId': MSG_ID, 'data': PAYLOAD}
         REC_MESSAGE = {'ackId': ACK_ID, 'message': MESSAGE}
         client = _Client(project=self.PROJECT)
         api = client.subscriber_api = _FauxSubscribererAPI()
@@ -349,13 +347,12 @@ class TestSubscription(unittest.TestCase):
                          (self.SUB_PATH, False, 1))
 
     def test_pull_w_return_immediately_w_max_messages_w_alt_client(self):
-        import base64
         from google.cloud.pubsub.message import Message
         ACK_ID = 'DEADBEEF'
         MSG_ID = 'BEADCAFE'
         PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD)
-        MESSAGE = {'messageId': MSG_ID, 'data': B64, 'attributes': {'a': 'b'}}
+        MESSAGE = {'messageId': MSG_ID, 'data': PAYLOAD,
+                   'attributes': {'a': 'b'}}
         REC_MESSAGE = {'ackId': ACK_ID, 'message': MESSAGE}
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)

--- a/pubsub/unit_tests/test_topic.py
+++ b/pubsub/unit_tests/test_topic.py
@@ -120,11 +120,9 @@ class TestTopic(unittest.TestCase):
         self.assertEqual(api._topic_deleted, self.TOPIC_PATH)
 
     def test_publish_single_bytes_wo_attrs_w_bound_client(self):
-        import base64
-        PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD).decode('ascii')
+        PAYLOAD = 'This is the message text'
         MSGID = 'DEADBEEF'
-        MESSAGE = {'data': B64, 'attributes': {}}
+        MESSAGE = {'data': PAYLOAD, 'attributes': {}}
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID]
@@ -136,7 +134,6 @@ class TestTopic(unittest.TestCase):
         self.assertEqual(api._topic_published, (self.TOPIC_PATH, [MESSAGE]))
 
     def test_publish_single_bytes_wo_attrs_w_add_timestamp_alt_client(self):
-        import base64
         import datetime
         from google.cloud.pubsub import topic as MUT
         from google.cloud._helpers import _RFC3339_MICROS
@@ -146,11 +143,10 @@ class TestTopic(unittest.TestCase):
         def _utcnow():
             return NOW
 
-        PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD).decode('ascii')
+        PAYLOAD = 'This is the message text'
         MSGID = 'DEADBEEF'
         MESSAGE = {
-            'data': B64,
+            'data': PAYLOAD,
             'attributes': {'timestamp': NOW.strftime(_RFC3339_MICROS)},
         }
         client1 = _Client(project=self.PROJECT)
@@ -167,12 +163,10 @@ class TestTopic(unittest.TestCase):
         self.assertEqual(api._topic_published, (self.TOPIC_PATH, [MESSAGE]))
 
     def test_publish_single_bytes_w_add_timestamp_w_ts_in_attrs(self):
-        import base64
-        PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD).decode('ascii')
+        PAYLOAD = 'This is the message text'
         MSGID = 'DEADBEEF'
         OVERRIDE = '2015-04-10T16:46:22.868399Z'
-        MESSAGE = {'data': B64,
+        MESSAGE = {'data': PAYLOAD,
                    'attributes': {'timestamp': OVERRIDE}}
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
@@ -186,11 +180,9 @@ class TestTopic(unittest.TestCase):
         self.assertEqual(api._topic_published, (self.TOPIC_PATH, [MESSAGE]))
 
     def test_publish_single_w_attrs(self):
-        import base64
-        PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD).decode('ascii')
+        PAYLOAD = 'This is the message text'
         MSGID = 'DEADBEEF'
-        MESSAGE = {'data': B64,
+        MESSAGE = {'data': PAYLOAD,
                    'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
@@ -202,17 +194,39 @@ class TestTopic(unittest.TestCase):
         self.assertEqual(msgid, MSGID)
         self.assertEqual(api._topic_published, (self.TOPIC_PATH, [MESSAGE]))
 
+    def test_publish_with_gax(self):
+        PAYLOAD = 'This is the message text'
+        MSGID = 'DEADBEEF'
+        MESSAGE = {'data': PAYLOAD, 'attributes': {}}
+        client = _Client(project=self.PROJECT)
+        api = client.publisher_api = _FauxPublisherAPI()
+        api._topic_publish_response = [MSGID]
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        msgid = topic.publish(PAYLOAD)
+
+        self.assertEqual(msgid, MSGID)
+        self.assertEqual(api._topic_published, (self.TOPIC_PATH, [MESSAGE]))
+
+    def test_publish_without_gax(self):
+        PAYLOAD = 'This is the message text'
+        MSGID = 'DEADBEEF'
+        MESSAGE = {'data': PAYLOAD, 'attributes': {}}
+        client = _Client(project=self.PROJECT)
+        api = client.publisher_api = _FauxPublisherAPI()
+        api._topic_publish_response = [MSGID]
+        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        msgid = topic.publish(PAYLOAD)
+
+        self.assertEqual(msgid, MSGID)
+        self.assertEqual(api._topic_published, (self.TOPIC_PATH, [MESSAGE]))
+
     def test_publish_multiple_w_bound_client(self):
-        import base64
-        PAYLOAD1 = b'This is the first message text'
-        PAYLOAD2 = b'This is the second message text'
-        B64_1 = base64.b64encode(PAYLOAD1)
-        B64_2 = base64.b64encode(PAYLOAD2)
+        PAYLOAD1 = 'This is the first message text'
+        PAYLOAD2 = 'This is the second message text'
         MSGID1 = 'DEADBEEF'
         MSGID2 = 'BEADCAFE'
-        MESSAGE1 = {'data': B64_1.decode('ascii'),
-                    'attributes': {}}
-        MESSAGE2 = {'data': B64_2.decode('ascii'),
+        MESSAGE1 = {'data': PAYLOAD1, 'attributes': {}}
+        MESSAGE2 = {'data': PAYLOAD2,
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
@@ -241,16 +255,13 @@ class TestTopic(unittest.TestCase):
         self.assertEqual(api._api_called, 0)
 
     def test_publish_multiple_w_alternate_client(self):
-        import base64
-        PAYLOAD1 = b'This is the first message text'
-        PAYLOAD2 = b'This is the second message text'
-        B64_1 = base64.b64encode(PAYLOAD1)
-        B64_2 = base64.b64encode(PAYLOAD2)
+        PAYLOAD1 = 'This is the first message text'
+        PAYLOAD2 = 'This is the second message text'
         MSGID1 = 'DEADBEEF'
         MSGID2 = 'BEADCAFE'
-        MESSAGE1 = {'data': B64_1.decode('ascii'), 'attributes': {}}
+        MESSAGE1 = {'data': PAYLOAD1, 'attributes': {}}
         MESSAGE2 = {
-            'data': B64_2.decode('ascii'),
+            'data': PAYLOAD2,
             'attributes': {'attr1': 'value1', 'attr2': 'value2'},
         }
         client1 = _Client(project=self.PROJECT)
@@ -598,10 +609,8 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(list(batch), ['ONE', 'TWO', 'THREE'])
 
     def test_publish_bytes_wo_attrs(self):
-        import base64
-        PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD).decode('ascii')
-        MESSAGE = {'data': B64,
+        PAYLOAD = 'This is the message text'
+        MESSAGE = {'data': PAYLOAD,
                    'attributes': {}}
         client = _Client(project=self.PROJECT)
         topic = _Topic()
@@ -610,10 +619,8 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(batch.messages, [MESSAGE])
 
     def test_publish_bytes_w_add_timestamp(self):
-        import base64
-        PAYLOAD = b'This is the message text'
-        B64 = base64.b64encode(PAYLOAD).decode('ascii')
-        MESSAGE = {'data': B64,
+        PAYLOAD = 'This is the message text'
+        MESSAGE = {'data': PAYLOAD,
                    'attributes': {'timestamp': 'TIMESTAMP'}}
         client = _Client(project=self.PROJECT)
         topic = _Topic(timestamp_messages=True)
@@ -622,16 +629,13 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(batch.messages, [MESSAGE])
 
     def test_commit_w_bound_client(self):
-        import base64
-        PAYLOAD1 = b'This is the first message text'
-        PAYLOAD2 = b'This is the second message text'
-        B64_1 = base64.b64encode(PAYLOAD1)
-        B64_2 = base64.b64encode(PAYLOAD2)
+        PAYLOAD1 = 'This is the first message text'
+        PAYLOAD2 = 'This is the second message text'
         MSGID1 = 'DEADBEEF'
         MSGID2 = 'BEADCAFE'
-        MESSAGE1 = {'data': B64_1.decode('ascii'),
+        MESSAGE1 = {'data': PAYLOAD1,
                     'attributes': {}}
-        MESSAGE2 = {'data': B64_2.decode('ascii'),
+        MESSAGE2 = {'data': PAYLOAD2,
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         client = _Client(project='PROJECT')
         api = client.publisher_api = _FauxPublisherAPI()
@@ -649,16 +653,12 @@ class TestBatch(unittest.TestCase):
                          (topic.full_name, [MESSAGE1, MESSAGE2]))
 
     def test_commit_w_alternate_client(self):
-        import base64
-        PAYLOAD1 = b'This is the first message text'
-        PAYLOAD2 = b'This is the second message text'
-        B64_1 = base64.b64encode(PAYLOAD1)
-        B64_2 = base64.b64encode(PAYLOAD2)
+        PAYLOAD1 = 'This is the first message text'
+        PAYLOAD2 = 'This is the second message text'
         MSGID1 = 'DEADBEEF'
         MSGID2 = 'BEADCAFE'
-        MESSAGE1 = {'data': B64_1.decode('ascii'),
-                    'attributes': {}}
-        MESSAGE2 = {'data': B64_2.decode('ascii'),
+        MESSAGE1 = {'data': PAYLOAD1, 'attributes': {}}
+        MESSAGE2 = {'data': PAYLOAD2,
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         client1 = _Client(project='PROJECT')
         client2 = _Client(project='PROJECT')
@@ -677,16 +677,12 @@ class TestBatch(unittest.TestCase):
                          (topic.full_name, [MESSAGE1, MESSAGE2]))
 
     def test_context_mgr_success(self):
-        import base64
-        PAYLOAD1 = b'This is the first message text'
-        PAYLOAD2 = b'This is the second message text'
-        B64_1 = base64.b64encode(PAYLOAD1)
-        B64_2 = base64.b64encode(PAYLOAD2)
+        PAYLOAD1 = 'This is the first message text'
+        PAYLOAD2 = 'This is the second message text'
         MSGID1 = 'DEADBEEF'
         MSGID2 = 'BEADCAFE'
-        MESSAGE1 = {'data': B64_1.decode('ascii'),
-                    'attributes': {}}
-        MESSAGE2 = {'data': B64_2.decode('ascii'),
+        MESSAGE1 = {'data': PAYLOAD1, 'attributes': {}}
+        MESSAGE2 = {'data': PAYLOAD2,
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         client = _Client(project='PROJECT')
         api = client.publisher_api = _FauxPublisherAPI()
@@ -705,14 +701,10 @@ class TestBatch(unittest.TestCase):
                          (topic.full_name, [MESSAGE1, MESSAGE2]))
 
     def test_context_mgr_failure(self):
-        import base64
-        PAYLOAD1 = b'This is the first message text'
-        PAYLOAD2 = b'This is the second message text'
-        B64_1 = base64.b64encode(PAYLOAD1)
-        B64_2 = base64.b64encode(PAYLOAD2)
-        MESSAGE1 = {'data': B64_1.decode('ascii'),
-                    'attributes': {}}
-        MESSAGE2 = {'data': B64_2.decode('ascii'),
+        PAYLOAD1 = 'This is the first message text'
+        PAYLOAD2 = 'This is the second message text'
+        MESSAGE1 = {'data': PAYLOAD1, 'attributes': {}}
+        MESSAGE2 = {'data': PAYLOAD2,
                     'attributes': {'attr1': 'value1', 'attr2': 'value2'}}
         client = _Client(project='PROJECT')
         api = client.publisher_api = _FauxPublisherAPI()


### PR DESCRIPTION
Protobuf encodes pubsub messages, and google-cloud-python did as well which resulted in a double encoding of the message when protobuf was in use.

Fixes: #2577