### PR TITLE
Replace types string with str.

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -108,7 +108,7 @@ class _ConfigurationProperty(object):
     Values will be stored on a `_configuration` helper attribute of the
     property's job instance.
 
-    :type name: string
+    :type name: str
     :param name:  name of the property
     """
 
@@ -139,7 +139,7 @@ class _ConfigurationProperty(object):
 class _TypedProperty(_ConfigurationProperty):
     """Property implementation:  validates based on value type.
 
-    :type name: string
+    :type name: str
     :param name:  name of the property
 
     :type property_type: type or sequence of types
@@ -164,7 +164,7 @@ class _EnumProperty(_ConfigurationProperty):
     Subclasses must define ``ALLOWED`` as a class-level constant:  it must
     be a sequence of strings.
 
-    :type name: string
+    :type name: str
     :param name:  name of the property.
     """
     def _validate(self, value):

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -103,7 +103,7 @@ class Client(JSONClient):
         See:
         https://cloud.google.com/bigquery/docs/reference/v2/datasets/list
 
-        :type include_all: boolean
+        :type include_all: bool
         :param include_all: True if results include hidden datasets.
 
         :type max_results: int
@@ -180,7 +180,7 @@ class Client(JSONClient):
                            not passed, the API will return the first page of
                            jobs.
 
-        :type all_users: boolean
+        :type all_users: bool
         :param all_users: if true, include jobs owned by all users in the
                           project.
 

--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -115,7 +115,7 @@ class Dataset(object):
     def project(self):
         """Project bound to the dataset.
 
-        :rtype: string
+        :rtype: str
         :returns: the project (derived from the client).
         """
         return self._client.project
@@ -124,7 +124,7 @@ class Dataset(object):
     def path(self):
         """URL path for the dataset's APIs.
 
-        :rtype: string
+        :rtype: str
         :returns: the path based on project and dataste name.
         """
         return '/projects/%s/datasets/%s' % (self.project, self.name)
@@ -168,7 +168,7 @@ class Dataset(object):
     def dataset_id(self):
         """ID for the dataset resource.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the ID (None until set from the server).
         """
         return self._properties.get('id')
@@ -177,7 +177,7 @@ class Dataset(object):
     def etag(self):
         """ETag for the dataset resource.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the ETag (None until set from the server).
         """
         return self._properties.get('etag')
@@ -198,7 +198,7 @@ class Dataset(object):
     def self_link(self):
         """URL for the dataset resource.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the URL (None until set from the server).
         """
         return self._properties.get('selfLink')
@@ -229,7 +229,7 @@ class Dataset(object):
     def description(self):
         """Description of the dataset.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: The description as set by the user, or None (the default).
         """
         return self._properties.get('description')
@@ -251,7 +251,7 @@ class Dataset(object):
     def friendly_name(self):
         """Title of the dataset.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: The name as set by the user, or None (the default).
         """
         return self._properties.get('friendlyName')
@@ -273,7 +273,7 @@ class Dataset(object):
     def location(self):
         """Location in which the dataset is hosted.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: The location as set by the user, or None (the default).
         """
         return self._properties.get('location')

--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -31,7 +31,7 @@ class AccessGrant(object):
 
     See https://cloud.google.com/bigquery/docs/reference/v2/datasets.
 
-    :type role: string
+    :type role: str
     :param role: Role granted to the entity. One of
 
                  * ``'OWNER'``
@@ -40,11 +40,11 @@ class AccessGrant(object):
 
                  May also be ``None`` if the ``entity_type`` is ``view``.
 
-    :type entity_type: string
+    :type entity_type: str
     :param entity_type: Type of entity being granted the role. One of
                         :attr:`ENTITY_TYPES`.
 
-    :type entity_id: string
+    :type entity_id: str
     :param entity_id: ID of entity being granted the role.
 
     :raises: :class:`ValueError` if the ``entity_type`` is not among
@@ -91,7 +91,7 @@ class Dataset(object):
     See:
     https://cloud.google.com/bigquery/docs/reference/v2/datasets
 
-    :type name: string
+    :type name: str
     :param name: the name of the dataset
 
     :type client: :class:`google.cloud.bigquery.client.Client`
@@ -238,7 +238,7 @@ class Dataset(object):
     def description(self, value):
         """Update description of the dataset.
 
-        :type value: string, or ``NoneType``
+        :type value: str, or ``NoneType``
         :param value: new description
 
         :raises: ValueError for invalid value types.
@@ -260,7 +260,7 @@ class Dataset(object):
     def friendly_name(self, value):
         """Update title of the dataset.
 
-        :type value: string, or ``NoneType``
+        :type value: str, or ``NoneType``
         :param value: new title
 
         :raises: ValueError for invalid value types.
@@ -282,7 +282,7 @@ class Dataset(object):
     def location(self, value):
         """Update location in which the dataset is hosted.
 
-        :type value: string, or ``NoneType``
+        :type value: str, or ``NoneType``
         :param value: new location
 
         :raises: ValueError for invalid value types.
@@ -545,7 +545,7 @@ class Dataset(object):
         :param max_results: maximum number of tables to return, If not
                             passed, defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of datasets. If
                            not passed, the API will return the first page of
                            datasets.
@@ -575,7 +575,7 @@ class Dataset(object):
     def table(self, name, schema=()):
         """Construct a table bound to this dataset.
 
-        :type name: string
+        :type name: str
         :param name: Name of the table.
 
         :type schema: list of :class:`google.cloud.bigquery.table.SchemaField`

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -96,7 +96,7 @@ class _BaseJob(object):
     def project(self):
         """Project bound to the job.
 
-        :rtype: string
+        :rtype: str
         :returns: the project (derived from the client).
         """
         return self._client.project
@@ -135,7 +135,7 @@ class _AsyncJob(_BaseJob):
     def job_type(self):
         """Type of job
 
-        :rtype: string
+        :rtype: str
         :returns: one of 'load', 'copy', 'extract', 'query'
         """
         return self._JOB_TYPE
@@ -144,7 +144,7 @@ class _AsyncJob(_BaseJob):
     def path(self):
         """URL path for the job's APIs.
 
-        :rtype: string
+        :rtype: str
         :returns: the path based on project and job name.
         """
         return '/projects/%s/jobs/%s' % (self.project, self.name)
@@ -153,7 +153,7 @@ class _AsyncJob(_BaseJob):
     def etag(self):
         """ETag for the job resource.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the ETag (None until set from the server).
         """
         return self._properties.get('etag')
@@ -162,7 +162,7 @@ class _AsyncJob(_BaseJob):
     def self_link(self):
         """URL for the job resource.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the URL (None until set from the server).
         """
         return self._properties.get('selfLink')
@@ -171,7 +171,7 @@ class _AsyncJob(_BaseJob):
     def user_email(self):
         """E-mail address of user who submitted the job.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the URL (None until set from the server).
         """
         return self._properties.get('user_email')
@@ -241,7 +241,7 @@ class _AsyncJob(_BaseJob):
     def state(self):
         """Status of the job.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the state (None until set from the server).
         """
         status = self._properties.get('status')

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -120,7 +120,7 @@ class _BaseJob(object):
 class _AsyncJob(_BaseJob):
     """Base class for asynchronous jobs.
 
-    :type name: string
+    :type name: str
     :param name: the name of the job
 
     :type client: :class:`google.cloud.bigquery.client.Client`
@@ -399,7 +399,7 @@ class _LoadConfiguration(object):
 class LoadTableFromStorageJob(_AsyncJob):
     """Asynchronous job for loading data into a table from CloudStorage.
 
-    :type name: string
+    :type name: str
     :param name: the name of the job
 
     :type destination: :class:`google.cloud.bigquery.table.Table`
@@ -648,7 +648,7 @@ class _CopyConfiguration(object):
 class CopyJob(_AsyncJob):
     """Asynchronous job: copy data into a table from other tables.
 
-    :type name: string
+    :type name: str
     :param name: the name of the job
 
     :type destination: :class:`google.cloud.bigquery.table.Table`
@@ -763,7 +763,7 @@ class _ExtractConfiguration(object):
 class ExtractTableToStorageJob(_AsyncJob):
     """Asynchronous job: extract data from a table into Cloud Storage.
 
-    :type name: string
+    :type name: str
     :param name: the name of the job
 
     :type source: :class:`google.cloud.bigquery.table.Table`
@@ -894,10 +894,10 @@ class _AsyncQueryConfiguration(object):
 class QueryJob(_AsyncJob):
     """Asynchronous job: query tables.
 
-    :type name: string
+    :type name: str
     :param name: the name of the job
 
-    :type query: string
+    :type query: str
     :param query: SQL query string
 
     :type client: :class:`google.cloud.bigquery.client.Client`

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -91,7 +91,7 @@ class QueryResults(object):
     def project(self):
         """Project bound to the job.
 
-        :rtype: string
+        :rtype: str
         :returns: the project (derived from the client).
         """
         return self._client.project
@@ -185,7 +185,7 @@ class QueryResults(object):
         See:
         https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#pageToken
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: Token generated on the server (None until set by the server).
         """
         return self._properties.get('pageToken')

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -42,7 +42,7 @@ class _SyncQueryConfiguration(object):
 class QueryResults(object):
     """Synchronous job: query tables.
 
-    :type query: string
+    :type query: str
     :param query: SQL query string
 
     :type client: :class:`google.cloud.bigquery.client.Client`
@@ -348,7 +348,7 @@ class QueryResults(object):
         :type max_results: integer or ``NoneType``
         :param max_results: maximum number of rows to return.
 
-        :type page_token: string or ``NoneType``
+        :type page_token: str or ``NoneType``
         :param page_token: token representing a cursor into the table's rows.
 
         :type start_index: integer or ``NoneType``

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -118,7 +118,7 @@ class QueryResults(object):
         See:
         https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#cacheHit
 
-        :rtype: boolean or ``NoneType``
+        :rtype: bool or ``NoneType``
         :returns: True if the query results were served from cache (None
                   until set by the server).
         """
@@ -131,7 +131,7 @@ class QueryResults(object):
         See:
         https://cloud.google.com/bigquery/docs/reference/v2/jobs/query#jobComplete
 
-        :rtype: boolean or ``NoneType``
+        :rtype: bool or ``NoneType``
         :returns: True if the query completed on the server (None
                   until set by the server).
         """

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -714,10 +714,10 @@ class Table(object):
         :param row_ids: Unique ids, one per row being inserted.  If not
                         passed, no de-duplication occurs.
 
-        :type skip_invalid_rows: boolean or ``NoneType``
+        :type skip_invalid_rows: bool or ``NoneType``
         :param skip_invalid_rows: skip rows w/ invalid data?
 
-        :type ignore_unknown_values: boolean or ``NoneType``
+        :type ignore_unknown_values: bool or ``NoneType``
         :param ignore_unknown_values: ignore columns beyond schema?
 
         :type template_suffix: str or ``NoneType``
@@ -826,7 +826,7 @@ class Table(object):
                               job configuration option; see
                               :meth:`google.cloud.bigquery.job.LoadJob`
 
-        :type rewind: boolean
+        :type rewind: bool
         :param rewind: If True, seek to the beginning of the file handle before
                        writing the file to Cloud Storage.
 
@@ -839,11 +839,11 @@ class Table(object):
         :type num_retries: integer
         :param num_retries: Number of upload retries. Defaults to 6.
 
-        :type allow_jagged_rows: boolean
+        :type allow_jagged_rows: bool
         :param allow_jagged_rows: job configuration option;  see
                                   :meth:`google.cloud.bigquery.job.LoadJob`.
 
-        :type allow_quoted_newlines: boolean
+        :type allow_quoted_newlines: bool
         :param allow_quoted_newlines: job configuration option; see
                                       :meth:`google.cloud.bigquery.job.LoadJob`.
 
@@ -859,7 +859,7 @@ class Table(object):
         :param field_delimiter: job configuration option; see
                                 :meth:`google.cloud.bigquery.job.LoadJob`.
 
-        :type ignore_unknown_values: boolean
+        :type ignore_unknown_values: bool
         :param ignore_unknown_values: job configuration option; see
                                       :meth:`google.cloud.bigquery.job.LoadJob`.
 

--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -317,7 +317,7 @@ class Client(_ClientFactoryMixin, _ClientProjectMixin):
         :type instance_id: str
         :param instance_id: The ID of the instance.
 
-        :type location: string
+        :type location: str
         :param location: location name, in form
                          ``projects/<project>/locations/<location>``; used to
                          set up the instance's cluster.

--- a/core/google/cloud/_helpers.py
+++ b/core/google/cloud/_helpers.py
@@ -526,7 +526,7 @@ def _pb_timestamp_to_rfc3339(timestamp_pb):
     :type timestamp_pb: :class:`google.protobuf.timestamp_pb2.Timestamp`
     :param timestamp_pb: A Google returned timestamp protobuf.
 
-    :rtype: string
+    :rtype: str
     :returns: An RFC 3339 formatted timestamp string.
     """
     timestamp = _pb_timestamp_to_datetime(timestamp_pb)

--- a/core/google/cloud/_helpers.py
+++ b/core/google/cloud/_helpers.py
@@ -438,7 +438,7 @@ def _datetime_to_rfc3339(value, ignore_zone=True):
     :type value: :class:`datetime.datetime`
     :param value: The datetime object to be converted to a string.
 
-    :type ignore_zone: boolean
+    :type ignore_zone: bool
     :param ignore_zone: If True, then the timezone (if any) of the datetime
                         object is ignored.
 

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -34,7 +34,7 @@ class _ClientFactoryMixin(object):
     def from_service_account_json(cls, json_credentials_path, *args, **kwargs):
         """Factory to retrieve JSON credentials while creating client.
 
-        :type json_credentials_path: string
+        :type json_credentials_path: str
         :param json_credentials_path: The path to a private key file (this file
                                       was given to you when you created the
                                       service account). This file must contain
@@ -69,10 +69,10 @@ class _ClientFactoryMixin(object):
           Unless you have an explicit reason to use a PKCS12 key for your
           service account, we recommend using a JSON key.
 
-        :type client_email: string
+        :type client_email: str
         :param client_email: The e-mail attached to the service account.
 
-        :type private_key_path: string
+        :type private_key_path: str
         :param private_key_path: The path to a private key file (this file was
                                  given to you when you created the service
                                  account). This file must be in P12 format.
@@ -127,7 +127,7 @@ class Client(_ClientFactoryMixin):
 class _ClientProjectMixin(object):
     """Mixin to allow setting the project on the client.
 
-    :type project: string
+    :type project: str
     :param project: the project which the client acts on behalf of. If not
                     passed falls back to the default inferred from the
                     environment.
@@ -160,7 +160,7 @@ class JSONClient(Client, _ClientProjectMixin):
     Assumes such APIs use the ``project`` and the client needs to store this
     value.
 
-    :type project: string
+    :type project: str
     :param project: the project which the client acts on behalf of. If not
                     passed falls back to the default inferred from the
                     environment.

--- a/core/google/cloud/connection.py
+++ b/core/google/cloud/connection.py
@@ -179,7 +179,7 @@ class JSONConnection(Connection):
                             Typically you shouldn't provide this and instead
                             use the default for the library.
 
-        :rtype: string
+        :rtype: str
         :returns: The URL assembled from the pieces provided.
         """
         url = cls.API_URL_TEMPLATE.format(

--- a/core/google/cloud/connection.py
+++ b/core/google/cloud/connection.py
@@ -162,7 +162,7 @@ class JSONConnection(Connection):
 
         Typically, you shouldn't need to use this method.
 
-        :type path: string
+        :type path: str
         :param path: The path to the resource (ie, ``'/b/bucket-name'``).
 
         :type query_params: dict or list
@@ -170,11 +170,11 @@ class JSONConnection(Connection):
                              key-value pairs) to insert into the query
                              string of the URL.
 
-        :type api_base_url: string
+        :type api_base_url: str
         :param api_base_url: The base URL for the API endpoint.
                              Typically you won't have to provide this.
 
-        :type api_version: string
+        :type api_version: str
         :param api_version: The version of the API to call.
                             Typically you shouldn't provide this and instead
                             use the default for the library.
@@ -199,16 +199,16 @@ class JSONConnection(Connection):
 
         Typically, you shouldn't need to use this method.
 
-        :type method: string
+        :type method: str
         :param method: The HTTP method to use in the request.
 
-        :type url: string
+        :type url: str
         :param url: The URL to send the request to.
 
-        :type data: string
+        :type data: str
         :param data: The data to send as the body of the request.
 
-        :type content_type: string
+        :type content_type: str
         :param content_type: The proper MIME type of the data provided.
 
         :type headers: dict
@@ -249,16 +249,16 @@ class JSONConnection(Connection):
 
         Allows batch context managers to override and defer a request.
 
-        :type method: string
+        :type method: str
         :param method: The HTTP method to use in the request.
 
-        :type url: string
+        :type url: str
         :param url: The URL to send the request to.
 
         :type headers: dict
         :param headers: A dictionary of HTTP headers to send with the request.
 
-        :type data: string
+        :type data: str
         :param data: The data to send as the body of the request.
 
         :type target_object: object or :class:`NoneType`
@@ -282,11 +282,11 @@ class JSONConnection(Connection):
         interact with the API using these primitives, this is the
         correct one to use.
 
-        :type method: string
+        :type method: str
         :param method: The HTTP method name (ie, ``GET``, ``POST``, etc).
                        Required.
 
-        :type path: string
+        :type path: str
         :param path: The path to the resource (ie, ``'/b/bucket-name'``).
                      Required.
 
@@ -295,23 +295,23 @@ class JSONConnection(Connection):
                              key-value pairs) to insert into the query
                              string of the URL.
 
-        :type data: string
+        :type data: str
         :param data: The data to send as the body of the request. Default is
                      the empty string.
 
-        :type content_type: string
+        :type content_type: str
         :param content_type: The proper MIME type of the data provided. Default
                              is None.
 
         :type headers: dict
         :param headers: extra HTTP headers to be sent with the request.
 
-        :type api_base_url: string
+        :type api_base_url: str
         :param api_base_url: The base URL for the API endpoint.
                              Typically you won't have to provide this.
                              Default is the standard API base URL.
 
-        :type api_version: string
+        :type api_version: str
         :param api_version: The version of the API to call.  Typically
                             you shouldn't provide this and instead use
                             the default for the library.  Default is the

--- a/core/google/cloud/credentials.py
+++ b/core/google/cloud/credentials.py
@@ -97,7 +97,7 @@ def _get_signed_query_params(credentials, expiration, string_to_sign):
     :type expiration: int or long
     :param expiration: When the signed URL should expire.
 
-    :type string_to_sign: string
+    :type string_to_sign: str
     :param string_to_sign: The string to be signed by the credentials.
 
     :raises AttributeError: If :meth: sign_blob is unavailable.
@@ -184,7 +184,7 @@ def generate_signed_url(credentials, resource, expiration,
     :param credentials: Credentials object with an associated private key to
                         sign text.
 
-    :type resource: string
+    :type resource: str
     :param resource: A pointer to a specific resource
                      (typically, ``/bucket-name/path/to/blob.txt``).
 

--- a/core/google/cloud/credentials.py
+++ b/core/google/cloud/credentials.py
@@ -220,7 +220,7 @@ def generate_signed_url(credentials, resource, expiration,
     :param generation: (Optional) A value that indicates which generation of
                        the resource to fetch.
 
-    :rtype: string
+    :rtype: str
     :returns: A signed URL you can use to access the resource
               until expiration.
     """

--- a/core/google/cloud/exceptions.py
+++ b/core/google/cloud/exceptions.py
@@ -184,10 +184,10 @@ def make_exception(response, content, error_info=None, use_json=True):
     :param response: A response object that defines a status code as the
                      status attribute.
 
-    :type content: string or dictionary
+    :type content: str or dictionary
     :param content: The body of the HTTP error response.
 
-    :type error_info: string
+    :type error_info: str
     :param error_info: Optional string giving extra information about the
                        failed request.
 

--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -345,7 +345,7 @@ class Iterator(object):
     def _has_next_page(self):
         """Determines whether or not there are more pages with results.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: Whether the iterator has more pages.
         """
         if self.page_number == 0:

--- a/core/google/cloud/streaming/buffered_stream.py
+++ b/core/google/cloud/streaming/buffered_stream.py
@@ -55,7 +55,7 @@ class BufferedStream(object):
     def stream_exhausted(self):
         """Does the stream have bytes remaining beyond the buffer
 
-        :rtype: boolean
+        :rtype: bool
         :returns: Boolean indicating if the stream is exhausted.
         """
         return self._stream_at_end

--- a/core/google/cloud/streaming/exceptions.py
+++ b/core/google/cloud/streaming/exceptions.py
@@ -32,7 +32,7 @@ class HttpError(CommunicationError):
     :type content: bytes
     :param content: payload of the response which returned the error
 
-    :type url: string
+    :type url: str
     :param url: URL of the response which returned the error
     """
     def __init__(self, response, content, url):
@@ -94,7 +94,7 @@ class RetryAfterError(HttpError):
     :type content: bytes
     :param content: payload of the response which returned the error.
 
-    :type url: string
+    :type url: str
     :param url: URL of the response which returned the error.
 
     :type retry_after: integer

--- a/core/google/cloud/streaming/http_wrapper.py
+++ b/core/google/cloud/streaming/http_wrapper.py
@@ -258,7 +258,7 @@ class Response(_ResponseTuple):
     def is_redirect(self):
         """Does this response contain a redirect
 
-        :rtype: boolean
+        :rtype: bool
         :returns: True if the status code indicates a redirect and the
                   'location' header is present.
         """

--- a/core/google/cloud/streaming/transfer.py
+++ b/core/google/cloud/streaming/transfer.py
@@ -178,7 +178,7 @@ class _Transfer(object):
         :type http: :class:`httplib2.Http` (or a worklike) or None.
         :param http: the Http instance to use to make requests.
 
-        :type url: string
+        :type url: str
         :param url: The url for this transfer.
         """
         self._ensure_uninitialized()
@@ -250,7 +250,7 @@ class Download(_Transfer):
     def from_file(cls, filename, overwrite=False, auto_transfer=True, **kwds):
         """Create a new download object from a filename.
 
-        :type filename: string
+        :type filename: str
         :param filename: path/filename for the target file
 
         :type overwrite: boolean
@@ -622,7 +622,7 @@ class Upload(_Transfer):
     :type stream: file-like object
     :param stream: stream to/from which data is downloaded/uploaded.
 
-    :type mime_type: string:
+    :type mime_type: str:
     :param mime_type: MIME type of the upload.
 
     :type total_size: integer or None
@@ -663,10 +663,10 @@ class Upload(_Transfer):
     def from_file(cls, filename, mime_type=None, auto_transfer=True, **kwds):
         """Create a new Upload object from a filename.
 
-        :type filename: string
+        :type filename: str
         :param filename: path/filename to the file being uploaded
 
-        :type mime_type: string
+        :type mime_type: str
         :param mime_type:  MIMEtype of the file being uploaded
 
         :type auto_transfer: boolean or None
@@ -697,7 +697,7 @@ class Upload(_Transfer):
         :type stream: writable file-like object
         :param stream: the target file
 
-        :type mime_type: string
+        :type mime_type: str
         :param mime_type:  MIMEtype of the file being uploaded
 
         :type total_size: integer or None
@@ -759,7 +759,7 @@ class Upload(_Transfer):
     def strategy(self, value):
         """Update upload strategy to use
 
-        :type value: string (one of :data:`SIMPLE_UPLOAD` or
+        :type value: str (one of :data:`SIMPLE_UPLOAD` or
                 :data:`RESUMABLE_UPLOAD`)
 
         :raises: :exc:`ValueError` if value is not one of the two allowed
@@ -1034,7 +1034,7 @@ class Upload(_Transfer):
     def _last_byte(range_header):
         """Parse the last byte from a 'Range' header.
 
-        :type range_header: string
+        :type range_header: str
         :param range_header: 'Range' header value per RFC 2616/7233
 
         :rtype: int

--- a/core/google/cloud/streaming/transfer.py
+++ b/core/google/cloud/streaming/transfer.py
@@ -163,7 +163,7 @@ class _Transfer(object):
     def url(self):
         """URL to / from which data is downloaded/uploaded.
 
-        :rtype: string
+        :rtype: str
         :returns: The URL where data is sent/received.
         """
         return self._url
@@ -318,7 +318,7 @@ class Download(_Transfer):
     def encoding(self):
         """'Content-Encoding' used to transfer the file
 
-        :rtype: string or None
+        :rtype: str or None
         :returns: The encoding of the downloaded content.
         """
         return self._encoding
@@ -732,7 +732,7 @@ class Upload(_Transfer):
     def mime_type(self):
         """MIMEtype of the file being uploaded.
 
-        :rtype: string
+        :rtype: str
         :returns: The mime-type of the upload.
         """
         return self._mime_type
@@ -750,7 +750,7 @@ class Upload(_Transfer):
     def strategy(self):
         """Upload strategy to use
 
-        :rtype: string or None
+        :rtype: str or None
         :returns: The strategy used to upload the data.
         """
         return self._strategy
@@ -972,7 +972,7 @@ class Upload(_Transfer):
         :type response: :class:`google.cloud.streaming.http_wrapper.Response`
         :param response: response to be queried
 
-        :rtype: string
+        :rtype: str
         :returns: The header used to determine the bytes range.
         """
         # NOTE: Per RFC 2616[1]/7233[2][3], 'Range' is a request header,

--- a/core/google/cloud/streaming/transfer.py
+++ b/core/google/cloud/streaming/transfer.py
@@ -52,13 +52,13 @@ class _Transfer(object):
     :type stream: file-like object
     :param stream: stream to/from which data is downloaded/uploaded.
 
-    :type close_stream: boolean
+    :type close_stream: bool
     :param close_stream: should this instance close the stream when deleted
 
     :type chunksize: integer
     :param chunksize: the size of chunks used to download/upload a file.
 
-    :type auto_transfer: boolean
+    :type auto_transfer: bool
     :param auto_transfer: should this instance automatically begin transfering
                           data when initialized
 
@@ -253,10 +253,10 @@ class Download(_Transfer):
         :type filename: str
         :param filename: path/filename for the target file
 
-        :type overwrite: boolean
+        :type overwrite: bool
         :param overwrite: should an existing file be overwritten
 
-        :type auto_transfer: boolean
+        :type auto_transfer: bool
         :param auto_transfer: should the transfer be started immediately
 
         :type kwds: dict
@@ -283,7 +283,7 @@ class Download(_Transfer):
         :type total_size: integer or None
         :param total_size: total size of the file to be downloaded
 
-        :type auto_transfer: boolean
+        :type auto_transfer: bool
         :param auto_transfer: should the transfer be started immediately
 
         :type kwds: dict
@@ -460,7 +460,7 @@ class Download(_Transfer):
         :type end: integer or None
         :param end: suggested last byte of the range.
 
-        :type use_chunks: boolean
+        :type use_chunks: bool
         :param use_chunks: If False, ignore :attr:`chunksize`.
 
         :rtype: str
@@ -558,7 +558,7 @@ class Download(_Transfer):
         :type end: integer or ``None``
         :param end: Where to stop fetching bytes. (See above.)
 
-        :type use_chunks: boolean
+        :type use_chunks: bool
         :param use_chunks: If False, ignore :attr:`chunksize`
                            and fetch this range in a single request.
                            If True, streams via chunks.
@@ -594,7 +594,7 @@ class Download(_Transfer):
 
         Writes retrieved bytes into :attr:`stream`.
 
-        :type use_chunks: boolean
+        :type use_chunks: bool
         :param use_chunks: If False, ignore :attr:`chunksize`
                            and stream this download in a single request.
                            If True, streams via chunks.
@@ -631,10 +631,10 @@ class Upload(_Transfer):
     :type http: :class:`httplib2.Http` (or workalike)
     :param http: Http instance used to perform requests.
 
-    :type close_stream: boolean
+    :type close_stream: bool
     :param close_stream: should this instance close the stream when deleted
 
-    :type auto_transfer: boolean
+    :type auto_transfer: bool
     :param auto_transfer: should this instance automatically begin transfering
                           data when initialized
 
@@ -669,7 +669,7 @@ class Upload(_Transfer):
         :type mime_type: str
         :param mime_type:  MIMEtype of the file being uploaded
 
-        :type auto_transfer: boolean or None
+        :type auto_transfer: bool or None
         :param auto_transfer: should the transfer be started immediately
 
         :type kwds: dict
@@ -703,7 +703,7 @@ class Upload(_Transfer):
         :type total_size: integer or None
         :param total_size:  Size of the file being uploaded
 
-        :type auto_transfer: boolean or None
+        :type auto_transfer: bool or None
         :param auto_transfer: should the transfer be started immediately
 
         :type kwds: dict
@@ -1065,7 +1065,7 @@ class Upload(_Transfer):
     def stream_file(self, use_chunks=True):
         """Upload the stream.
 
-        :type use_chunks: boolean
+        :type use_chunks: bool
         :param use_chunks: If False, send the stream in a single request.
                            Otherwise, send it in chunks.
 

--- a/core/google/cloud/streaming/transfer.py
+++ b/core/google/cloud/streaming/transfer.py
@@ -93,7 +93,7 @@ class _Transfer(object):
     def close_stream(self):
         """Should this instance close the stream when deleted.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: Boolean indicated if the stream should be closed.
         """
         return self._close_stream
@@ -190,7 +190,7 @@ class _Transfer(object):
     def initialized(self):
         """Has the instance been initialized
 
-        :rtype: boolean
+        :rtype: bool
         :returns: Boolean indicating if the current transfer
                   has been initialized.
         """
@@ -723,7 +723,7 @@ class Upload(_Transfer):
     def complete(self):
         """Has the entire stream been uploaded.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: Boolean indicated if the upload is complete.
         """
         return self._complete

--- a/core/google/cloud/streaming/util.py
+++ b/core/google/cloud/streaming/util.py
@@ -53,7 +53,7 @@ def acceptable_mime_type(accept_patterns, mime_type):
     :type mime_type: str
     :param mime_type: the MIME being checked
 
-    :rtype: boolean
+    :rtype: bool
     :returns: True if the supplied MIME type matches at least one of the
               patterns, else False.
     """

--- a/core/google/cloud/streaming/util.py
+++ b/core/google/cloud/streaming/util.py
@@ -50,7 +50,7 @@ def acceptable_mime_type(accept_patterns, mime_type):
     :type accept_patterns: list of string
     :param accept_patterns: acceptable MIME types.
 
-    :type mime_type: string
+    :type mime_type: str
     :param mime_type: the MIME being checked
 
     :rtype: boolean

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -50,7 +50,7 @@ def _determine_default_project(project=None):
     * Google App Engine application ID
     * Google Compute Engine project ID (from metadata server)
 
-    :type project: string
+    :type project: str
     :param project: Optional. The project to use as default.
 
     :rtype: str or ``NoneType``
@@ -75,7 +75,7 @@ def _extended_lookup(connection, project, key_pbs,
     :type connection: :class:`google.cloud.datastore.connection.Connection`
     :param connection: The connection used to connect to datastore.
 
-    :type project: string
+    :type project: str
     :param project: The project to make the request for.
 
     :type key_pbs: list of :class:`._generated.entity_pb2.Key`
@@ -95,7 +95,7 @@ def _extended_lookup(connection, project, key_pbs,
                      consistency.  If True, request ``EVENTUAL`` read
                      consistency.
 
-    :type transaction_id: string
+    :type transaction_id: str
     :param transaction_id: If passed, make the request in the scope of
                            the given transaction.  Incompatible with
                            ``eventual==True``.
@@ -146,10 +146,10 @@ def _extended_lookup(connection, project, key_pbs,
 class Client(_BaseClient, _ClientProjectMixin):
     """Convenience wrapper for invoking APIs/factories w/ a project.
 
-    :type project: string
+    :type project: str
     :param project: (optional) The project to pass to proxied API methods.
 
-    :type namespace: string
+    :type namespace: str
     :param namespace: (optional) namespace to pass to proxied API methods.
 
     :type credentials: :class:`oauth2client.client.OAuth2Credentials` or

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -53,7 +53,7 @@ def _determine_default_project(project=None):
     :type project: string
     :param project: Optional. The project to use as default.
 
-    :rtype: string or ``NoneType``
+    :rtype: str or ``NoneType``
     :returns: Default project if it can be determined.
     """
     if project is None:

--- a/datastore/google/cloud/datastore/connection.py
+++ b/datastore/google/cloud/datastore/connection.py
@@ -65,14 +65,14 @@ class _DatastoreAPIOverHttp(object):
     def _request(self, project, method, data):
         """Make a request over the Http transport to the Cloud Datastore API.
 
-        :type project: string
+        :type project: str
         :param project: The project to make the request for.
 
-        :type method: string
+        :type method: str
         :param method: The API call method name (ie, ``runQuery``,
                        ``lookup``, etc)
 
-        :type data: string
+        :type data: str
         :param data: The data to send with the API call.
                      Typically this is a serialized Protobuf string.
 
@@ -100,11 +100,11 @@ class _DatastoreAPIOverHttp(object):
     def _rpc(self, project, method, request_pb, response_pb_cls):
         """Make a protobuf RPC request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
-        :type method: string
+        :type method: str
         :param method: The name of the method to invoke.
 
         :type request_pb: :class:`google.protobuf.message.Message` instance
@@ -125,7 +125,7 @@ class _DatastoreAPIOverHttp(object):
     def lookup(self, project, request_pb):
         """Perform a ``lookup`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -141,7 +141,7 @@ class _DatastoreAPIOverHttp(object):
     def run_query(self, project, request_pb):
         """Perform a ``runQuery`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -157,7 +157,7 @@ class _DatastoreAPIOverHttp(object):
     def begin_transaction(self, project, request_pb):
         """Perform a ``beginTransaction`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -174,7 +174,7 @@ class _DatastoreAPIOverHttp(object):
     def commit(self, project, request_pb):
         """Perform a ``commit`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -190,7 +190,7 @@ class _DatastoreAPIOverHttp(object):
     def rollback(self, project, request_pb):
         """Perform a ``rollback`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -206,7 +206,7 @@ class _DatastoreAPIOverHttp(object):
     def allocate_ids(self, project, request_pb):
         """Perform an ``allocateIds`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -249,7 +249,7 @@ class _DatastoreAPIOverGRPC(object):
     def lookup(self, project, request_pb):
         """Perform a ``lookup`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -265,7 +265,7 @@ class _DatastoreAPIOverGRPC(object):
     def run_query(self, project, request_pb):
         """Perform a ``runQuery`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -287,7 +287,7 @@ class _DatastoreAPIOverGRPC(object):
     def begin_transaction(self, project, request_pb):
         """Perform a ``beginTransaction`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -304,7 +304,7 @@ class _DatastoreAPIOverGRPC(object):
     def commit(self, project, request_pb):
         """Perform a ``commit`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -328,7 +328,7 @@ class _DatastoreAPIOverGRPC(object):
     def rollback(self, project, request_pb):
         """Perform a ``rollback`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -344,7 +344,7 @@ class _DatastoreAPIOverGRPC(object):
     def allocate_ids(self, project, request_pb):
         """Perform an ``allocateIds`` request.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
@@ -407,18 +407,18 @@ class Connection(connection_module.Connection):
         This method is used internally to come up with the URL to use when
         making RPCs to the Cloud Datastore API.
 
-        :type project: string
+        :type project: str
         :param project: The project to connect to. This is
                         usually your project name in the cloud console.
 
-        :type method: string
+        :type method: str
         :param method: The API method to call (e.g. 'runQuery', 'lookup').
 
-        :type base_url: string
+        :type base_url: str
         :param base_url: The base URL where the API lives.
                          You shouldn't have to provide this.
 
-        :type api_version: string
+        :type api_version: str
         :param api_version: The version of the API to connect to.
                             You shouldn't have to provide this.
 
@@ -453,7 +453,7 @@ class Connection(connection_module.Connection):
         >>> connection.lookup('project', [key.to_protobuf()])
         [<Entity protobuf>]
 
-        :type project: string
+        :type project: str
         :param project: The project to look up the keys in.
 
         :type key_pbs: list of
@@ -465,7 +465,7 @@ class Connection(connection_module.Connection):
                          consistency.  If True, request ``EVENTUAL`` read
                          consistency.
 
-        :type transaction_id: string
+        :type transaction_id: str
         :param transaction_id: If passed, make the request in the scope of
                                the given transaction.  Incompatible with
                                ``eventual==True``.
@@ -504,13 +504,13 @@ class Connection(connection_module.Connection):
         Under the hood, the :class:`google.cloud.datastore.query.Query` class
         uses this method to fetch data.
 
-        :type project: string
+        :type project: str
         :param project: The project over which to run the query.
 
         :type query_pb: :class:`.datastore._generated.query_pb2.Query`
         :param query_pb: The Protobuf representing the query to run.
 
-        :type namespace: string
+        :type namespace: str
         :param namespace: The namespace over which to run the query.
 
         :type eventual: bool
@@ -518,7 +518,7 @@ class Connection(connection_module.Connection):
                          consistency.  If True, request ``EVENTUAL`` read
                          consistency.
 
-        :type transaction_id: string
+        :type transaction_id: str
         :param transaction_id: If passed, make the request in the scope of
                                the given transaction.  Incompatible with
                                ``eventual==True``.
@@ -548,7 +548,7 @@ class Connection(connection_module.Connection):
 
         Maps the ``DatastoreService.BeginTransaction`` protobuf RPC.
 
-        :type project: string
+        :type project: str
         :param project: The project to which the transaction applies.
 
         :rtype: bytes
@@ -563,13 +563,13 @@ class Connection(connection_module.Connection):
 
         Maps the ``DatastoreService.Commit`` protobuf RPC.
 
-        :type project: string
+        :type project: str
         :param project: The project to which the transaction applies.
 
         :type request: :class:`._generated.datastore_pb2.CommitRequest`
         :param request: The protobuf with the mutations being committed.
 
-        :type transaction_id: string or None
+        :type transaction_id: str or None
         :param transaction_id: The transaction ID returned from
                                :meth:`begin_transaction`.  Non-transactional
                                batches must pass ``None``.
@@ -597,10 +597,10 @@ class Connection(connection_module.Connection):
 
         Maps the ``DatastoreService.Rollback`` protobuf RPC.
 
-        :type project: string
+        :type project: str
         :param project: The project to which the transaction belongs.
 
-        :type transaction_id: string
+        :type transaction_id: str
         :param transaction_id: The transaction ID returned from
                                :meth:`begin_transaction`.
         """
@@ -614,7 +614,7 @@ class Connection(connection_module.Connection):
 
         Maps the ``DatastoreService.AllocateIds`` protobuf RPC.
 
-        :type project: string
+        :type project: str
         :param project: The project to which the transaction belongs.
 
         :type key_pbs: list of

--- a/datastore/google/cloud/datastore/connection.py
+++ b/datastore/google/cloud/datastore/connection.py
@@ -76,7 +76,7 @@ class _DatastoreAPIOverHttp(object):
         :param data: The data to send with the API call.
                      Typically this is a serialized Protobuf string.
 
-        :rtype: string
+        :rtype: str
         :returns: The string response content from the API call.
         :raises: :class:`google.cloud.exceptions.GoogleCloudError` if the
                  response code is not 200 OK.

--- a/datastore/google/cloud/datastore/entity.py
+++ b/datastore/google/cloud/datastore/entity.py
@@ -91,7 +91,7 @@ class Entity(dict):
         Entities compare equal if their keys compare equal and their
         properties compare equal.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: True if the entities compare equal, else False.
         """
         if not isinstance(other, Entity):
@@ -108,7 +108,7 @@ class Entity(dict):
         Entities compare equal if their keys compare equal and their
         properties compare equal.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: False if the entities compare equal, else True.
         """
         return not self.__eq__(other)

--- a/datastore/google/cloud/datastore/helpers.py
+++ b/datastore/google/cloud/datastore/helpers.py
@@ -452,7 +452,7 @@ class GeoPoint(object):
     def __eq__(self, other):
         """Compare two geo points for equality.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: True if the points compare equal, else False.
         """
         if not isinstance(other, GeoPoint):
@@ -464,7 +464,7 @@ class GeoPoint(object):
     def __ne__(self, other):
         """Compare two geo points for inequality.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: False if the points compare equal, else True.
         """
         return not self.__eq__(other)

--- a/datastore/google/cloud/datastore/helpers.py
+++ b/datastore/google/cloud/datastore/helpers.py
@@ -80,7 +80,7 @@ def _new_value_pb(entity_pb, name):
     :type entity_pb: :class:`.datastore._generated.entity_pb2.Entity`
     :param entity_pb: An entity protobuf to add a new property to.
 
-    :type name: string
+    :type name: str
     :param name: The name of the new property.
 
     :rtype: :class:`google.cloud.datastore._generated.entity_pb2.Value`
@@ -162,7 +162,7 @@ def _set_pb_meaning_from_entity(entity, name, value, value_pb,
     :type entity: :class:`google.cloud.datastore.entity.Entity`
     :param entity: The entity to be turned into a protobuf.
 
-    :type name: string
+    :type name: str
     :param name: The name of the property.
 
     :type value: object

--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -207,7 +207,7 @@ class Key(object):
     def completed_key(self, id_or_name):
         """Creates new key from existing partial key by adding final ID/name.
 
-        :type id_or_name: string or integer
+        :type id_or_name: str or integer
         :param id_or_name: ID or name to be added to the key.
 
         :rtype: :class:`google.cloud.datastore.key.Key`
@@ -385,7 +385,7 @@ def _validate_project(project, parent):
 
     If ``project`` is unset, attempt to infer the project from the environment.
 
-    :type project: string
+    :type project: str
     :param project: A project.
 
     :type parent: :class:`google.cloud.datastore.key.Key` or ``NoneType``

--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -269,7 +269,7 @@ class Key(object):
     def namespace(self):
         """Namespace getter.
 
-        :rtype: string
+        :rtype: str
         :returns: The namespace of the current key.
         """
         return self._namespace
@@ -298,7 +298,7 @@ class Key(object):
     def kind(self):
         """Kind getter. Based on the last element of path.
 
-        :rtype: string
+        :rtype: str
         :returns: The kind of the current key.
         """
         return self.path[-1]['kind']
@@ -316,7 +316,7 @@ class Key(object):
     def name(self):
         """Name getter. Based on the last element of path.
 
-        :rtype: string
+        :rtype: str
         :returns: The (string) name of the key.
         """
         return self.path[-1].get('name')
@@ -335,7 +335,7 @@ class Key(object):
     def project(self):
         """Project getter.
 
-        :rtype: string
+        :rtype: str
         :returns: The key's project.
         """
         return self._project
@@ -391,7 +391,7 @@ def _validate_project(project, parent):
     :type parent: :class:`google.cloud.datastore.key.Key` or ``NoneType``
     :param parent: The parent of the key or ``None``.
 
-    :rtype: string
+    :rtype: str
     :returns: The ``project`` passed in, or implied from the environment.
     :raises: :class:`ValueError` if ``project`` is ``None`` and no project
              can be inferred from the parent.

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -109,7 +109,7 @@ class Query(object):
     def namespace(self):
         """This query's namespace
 
-        :rtype: string or None
+        :rtype: str or None
         :returns: the namespace assigned to this query
         """
         return self._namespace or self._client.namespace
@@ -128,7 +128,7 @@ class Query(object):
     def kind(self):
         """Get the Kind of the Query.
 
-        :rtype: string
+        :rtype: str
         :returns: The kind for the query.
         """
         return self._kind

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -31,14 +31,14 @@ class Query(object):
     :type client: :class:`google.cloud.datastore.client.Client`
     :param client: The client used to connect to Datastore.
 
-    :type kind: string
+    :type kind: str
     :param kind: The kind to query.
 
-    :type project: string
+    :type project: str
     :param project: The project associated with the query.  If not passed,
                     uses the client's value.
 
-    :type namespace: string or None
+    :type namespace: str or None
     :param namespace: The namespace to which to restrict results.  If not
                       passed, uses the client's value.
 
@@ -118,7 +118,7 @@ class Query(object):
     def namespace(self, value):
         """Update the query's namespace.
 
-        :type value: string
+        :type value: str
         """
         if not isinstance(value, str):
             raise ValueError("Namespace must be a string")
@@ -137,7 +137,7 @@ class Query(object):
     def kind(self, value):
         """Update the Kind of the Query.
 
-        :type value: string
+        :type value: str
         :param value: updated kind for the query.
 
         .. note::
@@ -203,10 +203,10 @@ class Query(object):
           >>> query.add_filter('name', '=', 'James')
           >>> query.add_filter('age', '>', 50)
 
-        :type property_name: string
+        :type property_name: str
         :param property_name: A property name.
 
-        :type operator: string
+        :type operator: str
         :param operator: One of ``=``, ``<``, ``<=``, ``>``, ``>=``.
 
         :type value: :class:`int`, :class:`str`, :class:`bool`,
@@ -242,7 +242,7 @@ class Query(object):
     def projection(self, projection):
         """Set the fields returned the query.
 
-        :type projection: string or sequence of strings
+        :type projection: str or sequence of strings
         :param projection: Each value is a string giving the name of a
                            property to be included in the projection query.
         """
@@ -260,7 +260,7 @@ class Query(object):
         :type key: :class:`google.cloud.datastore.key.Key`
         :param key: The key to filter on.
 
-        :type operator: string
+        :type operator: str
         :param operator: (Optional) One of ``=``, ``<``, ``<=``, ``>``, ``>=``.
                          Defaults to ``=``.
         """
@@ -281,7 +281,7 @@ class Query(object):
 
         Sort fields will be applied in the order specified.
 
-        :type value: string or sequence of strings
+        :type value: str or sequence of strings
         :param value: Each value is a string giving the name of the
                       property on which to sort, optionally preceded by a
                       hyphen (-) to specify descending order.
@@ -304,7 +304,7 @@ class Query(object):
     def distinct_on(self, value):
         """Set fields used to group query results.
 
-        :type value: string or sequence of strings
+        :type value: str or sequence of strings
         :param value: Each value is a string giving the name of a
                       property to use to group results together.
         """

--- a/datastore/google/cloud/datastore/transaction.py
+++ b/datastore/google/cloud/datastore/transaction.py
@@ -100,7 +100,7 @@ class Transaction(Batch):
     def id(self):
         """Getter for the transaction ID.
 
-        :rtype: string
+        :rtype: str
         :returns: The ID of the current transaction.
         """
         return self._id

--- a/dns/google/cloud/dns/changes.py
+++ b/dns/google/cloud/dns/changes.py
@@ -74,7 +74,7 @@ class Changes(object):
     def path(self):
         """URL path for change set APIs.
 
-        :rtype: string
+        :rtype: str
         :returns: the path based on project, zone, and change set names.
         """
         return '/projects/%s/managedZones/%s/changes/%s' % (
@@ -84,7 +84,7 @@ class Changes(object):
     def name(self):
         """Name of the change set.
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: Name, as set by the back-end, or None.
         """
         return self._properties.get('id')
@@ -104,7 +104,7 @@ class Changes(object):
     def status(self):
         """Status of the change set.
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: Status, as set by the back-end, or None.
         """
         return self._properties.get('status')

--- a/dns/google/cloud/dns/changes.py
+++ b/dns/google/cloud/dns/changes.py
@@ -93,7 +93,7 @@ class Changes(object):
     def name(self, value):
         """Update name of the change set.
 
-        :type value: string
+        :type value: str
         :param value: New name for the changeset.
         """
         if not isinstance(value, six.string_types):

--- a/dns/google/cloud/dns/client.py
+++ b/dns/google/cloud/dns/client.py
@@ -24,7 +24,7 @@ from google.cloud.iterator import Iterator
 class Client(JSONClient):
     """Client to bundle configuration needed for API requests.
 
-    :type project: string
+    :type project: str
     :param project: the project which the client acts on behalf of. Will be
                     passed when creating a zone.  If not passed,
                     falls back to the default inferred from the environment.
@@ -88,14 +88,14 @@ class Client(JSONClient):
     def zone(self, name, dns_name=None, description=None):
         """Construct a zone bound to this client.
 
-        :type name: string
+        :type name: str
         :param name: Name of the zone.
 
-        :type dns_name: string or :class:`NoneType`
+        :type dns_name: str or :class:`NoneType`
         :param dns_name: DNS name of the zone.  If not passed, then calls
                          to :meth:`zone.create` will fail.
 
-        :type description: string or :class:`NoneType`
+        :type description: str or :class:`NoneType`
         :param description: the description for the zone.  If not passed,
                             defaults to the value of 'dns_name'.
 

--- a/dns/google/cloud/dns/resource_record_set.py
+++ b/dns/google/cloud/dns/resource_record_set.py
@@ -23,10 +23,10 @@ class ResourceRecordSet(object):
     See:
     https://cloud.google.com/dns/api/v1/resourceRecordSets
 
-    :type name: string
+    :type name: str
     :param name: the name of the record set.
 
-    :type record_type: string
+    :type record_type: str
     :param record_type: the RR type of the zone.
 
     :type ttl: integer

--- a/dns/google/cloud/dns/zone.py
+++ b/dns/google/cloud/dns/zone.py
@@ -29,10 +29,10 @@ class ManagedZone(object):
     See:
     https://cloud.google.com/dns/api/v1/managedZones
 
-    :type name: string
+    :type name: str
     :param name: the name of the zone
 
-    :type dns_name: string or :class:`NoneType`
+    :type dns_name: str or :class:`NoneType`
     :param dns_name: the DNS name of the zone.  If not passed, then calls
                      to :meth:`create` will fail.
 
@@ -40,7 +40,7 @@ class ManagedZone(object):
     :param client: A client which holds credentials and project configuration
                    for the zone (which requires a project).
 
-    :type description: string or :class:`NoneType`
+    :type description: str or :class:`NoneType`
     :param description: the description for the zone.  If not passed, defaults
                         to the value of 'dns_name'.
     """
@@ -135,7 +135,7 @@ class ManagedZone(object):
     def description(self, value):
         """Update description of the zone.
 
-        :type value: string, or ``NoneType``
+        :type value: str, or ``NoneType``
         :param value: new description
 
         :raises: ValueError for invalid value types.
@@ -162,7 +162,7 @@ class ManagedZone(object):
     def name_server_set(self, value):
         """Update named set of DNS name servers.
 
-        :type value: string, or ``NoneType``
+        :type value: str, or ``NoneType``
         :param value: new title
 
         :raises: ValueError for invalid value types.
@@ -174,10 +174,10 @@ class ManagedZone(object):
     def resource_record_set(self, name, record_type, ttl, rrdatas):
         """Construct a resource record set bound to this zone.
 
-        :type name: string
+        :type name: str
         :param name: Name of the record set.
 
-        :type record_type: string
+        :type record_type: str
         :param record_type: RR type
 
         :type ttl: integer
@@ -323,7 +323,7 @@ class ManagedZone(object):
         :param max_results: maximum number of zones to return, If not
                             passed, defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of zones. If
                            not passed, the API will return the first page of
                            zones.
@@ -356,7 +356,7 @@ class ManagedZone(object):
         :param max_results: maximum number of zones to return, If not
                             passed, defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of zones. If
                            not passed, the API will return the first page of
                            zones.

--- a/dns/google/cloud/dns/zone.py
+++ b/dns/google/cloud/dns/zone.py
@@ -81,7 +81,7 @@ class ManagedZone(object):
     def project(self):
         """Project bound to the zone.
 
-        :rtype: string
+        :rtype: str
         :returns: the project (derived from the client).
         """
         return self._client.project
@@ -90,7 +90,7 @@ class ManagedZone(object):
     def path(self):
         """URL path for the zone's APIs.
 
-        :rtype: string
+        :rtype: str
         :returns: the path based on project and dataste name.
         """
         return '/projects/%s/managedZones/%s' % (self.project, self.name)
@@ -117,7 +117,7 @@ class ManagedZone(object):
     def zone_id(self):
         """ID for the zone resource.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: the ID (None until set from the server).
         """
         return self._properties.get('id')
@@ -126,7 +126,7 @@ class ManagedZone(object):
     def description(self):
         """Description of the zone.
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: The description as set by the user, or None (the default).
         """
         return self._properties.get('description')
@@ -153,7 +153,7 @@ class ManagedZone(object):
         See:
         https://cloud.google.com/dns/api/v1/managedZones#nameServerSet
 
-        :rtype: string, or ``NoneType``
+        :rtype: str, or ``NoneType``
         :returns: The name as set by the user, or None (the default).
         """
         return self._properties.get('nameServerSet')

--- a/error_reporting/google/cloud/error_reporting/client.py
+++ b/error_reporting/google/cloud/error_reporting/client.py
@@ -24,24 +24,24 @@ class HTTPContext(object):
     """HTTPContext defines an object that captures the parameter for the
     httpRequest part of Error Reporting API
 
-    :type method: string
+    :type method: str
     :param method: The type of HTTP request, such as GET, POST, etc.
 
-    :type url: string
+    :type url: str
     :param url: The URL of the request
 
-    :type user_agent: string
+    :type user_agent: str
     :param user_agent: The user agent information that is provided with the
                        request.
 
-    :type referrer: string
+    :type referrer: str
     :param referrer: The referrer information that is provided with the
                      request.
 
     :type response_status_code: int
     :param response_status_code: The HTTP response status code for the request.
 
-    :type remote_ip: string
+    :type remote_ip: str
     :param remote_ip: The IP address from which the request originated. This
                       can be IPv4, IPv6, or a token which is derived from
                       the IP address, depending on the data that has been
@@ -65,7 +65,7 @@ class Client(object):
     """Error Reporting client. Currently Error Reporting is done by creating
     a Logging client.
 
-    :type project: string
+    :type project: str
     :param project: the project which the client acts on behalf of. If not
                     passed falls back to the default inferred from the
                     environment.
@@ -125,7 +125,7 @@ class Client(object):
 
         https://cloud.google.com/error-reporting/docs/formatting-error-messages
 
-        :type message: string
+        :type message: str
         :param message: The stack trace that was reported or logged by the
                    service.
 
@@ -143,7 +143,7 @@ class Client(object):
         :param http_context: The HTTP request which was processed when the
                              error was triggered.
 
-        :type user: string
+        :type user: str
         :param user: The user who caused or was affected by the crash. This can
                      be a user ID, an email address, or an arbitrary token that
                      uniquely identifies the user. When sending an error
@@ -194,7 +194,7 @@ class Client(object):
           :param http_context: The HTTP request which was processed when the
                                error was triggered.
 
-          :type user: string
+          :type user: str
           :param user: The user who caused or was affected by the crash. This
                        can be a user ID, an email address, or an arbitrary
                        token that uniquely identifies the user. When sending
@@ -230,7 +230,7 @@ class Client(object):
           :param http_context: The HTTP request which was processed when the
                                error was triggered.
 
-          :type user: string
+          :type user: str
           :param user: The user who caused or was affected by the crash. This
                        can be a user ID, an email address, or an arbitrary
                        token that uniquely identifies the user. When sending an

--- a/logging/google/cloud/logging/_gax.py
+++ b/logging/google/cloud/logging/_gax.py
@@ -91,7 +91,7 @@ class _LoggingAPI(object):
         :type entries: sequence of mapping
         :param entries: the log entry resources to log.
 
-        :type logger_name: string
+        :type logger_name: str
         :param logger_name: name of default logger to which to log the entries;
                             individual entries may override.
 
@@ -113,10 +113,10 @@ class _LoggingAPI(object):
     def logger_delete(self, project, logger_name):
         """API call:  delete all entries in a logger via a DELETE request
 
-        :type project: string
+        :type project: str
         :param project: ID of project containing the log entries to delete
 
-        :type logger_name: string
+        :type logger_name: str
         :param logger_name: name of logger containing the log entries to delete
         """
         options = None
@@ -142,7 +142,7 @@ class _SinksAPI(object):
     def list_sinks(self, project, page_size=0, page_token=None):
         """List sinks for the project associated with this client.
 
-        :type project: string
+        :type project: str
         :param project: ID of the project whose sinks are to be listed.
 
         :type page_size: int
@@ -176,17 +176,17 @@ class _SinksAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.sinks/create
 
-        :type project: string
+        :type project: str
         :param project: ID of the project in which to create the sink.
 
-        :type sink_name: string
+        :type sink_name: str
         :param sink_name: the name of the sink
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: the advanced logs filter expression defining the
                         entries exported by the sink.
 
-        :type destination: string
+        :type destination: str
         :param destination: destination URI for the entries exported by
                             the sink.
         """
@@ -205,10 +205,10 @@ class _SinksAPI(object):
     def sink_get(self, project, sink_name):
         """API call:  retrieve a sink resource.
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the sink.
 
-        :type sink_name: string
+        :type sink_name: str
         :param sink_name: the name of the sink
 
         :rtype: dict
@@ -228,17 +228,17 @@ class _SinksAPI(object):
     def sink_update(self, project, sink_name, filter_, destination):
         """API call:  update a sink resource.
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the sink.
 
-        :type sink_name: string
+        :type sink_name: str
         :param sink_name: the name of the sink
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: the advanced logs filter expression defining the
                         entries exported by the sink.
 
-        :type destination: string
+        :type destination: str
         :param destination: destination URI for the entries exported by
                             the sink.
 
@@ -260,10 +260,10 @@ class _SinksAPI(object):
     def sink_delete(self, project, sink_name):
         """API call:  delete a sink resource.
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the sink.
 
-        :type sink_name: string
+        :type sink_name: str
         :param sink_name: the name of the sink
         """
         options = None
@@ -289,7 +289,7 @@ class _MetricsAPI(object):
     def list_metrics(self, project, page_size=0, page_token=None):
         """List metrics for the project associated with this client.
 
-        :type project: string
+        :type project: str
         :param project: ID of the project whose metrics are to be listed.
 
         :type page_size: int
@@ -323,17 +323,17 @@ class _MetricsAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.metrics/create
 
-        :type project: string
+        :type project: str
         :param project: ID of the project in which to create the metric.
 
-        :type metric_name: string
+        :type metric_name: str
         :param metric_name: the name of the metric
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: the advanced logs filter expression defining the
                         entries exported by the metric.
 
-        :type description: string
+        :type description: str
         :param description: description of the metric.
         """
         options = None
@@ -351,10 +351,10 @@ class _MetricsAPI(object):
     def metric_get(self, project, metric_name):
         """API call:  retrieve a metric resource.
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the metric.
 
-        :type metric_name: string
+        :type metric_name: str
         :param metric_name: the name of the metric
 
         :rtype: dict
@@ -374,17 +374,17 @@ class _MetricsAPI(object):
     def metric_update(self, project, metric_name, filter_, description):
         """API call:  update a metric resource.
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the metric.
 
-        :type metric_name: string
+        :type metric_name: str
         :param metric_name: the name of the metric
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: the advanced logs filter expression defining the
                         entries exported by the metric.
 
-        :type description: string
+        :type description: str
         :param description: description of the metric.
 
         :rtype: dict
@@ -406,10 +406,10 @@ class _MetricsAPI(object):
     def metric_delete(self, project, metric_name):
         """API call:  delete a metric resource.
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the metric.
 
-        :type metric_name: string
+        :type metric_name: str
         :param metric_name: the name of the metric
         """
         options = None

--- a/logging/google/cloud/logging/connection.py
+++ b/logging/google/cloud/logging/connection.py
@@ -27,7 +27,7 @@ class Connection(base_connection.JSONConnection):
     :type http: :class:`httplib2.Http` or class that defines ``request()``.
     :param http: (Optional) HTTP object to make requests.
 
-    :type api_base_url: string
+    :type api_base_url: str
     :param api_base_url: The base of the API call URL. Defaults to the value
                          :attr:`Connection.API_BASE_URL`.
     """
@@ -123,7 +123,7 @@ class _LoggingAPI(object):
         :type entries: sequence of mapping
         :param entries: the log entry resources to log.
 
-        :type logger_name: string
+        :type logger_name: str
         :param logger_name: name of default logger to which to log the entries;
                             individual entries may override.
 
@@ -155,10 +155,10 @@ class _LoggingAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.logs/delete
 
-        :type project: string
+        :type project: str
         :param project: ID of project containing the log entries to delete
 
-        :type logger_name: string
+        :type logger_name: str
         :param logger_name: name of logger containing the log entries to delete
         """
         path = '/projects/%s/logs/%s' % (project, logger_name)
@@ -183,7 +183,7 @@ class _SinksAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.sinks/list
 
-        :type project: string
+        :type project: str
         :param project: ID of the project whose sinks are to be listed.
 
         :type page_size: int
@@ -220,17 +220,17 @@ class _SinksAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.sinks/create
 
-        :type project: string
+        :type project: str
         :param project: ID of the project in which to create the sink.
 
-        :type sink_name: string
+        :type sink_name: str
         :param sink_name: the name of the sink
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: the advanced logs filter expression defining the
                         entries exported by the sink.
 
-        :type destination: string
+        :type destination: str
         :param destination: destination URI for the entries exported by
                             the sink.
         """
@@ -248,10 +248,10 @@ class _SinksAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.sinks/get
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the sink.
 
-        :type sink_name: string
+        :type sink_name: str
         :param sink_name: the name of the sink
 
         :rtype: dict
@@ -266,17 +266,17 @@ class _SinksAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.sinks/update
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the sink.
 
-        :type sink_name: string
+        :type sink_name: str
         :param sink_name: the name of the sink
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: the advanced logs filter expression defining the
                         entries exported by the sink.
 
-        :type destination: string
+        :type destination: str
         :param destination: destination URI for the entries exported by
                             the sink.
         """
@@ -294,10 +294,10 @@ class _SinksAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.sinks/delete
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the sink.
 
-        :type sink_name: string
+        :type sink_name: str
         :param sink_name: the name of the sink
         """
         target = '/projects/%s/sinks/%s' % (project, sink_name)
@@ -322,7 +322,7 @@ class _MetricsAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.metrics/list
 
-        :type project: string
+        :type project: str
         :param project: ID of the project whose metrics are to be listed.
 
         :type page_size: int
@@ -359,17 +359,17 @@ class _MetricsAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.metrics/create
 
-        :type project: string
+        :type project: str
         :param project: ID of the project in which to create the metric.
 
-        :type metric_name: string
+        :type metric_name: str
         :param metric_name: the name of the metric
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: the advanced logs filter expression defining the
                         entries exported by the metric.
 
-        :type description: string
+        :type description: str
         :param description: description of the metric.
         """
         target = '/projects/%s/metrics' % (project,)
@@ -386,10 +386,10 @@ class _MetricsAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.metrics/get
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the metric.
 
-        :type metric_name: string
+        :type metric_name: str
         :param metric_name: the name of the metric
 
         :rtype: dict
@@ -404,17 +404,17 @@ class _MetricsAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.metrics/update
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the metric.
 
-        :type metric_name: string
+        :type metric_name: str
         :param metric_name: the name of the metric
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: the advanced logs filter expression defining the
                         entries exported by the metric.
 
-        :type description: string
+        :type description: str
         :param description: description of the metric.
         """
         target = '/projects/%s/metrics/%s' % (project, metric_name)
@@ -431,10 +431,10 @@ class _MetricsAPI(object):
         See:
         https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.metrics/delete
 
-        :type project: string
+        :type project: str
         :param project: ID of the project containing the metric.
 
-        :type metric_name: string
+        :type metric_name: str
         :param metric_name: the name of the metric.
         """
         target = '/projects/%s/metrics/%s' % (project, metric_name)

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -65,7 +65,7 @@ class _BaseEntry(object):
     :type labels: dict or :class:`NoneType`
     :param labels: (optional) mapping of labels for the entry
 
-    :type severity: string or :class:`NoneType`
+    :type severity: str or :class:`NoneType`
     :param severity: (optional) severity of event being logged.
 
     :type http_request: dict or :class:`NoneType`

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -25,7 +25,7 @@ class Logger(object):
     See:
     https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.logs
 
-    :type name: string
+    :type name: str
     :param name: the name of the logger
 
     :type client: :class:`google.cloud.logging.client.Client`
@@ -99,7 +99,7 @@ class Logger(object):
 
         Only one of ``text``, ``info``, or ``message`` should be passed.
 
-        :type text: string or :class:`NoneType`
+        :type text: str or :class:`NoneType`
         :param text: text payload
 
         :type info: dict or :class:`NoneType`
@@ -111,10 +111,10 @@ class Logger(object):
         :type labels: dict or :class:`NoneType`
         :param labels: labels passed in to calling method.
 
-        :type insert_id: string or :class:`NoneType`
+        :type insert_id: str or :class:`NoneType`
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: string or :class:`NoneType`
+        :type severity: str or :class:`NoneType`
         :param severity: (optional) severity of event being logged.
 
         :type http_request: dict or :class:`NoneType`
@@ -175,10 +175,10 @@ class Logger(object):
         :type labels: dict or :class:`NoneType`
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: string or :class:`NoneType`
+        :type insert_id: str or :class:`NoneType`
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: string or :class:`NoneType`
+        :type severity: str or :class:`NoneType`
         :param severity: (optional) severity of event being logged.
 
         :type http_request: dict or :class:`NoneType`
@@ -209,10 +209,10 @@ class Logger(object):
         :type labels: dict or :class:`NoneType`
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: string or :class:`NoneType`
+        :type insert_id: str or :class:`NoneType`
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: string or :class:`NoneType`
+        :type severity: str or :class:`NoneType`
         :param severity: (optional) severity of event being logged.
 
         :type http_request: dict or :class:`NoneType`
@@ -243,10 +243,10 @@ class Logger(object):
         :type labels: dict or :class:`NoneType`
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: string or :class:`NoneType`
+        :type insert_id: str or :class:`NoneType`
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: string or :class:`NoneType`
+        :type severity: str or :class:`NoneType`
         :param severity: (optional) severity of event being logged.
 
         :type http_request: dict or :class:`NoneType`
@@ -284,11 +284,11 @@ class Logger(object):
         :param projects: project IDs to include. If not passed,
                             defaults to the project bound to the client.
 
-        :type filter_: string
+        :type filter_: str
         :param filter_: a filter expression. See:
                         https://cloud.google.com/logging/docs/view/advanced_filters
 
-        :type order_by: string
+        :type order_by: str
         :param order_by: One of :data:`~google.cloud.logging.ASCENDING`
                          or :data:`~google.cloud.logging.DESCENDING`.
 
@@ -296,7 +296,7 @@ class Logger(object):
         :param page_size: maximum number of entries to return, If not passed,
                           defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of entries. If not
                            passed, the API will return the first page of
                            entries.
@@ -344,16 +344,16 @@ class Batch(object):
                  http_request=None):
         """Add a text entry to be logged during :meth:`commit`.
 
-        :type text: string
+        :type text: str
         :param text: the text entry
 
         :type labels: dict or :class:`NoneType`
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: string or :class:`NoneType`
+        :type insert_id: str or :class:`NoneType`
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: string or :class:`NoneType`
+        :type severity: str or :class:`NoneType`
         :param severity: (optional) severity of event being logged.
 
         :type http_request: dict or :class:`NoneType`
@@ -373,10 +373,10 @@ class Batch(object):
         :type labels: dict or :class:`NoneType`
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: string or :class:`NoneType`
+        :type insert_id: str or :class:`NoneType`
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: string or :class:`NoneType`
+        :type severity: str or :class:`NoneType`
         :param severity: (optional) severity of event being logged.
 
         :type http_request: dict or :class:`NoneType`
@@ -396,10 +396,10 @@ class Batch(object):
         :type labels: dict or :class:`NoneType`
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: string or :class:`NoneType`
+        :type insert_id: str or :class:`NoneType`
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: string or :class:`NoneType`
+        :type severity: str or :class:`NoneType`
         :param severity: (optional) severity of event being logged.
 
         :type http_request: dict or :class:`NoneType`

--- a/logging/google/cloud/logging/metric.py
+++ b/logging/google/cloud/logging/metric.py
@@ -23,10 +23,10 @@ class Metric(object):
     See:
     https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.metrics
 
-    :type name: string
+    :type name: str
     :param name: the name of the metric
 
-    :type filter_: string
+    :type filter_: str
     :param filter_: the advanced logs filter expression defining the entries
                    tracked by the metric.  If not passed, the instance should
                    already exist, to be refreshed via :meth:`reload`.
@@ -35,7 +35,7 @@ class Metric(object):
     :param client: A client which holds credentials and project configuration
                    for the metric (which requires a project).
 
-    :type description: string
+    :type description: str
     :param description: an optional description of the metric.
     """
     def __init__(self, name, filter_=None, client=None, description=''):

--- a/logging/google/cloud/logging/sink.py
+++ b/logging/google/cloud/logging/sink.py
@@ -23,15 +23,15 @@ class Sink(object):
     See:
     https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/projects.sinks
 
-    :type name: string
+    :type name: str
     :param name: the name of the sink
 
-    :type filter_: string
+    :type filter_: str
     :param filter_: the advanced logs filter expression defining the entries
                     exported by the sink.  If not passed, the instance should
                     already exist, to be refreshed via :meth:`reload`.
 
-    :type destination: string
+    :type destination: str
     :param destination: destination URI for the entries exported by the sink.
                         If not passed, the instance should already exist, to
                         be refreshed via :meth:`reload`.

--- a/monitoring/google/cloud/monitoring/_dataframe.py
+++ b/monitoring/google/cloud/monitoring/_dataframe.py
@@ -34,7 +34,7 @@ def _build_dataframe(time_series_iterable,
     :param time_series_iterable:
         An iterable (e.g., a query object) yielding time series.
 
-    :type label: string or None
+    :type label: str or None
     :param label:
         The label name to use for the dataframe header. This can be the name
         of a resource label or metric label (e.g., ``"instance_name"``), or

--- a/monitoring/google/cloud/monitoring/client.py
+++ b/monitoring/google/cloud/monitoring/client.py
@@ -50,7 +50,7 @@ _UTCNOW = datetime.datetime.utcnow  # To be replaced by tests.
 class Client(JSONClient):
     """Client to bundle configuration needed for API requests.
 
-    :type project: string
+    :type project: str
     :param project: The target project. If not passed, falls back to the
                     default inferred from the environment.
 
@@ -80,7 +80,7 @@ class Client(JSONClient):
             >>> query = client.query(minutes=5)
             >>> print(query.as_dataframe())  # Requires pandas.
 
-        :type metric_type: string
+        :type metric_type: str
         :param metric_type: The metric type name. The default value is
             :data:`Query.DEFAULT_METRIC_TYPE
             <google.cloud.monitoring.query.Query.DEFAULT_METRIC_TYPE>`,
@@ -158,19 +158,19 @@ class Client(JSONClient):
             ...     description='Cumulative count of HTTP responses.')
             >>> descriptor.create()
 
-        :type type_: string
+        :type type_: str
         :param type_:
             The metric type including a DNS name prefix. For example:
             ``"custom.googleapis.com/my_metric"``
 
-        :type metric_kind: string
+        :type metric_kind: str
         :param metric_kind:
             The kind of measurement. It must be one of
             :data:`MetricKind.GAUGE`, :data:`MetricKind.DELTA`,
             or :data:`MetricKind.CUMULATIVE`.
             See :class:`~google.cloud.monitoring.metric.MetricKind`.
 
-        :type value_type: string
+        :type value_type: str
         :param value_type:
             The value type of the metric. It must be one of
             :data:`ValueType.BOOL`, :data:`ValueType.INT64`,
@@ -184,13 +184,13 @@ class Client(JSONClient):
             A sequence of zero or more label descriptors specifying the labels
             used to identify a specific instance of this metric.
 
-        :type unit: string
+        :type unit: str
         :param unit: An optional unit in which the metric value is reported.
 
-        :type description: string
+        :type description: str
         :param description: An optional detailed description of the metric.
 
-        :type display_name: string
+        :type display_name: str
         :param display_name: An optional concise name for the metric.
 
         :rtype: :class:`MetricDescriptor`
@@ -221,7 +221,7 @@ class Client(JSONClient):
              ...                            'status': 'successful',
              ...                         })
 
-        :type type_: string
+        :type type_: str
         :param type_: The metric type name.
 
         :type labels: dict
@@ -248,7 +248,7 @@ class Client(JSONClient):
 
         https://cloud.google.com/monitoring/api/resources
 
-        :type type_: string
+        :type type_: str
         :param type_: The monitored resource type name.
 
         :type labels: dict
@@ -339,7 +339,7 @@ class Client(JSONClient):
             >>> METRIC = 'compute.googleapis.com/instance/cpu/utilization'
             >>> print(client.fetch_metric_descriptor(METRIC))
 
-        :type metric_type: string
+        :type metric_type: str
         :param metric_type: The metric type name.
 
         :rtype: :class:`~google.cloud.monitoring.metric.MetricDescriptor`
@@ -362,12 +362,12 @@ class Client(JSONClient):
             ...         type_prefix='custom.'):
             ...     print(descriptor.type)
 
-        :type filter_string: string or None
+        :type filter_string: str or None
         :param filter_string:
             An optional filter expression describing the metric descriptors
             to be returned. See the `filter documentation`_.
 
-        :type type_prefix: string or None
+        :type type_prefix: str or None
         :param type_prefix: An optional prefix constraining the selected
             metric types. This adds ``metric.type = starts_with("<prefix>")``
             to the filter.
@@ -389,7 +389,7 @@ class Client(JSONClient):
 
             >>> print(client.fetch_resource_descriptor('gce_instance'))
 
-        :type resource_type: string
+        :type resource_type: str
         :param resource_type: The resource type name.
 
         :rtype: :class:`~google.cloud.monitoring.resource.ResourceDescriptor`
@@ -408,7 +408,7 @@ class Client(JSONClient):
             >>> for descriptor in client.list_resource_descriptors():
             ...     print(descriptor.type)
 
-        :type filter_string: string or None
+        :type filter_string: str or None
         :param filter_string:
             An optional filter expression describing the resource descriptors
             to be returned. See the `filter documentation`_.
@@ -430,19 +430,19 @@ class Client(JSONClient):
           This will not make an HTTP request; it simply instantiates
           a group object owned by this client.
 
-        :type group_id: string or None
+        :type group_id: str or None
         :param group_id: The ID of the group.
 
-        :type display_name: string or None
+        :type display_name: str or None
         :param display_name:
             A user-assigned name for this group, used only for display
             purposes.
 
-        :type parent_id: string or None
+        :type parent_id: str or None
         :param parent_id:
             The ID of the group's parent, if it has one.
 
-        :type filter_string: string or None
+        :type filter_string: str or None
         :param filter_string:
             The filter string used to determine which monitored resources
             belong to this group.
@@ -478,7 +478,7 @@ class Client(JSONClient):
             >>> except google.cloud.exceptions.NotFound:
             >>>     print('That group does not exist!')
 
-        :type group_id: string
+        :type group_id: str
         :param group_id: The ID of the group.
 
         :rtype: :class:`~google.cloud.monitoring.group.Group`

--- a/monitoring/google/cloud/monitoring/client.py
+++ b/monitoring/google/cloud/monitoring/client.py
@@ -447,7 +447,7 @@ class Client(JSONClient):
             The filter string used to determine which monitored resources
             belong to this group.
 
-        :type is_cluster: boolean
+        :type is_cluster: bool
         :param is_cluster:
             If true, the members of this group are considered to be a cluster.
             The system can perform additional analysis on groups that are

--- a/monitoring/google/cloud/monitoring/connection.py
+++ b/monitoring/google/cloud/monitoring/connection.py
@@ -27,7 +27,7 @@ class Connection(base_connection.JSONConnection):
     :type http: :class:`httplib2.Http` or class that defines ``request()``
     :param http: (Optional) HTTP object to make requests.
 
-    :type api_base_url: string
+    :type api_base_url: str
     :param api_base_url: The base of the API call URL. Defaults to the value
                          :attr:`Connection.API_BASE_URL`.
     """

--- a/monitoring/google/cloud/monitoring/group.py
+++ b/monitoring/google/cloud/monitoring/group.py
@@ -45,7 +45,7 @@ def _group_id_from_name(path, project=None):
     :param project: The project associated with the request. It is
                     included for validation purposes.
 
-    :rtype: string
+    :rtype: str
     :returns: Group ID parsed from ``path``.
     :raises: :class:`ValueError` if the ``path`` is ill-formed or if
              the project from the ``path`` does not agree with the
@@ -63,7 +63,7 @@ def _group_name_from_id(project, group_id):
     :type group_id: string
     :param group_id: The group ID.
 
-    :rtype: string
+    :rtype: str
     :returns: The fully qualified name of the group.
     """
     return 'projects/{project}/groups/{group_id}'.format(

--- a/monitoring/google/cloud/monitoring/group.py
+++ b/monitoring/google/cloud/monitoring/group.py
@@ -92,7 +92,7 @@ class Group(object):
         The filter string used to determine which monitored resources belong to
         this group.
 
-    :type is_cluster: boolean
+    :type is_cluster: bool
     :param is_cluster:
         If true, the members of this group are considered to be a cluster. The
         system can perform additional analysis on groups that are clusters.

--- a/monitoring/google/cloud/monitoring/group.py
+++ b/monitoring/google/cloud/monitoring/group.py
@@ -38,10 +38,10 @@ _GROUP_TEMPLATE = re.compile(r"""
 def _group_id_from_name(path, project=None):
     """Validate a group URI path and get the group ID.
 
-    :type path: string
+    :type path: str
     :param path: URI path for a group API request.
 
-    :type project: string or None
+    :type project: str or None
     :param project: The project associated with the request. It is
                     included for validation purposes.
 
@@ -57,10 +57,10 @@ def _group_id_from_name(path, project=None):
 def _group_name_from_id(project, group_id):
     """Build the group name given the project and group ID.
 
-    :type project: string
+    :type project: str
     :param project: The project associated with the group.
 
-    :type group_id: string
+    :type group_id: str
     :param group_id: The group ID.
 
     :rtype: str
@@ -76,18 +76,18 @@ class Group(object):
     :type client: :class:`google.cloud.monitoring.client.Client`
     :param client: A client for operating on the metric descriptor.
 
-    :type group_id: string or None
+    :type group_id: str or None
     :param group_id: The ID of the group.
 
-    :type display_name: string or None
+    :type display_name: str or None
     :param display_name:
         A user-assigned name for this group, used only for display purposes.
 
-    :type parent_id: string or None
+    :type parent_id: str or None
     :param parent_id:
         The ID of the group's parent, if it has one.
 
-    :type filter_string: string or None
+    :type filter_string: str or None
     :param filter_string:
         The filter string used to determine which monitored resources belong to
         this group.
@@ -296,7 +296,7 @@ class Group(object):
             ...     print(member)
 
 
-        :type filter_string: string or None
+        :type filter_string: str or None
         :param filter_string:
             An optional list filter describing the members to be returned. The
             filter may reference the type, labels, and metadata of monitored
@@ -365,7 +365,7 @@ class Group(object):
         :type client: :class:`google.cloud.monitoring.client.Client`
         :param client: The client to use.
 
-        :type group_id: string
+        :type group_id: str
         :param group_id: The group ID.
 
         :rtype: :class:`Group`
@@ -386,17 +386,17 @@ class Group(object):
         :type client: :class:`google.cloud.monitoring.client.Client`
         :param client: The client to use.
 
-        :type children_of_group: string or None
+        :type children_of_group: str or None
         :param children_of_group:
             Returns groups whose parent_name field contains the group name. If
             no groups have this parent, the results are empty.
 
-        :type ancestors_of_group: string or None
+        :type ancestors_of_group: str or None
         :param ancestors_of_group:
             Returns groups that are ancestors of the specified group. If the
             specified group has no immediate parent, the results are empty.
 
-        :type descendants_of_group: string or None
+        :type descendants_of_group: str or None
         :param descendants_of_group:
             Returns the descendants of the specified group. This is a superset
             of the results returned by the children_of_group filter, and

--- a/monitoring/google/cloud/monitoring/label.py
+++ b/monitoring/google/cloud/monitoring/label.py
@@ -35,16 +35,16 @@ class LabelValueType(object):
 class LabelDescriptor(object):
     """Schema specification and documentation for a single label.
 
-    :type key: string
+    :type key: str
     :param key: The name of the label.
 
-    :type value_type: string
+    :type value_type: str
     :param value_type:
         The type of the label. It must be one of :data:`LabelValueType.STRING`,
         :data:`LabelValueType.BOOL`, or :data:`LabelValueType.INT64`.
         See :class:`LabelValueType`.
 
-    :type description: string
+    :type description: str
     :param description: A human-readable description for the label.
     """
 

--- a/monitoring/google/cloud/monitoring/metric.py
+++ b/monitoring/google/cloud/monitoring/metric.py
@@ -68,18 +68,18 @@ class MetricDescriptor(object):
     :type client: :class:`google.cloud.monitoring.client.Client`
     :param client: A client for operating on the metric descriptor.
 
-    :type type_: string
+    :type type_: str
     :param type_:
         The metric type including a DNS name prefix. For example:
         ``"compute.googleapis.com/instance/cpu/utilization"``
 
-    :type metric_kind: string
+    :type metric_kind: str
     :param metric_kind:
         The kind of measurement. It must be one of
         :data:`MetricKind.GAUGE`, :data:`MetricKind.DELTA`,
         or :data:`MetricKind.CUMULATIVE`. See :class:`MetricKind`.
 
-    :type value_type: string
+    :type value_type: str
     :param value_type:
         The value type of the metric. It must be one of
         :data:`ValueType.BOOL`, :data:`ValueType.INT64`,
@@ -93,16 +93,16 @@ class MetricDescriptor(object):
         A sequence of zero or more label descriptors specifying the labels
         used to identify a specific instance of this metric.
 
-    :type unit: string
+    :type unit: str
     :param unit: An optional unit in which the metric value is reported.
 
-    :type description: string
+    :type description: str
     :param description: An optional detailed description of the metric.
 
-    :type display_name: string
+    :type display_name: str
     :param display_name: An optional concise name for the metric.
 
-    :type name: string or None
+    :type name: str or None
     :param name:
         The "resource name" of the metric descriptor. For example:
         ``"projects/<project_id>/metricDescriptors/<type>"``. As
@@ -176,7 +176,7 @@ class MetricDescriptor(object):
         :type client: :class:`google.cloud.monitoring.client.Client`
         :param client: The client to use.
 
-        :type metric_type: string
+        :type metric_type: str
         :param metric_type: The metric type name.
 
         :rtype: :class:`MetricDescriptor`
@@ -198,12 +198,12 @@ class MetricDescriptor(object):
         :type client: :class:`google.cloud.monitoring.client.Client`
         :param client: The client to use.
 
-        :type filter_string: string or None
+        :type filter_string: str or None
         :param filter_string:
             An optional filter expression describing the metric descriptors
             to be returned. See the `filter documentation`_.
 
-        :type type_prefix: string or None
+        :type type_prefix: str or None
         :param type_prefix: An optional prefix constraining the selected
             metric types. This adds ``metric.type = starts_with("<prefix>")``
             to the filter.
@@ -324,7 +324,7 @@ class Metric(collections.namedtuple('Metric', 'type labels')):
     :meth:`~google.cloud.monitoring.client.Client.metric` factory method
     of the :class:`~google.cloud.monitoring.client.Client` class.
 
-    :type type: string
+    :type type: str
     :param type: The metric type name.
 
     :type labels: dict

--- a/monitoring/google/cloud/monitoring/query.py
+++ b/monitoring/google/cloud/monitoring/query.py
@@ -78,7 +78,7 @@ class Query(object):
     :type client: :class:`google.cloud.monitoring.client.Client`
     :param client: The client to use.
 
-    :type metric_type: string
+    :type metric_type: str
     :param metric_type: The metric type name. The default value is
         :data:`Query.DEFAULT_METRIC_TYPE
         <google.cloud.monitoring.query.Query.DEFAULT_METRIC_TYPE>`,
@@ -199,7 +199,7 @@ class Query(object):
 
             query = query.select_group('1234567')
 
-        :type group_id: string
+        :type group_id: str
         :param group_id: The ID of a group to filter by.
 
         :rtype: :class:`Query`
@@ -362,7 +362,7 @@ class Query(object):
 
             query = query.align('ALIGN_MEAN', minutes=5)
 
-        :type per_series_aligner: string
+        :type per_series_aligner: str
         :param per_series_aligner: The approach to be used to align
             individual time series. For example: :data:`Aligner.ALIGN_MEAN`.
             See :class:`Aligner` and the descriptions of the `supported
@@ -402,13 +402,13 @@ class Query(object):
             query = query.reduce(Reducer.REDUCE_MEAN,
                                  'resource.project_id', 'resource.zone')
 
-        :type cross_series_reducer: string
+        :type cross_series_reducer: str
         :param cross_series_reducer:
             The approach to be used to combine time series. For example:
             :data:`Reducer.REDUCE_MEAN`. See :class:`Reducer` and the
             descriptions of the `supported reducers`_.
 
-        :type group_by_fields: strings
+        :type group_by_fields: strs
         :param group_by_fields:
             Fields to be preserved by the reduction. For example, specifying
             just ``"resource.zone"`` will result in one time series per zone.
@@ -513,7 +513,7 @@ class Query(object):
         :type page_size: integer or None
         :param page_size: A limit on the number of points to return per page.
 
-        :type page_token: string or None
+        :type page_token: str or None
         :param page_token: A token to continue the retrieval.
         """
         yield 'filter', self.filter
@@ -575,7 +575,7 @@ class Query(object):
             dataframe = query.as_dataframe(
                 labels=['resource_type', 'instance_id'])
 
-        :type label: string or None
+        :type label: str or None
         :param label: The label name to use for the dataframe header.
             This can be the name of a resource label or metric label
             (e.g., ``"instance_name"``), or the string ``"resource_type"``.

--- a/monitoring/google/cloud/monitoring/query.py
+++ b/monitoring/google/cloud/monitoring/query.py
@@ -442,7 +442,7 @@ class Query(object):
             for timeseries in query.iter():
                 ...
 
-        :type headers_only: boolean
+        :type headers_only: bool
         :param headers_only:
              Whether to omit the point data from the time series objects.
 
@@ -505,7 +505,7 @@ class Query(object):
         We use a series of key-value pairs (suitable for passing to
         ``urlencode``) instead of a ``dict`` to allow for repeated fields.
 
-        :type headers_only: boolean
+        :type headers_only: bool
         :param headers_only:
              Whether to omit the point data from the
              :class:`~google.cloud.monitoring.timeseries.TimeSeries` objects.

--- a/monitoring/google/cloud/monitoring/resource.py
+++ b/monitoring/google/cloud/monitoring/resource.py
@@ -28,20 +28,20 @@ from google.cloud.monitoring.label import LabelDescriptor
 class ResourceDescriptor(object):
     """Specification of a monitored resource type and its schema.
 
-    :type name: string
+    :type name: str
     :param name:
         The "resource name" of the monitored resource descriptor:
         ``"projects/<project_id>/monitoredResourceDescriptors/<type>"``
 
-    :type type_: string
+    :type type_: str
     :param type_:
         The monitored resource type. For example: ``"gce_instance"``
 
-    :type display_name: string
+    :type display_name: str
     :param display_name:
         A concise name that might be displayed in user interfaces.
 
-    :type description: string
+    :type description: str
     :param description:
         A detailed description that might be used in documentation.
 
@@ -66,7 +66,7 @@ class ResourceDescriptor(object):
         :type client: :class:`google.cloud.monitoring.client.Client`
         :param client: The client to use.
 
-        :type resource_type: string
+        :type resource_type: str
         :param resource_type: The resource type name.
 
         :rtype: :class:`ResourceDescriptor`
@@ -88,7 +88,7 @@ class ResourceDescriptor(object):
         :type client: :class:`google.cloud.monitoring.client.Client`
         :param client: The client to use.
 
-        :type filter_string: string or None
+        :type filter_string: str or None
         :param filter_string:
             An optional filter expression describing the resource descriptors
             to be returned. See the `filter documentation`_.
@@ -163,7 +163,7 @@ class Resource(collections.namedtuple('Resource', 'type labels')):
     :meth:`~google.cloud.monitoring.client.Client.resource` factory method
     of the :class:`~google.cloud.monitoring.client.Client` class.
 
-    :type type: string
+    :type type: str
     :param type: The resource type name.
 
     :type labels: dict

--- a/monitoring/google/cloud/monitoring/timeseries.py
+++ b/monitoring/google/cloud/monitoring/timeseries.py
@@ -44,13 +44,13 @@ class TimeSeries(collections.namedtuple(
     :type resource: :class:`~google.cloud.monitoring.resource.Resource`
     :param resource: A resource object.
 
-    :type metric_kind: string
+    :type metric_kind: str
     :param metric_kind:
         The kind of measurement: :data:`MetricKind.GAUGE`,
         :data:`MetricKind.DELTA`, or :data:`MetricKind.CUMULATIVE`.
         See :class:`~google.cloud.monitoring.metric.MetricKind`.
 
-    :type value_type: string
+    :type value_type: str
     :param value_type:
         The value type of the metric: :data:`ValueType.BOOL`,
         :data:`ValueType.INT64`, :data:`ValueType.DOUBLE`,
@@ -176,10 +176,10 @@ def _make_typed_value(value):
 class Point(collections.namedtuple('Point', 'end_time start_time value')):
     """A single point in a time series.
 
-    :type end_time: string
+    :type end_time: str
     :param end_time: The end time in RFC3339 UTC "Zulu" format.
 
-    :type start_time: string or None
+    :type start_time: str or None
     :param start_time: An optional start time in RFC3339 UTC "Zulu" format.
 
     :type value: object

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -376,7 +376,7 @@ class _SubscriberAPI(object):
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
-        :type return_immediately: boolean
+        :type return_immediately: bool
         :param return_immediately: if True, the back-end returns even if no
                                    messages are available;  if False, the API
                                    call blocks until one or more messages are

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -46,14 +46,14 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/list
 
-        :type project: string
+        :type project: str
         :param project: project ID
 
         :type page_size: int
         :param page_size: maximum number of topics to return, If not passed,
                           defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of topics. If not
                            passed, the API will return the first page of
                            topics.
@@ -80,7 +80,7 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/create
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: fully-qualified path of the new topic, in format
                             ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
@@ -103,7 +103,7 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/get
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: fully-qualified path of the topic, in format
                         ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
@@ -126,7 +126,7 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/create
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: fully-qualified path of the new topic, in format
                             ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
         """
@@ -143,7 +143,7 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/publish
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: fully-qualified path of the topic, in format
                             ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
@@ -174,7 +174,7 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics.subscriptions/list
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: fully-qualified path of the topic, in format
                             ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
@@ -182,7 +182,7 @@ class _PublisherAPI(object):
         :param page_size: maximum number of subscriptions to return, If not
                           passed, defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of subscriptions.
                            If not passed, the API will return the first page
                            of subscriptions.
@@ -223,14 +223,14 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/list
 
-        :type project: string
+        :type project: str
         :param project: project ID
 
         :type page_size: int
         :param page_size: maximum number of subscriptions to return, If not
                           passed, defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of subscriptions.
                            If not passed, the API will return the first page
                            of subscriptions.
@@ -259,12 +259,12 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: the fully-qualified path of the topic being
                            subscribed, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
@@ -273,7 +273,7 @@ class _SubscriberAPI(object):
         :param ack_deadline: the deadline (in seconds) by which messages pulled
                              from the back-end must be acknowledged.
 
-        :type push_endpoint: string, or ``NoneType``
+        :type push_endpoint: str, or ``NoneType``
         :param push_endpoint: URL to which messages will be pushed by the
                               back-end.  If not set, the application must pull
                               messages.
@@ -305,7 +305,7 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
@@ -327,7 +327,7 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/delete
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
@@ -346,12 +346,12 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
-        :type push_endpoint: string, or ``NoneType``
+        :type push_endpoint: str, or ``NoneType``
         :param push_endpoint: URL to which messages will be pushed by the
                               back-end.  If not set, the application must pull
                               messages.
@@ -371,7 +371,7 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
@@ -405,7 +405,7 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
@@ -427,7 +427,7 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.

--- a/pubsub/google/cloud/pubsub/_helpers.py
+++ b/pubsub/google/cloud/pubsub/_helpers.py
@@ -38,10 +38,10 @@ _SUBSCRIPTION_TEMPLATE = re.compile(r"""
 def topic_name_from_path(path, project):
     """Validate a topic URI path and get the topic name.
 
-    :type path: string
+    :type path: str
     :param path: URI path for a topic API request.
 
-    :type project: string
+    :type project: str
     :param project: The project associated with the request. It is
                     included for validation purposes.
 
@@ -57,10 +57,10 @@ def topic_name_from_path(path, project):
 def subscription_name_from_path(path, project):
     """Validate a subscription URI path and get the subscription name.
 
-    :type path: string
+    :type path: str
     :param path: URI path for a subscription API request.
 
-    :type project: string
+    :type project: str
     :param project: The project associated with the request. It is
                     included for validation purposes.
 

--- a/pubsub/google/cloud/pubsub/_helpers.py
+++ b/pubsub/google/cloud/pubsub/_helpers.py
@@ -45,7 +45,7 @@ def topic_name_from_path(path, project):
     :param project: The project associated with the request. It is
                     included for validation purposes.
 
-    :rtype: string
+    :rtype: str
     :returns: Topic name parsed from ``path``.
     :raises: :class:`ValueError` if the ``path`` is ill-formed or if
              the project from the ``path`` does not agree with the
@@ -64,7 +64,7 @@ def subscription_name_from_path(path, project):
     :param project: The project associated with the request. It is
                     included for validation purposes.
 
-    :rtype: string
+    :rtype: str
     :returns: subscription name parsed from ``path``.
     :raises: :class:`ValueError` if the ``path`` is ill-formed or if
              the project from the ``path`` does not agree with the

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -47,7 +47,7 @@ _USE_GAX = _HAVE_GAX and not _DISABLE_GAX
 class Client(JSONClient):
     """Client to bundle configuration needed for API requests.
 
-    :type project: string
+    :type project: str
     :param project: the project which the client acts on behalf of. Will be
                     passed when creating a topic.  If not passed,
                     falls back to the default inferred from the environment.
@@ -113,7 +113,7 @@ class Client(JSONClient):
         :param page_size: maximum number of topics to return, If not passed,
                           defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of topics. If not
                            passed, the API will return the first page of
                            topics.
@@ -147,7 +147,7 @@ class Client(JSONClient):
         :param page_size: maximum number of topics to return, If not passed,
                           defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of topics. If not
                            passed, the API will return the first page of
                            topics.
@@ -176,7 +176,7 @@ class Client(JSONClient):
            :start-after: [START client_topic]
            :end-before: [END client_topic]
 
-        :type name: string
+        :type name: str
         :param name: the name of the topic to be constructed.
 
         :type timestamp_messages: boolean

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -179,7 +179,7 @@ class Client(JSONClient):
         :type name: str
         :param name: the name of the topic to be constructed.
 
-        :type timestamp_messages: boolean
+        :type timestamp_messages: bool
         :param timestamp_messages: To be passed to ``Topic`` constructor.
 
         :rtype: :class:`google.cloud.pubsub.topic.Topic`

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -400,7 +400,7 @@ class _SubscriberAPI(object):
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
-        :type return_immediately: boolean
+        :type return_immediately: bool
         :param return_immediately: if True, the back-end returns even if no
                                    messages are available;  if False, the API
                                    call blocks until one or more messages are

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -83,7 +83,7 @@ class Connection(base_connection.JSONConnection):
                             Typically you shouldn't provide this and instead
                             use the default for the library.
 
-        :rtype: string
+        :rtype: str
         :returns: The URL assembled from the pieces provided.
         """
         if api_base_url is None:

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -66,7 +66,7 @@ class Connection(base_connection.JSONConnection):
 
         Typically, you shouldn't need to use this method.
 
-        :type path: string
+        :type path: str
         :param path: The path to the resource.
 
         :type query_params: dict or list
@@ -74,11 +74,11 @@ class Connection(base_connection.JSONConnection):
                              key-value pairs) to insert into the query
                              string of the URL.
 
-        :type api_base_url: string
+        :type api_base_url: str
         :param api_base_url: The base URL for the API endpoint.
                              Typically you won't have to provide this.
 
-        :type api_version: string
+        :type api_version: str
         :param api_version: The version of the API to call.
                             Typically you shouldn't provide this and instead
                             use the default for the library.
@@ -109,14 +109,14 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/list
 
-        :type project: string
+        :type project: str
         :param project: project ID
 
         :type page_size: int
         :param page_size: maximum number of topics to return, If not passed,
                           defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of topics. If not
                            passed, the API will return the first page of
                            topics.
@@ -146,7 +146,7 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/create
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: the fully-qualified path of the new topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
@@ -162,7 +162,7 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/get
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: the fully-qualified path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
@@ -178,7 +178,7 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/delete
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: the fully-qualified path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
         """
@@ -191,7 +191,7 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/publish
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: the fully-qualified path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
@@ -214,7 +214,7 @@ class _PublisherAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics.subscriptions/list
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: the fully-qualified path of the topic, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
@@ -222,7 +222,7 @@ class _PublisherAPI(object):
         :param page_size: maximum number of subscriptions to return, If not
                           passed, defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of topics. If not
                            passed, the API will return the first page of
                            topics.
@@ -261,14 +261,14 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/list
 
-        :type project: string
+        :type project: str
         :param project: project ID
 
         :type page_size: int
         :param page_size: maximum number of subscriptions to return, If not
                           passed, defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of subscriptions.
                            If not passed, the API will return the first page
                            of subscriptions.
@@ -299,12 +299,12 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
-        :type topic_path: string
+        :type topic_path: str
         :param topic_path: the fully-qualified path of the topic being
                            subscribed, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
@@ -313,7 +313,7 @@ class _SubscriberAPI(object):
         :param ack_deadline: the deadline (in seconds) by which messages pulled
                             from the back-end must be acknowledged.
 
-        :type push_endpoint: string, or ``NoneType``
+        :type push_endpoint: str, or ``NoneType``
         :param push_endpoint: URL to which messages will be pushed by the
                               back-end.  If not set, the application must pull
                               messages.
@@ -339,7 +339,7 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/get
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
@@ -357,7 +357,7 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/delete
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
@@ -373,12 +373,12 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
-        :type push_endpoint: string, or ``NoneType``
+        :type push_endpoint: str, or ``NoneType``
         :param push_endpoint: URL to which messages will be pushed by the
                               back-end.  If not set, the application must pull
                               messages.
@@ -395,7 +395,7 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
@@ -427,7 +427,7 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyPushConfig
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
@@ -449,7 +449,7 @@ class _SubscriberAPI(object):
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
 
-        :type subscription_path: string
+        :type subscription_path: str
         :param subscription_path:
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
@@ -487,7 +487,7 @@ class _IAMPolicyAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/getIamPolicy
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/getIamPolicy
 
-        :type target_path: string
+        :type target_path: str
         :param target_path: the path of the target object.
 
         :rtype: dict
@@ -504,7 +504,7 @@ class _IAMPolicyAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/setIamPolicy
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/setIamPolicy
 
-        :type target_path: string
+        :type target_path: str
         :param target_path: the path of the target object.
 
         :type policy: dict
@@ -525,7 +525,7 @@ class _IAMPolicyAPI(object):
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/testIamPermissions
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/testIamPermissions
 
-        :type target_path: string
+        :type target_path: str
         :param target_path: the path of the target object.
 
         :type permissions: list of string

--- a/pubsub/google/cloud/pubsub/iam.py
+++ b/pubsub/google/cloud/pubsub/iam.py
@@ -101,7 +101,7 @@ class Policy(object):
     https://cloud.google.com/pubsub/docs/reference/rest/Shared.Types/Policy
     https://cloud.google.com/pubsub/docs/reference/rest/Shared.Types/Binding
 
-    :type etag: string
+    :type etag: str
     :param etag: ETag used to identify a unique of the policy
 
     :type version: int
@@ -120,7 +120,7 @@ class Policy(object):
     def user(email):
         """Factory method for a user member.
 
-        :type email: string
+        :type email: str
         :param email: E-mail for this particular user.
 
         :rtype: str
@@ -132,7 +132,7 @@ class Policy(object):
     def service_account(email):
         """Factory method for a service account member.
 
-        :type email: string
+        :type email: str
         :param email: E-mail for this particular service account.
 
         :rtype: str
@@ -144,7 +144,7 @@ class Policy(object):
     def group(email):
         """Factory method for a group member.
 
-        :type email: string
+        :type email: str
         :param email: An id or e-mail for this particular group.
 
         :rtype: str
@@ -156,7 +156,7 @@ class Policy(object):
     def domain(domain):
         """Factory method for a domain member.
 
-        :type domain: string
+        :type domain: str
         :param domain: The domain for this member.
 
         :rtype: str

--- a/pubsub/google/cloud/pubsub/iam.py
+++ b/pubsub/google/cloud/pubsub/iam.py
@@ -123,7 +123,7 @@ class Policy(object):
         :type email: string
         :param email: E-mail for this particular user.
 
-        :rtype: string
+        :rtype: str
         :returns: A member string corresponding to the given user.
         """
         return 'user:%s' % (email,)
@@ -135,7 +135,7 @@ class Policy(object):
         :type email: string
         :param email: E-mail for this particular service account.
 
-        :rtype: string
+        :rtype: str
         :returns: A member string corresponding to the given service account.
         """
         return 'serviceAccount:%s' % (email,)
@@ -147,7 +147,7 @@ class Policy(object):
         :type email: string
         :param email: An id or e-mail for this particular group.
 
-        :rtype: string
+        :rtype: str
         :returns: A member string corresponding to the given group.
         """
         return 'group:%s' % (email,)
@@ -159,7 +159,7 @@ class Policy(object):
         :type domain: string
         :param domain: The domain for this member.
 
-        :rtype: string
+        :rtype: str
         :returns: A member string corresponding to the given domain.
         """
         return 'domain:%s' % (domain,)
@@ -168,7 +168,7 @@ class Policy(object):
     def all_users():
         """Factory method for a member representing all users.
 
-        :rtype: string
+        :rtype: str
         :returns: A member string representing all users.
         """
         return 'allUsers'
@@ -177,7 +177,7 @@ class Policy(object):
     def authenticated_users():
         """Factory method for a member representing all authenticated users.
 
-        :rtype: string
+        :rtype: str
         :returns: A member string representing all authenticated users.
         """
         return 'allAuthenticatedUsers'

--- a/pubsub/google/cloud/pubsub/message.py
+++ b/pubsub/google/cloud/pubsub/message.py
@@ -71,7 +71,7 @@ class Message(object):
     def service_timestamp(self):
         """Return server-set timestamp.
 
-        :rtype: string
+        :rtype: str
         :returns: timestamp (in UTC timezone) in RFC 3339 format
         """
         return self._service_timestamp

--- a/pubsub/google/cloud/pubsub/message.py
+++ b/pubsub/google/cloud/pubsub/message.py
@@ -29,7 +29,7 @@ class Message(object):
     :type data: bytes
     :param data: the payload of the message.
 
-    :type message_id: string
+    :type message_id: str
     :param message_id: An ID assigned to the message by the API.
 
     :type attributes: dict or None

--- a/pubsub/google/cloud/pubsub/subscription.py
+++ b/pubsub/google/cloud/pubsub/subscription.py
@@ -127,7 +127,7 @@ class Subscription(object):
     def auto_ack(self, return_immediately=False, max_messages=1, client=None):
         """:class:`AutoAck` factory
 
-        :type return_immediately: boolean
+        :type return_immediately: bool
         :param return_immediately: passed through to :meth:`Subscription.pull`
 
         :type max_messages: int
@@ -299,7 +299,7 @@ class Subscription(object):
            :start-after: [START subscription_pull]
            :end-before: [END subscription_pull]
 
-        :type return_immediately: boolean
+        :type return_immediately: bool
         :param return_immediately: if True, the back-end returns even if no
                                    messages are available;  if False, the API
                                    call blocks until one or more messages are
@@ -480,7 +480,7 @@ class AutoAck(dict):
     :type subscription: :class:`Subscription`
     :param subscription: subscription to be pulled.
 
-    :type return_immediately: boolean
+    :type return_immediately: bool
     :param return_immediately: passed through to :meth:`Subscription.pull`
 
     :type max_messages: int

--- a/pubsub/google/cloud/pubsub/subscription.py
+++ b/pubsub/google/cloud/pubsub/subscription.py
@@ -26,7 +26,7 @@ class Subscription(object):
     See:
     https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions
 
-    :type name: string
+    :type name: str
     :param name: the name of the subscription.
 
     :type topic: :class:`google.cloud.pubsub.topic.Topic` or ``NoneType``
@@ -37,7 +37,7 @@ class Subscription(object):
     :param ack_deadline: the deadline (in seconds) by which messages pulled
                          from the back-end must be acknowledged.
 
-    :type push_endpoint: string
+    :type push_endpoint: str
     :param push_endpoint: URL to which messages will be pushed by the back-end.
                           If not set, the application must pull messages.
 
@@ -272,7 +272,7 @@ class Subscription(object):
            :start-after: [START subscription_pull_push]
            :end-before: [END subscription_pull_push]
 
-        :type push_endpoint: string
+        :type push_endpoint: str
         :param push_endpoint: URL to which messages will be pushed by the
                               back-end.  If None, the application must pull
                               messages.

--- a/pubsub/google/cloud/pubsub/topic.py
+++ b/pubsub/google/cloud/pubsub/topic.py
@@ -33,7 +33,7 @@ class Topic(object):
     See:
     https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics
 
-    :type name: string
+    :type name: str
     :param name: the name of the topic
 
     :type client: :class:`google.cloud.pubsub.client.Client`
@@ -71,14 +71,14 @@ class Topic(object):
            :start-after: [START topic_subscription_push]
            :end-before: [END topic_subscription_push]
 
-        :type name: string
+        :type name: str
         :param name: the name of the subscription
 
         :type ack_deadline: int
         :param ack_deadline: the deadline (in seconds) by which messages pulled
                              from the back-end must be acknowledged.
 
-        :type push_endpoint: string
+        :type push_endpoint: str
         :param push_endpoint: URL to which messages will be pushed by the
                               back-end. If not set, the application must pull
                               messages.
@@ -299,7 +299,7 @@ class Topic(object):
         :param page_size: maximum number of topics to return, If not passed,
                           defaults to a value set by the API.
 
-        :type page_token: string
+        :type page_token: str
         :param page_token: opaque marker for the next "page" of topics. If not
                            passed, the API will return the first page of
                            topics.

--- a/pubsub/google/cloud/pubsub/topic.py
+++ b/pubsub/google/cloud/pubsub/topic.py
@@ -40,7 +40,7 @@ class Topic(object):
     :param client: A client which holds credentials and project configuration
                    for the topic (which requires a project).
 
-    :type timestamp_messages: boolean
+    :type timestamp_messages: bool
     :param timestamp_messages: If true, the topic will add a ``timestamp`` key
                                to the attributes of each published message:
                                the value will be an RFC 3339 timestamp.

--- a/resource_manager/google/cloud/resource_manager/client.py
+++ b/resource_manager/google/cloud/resource_manager/client.py
@@ -63,7 +63,7 @@ class Client(BaseClient):
         :type project_id: str
         :param project_id: The ID for this project.
 
-        :type name: string
+        :type name: str
         :param name: The display name of the project.
 
         :type labels: dict

--- a/resource_manager/google/cloud/resource_manager/project.py
+++ b/resource_manager/google/cloud/resource_manager/project.py
@@ -39,13 +39,13 @@ class Project(object):
     See:
     https://cloud.google.com/resource-manager/reference/rest/v1beta1/projects
 
-    :type project_id: string
+    :type project_id: str
     :param project_id: The globally unique ID of the project.
 
     :type client: :class:`google.cloud.resource_manager.client.Client`
     :param client: The Client used with this project.
 
-    :type name: string
+    :type name: str
     :param name: The display name of the project.
 
     :type labels: dict

--- a/scripts/verify_included_modules.py
+++ b/scripts/verify_included_modules.py
@@ -87,7 +87,7 @@ def is_valid_module(filename):
     Assumes if is just the end of a path (i.e. does not contain
     ``os.path.sep``.
 
-    :type filename: string
+    :type filename: str
     :param filename: The name of a file.
 
     :rtype: bool
@@ -106,10 +106,10 @@ def is_valid_module(filename):
 def get_public_modules(path, base_package=None):
     """Get list of all public modules relative to a path.
 
-    :type path: string
+    :type path: str
     :param path: The path containing the python modules.
 
-    :type base_package: string
+    :type base_package: str
     :param base_package: (Optional) A package to prepend in
                          front of the path.
 

--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -28,7 +28,7 @@ class _PropertyMixin(object):
       - client
       - path
 
-    :type name: string
+    :type name: str
     :param name: The name of the object.
     """
 
@@ -88,7 +88,7 @@ class _PropertyMixin(object):
         It **will not** reload the properties from the server. The behavior is
         local only and syncing occurs via :meth:`patch`.
 
-        :type name: string
+        :type name: str
         :param name: The field name to update.
 
         :type value: object

--- a/storage/google/cloud/storage/acl.py
+++ b/storage/google/cloud/storage/acl.py
@@ -85,10 +85,10 @@ class _ACLEntity(object):
     This is a helper class that you likely won't ever construct
     outside of using the factor methods on the :class:`ACL` object.
 
-    :type entity_type: string
+    :type entity_type: str
     :param entity_type: The type of entity (ie, 'group' or 'user').
 
-    :type identifier: string
+    :type identifier: str
     :param identifier: The ID or e-mail of the entity. For the special
                        entity types (like 'allUsers') this is optional.
     """
@@ -123,7 +123,7 @@ class _ACLEntity(object):
     def grant(self, role):
         """Add a role to the entity.
 
-        :type role: string
+        :type role: str
         :param role: The role to add to the entity.
         """
         self.roles.add(role)
@@ -131,7 +131,7 @@ class _ACLEntity(object):
     def revoke(self, role):
         """Remove a role from the entity.
 
-        :type role: string
+        :type role: str
         :param role: The role to remove from the entity.
         """
         if role in self.roles:
@@ -298,11 +298,11 @@ class ACL(object):
         create a new one and add it to the list of known entities for
         this ACL.
 
-        :type entity_type: string
+        :type entity_type: str
         :param entity_type: The type of entity to create
                             (ie, ``user``, ``group``, etc)
 
-        :type identifier: string
+        :type identifier: str
         :param identifier: The ID of the entity (if applicable).
                            This can be either an ID or an e-mail address.
 
@@ -319,7 +319,7 @@ class ACL(object):
     def user(self, identifier):
         """Factory method for a user Entity.
 
-        :type identifier: string
+        :type identifier: str
         :param identifier: An id or e-mail for this particular user.
 
         :rtype: :class:`_ACLEntity`
@@ -330,7 +330,7 @@ class ACL(object):
     def group(self, identifier):
         """Factory method for a group Entity.
 
-        :type identifier: string
+        :type identifier: str
         :param identifier: An id or e-mail for this particular group.
 
         :rtype: :class:`_ACLEntity`
@@ -341,7 +341,7 @@ class ACL(object):
     def domain(self, domain):
         """Factory method for a domain Entity.
 
-        :type domain: string
+        :type domain: str
         :param domain: The domain for this entity.
 
         :rtype: :class:`_ACLEntity`
@@ -419,7 +419,7 @@ class ACL(object):
         :param acl: The ACL object to save.  If left blank, this will save
                     current entries.
 
-        :type predefined: string or None
+        :type predefined: str or None
         :param predefined: An identifier for a predefined ACL.  Must be one
                            of the keys in :attr:`PREDEFINED_JSON_ACLS`
                            If passed, `acl` must be None.
@@ -470,7 +470,7 @@ class ACL(object):
     def save_predefined(self, predefined, client=None):
         """Save this ACL for the current bucket using a predefined ACL.
 
-        :type predefined: string
+        :type predefined: str
         :param predefined: An identifier for a predefined ACL.  Must be one
                            of the keys in :attr:`PREDEFINED_JSON_ACLS`
                            or :attr:`PREDEFINED_XML_ACLS` (which will be

--- a/storage/google/cloud/storage/acl.py
+++ b/storage/google/cloud/storage/acl.py
@@ -258,7 +258,7 @@ class ACL(object):
         :type entity: :class:`_ACLEntity`
         :param entity: The entity to check for existence in this ACL.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: True of the entity exists in the ACL.
         """
         self._ensure_loaded()

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -50,7 +50,7 @@ _API_ACCESS_ENDPOINT = 'https://storage.googleapis.com'
 class Blob(_PropertyMixin):
     """A wrapper around Cloud Storage's concept of an ``Object``.
 
-    :type name: string
+    :type name: str
     :param name: The name of the blob.  This corresponds to the
                  unique path of the object in the bucket.
 
@@ -109,10 +109,10 @@ class Blob(_PropertyMixin):
     def path_helper(bucket_path, blob_name):
         """Relative URL path for a blob.
 
-        :type bucket_path: string
+        :type bucket_path: str
         :param bucket_path: The URL path for a bucket.
 
-        :type blob_name: string
+        :type blob_name: str
         :param blob_name: The name of the blob.
 
         :rtype: str
@@ -355,7 +355,7 @@ class Blob(_PropertyMixin):
     def download_to_filename(self, filename, client=None):
         """Download the contents of this blob into a named file.
 
-        :type filename: string
+        :type filename: str
         :param filename: A filename to be passed to ``open``.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -450,7 +450,7 @@ class Blob(_PropertyMixin):
                      :func:`os.fstat`. (If the file handle is not from the
                      filesystem this won't be possible.)
 
-        :type content_type: string or ``NoneType``
+        :type content_type: str or ``NoneType``
         :param content_type: Optional type of content being uploaded.
 
         :type num_retries: integer
@@ -564,10 +564,10 @@ class Blob(_PropertyMixin):
            `lifecycle <https://cloud.google.com/storage/docs/lifecycle>`_
            API documents for details.
 
-        :type filename: string
+        :type filename: str
         :param filename: The path to the file.
 
-        :type content_type: string or ``NoneType``
+        :type content_type: str or ``NoneType``
         :param content_type: Optional type of content being uploaded.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -601,7 +601,7 @@ class Blob(_PropertyMixin):
         :param data: The data to store in this blob.  If the value is
                      text, it will be encoded as UTF-8.
 
-        :type content_type: string
+        :type content_type: str
         :param content_type: Optional type of content being uploaded. Defaults
                              to ``'text/plain'``.
 

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -440,7 +440,7 @@ class Blob(_PropertyMixin):
         :type file_obj: file
         :param file_obj: A file handle open for reading.
 
-        :type rewind: boolean
+        :type rewind: bool
         :param rewind: If True, seek to the beginning of the file handle before
                        writing the file to Cloud Storage.
 

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -254,7 +254,7 @@ class Blob(_PropertyMixin):
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the blob's bucket.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: True if the blob exists in Cloud Storage.
         """
         client = self._require_client(client)

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -115,7 +115,7 @@ class Blob(_PropertyMixin):
         :type blob_name: string
         :param blob_name: The name of the blob.
 
-        :rtype: string
+        :rtype: str
         :returns: The relative URL path for ``blob_name``.
         """
         return bucket_path + '/o/' + quote(blob_name, safe='')
@@ -137,7 +137,7 @@ class Blob(_PropertyMixin):
     def path(self):
         """Getter property for the URL path to this Blob.
 
-        :rtype: string
+        :rtype: str
         :returns: The URL path to this Blob.
         """
         if not self.name:
@@ -709,7 +709,7 @@ class Blob(_PropertyMixin):
 
     If the property is not set locally, returns ``None``.
 
-    :rtype: string or ``NoneType``
+    :rtype: str or ``NoneType``
     """
 
     content_disposition = _scalar_property('contentDisposition')
@@ -720,7 +720,7 @@ class Blob(_PropertyMixin):
 
     If the property is not set locally, returns ``None``.
 
-    :rtype: string or ``NoneType``
+    :rtype: str or ``NoneType``
     """
 
     content_encoding = _scalar_property('contentEncoding')
@@ -731,7 +731,7 @@ class Blob(_PropertyMixin):
 
     If the property is not set locally, returns ``None``.
 
-    :rtype: string or ``NoneType``
+    :rtype: str or ``NoneType``
     """
 
     content_language = _scalar_property('contentLanguage')
@@ -742,7 +742,7 @@ class Blob(_PropertyMixin):
 
     If the property is not set locally, returns ``None``.
 
-    :rtype: string or ``NoneType``
+    :rtype: str or ``NoneType``
     """
 
     content_type = _scalar_property('contentType')
@@ -753,7 +753,7 @@ class Blob(_PropertyMixin):
 
     If the property is not set locally, returns ``None``.
 
-    :rtype: string or ``NoneType``
+    :rtype: str or ``NoneType``
     """
 
     crc32c = _scalar_property('crc32c')
@@ -764,7 +764,7 @@ class Blob(_PropertyMixin):
 
     If the property is not set locally, returns ``None``.
 
-    :rtype: string or ``NoneType``
+    :rtype: str or ``NoneType``
     """
 
     @property
@@ -789,7 +789,7 @@ class Blob(_PropertyMixin):
         See: http://tools.ietf.org/html/rfc2616#section-3.11 and
              https://cloud.google.com/storage/docs/json_api/v1/objects
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: The blob etag or ``None`` if the property is not set locally.
         """
         return self._properties.get('etag')
@@ -814,7 +814,7 @@ class Blob(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/json_api/v1/objects
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: The ID of the blob or ``None`` if the property is not
                   set locally.
         """
@@ -828,7 +828,7 @@ class Blob(_PropertyMixin):
 
     If the property is not set locally, returns ``None``.
 
-    :rtype: string or ``NoneType``
+    :rtype: str or ``NoneType``
     """
 
     @property
@@ -837,7 +837,7 @@ class Blob(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/json_api/v1/objects
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: The media link for the blob or ``None`` if the property is
                   not set locally.
         """
@@ -898,7 +898,7 @@ class Blob(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/json_api/v1/objects
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: The self link for the blob or ``None`` if the property is
                   not set locally.
         """
@@ -924,7 +924,7 @@ class Blob(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/storage-classes
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: If set, one of "MULTI_REGIONAL", "REGIONAL",
                   "NEARLINE", "COLDLINE", "STANDARD", or
                   "DURABLE_REDUCED_AVAILABILITY", else ``None``.

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -193,7 +193,7 @@ class Bucket(_PropertyMixin):
         :type bucket_name: string
         :param bucket_name: The bucket name in the path.
 
-        :rtype: string
+        :rtype: str
         :returns: The relative URL path for ``bucket_name``.
         """
         return '/b/' + bucket_name
@@ -541,7 +541,7 @@ class Bucket(_PropertyMixin):
         See: http://tools.ietf.org/html/rfc2616#section-3.11 and
              https://cloud.google.com/storage/docs/json_api/v1/buckets
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: The bucket etag or ``None`` if the property is not
                   set locally.
         """
@@ -553,7 +553,7 @@ class Bucket(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/json_api/v1/buckets
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: The ID of the bucket or ``None`` if the property is not
                   set locally.
         """
@@ -584,7 +584,7 @@ class Bucket(_PropertyMixin):
 
     If the property is not set locally, returns ``None``.
 
-    :rtype: string or ``NoneType``
+    :rtype: str or ``NoneType``
     """
 
     def get_logging(self):
@@ -666,7 +666,7 @@ class Bucket(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/json_api/v1/buckets
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: The self link for the bucket or ``None`` if the property is
                   not set locally.
         """
@@ -678,7 +678,7 @@ class Bucket(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/storage-classes
 
-        :rtype: string or ``NoneType``
+        :rtype: str or ``NoneType``
         :returns: If set, one of "MULTI_REGIONAL", "REGIONAL",
                   "NEARLINE", "COLDLINE", "STANDARD", or
                   "DURABLE_REDUCED_AVAILABILITY", else ``None``.

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -134,7 +134,7 @@ class Bucket(_PropertyMixin):
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the current bucket.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: True if the bucket exists in Cloud Storage.
         """
         client = self._require_client(client)
@@ -720,7 +720,7 @@ class Bucket(_PropertyMixin):
         See:  https://cloud.google.com/storage/docs/object-versioning for
         details.
 
-        :rtype: boolean
+        :rtype: bool
         :returns: True if enabled, else False.
         """
         versioning = self._properties.get('versioning', {})

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -74,7 +74,7 @@ class Bucket(_PropertyMixin):
     :param client: A client which holds credentials and project configuration
                    for the bucket (which requires a project).
 
-    :type name: string
+    :type name: str
     :param name: The name of the bucket.
     """
 
@@ -108,7 +108,7 @@ class Bucket(_PropertyMixin):
           This will not make an HTTP request; it simply instantiates
           a blob object owned by this bucket.
 
-        :type blob_name: string
+        :type blob_name: str
         :param blob_name: The name of the blob to be instantiated.
 
         :type chunk_size: integer
@@ -190,7 +190,7 @@ class Bucket(_PropertyMixin):
     def path_helper(bucket_name):
         """Relative URL path for a bucket.
 
-        :type bucket_name: string
+        :type bucket_name: str
         :param bucket_name: The bucket name in the path.
 
         :rtype: str
@@ -219,7 +219,7 @@ class Bucket(_PropertyMixin):
           >>> print(bucket.get_blob('/does-not-exist.txt'))
           None
 
-        :type blob_name: string
+        :type blob_name: str
         :param blob_name: The name of the blob to retrieve.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -386,7 +386,7 @@ class Bucket(_PropertyMixin):
           ... except NotFound:
           ...   pass
 
-        :type blob_name: string
+        :type blob_name: str
         :param blob_name: A blob name to delete.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -452,7 +452,7 @@ class Bucket(_PropertyMixin):
         :param destination_bucket: The bucket into which the blob should be
                                    copied.
 
-        :type new_name: string
+        :type new_name: str
         :param new_name: (optional) the new name for the copied file.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -494,7 +494,7 @@ class Bucket(_PropertyMixin):
         :type blob: :class:`google.cloud.storage.blob.Blob`
         :param blob: The blob to be renamed.
 
-        :type new_name: string
+        :type new_name: str
         :param new_name: The new name for this blob.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -604,10 +604,10 @@ class Bucket(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/accesslogs#delivery
 
-        :type bucket_name: string
+        :type bucket_name: str
         :param bucket_name: name of bucket in which to store access logs
 
-        :type object_prefix: string
+        :type object_prefix: str
         :param object_prefix: prefix for access log filenames
         """
         info = {'logBucket': bucket_name, 'logObjectPrefix': object_prefix}
@@ -691,7 +691,7 @@ class Bucket(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/storage-classes
 
-        :type value: string
+        :type value: str
         :param value: one of "MULTI_REGIONAL", "REGIONAL", "NEARLINE",
                       "COLDLINE", "STANDARD", or "DURABLE_REDUCED_AVAILABILITY"
         """
@@ -764,12 +764,12 @@ class Bucket(_PropertyMixin):
         the bucket, and anything else I add to the bucket.  Just make it
         all public."
 
-        :type main_page_suffix: string
+        :type main_page_suffix: str
         :param main_page_suffix: The page to use as the main page
                                  of a directory.
                                  Typically something like index.html.
 
-        :type not_found_page: string
+        :type not_found_page: str
         :param not_found_page: The file to use when a page isn't found.
         """
         data = {

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -331,7 +331,7 @@ class Bucket(_PropertyMixin):
         is to prevent accidental bucket deletion and to prevent extremely long
         runtime of this method.
 
-        :type force: boolean
+        :type force: bool
         :param force: If True, empties the bucket's objects then deletes it.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -793,11 +793,11 @@ class Bucket(_PropertyMixin):
         objects / blobs this will cowardly refuse to make the objects public.
         This is to prevent extremely long runtime of this method.
 
-        :type recursive: boolean
+        :type recursive: bool
         :param recursive: If True, this will make all blobs inside the bucket
                           public as well.
 
-        :type future: boolean
+        :type future: bool
         :param future: If True, this will make all objects created in the
                        future public as well.
 

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -27,7 +27,7 @@ from google.cloud.storage.connection import Connection
 class Client(JSONClient):
     """Client to bundle configuration needed for API requests.
 
-    :type project: string
+    :type project: str
     :param project: the project which the client acts on behalf of. Will be
                     passed when creating a topic.  If not passed,
                     falls back to the default inferred from the environment.
@@ -121,7 +121,7 @@ class Client(JSONClient):
           This will not make an HTTP request; it simply instantiates
           a bucket object owned by this client.
 
-        :type bucket_name: string
+        :type bucket_name: str
         :param bucket_name: The name of the bucket to be instantiated.
 
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
@@ -156,7 +156,7 @@ class Client(JSONClient):
 
         This implements "storage.buckets.get".
 
-        :type bucket_name: string
+        :type bucket_name: str
         :param bucket_name: The name of the bucket to get.
 
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
@@ -180,7 +180,7 @@ class Client(JSONClient):
           >>> print(bucket)
           <Bucket: my-bucket>
 
-        :type bucket_name: string
+        :type bucket_name: str
         :param bucket_name: The name of the bucket to get.
 
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
@@ -205,7 +205,7 @@ class Client(JSONClient):
         If the bucket already exists, will raise
         :class:`google.cloud.exceptions.Conflict`.
 
-        :type bucket_name: string
+        :type bucket_name: str
         :param bucket_name: The bucket name to create.
 
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
@@ -230,20 +230,20 @@ class Client(JSONClient):
         :type max_results: integer or ``NoneType``
         :param max_results: Optional. Maximum number of buckets to return.
 
-        :type page_token: string or ``NoneType``
+        :type page_token: str or ``NoneType``
         :param page_token: Optional. Opaque marker for the next "page" of
                            buckets. If not passed, will return the first page
                            of buckets.
 
-        :type prefix: string or ``NoneType``
+        :type prefix: str or ``NoneType``
         :param prefix: Optional. Filter results to buckets whose names begin
                        with this prefix.
 
-        :type projection: string or ``NoneType``
+        :type projection: str or ``NoneType``
         :param projection: If used, must be 'full' or 'noAcl'. Defaults to
                            'noAcl'. Specifies the set of properties to return.
 
-        :type fields: string or ``NoneType``
+        :type fields: str or ``NoneType``
         :param fields: Selector specifying which fields to include in a
                        partial response. Must be a list of fields. For example
                        to get a partial response with just the next page token

--- a/vision/google/cloud/vision/connection.py
+++ b/vision/google/cloud/vision/connection.py
@@ -29,7 +29,7 @@ class Connection(base_connection.JSONConnection):
     :type http: :class:`httplib2.Http` or class that defines ``request()``.
     :param http: (Optional) HTTP object to make requests.
 
-    :type api_base_url: string
+    :type api_base_url: str
     :param api_base_url: The base of the API call URL. Defaults to the value
                          :attr:`Connection.API_BASE_URL`.
     """


### PR DESCRIPTION
Based on this comment: https://github.com/GoogleCloudPlatform/google-cloud-python/pull/2485#discussion_r83267163

For rtypes, used the command:

    ag -l 'rtype: string' | xargs sed -i .bak 's/rtype: string/rtype: str/g'

For types, used the command:

    ag -l 'type ([^:]+): string' | \
        xargs gsed -r -i.bak -e 's/type ([^:]+): string/type \1: str/g'

Note: [-r for gsed (GNU sed) is needed for group matching](http://superuser.com/a/336819/125262).