### PR TITLE
Replace :: with `.. code-block:: console`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ If you need support for other Google APIs, check out the
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud
 

--- a/bigquery/README.rst
+++ b/bigquery/README.rst
@@ -12,7 +12,7 @@ Python Client for Google BigQuery
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-bigquery
 

--- a/bigtable/README.rst
+++ b/bigtable/README.rst
@@ -12,7 +12,7 @@ Python Client for Google Cloud Bigtable
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-bigtable
 

--- a/core/README.rst
+++ b/core/README.rst
@@ -12,6 +12,6 @@ used by all of the ``google-cloud-*``.
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-core

--- a/datastore/README.rst
+++ b/datastore/README.rst
@@ -12,7 +12,7 @@ Python Client for Google Cloud Datastore
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-datastore
 

--- a/dns/README.rst
+++ b/dns/README.rst
@@ -12,7 +12,7 @@ Python Client for Google Cloud DNS
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-dns
 

--- a/error_reporting/README.rst
+++ b/error_reporting/README.rst
@@ -12,7 +12,7 @@ Python Client for Stackdriver Error Reporting
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-error-reporting
 

--- a/language/README.rst
+++ b/language/README.rst
@@ -12,7 +12,7 @@ Python Client for Google Cloud Natural Language
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-language
     $ # OR

--- a/logging/README.rst
+++ b/logging/README.rst
@@ -12,7 +12,7 @@ Python Client for Stackdriver Logging
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-logging
 

--- a/monitoring/README.rst
+++ b/monitoring/README.rst
@@ -12,7 +12,7 @@ Python Client for Stackdriver Monitoring
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-monitoring
 

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -12,7 +12,7 @@ Python Client for Google Cloud Pub / Sub
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-pubsub
 

--- a/resource_manager/README.rst
+++ b/resource_manager/README.rst
@@ -12,7 +12,7 @@ Python Client for Google Cloud Resource Manager
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-resource-manager
 

--- a/speech/README.rst
+++ b/speech/README.rst
@@ -12,7 +12,7 @@ Python Client for Google Cloud Speech
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-speech
 

--- a/storage/README.rst
+++ b/storage/README.rst
@@ -12,7 +12,7 @@ Python Client for Google Cloud Storage
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-storage
 

--- a/translate/README.rst
+++ b/translate/README.rst
@@ -12,7 +12,7 @@ Python Client for Google Translate
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-translate
 

--- a/vision/README.rst
+++ b/vision/README.rst
@@ -12,7 +12,7 @@ Python Client for Google Cloud Vision
 Quick Start
 -----------
 
-::
+.. code-block:: console
 
     $ pip install --upgrade google-cloud-vision
 


### PR DESCRIPTION
Towards #2404.

FYI doing this at @jonparrott's request (not because `::` is invalid RST)