### PR TITLE
Remove None & NoneType from parameter types in docstrings.

### DIFF
--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -216,8 +216,8 @@ class Dataset(object):
     def default_table_expiration_ms(self, value):
         """Update default expiration time for tables in the dataset.
 
-        :type value: int, or ``NoneType``
-        :param value: new default time, in milliseconds
+        :type value: int
+        :param value: (Optional) new default time, in milliseconds
 
         :raises: ValueError for invalid value types.
         """
@@ -238,8 +238,8 @@ class Dataset(object):
     def description(self, value):
         """Update description of the dataset.
 
-        :type value: str, or ``NoneType``
-        :param value: new description
+        :type value: str
+        :param value: (Optional) new description
 
         :raises: ValueError for invalid value types.
         """
@@ -260,8 +260,8 @@ class Dataset(object):
     def friendly_name(self, value):
         """Update title of the dataset.
 
-        :type value: str, or ``NoneType``
-        :param value: new title
+        :type value: str
+        :param value: (Optional) new title
 
         :raises: ValueError for invalid value types.
         """
@@ -282,8 +282,8 @@ class Dataset(object):
     def location(self, value):
         """Update location in which the dataset is hosted.
 
-        :type value: str, or ``NoneType``
-        :param value: new location
+        :type value: str
+        :param value: (Optional) new location
 
         :raises: ValueError for invalid value types.
         """

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -349,14 +349,15 @@ class QueryResults(object):
         :param max_results: (Optional) maximum number of rows to return.
 
         :type page_token: str
-        :param page_token: (Optional) token representing a cursor into the table's rows.
+        :param page_token:
+            (Optional) token representing a cursor into the table's rows.
 
         :type start_index: int
         :param start_index: (Optional) zero-based index of starting row
 
         :type timeout_ms: int
-        :param timeout_ms: (Optional) timeout, in milliseconds, to wait for query to
-                           complete
+        :param timeout_ms:
+            (Optional) timeout, in milliseconds, to wait for query to complete
 
         :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -345,17 +345,17 @@ class QueryResults(object):
         See:
         https://cloud.google.com/bigquery/docs/reference/v2/jobs/getQueryResults
 
-        :type max_results: int or ``NoneType``
-        :param max_results: maximum number of rows to return.
+        :type max_results: int
+        :param max_results: (Optional) maximum number of rows to return.
 
-        :type page_token: str or ``NoneType``
-        :param page_token: token representing a cursor into the table's rows.
+        :type page_token: str
+        :param page_token: (Optional) token representing a cursor into the table's rows.
 
-        :type start_index: int or ``NoneType``
-        :param start_index: zero-based index of starting row
+        :type start_index: int
+        :param start_index: (Optional) zero-based index of starting row
 
-        :type timeout_ms: int or ``NoneType``
-        :param timeout_ms: timeout, in milliseconds, to wait for query to
+        :type timeout_ms: int
+        :param timeout_ms: (Optional) timeout, in milliseconds, to wait for query to
                            complete
 
         :type client: :class:`~google.cloud.bigquery.client.Client` or

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -264,8 +264,8 @@ class Table(object):
     def description(self, value):
         """Update description of the table.
 
-        :type value: str, or ``NoneType``
-        :param value: new description
+        :type value: str
+        :param value: (Optional) new description
 
         :raises: ValueError for invalid value types.
         """
@@ -289,8 +289,8 @@ class Table(object):
     def expires(self, value):
         """Update datetime at which the table will be removed.
 
-        :type value: ``datetime.datetime``, or ``NoneType``
-        :param value: the new expiration time, or None
+        :type value: ``datetime.datetime``
+        :param value: (Optional) the new expiration time, or None
         """
         if not isinstance(value, datetime.datetime) and value is not None:
             raise ValueError("Pass a datetime, or None")
@@ -309,8 +309,8 @@ class Table(object):
     def friendly_name(self, value):
         """Update title of the table.
 
-        :type value: str, or ``NoneType``
-        :param value: new title
+        :type value: str
+        :param value: (Optional) new title
 
         :raises: ValueError for invalid value types.
         """
@@ -331,8 +331,8 @@ class Table(object):
     def location(self, value):
         """Update location in which the table is hosted.
 
-        :type value: str, or ``NoneType``
-        :param value: new location
+        :type value: str
+        :param value: (Optional) new location
 
         :raises: ValueError for invalid value types.
         """
@@ -554,17 +554,17 @@ class Table(object):
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
 
-        :type friendly_name: str or ``NoneType``
-        :param friendly_name: point in time at which the table expires.
+        :type friendly_name: str
+        :param friendly_name: (Optional) point in time at which the table expires.
 
-        :type description: str or ``NoneType``
-        :param description: point in time at which the table expires.
+        :type description: str
+        :param description: (Optional) point in time at which the table expires.
 
-        :type location: str or ``NoneType``
-        :param location: point in time at which the table expires.
+        :type location: str
+        :param location: (Optional) point in time at which the table expires.
 
-        :type expires: :class:`datetime.datetime` or ``NoneType``
-        :param expires: point in time at which the table expires.
+        :type expires: :class:`datetime.datetime`
+        :param expires: (Optional) point in time at which the table expires.
 
         :type view_query: str
         :param view_query: SQL query defining the table as a view
@@ -654,11 +654,12 @@ class Table(object):
            incomplete.  To ensure that the local copy of the schema is
            up-to-date, call the table's ``reload`` method.
 
-        :type max_results: int or ``NoneType``
-        :param max_results: maximum number of rows to return.
+        :type max_results: int
+        :param max_results: (Optional) maximum number of rows to return.
 
-        :type page_token: str or ``NoneType``
-        :param page_token: token representing a cursor into the table's rows.
+        :type page_token: str
+        :param page_token:
+            (Optional) token representing a cursor into the table's rows.
 
         :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``
@@ -714,18 +715,18 @@ class Table(object):
         :param row_ids: Unique ids, one per row being inserted.  If not
                         passed, no de-duplication occurs.
 
-        :type skip_invalid_rows: bool or ``NoneType``
-        :param skip_invalid_rows: skip rows w/ invalid data?
+        :type skip_invalid_rows: bool
+        :param skip_invalid_rows: (Optional) skip rows w/ invalid data?
 
-        :type ignore_unknown_values: bool or ``NoneType``
-        :param ignore_unknown_values: ignore columns beyond schema?
+        :type ignore_unknown_values: bool
+        :param ignore_unknown_values: (Optional) ignore columns beyond schema?
 
-        :type template_suffix: str or ``NoneType``
-        :param template_suffix: treat ``name`` as a template table and provide
-                                a suffix. BigQuery will create the table
-                                ``<name> + <template_suffix>`` based on the
-                                schema of the template table. See:
-                                https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables
+        :type template_suffix: str
+        :param template_suffix:
+            (Optional) treat ``name`` as a template table and provide a suffix.
+            BigQuery will create the table ``<name> + <template_suffix>`` based
+            on the schema of the template table. See:
+            https://cloud.google.com/bigquery/streaming-data-into-bigquery#template-tables
 
         :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -555,13 +555,14 @@ class Table(object):
                        ``client`` stored on the current dataset.
 
         :type friendly_name: str
-        :param friendly_name: (Optional) point in time at which the table expires.
+        :param friendly_name: (Optional) a descriptive name for this table.
 
         :type description: str
-        :param description: (Optional) point in time at which the table expires.
+        :param description: (Optional) a description of this table.
 
         :type location: str
-        :param location: (Optional) point in time at which the table expires.
+        :param location:
+            (Optional) the geographic location where the table resides.
 
         :type expires: :class:`datetime.datetime`
         :param expires: (Optional) point in time at which the table expires.

--- a/core/google/cloud/_helpers.py
+++ b/core/google/cloud/_helpers.py
@@ -366,8 +366,8 @@ def _microseconds_from_datetime(value):
 def _millis_from_datetime(value):
     """Convert non-none datetime to timestamp, assuming UTC.
 
-    :type value: :class:`datetime.datetime`, or None
-    :param value: the timestamp
+    :type value: :class:`datetime.datetime`
+    :param value: (Optional) the timestamp
 
     :rtype: int, or ``NoneType``
     :returns: the timestamp, in milliseconds, or None
@@ -554,8 +554,8 @@ def _name_from_project_path(path, project, template):
     :type path: str
     :param path: URI path containing the name.
 
-    :type project: str or NoneType
-    :param project: The project associated with the request. It is
+    :type project: str
+    :param project: (Optional) The project associated with the request. It is
                     included for validation purposes.  If passed as None,
                     disables validation.
 

--- a/core/google/cloud/connection.py
+++ b/core/google/cloud/connection.py
@@ -214,8 +214,8 @@ class JSONConnection(Connection):
         :type headers: dict
         :param headers: A dictionary of HTTP headers to send with the request.
 
-        :type target_object: object or :class:`NoneType`
-        :param target_object: Argument to be used by library callers.
+        :type target_object: object
+        :param target_object: (Optional) Argument to be used by library callers.
                               This can allow custom behavior, for example, to
                               defer an HTTP request and complete initialization
                               of the object at a later time.
@@ -261,8 +261,8 @@ class JSONConnection(Connection):
         :type data: str
         :param data: The data to send as the body of the request.
 
-        :type target_object: object or :class:`NoneType`
-        :param target_object: Unused ``target_object`` here but may be used
+        :type target_object: object
+        :param target_object: (Optional) Unused ``target_object`` here but may be used
                               by a superclass.
 
         :rtype: tuple of ``response`` (a dictionary of sorts)
@@ -323,8 +323,8 @@ class JSONConnection(Connection):
                             response as JSON and raise an exception if
                             that cannot be done.  Default is True.
 
-        :type _target_object: :class:`object` or :class:`NoneType`
-        :param _target_object: Protected argument to be used by library
+        :type _target_object: :class:`object`
+        :param _target_object: (Optional) Protected argument to be used by library
                                callers. This can allow custom behavior, for
                                example, to defer an HTTP request and complete
                                initialization of the object at a later time.

--- a/core/google/cloud/connection.py
+++ b/core/google/cloud/connection.py
@@ -215,10 +215,10 @@ class JSONConnection(Connection):
         :param headers: A dictionary of HTTP headers to send with the request.
 
         :type target_object: object
-        :param target_object: (Optional) Argument to be used by library callers.
-                              This can allow custom behavior, for example, to
-                              defer an HTTP request and complete initialization
-                              of the object at a later time.
+        :param target_object:
+            (Optional) Argument to be used by library callers.  This can allow
+            custom behavior, for example, to defer an HTTP request and complete
+            initialization of the object at a later time.
 
         :rtype: tuple of ``response`` (a dictionary of sorts)
                 and ``content`` (a string).
@@ -262,8 +262,9 @@ class JSONConnection(Connection):
         :param data: The data to send as the body of the request.
 
         :type target_object: object
-        :param target_object: (Optional) Unused ``target_object`` here but may be used
-                              by a superclass.
+        :param target_object:
+            (Optional) Unused ``target_object`` here but may be used by a
+            superclass.
 
         :rtype: tuple of ``response`` (a dictionary of sorts)
                 and ``content`` (a string).
@@ -324,10 +325,10 @@ class JSONConnection(Connection):
                             that cannot be done.  Default is True.
 
         :type _target_object: :class:`object`
-        :param _target_object: (Optional) Protected argument to be used by library
-                               callers. This can allow custom behavior, for
-                               example, to defer an HTTP request and complete
-                               initialization of the object at a later time.
+        :param _target_object:
+            (Optional) Protected argument to be used by library callers. This
+            can allow custom behavior, for example, to defer an HTTP request
+            and complete initialization of the object at a later time.
 
         :raises: Exception if the response code is not 200 OK.
         :rtype: dict or str

--- a/core/google/cloud/streaming/buffered_stream.py
+++ b/core/google/cloud/streaming/buffered_stream.py
@@ -81,8 +81,8 @@ class BufferedStream(object):
     def read(self, size=None):
         """Read bytes from the buffer.
 
-        :type size: int or None
-        :param size: How many bytes to read (defaults to all remaining bytes).
+        :type size: int
+        :param size: (Optional) How many bytes to read (defaults to all remaining bytes).
 
         :rtype: str
         :returns: The data read from the stream.

--- a/core/google/cloud/streaming/buffered_stream.py
+++ b/core/google/cloud/streaming/buffered_stream.py
@@ -82,7 +82,9 @@ class BufferedStream(object):
         """Read bytes from the buffer.
 
         :type size: int
-        :param size: (Optional) How many bytes to read (defaults to all remaining bytes).
+        :param size:
+            (Optional) How many bytes to read (defaults to all remaining
+            bytes).
 
         :rtype: str
         :returns: The data read from the stream.

--- a/core/google/cloud/streaming/http_wrapper.py
+++ b/core/google/cloud/streaming/http_wrapper.py
@@ -81,7 +81,8 @@ def _httplib2_debug_level(http_request, level, http=None):
     :param level: the debuglevel for logging.
 
     :type http: :class:`httplib2.Http`
-    :param http: (Optional) the instance on whose connections to set the debuglevel.
+    :param http:
+        (Optional) the instance on whose connections to set the debuglevel.
     """
     if http_request.loggable_body is None:
         yield

--- a/core/google/cloud/streaming/http_wrapper.py
+++ b/core/google/cloud/streaming/http_wrapper.py
@@ -80,8 +80,8 @@ def _httplib2_debug_level(http_request, level, http=None):
     :type level: int
     :param level: the debuglevel for logging.
 
-    :type http: :class:`httplib2.Http`, or ``None``
-    :param http: the instance on whose connections to set the debuglevel.
+    :type http: :class:`httplib2.Http`
+    :param http: (Optional) the instance on whose connections to set the debuglevel.
     """
     if http_request.loggable_body is None:
         yield
@@ -115,8 +115,8 @@ class Request(object):
     :type http_method: str
     :param http_method: the HTTP method to use for the request
 
-    :type headers: mapping or None
-    :param headers: headers to be sent with the request
+    :type headers: mapping
+    :param headers: (Optional) headers to be sent with the request
 
     :type body: str
     :param body: body to be sent with the request

--- a/core/google/cloud/streaming/stream_slice.py
+++ b/core/google/cloud/streaming/stream_slice.py
@@ -66,7 +66,9 @@ class StreamSlice(object):
         raise :exc:`IncompleteRead`.
 
         :type size: int
-        :param size: (Optional) If provided, read no more than size bytes from the stream.
+        :param size:
+            (Optional) If provided, read no more than size bytes from the
+            stream.
 
         :rtype: bytes
         :returns: bytes read from this slice.

--- a/core/google/cloud/streaming/stream_slice.py
+++ b/core/google/cloud/streaming/stream_slice.py
@@ -65,8 +65,8 @@ class StreamSlice(object):
         slice indicates we should still be able to read more bytes, we
         raise :exc:`IncompleteRead`.
 
-        :type size: int or None
-        :param size: If provided, read no more than size bytes from the stream.
+        :type size: int
+        :param size: (Optional) If provided, read no more than size bytes from the stream.
 
         :rtype: bytes
         :returns: bytes read from this slice.

--- a/core/google/cloud/streaming/transfer.py
+++ b/core/google/cloud/streaming/transfer.py
@@ -670,7 +670,8 @@ class Upload(_Transfer):
         :param mime_type:  MIMEtype of the file being uploaded
 
         :type auto_transfer: bool
-        :param auto_transfer: (Optional) should the transfer be started immediately
+        :param auto_transfer:
+            (Optional) should the transfer be started immediately
 
         :type kwds: dict
         :param kwds:  keyword arguments:  passed
@@ -704,7 +705,8 @@ class Upload(_Transfer):
         :param total_size: (Optional)  Size of the file being uploaded
 
         :type auto_transfer: bool
-        :param auto_transfer: (Optional) should the transfer be started immediately
+        :param auto_transfer:
+            (Optional) should the transfer be started immediately
 
         :type kwds: dict
         :param kwds:  keyword arguments:  passed

--- a/core/google/cloud/streaming/transfer.py
+++ b/core/google/cloud/streaming/transfer.py
@@ -280,8 +280,8 @@ class Download(_Transfer):
         :type stream: writable file-like object
         :param stream: the target file
 
-        :type total_size: int or None
-        :param total_size: total size of the file to be downloaded
+        :type total_size: int
+        :param total_size: (Optional) total size of the file to be downloaded
 
         :type auto_transfer: bool
         :param auto_transfer: should the transfer be started immediately
@@ -457,8 +457,8 @@ class Download(_Transfer):
         :type start: int
         :param start: start byte of the range.
 
-        :type end: int or None
-        :param end: suggested last byte of the range.
+        :type end: int
+        :param end: (Optional) suggested last byte of the range.
 
         :type use_chunks: bool
         :param use_chunks: If False, ignore :attr:`chunksize`.
@@ -493,8 +493,8 @@ class Download(_Transfer):
         :type start: int
         :param start: start byte of the range.
 
-        :type end: int or None
-        :param end: end byte of the range.
+        :type end: int
+        :param end: (Optional) end byte of the range.
 
         :rtype: :class:`google.cloud.streaming.http_wrapper.Response`
         :returns: response from the chunk request.
@@ -555,8 +555,8 @@ class Download(_Transfer):
         :type start: int
         :param start: Where to start fetching bytes. (See above.)
 
-        :type end: int or ``None``
-        :param end: Where to stop fetching bytes. (See above.)
+        :type end: int
+        :param end: (Optional) Where to stop fetching bytes. (See above.)
 
         :type use_chunks: bool
         :param use_chunks: If False, ignore :attr:`chunksize`
@@ -625,8 +625,8 @@ class Upload(_Transfer):
     :type mime_type: str:
     :param mime_type: MIME type of the upload.
 
-    :type total_size: int or None
-    :param total_size: Total upload size for the stream.
+    :type total_size: int
+    :param total_size: (Optional) Total upload size for the stream.
 
     :type http: :class:`httplib2.Http` (or workalike)
     :param http: Http instance used to perform requests.
@@ -669,8 +669,8 @@ class Upload(_Transfer):
         :type mime_type: str
         :param mime_type:  MIMEtype of the file being uploaded
 
-        :type auto_transfer: bool or None
-        :param auto_transfer: should the transfer be started immediately
+        :type auto_transfer: bool
+        :param auto_transfer: (Optional) should the transfer be started immediately
 
         :type kwds: dict
         :param kwds:  keyword arguments:  passed
@@ -700,11 +700,11 @@ class Upload(_Transfer):
         :type mime_type: str
         :param mime_type:  MIMEtype of the file being uploaded
 
-        :type total_size: int or None
-        :param total_size:  Size of the file being uploaded
+        :type total_size: int
+        :param total_size: (Optional)  Size of the file being uploaded
 
-        :type auto_transfer: bool or None
-        :param auto_transfer: should the transfer be started immediately
+        :type auto_transfer: bool
+        :param auto_transfer: (Optional) should the transfer be started immediately
 
         :type kwds: dict
         :param kwds:  keyword arguments:  passed
@@ -784,8 +784,8 @@ class Upload(_Transfer):
     def total_size(self, value):
         """Update total size of the stream to be uploaded.
 
-        :type value: int or None
-        :param value: the size
+        :type value: int
+        :param value: (Optional) the size
         """
         self._ensure_uninitialized()
         self._total_size = value
@@ -1048,8 +1048,8 @@ class Upload(_Transfer):
 
         Helper for :meth:`stream_file`.
 
-        :type chunksize: int or None
-        :param chunksize: the chunk size to be tested.
+        :type chunksize: int
+        :param chunksize: (Optional) the chunk size to be tested.
 
         :raises: :exc:`ValueError` if ``chunksize`` is not a multiple
                  of the server-specified granulariy.

--- a/datastore/google/cloud/datastore/connection.py
+++ b/datastore/google/cloud/datastore/connection.py
@@ -569,8 +569,8 @@ class Connection(connection_module.Connection):
         :type request: :class:`._generated.datastore_pb2.CommitRequest`
         :param request: The protobuf with the mutations being committed.
 
-        :type transaction_id: str or None
-        :param transaction_id: The transaction ID returned from
+        :type transaction_id: str
+        :param transaction_id: (Optional) The transaction ID returned from
                                :meth:`begin_transaction`.  Non-transactional
                                batches must pass ``None``.
 

--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -388,8 +388,8 @@ def _validate_project(project, parent):
     :type project: str
     :param project: A project.
 
-    :type parent: :class:`google.cloud.datastore.key.Key` or ``NoneType``
-    :param parent: The parent of the key or ``None``.
+    :type parent: :class:`google.cloud.datastore.key.Key`
+    :param parent: (Optional) The parent of the key or ``None``.
 
     :rtype: str
     :returns: The ``project`` passed in, or implied from the environment.

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -38,12 +38,12 @@ class Query(object):
     :param project: The project associated with the query.  If not passed,
                     uses the client's value.
 
-    :type namespace: str or None
-    :param namespace: The namespace to which to restrict results.  If not
+    :type namespace: str
+    :param namespace: (Optional) The namespace to which to restrict results.  If not
                       passed, uses the client's value.
 
-    :type ancestor: :class:`google.cloud.datastore.key.Key` or None
-    :param ancestor: key of the ancestor to which this query's results are
+    :type ancestor: :class:`google.cloud.datastore.key.Key`
+    :param ancestor: (Optional) key of the ancestor to which this query's results are
                      restricted.
 
     :type filters: sequence of (property_name, operator, value) tuples
@@ -327,8 +327,8 @@ class Query(object):
           >>> list(query.fetch(1))
           [<Entity object>]
 
-        :type limit: int or None
-        :param limit: An optional limit passed through to the iterator.
+        :type limit: int
+        :param limit: (Optional) An optional limit passed through to the iterator.
 
         :type offset: int
         :param offset: An optional offset passed through to the iterator.

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -35,16 +35,19 @@ class Query(object):
     :param kind: The kind to query.
 
     :type project: str
-    :param project: The project associated with the query.  If not passed,
-                    uses the client's value.
+    :param project:
+        (Optional) The project associated with the query.  If not passed, uses
+        the client's value.
 
     :type namespace: str
-    :param namespace: (Optional) The namespace to which to restrict results.  If not
-                      passed, uses the client's value.
+    :param namespace:
+        (Optional) The namespace to which to restrict results.  If not passed,
+        uses the client's value.
 
     :type ancestor: :class:`google.cloud.datastore.key.Key`
-    :param ancestor: (Optional) key of the ancestor to which this query's results are
-                     restricted.
+    :param ancestor:
+        (Optional) key of the ancestor to which this query's results are
+        restricted.
 
     :type filters: sequence of (property_name, operator, value) tuples
     :param filters: property filters applied by this query.
@@ -328,16 +331,16 @@ class Query(object):
           [<Entity object>]
 
         :type limit: int
-        :param limit: (Optional) An optional limit passed through to the iterator.
+        :param limit: (Optional) limit passed through to the iterator.
 
         :type offset: int
-        :param offset: An optional offset passed through to the iterator.
+        :param offset: (Optional) offset passed through to the iterator.
 
         :type start_cursor: bytes
-        :param start_cursor: An optional cursor passed through to the iterator.
+        :param start_cursor: (Optional) cursor passed through to the iterator.
 
         :type end_cursor: bytes
-        :param end_cursor: An optional cursor passed through to the iterator.
+        :param end_cursor: (Optional) cursor passed through to the iterator.
 
         :type client: :class:`google.cloud.datastore.client.Client`
         :param client: client used to connect to datastore.

--- a/dns/google/cloud/dns/changes.py
+++ b/dns/google/cloud/dns/changes.py
@@ -170,8 +170,9 @@ class Changes(object):
         """Check client or verify over-ride.
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
 
         :rtype: :class:`google.cloud.dns.client.Client`
         :returns: The client passed in or the currently bound client.
@@ -208,8 +209,9 @@ class Changes(object):
         https://cloud.google.com/dns/api/v1/changes/create
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
         """
         if len(self.additions) == 0 and len(self.deletions) == 0:
             raise ValueError("No record sets added or deleted")
@@ -227,8 +229,9 @@ class Changes(object):
         https://cloud.google.com/dns/api/v1/changes/get
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
 
         :rtype: bool
         :returns: Boolean indicating existence of the changes.
@@ -249,8 +252,9 @@ class Changes(object):
         https://cloud.google.com/dns/api/v1/changes/get
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
         """
         client = self._require_client(client)
 

--- a/dns/google/cloud/dns/changes.py
+++ b/dns/google/cloud/dns/changes.py
@@ -169,8 +169,8 @@ class Changes(object):
     def _require_client(self, client):
         """Check client or verify over-ride.
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
 
         :rtype: :class:`google.cloud.dns.client.Client`
@@ -207,8 +207,8 @@ class Changes(object):
         See:
         https://cloud.google.com/dns/api/v1/changes/create
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
         """
         if len(self.additions) == 0 and len(self.deletions) == 0:
@@ -226,8 +226,8 @@ class Changes(object):
         See
         https://cloud.google.com/dns/api/v1/changes/get
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
 
         :rtype: bool
@@ -248,8 +248,8 @@ class Changes(object):
         See
         https://cloud.google.com/dns/api/v1/changes/get
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
         """
         client = self._require_client(client)

--- a/dns/google/cloud/dns/client.py
+++ b/dns/google/cloud/dns/client.py
@@ -92,12 +92,14 @@ class Client(JSONClient):
         :param name: Name of the zone.
 
         :type dns_name: str
-        :param dns_name: (Optional) DNS name of the zone.  If not passed, then calls
-                         to :meth:`zone.create` will fail.
+        :param dns_name:
+            (Optional) DNS name of the zone.  If not passed, then calls to
+            :meth:`zone.create` will fail.
 
         :type description: str
-        :param description: (Optional) the description for the zone.  If not passed,
-                            defaults to the value of 'dns_name'.
+        :param description:
+            (Optional) the description for the zone.  If not passed, defaults
+            to the value of 'dns_name'.
 
         :rtype: :class:`google.cloud.dns.zone.ManagedZone`
         :returns: a new ``ManagedZone`` instance.

--- a/dns/google/cloud/dns/client.py
+++ b/dns/google/cloud/dns/client.py
@@ -91,12 +91,12 @@ class Client(JSONClient):
         :type name: str
         :param name: Name of the zone.
 
-        :type dns_name: str or :class:`NoneType`
-        :param dns_name: DNS name of the zone.  If not passed, then calls
+        :type dns_name: str
+        :param dns_name: (Optional) DNS name of the zone.  If not passed, then calls
                          to :meth:`zone.create` will fail.
 
-        :type description: str or :class:`NoneType`
-        :param description: the description for the zone.  If not passed,
+        :type description: str
+        :param description: (Optional) the description for the zone.  If not passed,
                             defaults to the value of 'dns_name'.
 
         :rtype: :class:`google.cloud.dns.zone.ManagedZone`

--- a/dns/google/cloud/dns/zone.py
+++ b/dns/google/cloud/dns/zone.py
@@ -32,16 +32,16 @@ class ManagedZone(object):
     :type name: str
     :param name: the name of the zone
 
-    :type dns_name: str or :class:`NoneType`
-    :param dns_name: the DNS name of the zone.  If not passed, then calls
+    :type dns_name: str
+    :param dns_name: (Optional) the DNS name of the zone.  If not passed, then calls
                      to :meth:`create` will fail.
 
     :type client: :class:`google.cloud.dns.client.Client`
     :param client: A client which holds credentials and project configuration
                    for the zone (which requires a project).
 
-    :type description: str or :class:`NoneType`
-    :param description: the description for the zone.  If not passed, defaults
+    :type description: str
+    :param description: (Optional) the description for the zone.  If not passed, defaults
                         to the value of 'dns_name'.
     """
 
@@ -135,8 +135,8 @@ class ManagedZone(object):
     def description(self, value):
         """Update description of the zone.
 
-        :type value: str, or ``NoneType``
-        :param value: new description
+        :type value: str
+        :param value: (Optional) new description
 
         :raises: ValueError for invalid value types.
         """
@@ -162,8 +162,8 @@ class ManagedZone(object):
     def name_server_set(self, value):
         """Update named set of DNS name servers.
 
-        :type value: str, or ``NoneType``
-        :param value: new title
+        :type value: str
+        :param value: (Optional) new title
 
         :raises: ValueError for invalid value types.
         """
@@ -202,8 +202,8 @@ class ManagedZone(object):
     def _require_client(self, client):
         """Check client or verify over-ride.
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
 
         :rtype: :class:`google.cloud.dns.client.Client`
@@ -250,8 +250,8 @@ class ManagedZone(object):
         See:
         https://cloud.google.com/dns/api/v1/managedZones/create
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
         """
         client = self._require_client(client)
@@ -266,8 +266,8 @@ class ManagedZone(object):
         See
         https://cloud.google.com/dns/api/v1/managedZones/get
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
 
         :rtype: bool
@@ -289,8 +289,8 @@ class ManagedZone(object):
         See
         https://cloud.google.com/dns/api/v1/managedZones/get
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
         """
         client = self._require_client(client)
@@ -305,8 +305,8 @@ class ManagedZone(object):
         See:
         https://cloud.google.com/dns/api/v1/managedZones/delete
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
         """
         client = self._require_client(client)
@@ -328,8 +328,8 @@ class ManagedZone(object):
                            not passed, the API will return the first page of
                            zones.
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
 
         :rtype: :class:`~google.cloud.iterator.Iterator`
@@ -361,8 +361,8 @@ class ManagedZone(object):
                            not passed, the API will return the first page of
                            zones.
 
-        :type client: :class:`google.cloud.dns.client.Client` or ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
+        :type client: :class:`google.cloud.dns.client.Client`
+        :param client: (Optional) the client to use.  If not passed, falls back to the
                        ``client`` stored on the current zone.
 
         :rtype: :class:`~google.cloud.iterator.Iterator`

--- a/dns/google/cloud/dns/zone.py
+++ b/dns/google/cloud/dns/zone.py
@@ -33,16 +33,18 @@ class ManagedZone(object):
     :param name: the name of the zone
 
     :type dns_name: str
-    :param dns_name: (Optional) the DNS name of the zone.  If not passed, then calls
-                     to :meth:`create` will fail.
+    :param dns_name:
+        (Optional) the DNS name of the zone.  If not passed, then calls to
+        :meth:`create` will fail.
 
     :type client: :class:`google.cloud.dns.client.Client`
     :param client: A client which holds credentials and project configuration
                    for the zone (which requires a project).
 
     :type description: str
-    :param description: (Optional) the description for the zone.  If not passed, defaults
-                        to the value of 'dns_name'.
+    :param description:
+        (Optional) the description for the zone.  If not passed, defaults to
+        the value of 'dns_name'.
     """
 
     def __init__(self, name, dns_name=None, client=None, description=None):
@@ -203,8 +205,9 @@ class ManagedZone(object):
         """Check client or verify over-ride.
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
 
         :rtype: :class:`google.cloud.dns.client.Client`
         :returns: The client passed in or the currently bound client.
@@ -251,8 +254,9 @@ class ManagedZone(object):
         https://cloud.google.com/dns/api/v1/managedZones/create
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
         """
         client = self._require_client(client)
         path = '/projects/%s/managedZones' % (self.project,)
@@ -267,8 +271,9 @@ class ManagedZone(object):
         https://cloud.google.com/dns/api/v1/managedZones/get
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
 
         :rtype: bool
         :returns: Boolean indicating existence of the managed zone.
@@ -290,8 +295,9 @@ class ManagedZone(object):
         https://cloud.google.com/dns/api/v1/managedZones/get
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
         """
         client = self._require_client(client)
 
@@ -306,8 +312,9 @@ class ManagedZone(object):
         https://cloud.google.com/dns/api/v1/managedZones/delete
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
         """
         client = self._require_client(client)
         client.connection.api_request(method='DELETE', path=self.path)
@@ -329,8 +336,9 @@ class ManagedZone(object):
                            zones.
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
 
         :rtype: :class:`~google.cloud.iterator.Iterator`
         :returns: Iterator of :class:`~.resource_record_set.ResourceRecordSet`
@@ -362,8 +370,9 @@ class ManagedZone(object):
                            zones.
 
         :type client: :class:`google.cloud.dns.client.Client`
-        :param client: (Optional) the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current zone.
+        :param client:
+            (Optional) the client to use.  If not passed, falls back to the
+            ``client`` stored on the current zone.
 
         :rtype: :class:`~google.cloud.iterator.Iterator`
         :returns: Iterator of :class:`~.changes.Changes`

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -140,8 +140,9 @@ class Client(JSONClient):
         :param resource: one entry resource from API response
 
         :type loggers: dict
-        :param loggers: (Optional) A mapping of logger fullnames -> loggers.  If not
-                        passed, the entry will have a newly-created logger.
+        :param loggers:
+            (Optional) A mapping of logger fullnames -> loggers.  If not
+            passed, the entry will have a newly-created logger.
 
         :rtype: One of:
                 :class:`google.cloud.logging.entries.TextEntry`,

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -139,8 +139,8 @@ class Client(JSONClient):
         :type resource: dict
         :param resource: one entry resource from API response
 
-        :type loggers: dict or None
-        :param loggers: A mapping of logger fullnames -> loggers.  If not
+        :type loggers: dict
+        :param loggers: (Optional) A mapping of logger fullnames -> loggers.  If not
                         passed, the entry will have a newly-created logger.
 
         :rtype: One of:

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -95,8 +95,9 @@ class _BaseEntry(object):
                        configuration.
 
         :type loggers: dict
-        :param loggers: (Optional) A mapping of logger fullnames -> loggers.  If not
-                        passed, the entry will have a newly-created logger.
+        :param loggers:
+            (Optional) A mapping of logger fullnames -> loggers.  If not
+            passed, the entry will have a newly-created logger.
 
         :rtype: :class:`google.cloud.logging.entries.TextEntry`
         :returns: Text entry parsed from ``resource``.

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -56,19 +56,19 @@ class _BaseEntry(object):
     :type logger: :class:`google.cloud.logging.logger.Logger`
     :param logger: the logger used to write the entry.
 
-    :type insert_id: text, or :class:`NoneType`
+    :type insert_id: text
     :param insert_id: (optional) the ID used to identify an entry uniquely.
 
-    :type timestamp: :class:`datetime.datetime`, or :class:`NoneType`
+    :type timestamp: :class:`datetime.datetime`
     :param timestamp: (optional) timestamp for the entry
 
-    :type labels: dict or :class:`NoneType`
+    :type labels: dict
     :param labels: (optional) mapping of labels for the entry
 
-    :type severity: str or :class:`NoneType`
+    :type severity: str
     :param severity: (optional) severity of event being logged.
 
-    :type http_request: dict or :class:`NoneType`
+    :type http_request: dict
     :param http_request: (optional) info about HTTP request associated with
                          the entry
     """
@@ -94,8 +94,8 @@ class _BaseEntry(object):
         :param client: Client which holds credentials and project
                        configuration.
 
-        :type loggers: dict or None
-        :param loggers: A mapping of logger fullnames -> loggers.  If not
+        :type loggers: dict
+        :param loggers: (Optional) A mapping of logger fullnames -> loggers.  If not
                         passed, the entry will have a newly-created logger.
 
         :rtype: :class:`google.cloud.logging.entries.TextEntry`

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -32,7 +32,7 @@ class Logger(object):
     :param client: A client which holds credentials and project configuration
                    for the logger (which requires a project).
 
-    :type labels: dict or :class:`NoneType`
+    :type labels: dict
     :param labels: (optional) mapping of default labels for entries written
                    via this logger.
     """
@@ -99,25 +99,25 @@ class Logger(object):
 
         Only one of ``text``, ``info``, or ``message`` should be passed.
 
-        :type text: str or :class:`NoneType`
-        :param text: text payload
+        :type text: str
+        :param text: (Optional) text payload
 
-        :type info: dict or :class:`NoneType`
-        :param info: struct payload
+        :type info: dict
+        :param info: (Optional) struct payload
 
         :type message: Protobuf message or :class:`NoneType`
         :param message: protobuf payload
 
-        :type labels: dict or :class:`NoneType`
-        :param labels: labels passed in to calling method.
+        :type labels: dict
+        :param labels: (Optional) labels passed in to calling method.
 
-        :type insert_id: str or :class:`NoneType`
+        :type insert_id: str
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: str or :class:`NoneType`
+        :type severity: str
         :param severity: (optional) severity of event being logged.
 
-        :type http_request: dict or :class:`NoneType`
+        :type http_request: dict
         :param http_request: (optional) info about HTTP request associated with
                              the entry
 
@@ -172,16 +172,16 @@ class Logger(object):
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current logger.
 
-        :type labels: dict or :class:`NoneType`
+        :type labels: dict
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: str or :class:`NoneType`
+        :type insert_id: str
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: str or :class:`NoneType`
+        :type severity: str
         :param severity: (optional) severity of event being logged.
 
-        :type http_request: dict or :class:`NoneType`
+        :type http_request: dict
         :param http_request: (optional) info about HTTP request associated with
                              the entry
         """
@@ -206,16 +206,16 @@ class Logger(object):
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current logger.
 
-        :type labels: dict or :class:`NoneType`
+        :type labels: dict
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: str or :class:`NoneType`
+        :type insert_id: str
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: str or :class:`NoneType`
+        :type severity: str
         :param severity: (optional) severity of event being logged.
 
-        :type http_request: dict or :class:`NoneType`
+        :type http_request: dict
         :param http_request: (optional) info about HTTP request associated with
                              the entry.
         """
@@ -240,16 +240,16 @@ class Logger(object):
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current logger.
 
-        :type labels: dict or :class:`NoneType`
+        :type labels: dict
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: str or :class:`NoneType`
+        :type insert_id: str
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: str or :class:`NoneType`
+        :type severity: str
         :param severity: (optional) severity of event being logged.
 
-        :type http_request: dict or :class:`NoneType`
+        :type http_request: dict
         :param http_request: (optional) info about HTTP request associated with
                              the entry.
         """
@@ -347,16 +347,16 @@ class Batch(object):
         :type text: str
         :param text: the text entry
 
-        :type labels: dict or :class:`NoneType`
+        :type labels: dict
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: str or :class:`NoneType`
+        :type insert_id: str
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: str or :class:`NoneType`
+        :type severity: str
         :param severity: (optional) severity of event being logged.
 
-        :type http_request: dict or :class:`NoneType`
+        :type http_request: dict
         :param http_request: (optional) info about HTTP request associated with
                              the entry.
         """
@@ -370,16 +370,16 @@ class Batch(object):
         :type info: dict
         :param info: the struct entry
 
-        :type labels: dict or :class:`NoneType`
+        :type labels: dict
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: str or :class:`NoneType`
+        :type insert_id: str
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: str or :class:`NoneType`
+        :type severity: str
         :param severity: (optional) severity of event being logged.
 
-        :type http_request: dict or :class:`NoneType`
+        :type http_request: dict
         :param http_request: (optional) info about HTTP request associated with
                              the entry.
         """
@@ -393,16 +393,16 @@ class Batch(object):
         :type message: protobuf message
         :param message: the protobuf entry
 
-        :type labels: dict or :class:`NoneType`
+        :type labels: dict
         :param labels: (optional) mapping of labels for the entry.
 
-        :type insert_id: str or :class:`NoneType`
+        :type insert_id: str
         :param insert_id: (optional) unique ID for log entry.
 
-        :type severity: str or :class:`NoneType`
+        :type severity: str
         :param severity: (optional) severity of event being logged.
 
-        :type http_request: dict or :class:`NoneType`
+        :type http_request: dict
         :param http_request: (optional) info about HTTP request associated with
                              the entry.
         """

--- a/monitoring/google/cloud/monitoring/_dataframe.py
+++ b/monitoring/google/cloud/monitoring/_dataframe.py
@@ -36,9 +36,9 @@ def _build_dataframe(time_series_iterable,
 
     :type label: str
     :param label:
-        (Optional) The label name to use for the dataframe header. This can be the name
-        of a resource label or metric label (e.g., ``"instance_name"``), or
-        the string ``"resource_type"``.
+        (Optional) The label name to use for the dataframe header. This can be
+        the name of a resource label or metric label (e.g.,
+        ``"instance_name"``), or the string ``"resource_type"``.
 
     :type labels: list of strings, or None
     :param labels:

--- a/monitoring/google/cloud/monitoring/_dataframe.py
+++ b/monitoring/google/cloud/monitoring/_dataframe.py
@@ -34,9 +34,9 @@ def _build_dataframe(time_series_iterable,
     :param time_series_iterable:
         An iterable (e.g., a query object) yielding time series.
 
-    :type label: str or None
+    :type label: str
     :param label:
-        The label name to use for the dataframe header. This can be the name
+        (Optional) The label name to use for the dataframe header. This can be the name
         of a resource label or metric label (e.g., ``"instance_name"``), or
         the string ``"resource_type"``.
 

--- a/monitoring/google/cloud/monitoring/client.py
+++ b/monitoring/google/cloud/monitoring/client.py
@@ -88,8 +88,8 @@ class Client(JSONClient):
             demonstration purposes and is subject to change. See the
             `supported metrics`_.
 
-        :type end_time: :class:`datetime.datetime` or None
-        :param end_time: The end time (inclusive) of the time interval
+        :type end_time: :class:`datetime.datetime`
+        :param end_time: (Optional) The end time (inclusive) of the time interval
             for which results should be returned, as a datetime object.
             The default is the start of the current minute.
 
@@ -362,13 +362,13 @@ class Client(JSONClient):
             ...         type_prefix='custom.'):
             ...     print(descriptor.type)
 
-        :type filter_string: str or None
+        :type filter_string: str
         :param filter_string:
-            An optional filter expression describing the metric descriptors
+            (Optional) An optional filter expression describing the metric descriptors
             to be returned. See the `filter documentation`_.
 
-        :type type_prefix: str or None
-        :param type_prefix: An optional prefix constraining the selected
+        :type type_prefix: str
+        :param type_prefix: (Optional) An optional prefix constraining the selected
             metric types. This adds ``metric.type = starts_with("<prefix>")``
             to the filter.
 
@@ -408,9 +408,9 @@ class Client(JSONClient):
             >>> for descriptor in client.list_resource_descriptors():
             ...     print(descriptor.type)
 
-        :type filter_string: str or None
+        :type filter_string: str
         :param filter_string:
-            An optional filter expression describing the resource descriptors
+            (Optional) An optional filter expression describing the resource descriptors
             to be returned. See the `filter documentation`_.
 
         :rtype: list of
@@ -430,21 +430,21 @@ class Client(JSONClient):
           This will not make an HTTP request; it simply instantiates
           a group object owned by this client.
 
-        :type group_id: str or None
-        :param group_id: The ID of the group.
+        :type group_id: str
+        :param group_id: (Optional) The ID of the group.
 
-        :type display_name: str or None
+        :type display_name: str
         :param display_name:
-            A user-assigned name for this group, used only for display
+            (Optional) A user-assigned name for this group, used only for display
             purposes.
 
-        :type parent_id: str or None
+        :type parent_id: str
         :param parent_id:
-            The ID of the group's parent, if it has one.
+            (Optional) The ID of the group's parent, if it has one.
 
-        :type filter_string: str or None
+        :type filter_string: str
         :param filter_string:
-            The filter string used to determine which monitored resources
+            (Optional) The filter string used to determine which monitored resources
             belong to this group.
 
         :type is_cluster: bool

--- a/monitoring/google/cloud/monitoring/client.py
+++ b/monitoring/google/cloud/monitoring/client.py
@@ -89,7 +89,8 @@ class Client(JSONClient):
             `supported metrics`_.
 
         :type end_time: :class:`datetime.datetime`
-        :param end_time: (Optional) The end time (inclusive) of the time interval
+        :param end_time:
+            (Optional) The end time (inclusive) of the time interval
             for which results should be returned, as a datetime object.
             The default is the start of the current minute.
 
@@ -364,13 +365,14 @@ class Client(JSONClient):
 
         :type filter_string: str
         :param filter_string:
-            (Optional) An optional filter expression describing the metric descriptors
-            to be returned. See the `filter documentation`_.
+            (Optional) An optional filter expression describing the metric
+            descriptors to be returned. See the `filter documentation`_.
 
         :type type_prefix: str
-        :param type_prefix: (Optional) An optional prefix constraining the selected
-            metric types. This adds ``metric.type = starts_with("<prefix>")``
-            to the filter.
+        :param type_prefix:
+            (Optional) An optional prefix constraining the selected metric
+            types. This adds ``metric.type = starts_with("<prefix>")`` to the
+            filter.
 
         :rtype:
             list of :class:`~google.cloud.monitoring.metric.MetricDescriptor`
@@ -410,8 +412,8 @@ class Client(JSONClient):
 
         :type filter_string: str
         :param filter_string:
-            (Optional) An optional filter expression describing the resource descriptors
-            to be returned. See the `filter documentation`_.
+            (Optional) An optional filter expression describing the resource
+            descriptors to be returned. See the `filter documentation`_.
 
         :rtype: list of
                 :class:`~google.cloud.monitoring.resource.ResourceDescriptor`
@@ -435,8 +437,8 @@ class Client(JSONClient):
 
         :type display_name: str
         :param display_name:
-            (Optional) A user-assigned name for this group, used only for display
-            purposes.
+            (Optional) A user-assigned name for this group, used only for
+            display purposes.
 
         :type parent_id: str
         :param parent_id:
@@ -444,8 +446,8 @@ class Client(JSONClient):
 
         :type filter_string: str
         :param filter_string:
-            (Optional) The filter string used to determine which monitored resources
-            belong to this group.
+            (Optional) The filter string used to determine which monitored
+            resources belong to this group.
 
         :type is_cluster: bool
         :param is_cluster:

--- a/monitoring/google/cloud/monitoring/group.py
+++ b/monitoring/google/cloud/monitoring/group.py
@@ -41,8 +41,8 @@ def _group_id_from_name(path, project=None):
     :type path: str
     :param path: URI path for a group API request.
 
-    :type project: str or None
-    :param project: The project associated with the request. It is
+    :type project: str
+    :param project: (Optional) The project associated with the request. It is
                     included for validation purposes.
 
     :rtype: str
@@ -76,20 +76,20 @@ class Group(object):
     :type client: :class:`google.cloud.monitoring.client.Client`
     :param client: A client for operating on the metric descriptor.
 
-    :type group_id: str or None
-    :param group_id: The ID of the group.
+    :type group_id: str
+    :param group_id: (Optional) The ID of the group.
 
-    :type display_name: str or None
+    :type display_name: str
     :param display_name:
-        A user-assigned name for this group, used only for display purposes.
+        (Optional) A user-assigned name for this group, used only for display purposes.
 
-    :type parent_id: str or None
+    :type parent_id: str
     :param parent_id:
-        The ID of the group's parent, if it has one.
+        (Optional) The ID of the group's parent, if it has one.
 
-    :type filter_string: str or None
+    :type filter_string: str
     :param filter_string:
-        The filter string used to determine which monitored resources belong to
+        (Optional) The filter string used to determine which monitored resources belong to
         this group.
 
     :type is_cluster: bool
@@ -296,21 +296,21 @@ class Group(object):
             ...     print(member)
 
 
-        :type filter_string: str or None
+        :type filter_string: str
         :param filter_string:
-            An optional list filter describing the members to be returned. The
+            (Optional) An optional list filter describing the members to be returned. The
             filter may reference the type, labels, and metadata of monitored
             resources that comprise the group. See the `filter documentation`_.
 
-        :type end_time: :class:`datetime.datetime` or None
+        :type end_time: :class:`datetime.datetime`
         :param end_time:
-            The end time (inclusive) of the time interval for which results
+            (Optional) The end time (inclusive) of the time interval for which results
             should be returned, as a datetime object. If ``start_time`` is
             specified, then this must also be specified.
 
-        :type start_time: :class:`datetime.datetime` or None
+        :type start_time: :class:`datetime.datetime`
         :param start_time:
-            The start time (exclusive) of the time interval for which results
+            (Optional) The start time (exclusive) of the time interval for which results
             should be returned, as a datetime object.
 
         :rtype: list of :class:`~google.cloud.monitoring.resource.Resource`
@@ -386,19 +386,19 @@ class Group(object):
         :type client: :class:`google.cloud.monitoring.client.Client`
         :param client: The client to use.
 
-        :type children_of_group: str or None
+        :type children_of_group: str
         :param children_of_group:
-            Returns groups whose parent_name field contains the group name. If
+            (Optional) Returns groups whose parent_name field contains the group name. If
             no groups have this parent, the results are empty.
 
-        :type ancestors_of_group: str or None
+        :type ancestors_of_group: str
         :param ancestors_of_group:
-            Returns groups that are ancestors of the specified group. If the
+            (Optional) Returns groups that are ancestors of the specified group. If the
             specified group has no immediate parent, the results are empty.
 
-        :type descendants_of_group: str or None
+        :type descendants_of_group: str
         :param descendants_of_group:
-            Returns the descendants of the specified group. This is a superset
+            (Optional) Returns the descendants of the specified group. This is a superset
             of the results returned by the children_of_group filter, and
             includes children-of-children, and so forth.
 

--- a/monitoring/google/cloud/monitoring/group.py
+++ b/monitoring/google/cloud/monitoring/group.py
@@ -81,7 +81,8 @@ class Group(object):
 
     :type display_name: str
     :param display_name:
-        (Optional) A user-assigned name for this group, used only for display purposes.
+        (Optional) A user-assigned name for this group, used only for display
+        purposes.
 
     :type parent_id: str
     :param parent_id:
@@ -89,8 +90,8 @@ class Group(object):
 
     :type filter_string: str
     :param filter_string:
-        (Optional) The filter string used to determine which monitored resources belong to
-        this group.
+        (Optional) The filter string used to determine which monitored
+        resources belong to this group.
 
     :type is_cluster: bool
     :param is_cluster:
@@ -298,20 +299,21 @@ class Group(object):
 
         :type filter_string: str
         :param filter_string:
-            (Optional) An optional list filter describing the members to be returned. The
-            filter may reference the type, labels, and metadata of monitored
-            resources that comprise the group. See the `filter documentation`_.
+            (Optional) An optional list filter describing the members to be
+            returned. The filter may reference the type, labels, and metadata
+            of monitored resources that comprise the group. See the `filter
+            documentation`_.
 
         :type end_time: :class:`datetime.datetime`
         :param end_time:
-            (Optional) The end time (inclusive) of the time interval for which results
-            should be returned, as a datetime object. If ``start_time`` is
-            specified, then this must also be specified.
+            (Optional) The end time (inclusive) of the time interval for which
+            results should be returned, as a datetime object. If ``start_time``
+            is specified, then this must also be specified.
 
         :type start_time: :class:`datetime.datetime`
         :param start_time:
-            (Optional) The start time (exclusive) of the time interval for which results
-            should be returned, as a datetime object.
+            (Optional) The start time (exclusive) of the time interval for
+            which results should be returned, as a datetime object.
 
         :rtype: list of :class:`~google.cloud.monitoring.resource.Resource`
         :returns: A list of resource instances.
@@ -388,19 +390,20 @@ class Group(object):
 
         :type children_of_group: str
         :param children_of_group:
-            (Optional) Returns groups whose parent_name field contains the group name. If
-            no groups have this parent, the results are empty.
+            (Optional) Returns groups whose parent_name field contains the
+            group name. If no groups have this parent, the results are empty.
 
         :type ancestors_of_group: str
         :param ancestors_of_group:
-            (Optional) Returns groups that are ancestors of the specified group. If the
-            specified group has no immediate parent, the results are empty.
+            (Optional) Returns groups that are ancestors of the specified
+            group. If the specified group has no immediate parent, the results
+            are empty.
 
         :type descendants_of_group: str
         :param descendants_of_group:
-            (Optional) Returns the descendants of the specified group. This is a superset
-            of the results returned by the children_of_group filter, and
-            includes children-of-children, and so forth.
+            (Optional) Returns the descendants of the specified group. This is
+            a superset of the results returned by the children_of_group filter,
+            and includes children-of-children, and so forth.
 
         :rtype: list of :class:`~google.cloud.monitoring.group.Group`
         :returns: A list of group instances.

--- a/monitoring/google/cloud/monitoring/metric.py
+++ b/monitoring/google/cloud/monitoring/metric.py
@@ -200,13 +200,13 @@ class MetricDescriptor(object):
 
         :type filter_string: str
         :param filter_string:
-            (Optional) An optional filter expression describing the metric descriptors
-            to be returned. See the `filter documentation`_.
+            (Optional) Filter expression describing the metric descriptors to
+            be returned. See the `filter documentation`_.
 
         :type type_prefix: str
-        :param type_prefix: (Optional) An optional prefix constraining the selected
-            metric types. This adds ``metric.type = starts_with("<prefix>")``
-            to the filter.
+        :param type_prefix:
+            (Optional) Prefix constraining the selected metric types. This adds
+            ``metric.type = starts_with("<prefix>")`` to the filter.
 
         :rtype: list of :class:`MetricDescriptor`
         :returns: A list of metric descriptor instances.

--- a/monitoring/google/cloud/monitoring/metric.py
+++ b/monitoring/google/cloud/monitoring/metric.py
@@ -102,9 +102,9 @@ class MetricDescriptor(object):
     :type display_name: str
     :param display_name: An optional concise name for the metric.
 
-    :type name: str or None
+    :type name: str
     :param name:
-        The "resource name" of the metric descriptor. For example:
+        (Optional) The "resource name" of the metric descriptor. For example:
         ``"projects/<project_id>/metricDescriptors/<type>"``. As
         retrieved from the service, this will always be specified.
         You can and should omit it when constructing an instance for
@@ -198,13 +198,13 @@ class MetricDescriptor(object):
         :type client: :class:`google.cloud.monitoring.client.Client`
         :param client: The client to use.
 
-        :type filter_string: str or None
+        :type filter_string: str
         :param filter_string:
-            An optional filter expression describing the metric descriptors
+            (Optional) An optional filter expression describing the metric descriptors
             to be returned. See the `filter documentation`_.
 
-        :type type_prefix: str or None
-        :param type_prefix: An optional prefix constraining the selected
+        :type type_prefix: str
+        :param type_prefix: (Optional) An optional prefix constraining the selected
             metric types. This adds ``metric.type = starts_with("<prefix>")``
             to the filter.
 

--- a/monitoring/google/cloud/monitoring/query.py
+++ b/monitoring/google/cloud/monitoring/query.py
@@ -180,7 +180,8 @@ class Query(object):
             for which results should be returned, as a datetime object.
 
         :type start_time: :class:`datetime.datetime`
-        :param start_time: (Optional) The start time (exclusive) of the time interval
+        :param start_time:
+            (Optional) The start time (exclusive) of the time interval
             for which results should be returned, as a datetime object.
             If not specified, the interval is a point in time.
 
@@ -448,9 +449,9 @@ class Query(object):
 
         :type page_size: int
         :param page_size:
-            (Optional) An optional positive number specifying the maximum number of
-            points to return per page. This can be used to control how far
-            the iterator reads ahead.
+            (Optional) Positive number specifying the maximum number of points
+            to return per page. This can be used to control how far the
+            iterator reads ahead.
 
         :raises: :exc:`ValueError` if the query time interval has not been
             specified.
@@ -511,7 +512,8 @@ class Query(object):
              :class:`~google.cloud.monitoring.timeseries.TimeSeries` objects.
 
         :type page_size: int
-        :param page_size: (Optional) A limit on the number of points to return per page.
+        :param page_size:
+            (Optional) A limit on the number of points to return per page.
 
         :type page_token: str
         :param page_token: (Optional) A token to continue the retrieval.
@@ -576,7 +578,8 @@ class Query(object):
                 labels=['resource_type', 'instance_id'])
 
         :type label: str
-        :param label: (Optional) The label name to use for the dataframe header.
+        :param label:
+            (Optional) The label name to use for the dataframe header.
             This can be the name of a resource label or metric label
             (e.g., ``"instance_name"``), or the string ``"resource_type"``.
 

--- a/monitoring/google/cloud/monitoring/query.py
+++ b/monitoring/google/cloud/monitoring/query.py
@@ -86,8 +86,8 @@ class Query(object):
         demonstration purposes and is subject to change. See the
         `supported metrics`_.
 
-    :type end_time: :class:`datetime.datetime` or None
-    :param end_time: The end time (inclusive) of the time interval
+    :type end_time: :class:`datetime.datetime`
+    :param end_time: (Optional) The end time (inclusive) of the time interval
         for which results should be returned, as a datetime object.
         The default is the start of the current minute.
 
@@ -179,8 +179,8 @@ class Query(object):
         :param end_time: The end time (inclusive) of the time interval
             for which results should be returned, as a datetime object.
 
-        :type start_time: :class:`datetime.datetime` or None
-        :param start_time: The start time (exclusive) of the time interval
+        :type start_time: :class:`datetime.datetime`
+        :param start_time: (Optional) The start time (exclusive) of the time interval
             for which results should be returned, as a datetime object.
             If not specified, the interval is a point in time.
 
@@ -446,9 +446,9 @@ class Query(object):
         :param headers_only:
              Whether to omit the point data from the time series objects.
 
-        :type page_size: int or None
+        :type page_size: int
         :param page_size:
-            An optional positive number specifying the maximum number of
+            (Optional) An optional positive number specifying the maximum number of
             points to return per page. This can be used to control how far
             the iterator reads ahead.
 
@@ -510,11 +510,11 @@ class Query(object):
              Whether to omit the point data from the
              :class:`~google.cloud.monitoring.timeseries.TimeSeries` objects.
 
-        :type page_size: int or None
-        :param page_size: A limit on the number of points to return per page.
+        :type page_size: int
+        :param page_size: (Optional) A limit on the number of points to return per page.
 
-        :type page_token: str or None
-        :param page_token: A token to continue the retrieval.
+        :type page_token: str
+        :param page_token: (Optional) A token to continue the retrieval.
         """
         yield 'filter', self.filter
 
@@ -575,8 +575,8 @@ class Query(object):
             dataframe = query.as_dataframe(
                 labels=['resource_type', 'instance_id'])
 
-        :type label: str or None
-        :param label: The label name to use for the dataframe header.
+        :type label: str
+        :param label: (Optional) The label name to use for the dataframe header.
             This can be the name of a resource label or metric label
             (e.g., ``"instance_name"``), or the string ``"resource_type"``.
 

--- a/monitoring/google/cloud/monitoring/resource.py
+++ b/monitoring/google/cloud/monitoring/resource.py
@@ -88,9 +88,9 @@ class ResourceDescriptor(object):
         :type client: :class:`google.cloud.monitoring.client.Client`
         :param client: The client to use.
 
-        :type filter_string: str or None
+        :type filter_string: str
         :param filter_string:
-            An optional filter expression describing the resource descriptors
+            (Optional) An optional filter expression describing the resource descriptors
             to be returned. See the `filter documentation`_.
 
         :rtype: list of :class:`ResourceDescriptor`

--- a/monitoring/google/cloud/monitoring/resource.py
+++ b/monitoring/google/cloud/monitoring/resource.py
@@ -90,8 +90,8 @@ class ResourceDescriptor(object):
 
         :type filter_string: str
         :param filter_string:
-            (Optional) An optional filter expression describing the resource descriptors
-            to be returned. See the `filter documentation`_.
+            (Optional) An optional filter expression describing the resource
+            descriptors to be returned. See the `filter documentation`_.
 
         :rtype: list of :class:`ResourceDescriptor`
         :returns: A list of resource descriptor instances.

--- a/monitoring/google/cloud/monitoring/timeseries.py
+++ b/monitoring/google/cloud/monitoring/timeseries.py
@@ -180,7 +180,7 @@ class Point(collections.namedtuple('Point', 'end_time start_time value')):
     :param end_time: The end time in RFC3339 UTC "Zulu" format.
 
     :type start_time: str
-    :param start_time: (Optional) An optional start time in RFC3339 UTC "Zulu" format.
+    :param start_time: (Optional) The start time in RFC3339 UTC "Zulu" format.
 
     :type value: object
     :param value: The metric value. This can be a scalar or a distribution.

--- a/monitoring/google/cloud/monitoring/timeseries.py
+++ b/monitoring/google/cloud/monitoring/timeseries.py
@@ -179,8 +179,8 @@ class Point(collections.namedtuple('Point', 'end_time start_time value')):
     :type end_time: str
     :param end_time: The end time in RFC3339 UTC "Zulu" format.
 
-    :type start_time: str or None
-    :param start_time: An optional start time in RFC3339 UTC "Zulu" format.
+    :type start_time: str
+    :param start_time: (Optional) An optional start time in RFC3339 UTC "Zulu" format.
 
     :type value: object
     :param value: The metric value. This can be a scalar or a distribution.

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -269,12 +269,12 @@ class _SubscriberAPI(object):
                            subscribed, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
-        :type ack_deadline: int, or ``NoneType``
-        :param ack_deadline: the deadline (in seconds) by which messages pulled
+        :type ack_deadline: int
+        :param ack_deadline: (Optional) the deadline (in seconds) by which messages pulled
                              from the back-end must be acknowledged.
 
-        :type push_endpoint: str, or ``NoneType``
-        :param push_endpoint: URL to which messages will be pushed by the
+        :type push_endpoint: str
+        :param push_endpoint: (Optional) URL to which messages will be pushed by the
                               back-end.  If not set, the application must pull
                               messages.
 
@@ -351,8 +351,8 @@ class _SubscriberAPI(object):
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
-        :type push_endpoint: str, or ``NoneType``
-        :param push_endpoint: URL to which messages will be pushed by the
+        :type push_endpoint: str
+        :param push_endpoint: (Optional) URL to which messages will be pushed by the
                               back-end.  If not set, the application must pull
                               messages.
         """

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -270,13 +270,14 @@ class _SubscriberAPI(object):
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
         :type ack_deadline: int
-        :param ack_deadline: (Optional) the deadline (in seconds) by which messages pulled
-                             from the back-end must be acknowledged.
+        :param ack_deadline:
+            (Optional) the deadline (in seconds) by which messages pulled from
+            the back-end must be acknowledged.
 
         :type push_endpoint: str
-        :param push_endpoint: (Optional) URL to which messages will be pushed by the
-                              back-end.  If not set, the application must pull
-                              messages.
+        :param push_endpoint:
+            (Optional) URL to which messages will be pushed by the back-end.
+            If not set, the application must pull messages.
 
         :rtype: dict
         :returns: ``Subscription`` resource returned from the API.
@@ -352,9 +353,9 @@ class _SubscriberAPI(object):
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type push_endpoint: str
-        :param push_endpoint: (Optional) URL to which messages will be pushed by the
-                              back-end.  If not set, the application must pull
-                              messages.
+        :param push_endpoint:
+            (Optional) URL to which messages will be pushed by the back-end.
+            If not set, the application must pull messages.
         """
         push_config = PushConfig(push_endpoint=push_endpoint)
         try:

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -309,12 +309,12 @@ class _SubscriberAPI(object):
                            subscribed, in format
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
-        :type ack_deadline: int, or ``NoneType``
-        :param ack_deadline: the deadline (in seconds) by which messages pulled
+        :type ack_deadline: int
+        :param ack_deadline: (Optional) the deadline (in seconds) by which messages pulled
                             from the back-end must be acknowledged.
 
-        :type push_endpoint: str, or ``NoneType``
-        :param push_endpoint: URL to which messages will be pushed by the
+        :type push_endpoint: str
+        :param push_endpoint: (Optional) URL to which messages will be pushed by the
                               back-end.  If not set, the application must pull
                               messages.
 
@@ -378,8 +378,8 @@ class _SubscriberAPI(object):
             the fully-qualified path of the new subscription, in format
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
-        :type push_endpoint: str, or ``NoneType``
-        :param push_endpoint: URL to which messages will be pushed by the
+        :type push_endpoint: str
+        :param push_endpoint: (Optional) URL to which messages will be pushed by the
                               back-end.  If not set, the application must pull
                               messages.
         """

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -310,13 +310,14 @@ class _SubscriberAPI(object):
                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
 
         :type ack_deadline: int
-        :param ack_deadline: (Optional) the deadline (in seconds) by which messages pulled
-                            from the back-end must be acknowledged.
+        :param ack_deadline:
+            (Optional) the deadline (in seconds) by which messages pulled from
+            the back-end must be acknowledged.
 
         :type push_endpoint: str
-        :param push_endpoint: (Optional) URL to which messages will be pushed by the
-                              back-end.  If not set, the application must pull
-                              messages.
+        :param push_endpoint:
+            (Optional) URL to which messages will be pushed by the back-end.
+            If not set, the application must pull messages.
 
         :rtype: dict
         :returns: ``Subscription`` resource returned from the API.
@@ -379,9 +380,9 @@ class _SubscriberAPI(object):
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
 
         :type push_endpoint: str
-        :param push_endpoint: (Optional) URL to which messages will be pushed by the
-                              back-end.  If not set, the application must pull
-                              messages.
+        :param push_endpoint:
+            (Optional) URL to which messages will be pushed by the back-end.
+            If not set, the application must pull messages.
         """
         conn = self._connection
         path = '/%s:modifyPushConfig' % (subscription_path,)

--- a/pubsub/google/cloud/pubsub/message.py
+++ b/pubsub/google/cloud/pubsub/message.py
@@ -32,8 +32,8 @@ class Message(object):
     :type message_id: str
     :param message_id: An ID assigned to the message by the API.
 
-    :type attributes: dict or None
-    :param attributes: Extra metadata associated by the publisher with the
+    :type attributes: dict
+    :param attributes: (Optional) Extra metadata associated by the publisher with the
                        message.
     """
     _service_timestamp = None
@@ -80,8 +80,8 @@ class Message(object):
     def from_api_repr(cls, api_repr):
         """Factory:  construct message from API representation.
 
-        :type api_repr: dict or None
-        :param api_repr: The API representation of the message
+        :type api_repr: dict
+        :param api_repr: (Optional) The API representation of the message
 
         :rtype: :class:`Message`
         :returns: The message created from the response.

--- a/pubsub/google/cloud/pubsub/message.py
+++ b/pubsub/google/cloud/pubsub/message.py
@@ -33,8 +33,8 @@ class Message(object):
     :param message_id: An ID assigned to the message by the API.
 
     :type attributes: dict
-    :param attributes: (Optional) Extra metadata associated by the publisher with the
-                       message.
+    :param attributes:
+        (Optional) Extra metadata associated by the publisher with the message.
     """
     _service_timestamp = None
 

--- a/pubsub/google/cloud/pubsub/subscription.py
+++ b/pubsub/google/cloud/pubsub/subscription.py
@@ -30,21 +30,23 @@ class Subscription(object):
     :param name: the name of the subscription.
 
     :type topic: :class:`google.cloud.pubsub.topic.Topic`
-    :param topic: (Optional) the topic to which the subscription belongs;  if ``None``,
-                  the subscription's topic has been deleted.
+    :param topic:
+        (Optional) the topic to which the subscription belongs;  if ``None``,
+        the subscription's topic has been deleted.
 
     :type ack_deadline: int
     :param ack_deadline: the deadline (in seconds) by which messages pulled
                          from the back-end must be acknowledged.
 
     :type push_endpoint: str
-    :param push_endpoint: URL to which messages will be pushed by the back-end.
-                          If not set, the application must pull messages.
+    :param push_endpoint:
+        (Optional) URL to which messages will be pushed by the back-end.  If
+        not set, the application must pull messages.
 
-    :type client: :class:`~google.cloud.pubsub.client.Client` or
-                  ``NoneType``
-    :param client: the client to use.  If not passed, falls back to the
-                   ``client`` stored on the topic.
+    :type client: :class:`~google.cloud.pubsub.client.Client`
+    :param client:
+        (Optional) The client to use.  If not passed, falls back to the
+        ``client`` stored on the topic.
     """
 
     _DELETED_TOPIC_PATH = '_deleted-topic_'
@@ -82,8 +84,9 @@ class Subscription(object):
                        configuration for a topic.
 
         :type topics: dict
-        :param topics: (Optional) A mapping of topic names -> topics.  If not passed,
-                       the subscription will have a newly-created topic.
+        :param topics:
+            (Optional) A mapping of topic names -> topics.  If not passed, the
+            subscription will have a newly-created topic.
 
         :rtype: :class:`google.cloud.pubsub.subscription.Subscription`
         :returns: Subscription parsed from ``resource``.

--- a/pubsub/google/cloud/pubsub/subscription.py
+++ b/pubsub/google/cloud/pubsub/subscription.py
@@ -29,8 +29,8 @@ class Subscription(object):
     :type name: str
     :param name: the name of the subscription.
 
-    :type topic: :class:`google.cloud.pubsub.topic.Topic` or ``NoneType``
-    :param topic: the topic to which the subscription belongs;  if ``None``,
+    :type topic: :class:`google.cloud.pubsub.topic.Topic`
+    :param topic: (Optional) the topic to which the subscription belongs;  if ``None``,
                   the subscription's topic has been deleted.
 
     :type ack_deadline: int
@@ -81,8 +81,8 @@ class Subscription(object):
         :param client: Client which holds credentials and project
                        configuration for a topic.
 
-        :type topics: dict or None
-        :param topics: A mapping of topic names -> topics.  If not passed,
+        :type topics: dict
+        :param topics: (Optional) A mapping of topic names -> topics.  If not passed,
                        the subscription will have a newly-created topic.
 
         :rtype: :class:`google.cloud.pubsub.subscription.Subscription`

--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -147,7 +147,7 @@ def get_python_files(all_files=None):
     NOTE: This requires ``git`` to be installed and requires that this
           is run within the ``git`` repository.
 
-    :type all_files: list or ``NoneType``
+    :type all_files: list
     :param all_files: Optional list of files to be linted.
 
     :rtype: tuple

--- a/storage/google/cloud/storage/acl.py
+++ b/storage/google/cloud/storage/acl.py
@@ -419,8 +419,8 @@ class ACL(object):
         :param acl: The ACL object to save.  If left blank, this will save
                     current entries.
 
-        :type predefined: str or None
-        :param predefined: An identifier for a predefined ACL.  Must be one
+        :type predefined: str
+        :param predefined: (Optional) An identifier for a predefined ACL.  Must be one
                            of the keys in :attr:`PREDEFINED_JSON_ACLS`
                            If passed, `acl` must be None.
 

--- a/storage/google/cloud/storage/acl.py
+++ b/storage/google/cloud/storage/acl.py
@@ -420,9 +420,9 @@ class ACL(object):
                     current entries.
 
         :type predefined: str
-        :param predefined: (Optional) An identifier for a predefined ACL.  Must be one
-                           of the keys in :attr:`PREDEFINED_JSON_ACLS`
-                           If passed, `acl` must be None.
+        :param predefined:
+            (Optional) An identifier for a predefined ACL.  Must be one of the
+            keys in :attr:`PREDEFINED_JSON_ACLS` If passed, `acl` must be None.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``

--- a/storage/google/cloud/storage/batch.py
+++ b/storage/google/cloud/storage/batch.py
@@ -155,10 +155,10 @@ class Batch(Connection):
         :param data: The data to send as the body of the request.
 
         :type target_object: object
-        :param target_object: (Optional) This allows us to enable custom behavior in our
-                              batch connection. Here we defer an HTTP request
-                              and complete initialization of the object at a
-                              later time.
+        :param target_object:
+            (Optional) This allows us to enable custom behavior in our batch
+            connection. Here we defer an HTTP request and complete
+            initialization of the object at a later time.
 
         :rtype: tuple of ``response`` (a dictionary of sorts)
                 and ``content`` (a string).

--- a/storage/google/cloud/storage/batch.py
+++ b/storage/google/cloud/storage/batch.py
@@ -44,8 +44,8 @@ class MIMEApplicationHTTP(MIMEApplication):
     :type headers:  dict
     :param headers: HTTP headers
 
-    :type body: str or None
-    :param body: HTTP payload
+    :type body: str
+    :param body: (Optional) HTTP payload
 
     """
     def __init__(self, method, uri, headers, body):
@@ -154,8 +154,8 @@ class Batch(Connection):
         :type data: str
         :param data: The data to send as the body of the request.
 
-        :type target_object: object or :class:`NoneType`
-        :param target_object: This allows us to enable custom behavior in our
+        :type target_object: object
+        :param target_object: (Optional) This allows us to enable custom behavior in our
                               batch connection. Here we defer an HTTP request
                               and complete initialization of the object at a
                               later time.

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -94,8 +94,8 @@ class Blob(_PropertyMixin):
     def chunk_size(self, value):
         """Set the blob's default chunk size.
 
-        :type value: int or ``NoneType``
-        :param value: The current blob's chunk size, if it is set.
+        :type value: int
+        :param value: (Optional) The current blob's chunk size, if it is set.
 
         :raises: :class:`ValueError` if ``value`` is not ``None`` and is not a
                  multiple of 256 KB.
@@ -450,7 +450,7 @@ class Blob(_PropertyMixin):
                      :func:`os.fstat`. (If the file handle is not from the
                      filesystem this won't be possible.)
 
-        :type content_type: str or ``NoneType``
+        :type content_type: str
         :param content_type: Optional type of content being uploaded.
 
         :type num_retries: int
@@ -567,7 +567,7 @@ class Blob(_PropertyMixin):
         :type filename: str
         :param filename: The path to the file.
 
-        :type content_type: str or ``NoneType``
+        :type content_type: str
         :param content_type: Optional type of content being uploaded.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -861,8 +861,8 @@ class Blob(_PropertyMixin):
 
         See: https://cloud.google.com/storage/docs/json_api/v1/objects
 
-        :type value: dict or ``NoneType``
-        :param value: The blob metadata to set.
+        :type value: dict
+        :param value: (Optional) The blob metadata to set.
         """
         self._patch_property('metadata', value)
 

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -240,15 +240,16 @@ class Client(JSONClient):
                        with this prefix.
 
         :type projection: str
-        :param projection: (Optional) If used, must be 'full' or 'noAcl'. Defaults to
-                           'noAcl'. Specifies the set of properties to return.
+        :param projection:
+            (Optional) Specifies the set of properties to return. If used, must
+            be 'full' or 'noAcl'. Defaults to 'noAcl'.
 
         :type fields: str
-        :param fields: (Optional) Selector specifying which fields to include in a
-                       partial response. Must be a list of fields. For example
-                       to get a partial response with just the next page token
-                       and the language of each bucket returned:
-                       'items/id,nextPageToken'
+        :param fields:
+            (Optional) Selector specifying which fields to include in a partial
+            response. Must be a list of fields. For example to get a partial
+            response with just the next page token and the language of each
+            bucket returned: 'items/id,nextPageToken'
 
         :rtype: :class:`~google.cloud.iterator.Iterator`
         :returns: Iterator of all :class:`~google.cloud.storage.bucket.Bucket`

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -227,24 +227,24 @@ class Client(JSONClient):
 
         This implements "storage.buckets.list".
 
-        :type max_results: int or ``NoneType``
+        :type max_results: int
         :param max_results: Optional. Maximum number of buckets to return.
 
-        :type page_token: str or ``NoneType``
+        :type page_token: str
         :param page_token: Optional. Opaque marker for the next "page" of
                            buckets. If not passed, will return the first page
                            of buckets.
 
-        :type prefix: str or ``NoneType``
+        :type prefix: str
         :param prefix: Optional. Filter results to buckets whose names begin
                        with this prefix.
 
-        :type projection: str or ``NoneType``
-        :param projection: If used, must be 'full' or 'noAcl'. Defaults to
+        :type projection: str
+        :param projection: (Optional) If used, must be 'full' or 'noAcl'. Defaults to
                            'noAcl'. Specifies the set of properties to return.
 
-        :type fields: str or ``NoneType``
-        :param fields: Selector specifying which fields to include in a
+        :type fields: str
+        :param fields: (Optional) Selector specifying which fields to include in a
                        partial response. Must be a list of fields. For example
                        to get a partial response with just the next page token
                        and the language of each bucket returned:


### PR DESCRIPTION
Based on comment: https://github.com/GoogleCloudPlatform/google-cloud-python/pull/2580#pullrequestreview-5178193

Uses this script:
https://gist.github.com/tswast/fa8bd1cbdf84e0777109d217c2271622

I manually adjusted whitespace to fix lint errors.