### PR TITLE
Implement Iterator.pages and simplify items iteration

### DIFF
--- a/bigquery/unit_tests/test_client.py
+++ b/bigquery/unit_tests/test_client.py
@@ -35,6 +35,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(client.connection.http, http)
 
     def test_list_projects_defaults(self):
+        import six
         from google.cloud.bigquery.client import Project
         PROJECT_1 = 'PROJECT_ONE'
         PROJECT_2 = 'PROJECT_TWO'
@@ -60,8 +61,8 @@ class TestClient(unittest.TestCase):
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_projects()
-        iterator.update_page()
-        projects = list(iterator.page)
+        page = six.next(iterator.pages)
+        projects = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(projects), len(DATA['projects']))
@@ -78,6 +79,8 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_projects_explicit_response_missing_projects_key(self):
+        import six
+
         PROJECT = 'PROJECT'
         PATH = 'projects'
         TOKEN = 'TOKEN'
@@ -87,8 +90,8 @@ class TestClient(unittest.TestCase):
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_projects(max_results=3, page_token=TOKEN)
-        iterator.update_page()
-        projects = list(iterator.page)
+        page = six.next(iterator.pages)
+        projects = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(projects), 0)
@@ -102,6 +105,7 @@ class TestClient(unittest.TestCase):
                          {'maxResults': 3, 'pageToken': TOKEN})
 
     def test_list_datasets_defaults(self):
+        import six
         from google.cloud.bigquery.dataset import Dataset
         PROJECT = 'PROJECT'
         DATASET_1 = 'dataset_one'
@@ -128,8 +132,8 @@ class TestClient(unittest.TestCase):
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_datasets()
-        iterator.update_page()
-        datasets = list(iterator.page)
+        page = six.next(iterator.pages)
+        datasets = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(datasets), len(DATA['datasets']))
@@ -145,6 +149,8 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_datasets_explicit_response_missing_datasets_key(self):
+        import six
+
         PROJECT = 'PROJECT'
         PATH = 'projects/%s/datasets' % PROJECT
         TOKEN = 'TOKEN'
@@ -155,8 +161,8 @@ class TestClient(unittest.TestCase):
 
         iterator = client.list_datasets(
             include_all=True, max_results=3, page_token=TOKEN)
-        iterator.update_page()
-        datasets = list(iterator.page)
+        page = six.next(iterator.pages)
+        datasets = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(datasets), 0)
@@ -189,6 +195,7 @@ class TestClient(unittest.TestCase):
             client.job_from_resource({'configuration': {'nonesuch': {}}})
 
     def test_list_jobs_defaults(self):
+        import six
         from google.cloud.bigquery.job import LoadTableFromStorageJob
         from google.cloud.bigquery.job import CopyJob
         from google.cloud.bigquery.job import ExtractTableToStorageJob
@@ -301,8 +308,8 @@ class TestClient(unittest.TestCase):
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_jobs()
-        iterator.update_page()
-        jobs = list(iterator.page)
+        page = six.next(iterator.pages)
+        jobs = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(jobs), len(DATA['jobs']))
@@ -319,6 +326,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], {'projection': 'full'})
 
     def test_list_jobs_load_job_wo_sourceUris(self):
+        import six
         from google.cloud.bigquery.job import LoadTableFromStorageJob
         PROJECT = 'PROJECT'
         DATASET = 'test_dataset'
@@ -356,8 +364,8 @@ class TestClient(unittest.TestCase):
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_jobs()
-        iterator.update_page()
-        jobs = list(iterator.page)
+        page = six.next(iterator.pages)
+        jobs = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(jobs), len(DATA['jobs']))
@@ -374,6 +382,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], {'projection': 'full'})
 
     def test_list_jobs_explicit_missing(self):
+        import six
         PROJECT = 'PROJECT'
         PATH = 'projects/%s/jobs' % PROJECT
         DATA = {}
@@ -384,8 +393,8 @@ class TestClient(unittest.TestCase):
 
         iterator = client.list_jobs(max_results=1000, page_token=TOKEN,
                                     all_users=True, state_filter='done')
-        iterator.update_page()
-        jobs = list(iterator.page)
+        page = six.next(iterator.pages)
+        jobs = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(jobs), 0)

--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -43,64 +43,38 @@ requests)::
     ...         break
 
 When iterating, not every new item will send a request to the server.
-To monitor these requests, track the current page of the iterator::
+To iterate based on each page of items (where a page corresponds to
+a request)::
 
     >>> iterator = Iterator(...)
-    >>> iterator.page_number
-    0
-    >>> next(iterator)
-    <MyItemClass at 0x7f1d3cccf690>
-    >>> iterator.page_number
-    1
-    >>> iterator.page.remaining
-    1
-    >>> next(iterator)
-    <MyItemClass at 0x7f1d3cccfe90>
-    >>> iterator.page_number
-    1
-    >>> iterator.page.remaining
-    0
-    >>> next(iterator)
-    <MyItemClass at 0x7f1d3cccffd0>
-    >>> iterator.page_number
-    2
-    >>> iterator.page.remaining
-    19
+    >>> for page in iterator.pages:
+    ...     print('=' * 20)
+    ...     print('    Page number: %d' % (iterator.page_number,))
+    ...     print('  Items in page: %d' % (page.num_items,))
+    ...     print('     First item: %r' % (next(page),))
+    ...     print('Items remaining: %d' % (page.remaining,))
+    ...     print('Next page token: %s' % (iterator.next_page_token,))
+    ====================
+        Page number: 1
+      Items in page: 1
+         First item: <MyItemClass at 0x7f1d3cccf690>
+    Items remaining: 0
+    Next page token: eav1OzQB0OM8rLdGXOEsyQWSG
+    ====================
+        Page number: 2
+      Items in page: 19
+         First item: <MyItemClass at 0x7f1d3cccffd0>
+    Items remaining: 18
+    Next page token: None
 
-It's also possible to consume an entire page and handle the paging process
-manually::
+To consume an entire page::
 
-    >>> iterator = Iterator(...)
-    >>> # Manually pull down the first page.
-    >>> iterator.update_page()
-    >>> items = list(iterator.page)
-    >>> items
+    >>> list(page)
     [
         <MyItemClass at 0x7fd64a098ad0>,
         <MyItemClass at 0x7fd64a098ed0>,
         <MyItemClass at 0x7fd64a098e90>,
     ]
-    >>> iterator.page.remaining
-    0
-    >>> iterator.page.num_items
-    3
-    >>> iterator.next_page_token
-    'eav1OzQB0OM8rLdGXOEsyQWSG'
-    >>>
-    >>> # Ask for the next page to be grabbed.
-    >>> iterator.update_page()
-    >>> list(iterator.page)
-    [
-        <MyItemClass at 0x7fea740abdd0>,
-        <MyItemClass at 0x7fea740abe50>,
-    ]
-    >>>
-    >>> # When there are no more results
-    >>> iterator.next_page_token is None
-    True
-    >>> iterator.update_page()
-    >>> iterator.page is None
-    True
 """
 
 

--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -314,16 +314,13 @@ class Iterator(object):
         return self._page
 
     def __iter__(self):
-        """The :class:`Iterator` is an iterator.
-
-        :rtype: :class:`Iterator`
-        :returns: Current instance.
-        :raises ValueError: If the iterator has already been started.
-        """
-        if self._started:
-            raise ValueError('Iterator has already started', self)
-        self._started = True
-        return self
+        """Iterator for each item returned."""
+        # NOTE: We don't check if the iterator has started since the pages
+        #       iterator already does this.
+        for page in self.pages:
+            for item in page:
+                self.num_results += 1
+                yield item
 
     def update_page(self, require_empty=True):
         """Move to the next page in the result set.
@@ -363,18 +360,6 @@ class Iterator(object):
             if require_empty:
                 msg = _PAGE_ERR_TEMPLATE % (self._page, self.page.remaining)
                 raise ValueError(msg)
-
-    def next(self):
-        """Get the next item from the request."""
-        self.update_page(require_empty=False)
-        if self.page is None:
-            raise StopIteration
-        item = six.next(self.page)
-        self.num_results += 1
-        return item
-
-    # Alias needed for Python 2/3 support.
-    __next__ = next
 
     def _has_next_page(self):
         """Determines whether or not there are more pages with results.

--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -282,6 +282,7 @@ class Iterator(object):
             page = Page(self, response, self._items_key,
                         self._item_to_value)
             self._page_start(self, page, response)
+            self.num_results += page.num_items
             yield page
 
     @property
@@ -302,6 +303,9 @@ class Iterator(object):
         # NOTE: We don't check if the iterator has started since the pages
         #       iterator already does this.
         for page in self.pages:
+            # Decrement the total results since the pages iterator adds
+            # to it when each page is encountered.
+            self.num_results -= page.num_items
             for item in page:
                 self.num_results += 1
                 yield item

--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -274,6 +274,31 @@ class Iterator(object):
             raise ValueError('Using a reserved parameter',
                              reserved_in_use)
 
+    def _pages_iter(self):
+        """Generator of pages of API responses.
+
+        Yields :class:`Page` instances.
+        """
+        while self._has_next_page():
+            response = self._get_next_page_response()
+            page = Page(self, response, self._items_key,
+                        self._item_to_value)
+            self._page_start(self, page, response)
+            yield page
+
+    @property
+    def pages(self):
+        """Iterator of pages in the response.
+
+        :rtype: :class:`~types.GeneratorType`
+        :returns: A generator of :class:`Page` instances.
+        :raises ValueError: If the iterator has already been started.
+        """
+        if self._started:
+            raise ValueError('Iterator has already started', self)
+        self._started = True
+        return self._pages_iter()
+
     @property
     def page(self):
         """The current page of results that has been retrieved.

--- a/dns/unit_tests/test_client.py
+++ b/dns/unit_tests/test_client.py
@@ -106,6 +106,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_zones_defaults(self):
+        import six
         from google.cloud.dns.zone import ManagedZone
         ID_1 = '123'
         ZONE_1 = 'zone_one'
@@ -133,8 +134,8 @@ class TestClient(unittest.TestCase):
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_zones()
-        iterator.update_page()
-        zones = list(iterator.page)
+        page = six.next(iterator.pages)
+        zones = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(zones), len(DATA['managedZones']))
@@ -151,6 +152,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_zones_explicit(self):
+        import six
         from google.cloud.dns.zone import ManagedZone
         ID_1 = '123'
         ZONE_1 = 'zone_one'
@@ -177,8 +179,8 @@ class TestClient(unittest.TestCase):
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_zones(max_results=3, page_token=TOKEN)
-        iterator.update_page()
-        zones = list(iterator.page)
+        page = six.next(iterator.pages)
+        zones = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(zones), len(DATA['managedZones']))

--- a/dns/unit_tests/test_zone.py
+++ b/dns/unit_tests/test_zone.py
@@ -409,6 +409,7 @@ class TestManagedZone(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_resource_record_sets_defaults(self):
+        import six
         from google.cloud.dns.resource_record_set import ResourceRecordSet
         PATH = 'projects/%s/managedZones/%s/rrsets' % (
             self.PROJECT, self.ZONE_NAME)
@@ -442,8 +443,8 @@ class TestManagedZone(unittest.TestCase):
 
         iterator = zone.list_resource_record_sets()
         self.assertIs(zone, iterator.zone)
-        iterator.update_page()
-        rrsets = list(iterator.page)
+        page = six.next(iterator.pages)
+        rrsets = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(rrsets), len(DATA['rrsets']))
@@ -461,6 +462,7 @@ class TestManagedZone(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_resource_record_sets_explicit(self):
+        import six
         from google.cloud.dns.resource_record_set import ResourceRecordSet
         PATH = 'projects/%s/managedZones/%s/rrsets' % (
             self.PROJECT, self.ZONE_NAME)
@@ -496,8 +498,8 @@ class TestManagedZone(unittest.TestCase):
         iterator = zone.list_resource_record_sets(
             max_results=3, page_token=TOKEN, client=client2)
         self.assertIs(zone, iterator.zone)
-        iterator.update_page()
-        rrsets = list(iterator.page)
+        page = six.next(iterator.pages)
+        rrsets = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(rrsets), len(DATA['rrsets']))
@@ -553,6 +555,7 @@ class TestManagedZone(unittest.TestCase):
         return result
 
     def test_list_changes_defaults(self):
+        import six
         from google.cloud.dns.changes import Changes
         from google.cloud.dns.resource_record_set import ResourceRecordSet
 
@@ -569,8 +572,8 @@ class TestManagedZone(unittest.TestCase):
 
         iterator = zone.list_changes()
         self.assertIs(zone, iterator.zone)
-        iterator.update_page()
-        changes = list(iterator.page)
+        page = six.next(iterator.pages)
+        changes = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(changes), len(data['changes']))
@@ -606,6 +609,7 @@ class TestManagedZone(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % (path,))
 
     def test_list_changes_explicit(self):
+        import six
         from google.cloud.dns.changes import Changes
         from google.cloud.dns.resource_record_set import ResourceRecordSet
 
@@ -624,8 +628,8 @@ class TestManagedZone(unittest.TestCase):
         iterator = zone.list_changes(
             max_results=3, page_token=page_token, client=client2)
         self.assertIs(zone, iterator.zone)
-        iterator.update_page()
-        changes = list(iterator.page)
+        page = six.next(iterator.pages)
+        changes = list(page)
         token = iterator.next_page_token
 
         self.assertEqual(len(changes), len(data['changes']))

--- a/resource_manager/unit_tests/test_client.py
+++ b/resource_manager/unit_tests/test_client.py
@@ -229,6 +229,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(list(page), [])
 
     def test_page_non_empty_response(self):
+        import six
         from google.cloud.resource_manager.project import Project
 
         project_id = 'project-id'
@@ -253,10 +254,9 @@ class TestClient(unittest.TestCase):
         iterator = client.list_projects()
         iterator._get_next_page_response = dummy_response
 
-        iterator.update_page()
-        page = iterator.page
+        page = six.next(iterator.pages)
         self.assertEqual(page.num_items, 1)
-        project = iterator.next()
+        project = six.next(page)
         self.assertEqual(page.remaining, 0)
         self.assertIsInstance(project, Project)
         self.assertEqual(project.project_id, project_id)

--- a/storage/unit_tests/test_bucket.py
+++ b/storage/unit_tests/test_bucket.py
@@ -991,6 +991,7 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(iterator.prefixes, set())
 
     def test_page_non_empty_response(self):
+        import six
         from google.cloud.storage.blob import Blob
 
         blob_name = 'blob-name'
@@ -1006,17 +1007,17 @@ class Test_Bucket(unittest.TestCase):
         iterator = bucket.list_blobs()
         iterator._get_next_page_response = dummy_response
 
-        iterator.update_page()
-        page = iterator.page
+        page = six.next(iterator.pages)
         self.assertEqual(page.prefixes, ('foo',))
         self.assertEqual(page.num_items, 1)
-        blob = iterator.next()
+        blob = six.next(page)
         self.assertEqual(page.remaining, 0)
         self.assertIsInstance(blob, Blob)
         self.assertEqual(blob.name, blob_name)
         self.assertEqual(iterator.prefixes, set(['foo']))
 
     def test_cumulative_prefixes(self):
+        import six
         from google.cloud.storage.blob import Blob
 
         BLOB_NAME = 'blob-name1'
@@ -1041,18 +1042,17 @@ class Test_Bucket(unittest.TestCase):
         iterator._get_next_page_response = dummy_response
 
         # Parse first response.
-        iterator.update_page()
-        page1 = iterator.page
+        pages_iter = iterator.pages
+        page1 = six.next(pages_iter)
         self.assertEqual(page1.prefixes, ('foo',))
         self.assertEqual(page1.num_items, 1)
-        blob = iterator.next()
+        blob = six.next(page1)
         self.assertEqual(page1.remaining, 0)
         self.assertIsInstance(blob, Blob)
         self.assertEqual(blob.name, BLOB_NAME)
         self.assertEqual(iterator.prefixes, set(['foo']))
         # Parse second response.
-        iterator.update_page()
-        page2 = iterator.page
+        page2 = six.next(pages_iter)
         self.assertEqual(page2.prefixes, ('bar',))
         self.assertEqual(page2.num_items, 0)
         self.assertEqual(iterator.prefixes, set(['foo', 'bar']))

--- a/storage/unit_tests/test_client.py
+++ b/storage/unit_tests/test_client.py
@@ -381,6 +381,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(list(page), [])
 
     def test_page_non_empty_response(self):
+        import six
         from google.cloud.storage.bucket import Bucket
 
         project = 'PROJECT'
@@ -396,10 +397,9 @@ class TestClient(unittest.TestCase):
         iterator = client.list_buckets()
         iterator._get_next_page_response = dummy_response
 
-        iterator.update_page()
-        page = iterator.page
+        page = six.next(iterator.pages)
         self.assertEqual(page.num_items, 1)
-        bucket = iterator.next()
+        bucket = six.next(page)
         self.assertEqual(page.remaining, 0)
         self.assertIsInstance(bucket, Bucket)
         self.assertEqual(bucket.name, blob_name)


### PR DESCRIPTION
Fixes #2548. As mentioned in #2529, this came from trying to design for the case that a page of responses came from GAX instead of from an HTTP response.

I have left alone `Iterator.next_page_token` and `Iterator.page_number` for now but think the token should be moved to the `Page` and the page number should just be removed (people can just use `enumerate(iterator.pages)` if they want the page number).

~~**NOTE**: Has #2592 as diffbase.~~