### PR TITLE
Using Iterators for list_topics() in Pub/Sub.

### DIFF
--- a/core/google/cloud/_testing.py
+++ b/core/google/cloud/_testing.py
@@ -83,10 +83,8 @@ class _GAXPageIterator(object):
     def next(self):
         if self._items is None:
             raise StopIteration
-        else:
-            items = self._items
-            self._items = None
-            return items
+        items, self._items = self._items, None
+        return items
 
     __next__ = next
 

--- a/core/google/cloud/_testing.py
+++ b/core/google/cloud/_testing.py
@@ -81,5 +81,14 @@ class _GAXPageIterator(object):
         self.page_token = page_token
 
     def next(self):
-        items, self._items = self._items, None
-        return items
+        if self._items is None:
+            raise StopIteration
+        else:
+            items = self._items
+            self._items = None
+            return items
+
+    __next__ = next
+
+    def __iter__(self):
+        return self

--- a/core/unit_tests/test_iterator.py
+++ b/core/unit_tests/test_iterator.py
@@ -128,6 +128,22 @@ class TestIterator(unittest.TestCase):
         with self.assertRaises(ValueError):
             self._makeOne(client, path, None, extra_params=extra_params)
 
+    def test_constructor_non_default_page_iter(self):
+        connection = _Connection()
+        client = _Client(connection)
+        path = '/foo'
+        result = object()
+        called = []
+
+        def page_iter(iterator):
+            called.append(iterator)
+            return result
+
+        iterator = self._makeOne(client, path, None,
+                                 page_iter=page_iter)
+        self.assertEqual(called, [iterator])
+        self.assertIs(iterator._page_iter, result)
+
     def test_pages_iter_empty_then_another(self):
         import six
         from google.cloud._testing import _Monkey

--- a/docs/pubsub_snippets.py
+++ b/docs/pubsub_snippets.py
@@ -46,13 +46,8 @@ def client_list_topics(client, to_delete):  # pylint: disable=unused-argument
         pass
 
     # [START client_list_topics]
-    topics, token = client.list_topics()   # API request
-    while True:
-        for topic in topics:
-            do_something_with(topic)
-        if token is None:
-            break
-        topics, token = client.list_topics(page_token=token)  # API request
+    for topic in client.list_topics():   # API request(s)
+        do_something_with(topic)
     # [END client_list_topics]
 
 

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -14,6 +14,8 @@
 
 """GAX wrapper for Pubsub API requests."""
 
+import functools
+
 from google.cloud.gapic.pubsub.v1.publisher_api import PublisherApi
 from google.cloud.gapic.pubsub.v1.subscriber_api import SubscriberApi
 from google.gax import CallOptions
@@ -29,6 +31,12 @@ from google.cloud._helpers import _to_bytes
 from google.cloud._helpers import _pb_timestamp_to_rfc3339
 from google.cloud.exceptions import Conflict
 from google.cloud.exceptions import NotFound
+from google.cloud.iterator import Iterator
+from google.cloud.iterator import Page
+from google.cloud.pubsub.topic import Topic
+
+
+_FAKE_ITEMS_KEY = 'not-a-key'
 
 
 class _PublisherAPI(object):
@@ -58,11 +66,9 @@ class _PublisherAPI(object):
                            passed, the API will return the first page of
                            topics.
 
-        :rtype: tuple, (list, str)
-        :returns: list of ``Topic`` resource dicts, plus a
-                  "next page token" string:  if not None, indicates that
-                  more topics can be retrieved with another call (pass that
-                  value as ``page_token``).
+        :rtype: :class:`~google.cloud.iterator.Iterator`
+        :returns: Iterator of :class:`~google.cloud.pubsub.topic.Topic`
+                  accessible to the current API.
         """
         if page_token is None:
             page_token = INITIAL_PAGE
@@ -70,9 +76,14 @@ class _PublisherAPI(object):
         path = 'projects/%s' % (project,)
         page_iter = self._gax_api.list_topics(
             path, page_size=page_size, options=options)
-        topics = [{'name': topic_pb.name} for topic_pb in page_iter.next()]
-        token = page_iter.page_token or None
-        return topics, token
+        page_iter = functools.partial(_recast_page_iterator, page_iter)
+
+        # NOTE: We don't currently have access to the client, so callers
+        #       that want the client, must manually bind the client to the
+        #       iterator instance returned.
+        return Iterator(client=None, path=path,
+                        item_to_value=_item_to_topic,
+                        page_iter=page_iter)
 
     def topic_create(self, topic_path):
         """API call:  create a topic
@@ -543,3 +554,42 @@ def make_gax_subscriber_api(connection):
     if connection.in_emulator:
         channel = insecure_channel(connection.host)
     return SubscriberApi(channel=channel)
+
+
+def _item_to_topic(iterator, resource):
+    """Convert a JSON job to the native object.
+
+    :type iterator: :class:`~google.cloud.iterator.Iterator`
+    :param iterator: The iterator that is currently in use.
+
+    :type resource: :class:`google.pubsub.v1.pubsub_pb2.Topic`
+    :param resource: A topic returned from the API.
+
+    :rtype: :class:`~google.cloud.pubsub.topic.Topic`
+    :returns: The next topic in the page.
+    """
+    return Topic.from_api_repr(
+        {'name': resource.name}, iterator.client)
+
+
+def _recast_page_iterator(page_iter, iterator):
+    """Wrap GAX pages generator.
+
+    In particular, wrap each page and capture some state from the
+    GAX iterator.
+
+    Yields :class:`~google.cloud.iterator.Page` instances
+
+    :type page_iter: :class:`~google.gax.PageIterator`
+    :param page_iter: The iterator to wrap.
+
+    :type iterator: :class:`~google.cloud.iterator.Iterator`
+    :param iterator: The iterator that owns each page.
+    """
+    for items in page_iter:
+        fake_response = {_FAKE_ITEMS_KEY: items}
+        page = Page(
+            iterator, fake_response, _FAKE_ITEMS_KEY, _item_to_topic)
+        iterator.next_page_token = page_iter.page_token or None
+        iterator.num_results += page.num_items
+        yield page

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -44,9 +44,14 @@ class _PublisherAPI(object):
 
     :type gax_api: :class:`google.pubsub.v1.publisher_api.PublisherApi`
     :param gax_api: API object used to make GAX requests.
+
+    :type client: :class:`~google.cloud.pubsub.client.Client`
+    :param client: The client that owns this API object.
     """
-    def __init__(self, gax_api):
+
+    def __init__(self, gax_api, client):
         self._gax_api = gax_api
+        self._client = client
 
     def list_topics(self, project, page_size=0, page_token=None):
         """List topics for the project associated with this API.
@@ -78,10 +83,7 @@ class _PublisherAPI(object):
             path, page_size=page_size, options=options)
         page_iter = functools.partial(_recast_page_iterator, page_iter)
 
-        # NOTE: We don't currently have access to the client, so callers
-        #       that want the client, must manually bind the client to the
-        #       iterator instance returned.
-        return Iterator(client=None, path=path,
+        return Iterator(client=self._client, path=path,
                         item_to_value=_item_to_topic,
                         page_iter=page_iter)
 

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -131,18 +131,17 @@ class Client(JSONClient):
                            passed, the API will return the first page of
                            topics.
 
-        :rtype: tuple, (list, str)
-        :returns: list of :class:`google.cloud.pubsub.topic.Topic`, plus a
-                  "next page token" string:  if not None, indicates that
-                  more topics can be retrieved with another call (pass that
-                  value as ``page_token``).
+        :rtype: :class:`~google.cloud.iterator.Iterator`
+        :returns: Iterator of :class:`~google.cloud.pubsub.topic.Topic`
+                  accessible to the current API.
         """
         api = self.publisher_api
-        resources, next_token = api.list_topics(
+        iterator = api.list_topics(
             self.project, page_size, page_token)
-        topics = [Topic.from_api_repr(resource, self)
-                  for resource in resources]
-        return topics, next_token
+        # NOTE: Make sure to set the client since ``api.list_topics()`` may
+        #       not have access to the current client.
+        iterator.client = self
+        return iterator
 
     def list_subscriptions(self, page_size=None, page_token=None):
         """List subscriptions for the project associated with this client.

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -87,9 +87,9 @@ class Client(JSONClient):
         if self._publisher_api is None:
             if self._use_gax:
                 generated = make_gax_publisher_api(self.connection)
-                self._publisher_api = GAXPublisherAPI(generated)
+                self._publisher_api = GAXPublisherAPI(generated, self)
             else:
-                self._publisher_api = JSONPublisherAPI(self.connection)
+                self._publisher_api = JSONPublisherAPI(self)
         return self._publisher_api
 
     @property
@@ -136,12 +136,8 @@ class Client(JSONClient):
                   accessible to the current API.
         """
         api = self.publisher_api
-        iterator = api.list_topics(
+        return api.list_topics(
             self.project, page_size, page_token)
-        # NOTE: Make sure to set the client since ``api.list_topics()`` may
-        #       not have access to the current client.
-        iterator.client = self
-        return iterator
 
     def list_subscriptions(self, page_size=None, page_token=None):
         """List subscriptions for the project associated with this client.

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -99,15 +99,15 @@ class Connection(base_connection.JSONConnection):
 class _PublisherAPI(object):
     """Helper mapping publisher-related APIs.
 
-    :type connection: :class:`Connection`
-    :param connection: the connection used to make API requests.
+    :type client: :class:`~google.cloud.pubsub.client.Client`
+    :param client: the client used to make API requests.
     """
 
-    def __init__(self, connection):
-        self._connection = connection
+    def __init__(self, client):
+        self._client = client
+        self._connection = client.connection
 
-    @staticmethod
-    def list_topics(project, page_size=None, page_token=None):
+    def list_topics(self, project, page_size=None, page_token=None):
         """API call:  list topics for a given project
 
         See:
@@ -134,10 +134,7 @@ class _PublisherAPI(object):
             extra_params['pageSize'] = page_size
         path = '/projects/%s/topics' % (project,)
 
-        # NOTE: We don't currently have access to the client, so callers
-        #       that want the client, must manually bind the client to the
-        #       iterator instance returned.
-        return Iterator(client=None, path=path,
+        return Iterator(client=self._client, path=path,
                         items_key='topics', item_to_value=_item_to_topic,
                         page_token=page_token, extra_params=extra_params)
 

--- a/pubsub/unit_tests/test__gax.py
+++ b/pubsub/unit_tests/test__gax.py
@@ -50,8 +50,10 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
     def test_ctor(self):
         gax_api = _GAXPublisherAPI()
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
         self.assertIs(api._gax_api, gax_api)
+        self.assertIs(api._client, client)
 
     def test_list_topics_no_paging(self):
         from google.gax import INITIAL_PAGE
@@ -61,11 +63,10 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         TOKEN = 'TOKEN'
         response = _GAXPageIterator([_TopicPB(self.TOPIC_PATH)], TOKEN)
         gax_api = _GAXPublisherAPI(_list_topics_response=response)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         iterator = api.list_topics(self.PROJECT)
-        # Add back the client to support API requests.
-        iterator.client = _Client(self.PROJECT)
         topics = list(iterator)
         next_token = iterator.next_page_token
 
@@ -91,12 +92,11 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator(
             [_TopicPB(self.TOPIC_PATH)], NEW_TOKEN)
         gax_api = _GAXPublisherAPI(_list_topics_response=response)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         iterator = api.list_topics(
             self.PROJECT, page_size=SIZE, page_token=TOKEN)
-        # Add back the client to support API requests.
-        iterator.client = _Client(self.PROJECT)
         topics = list(iterator)
         next_token = iterator.next_page_token
 
@@ -115,7 +115,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_create(self):
         topic_pb = _TopicPB(self.TOPIC_PATH)
         gax_api = _GAXPublisherAPI(_create_topic_response=topic_pb)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         resource = api.topic_create(self.TOPIC_PATH)
 
@@ -127,7 +128,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_create_already_exists(self):
         from google.cloud.exceptions import Conflict
         gax_api = _GAXPublisherAPI(_create_topic_conflict=True)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         with self.assertRaises(Conflict):
             api.topic_create(self.TOPIC_PATH)
@@ -139,7 +141,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_create_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.topic_create(self.TOPIC_PATH)
@@ -151,7 +154,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_get_hit(self):
         topic_pb = _TopicPB(self.TOPIC_PATH)
         gax_api = _GAXPublisherAPI(_get_topic_response=topic_pb)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         resource = api.topic_get(self.TOPIC_PATH)
 
@@ -163,7 +167,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_get_miss(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXPublisherAPI()
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.topic_get(self.TOPIC_PATH)
@@ -175,7 +180,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_get_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.topic_get(self.TOPIC_PATH)
@@ -186,7 +192,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
     def test_topic_delete_hit(self):
         gax_api = _GAXPublisherAPI(_delete_topic_ok=True)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         api.topic_delete(self.TOPIC_PATH)
 
@@ -197,7 +204,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_delete_miss(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXPublisherAPI(_delete_topic_ok=False)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.topic_delete(self.TOPIC_PATH)
@@ -209,7 +217,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_delete_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.topic_delete(self.TOPIC_PATH)
@@ -226,7 +235,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         MESSAGE = {'data': B64, 'attributes': {}}
         response = _PublishResponsePB([MSGID])
         gax_api = _GAXPublisherAPI(_publish_response=response)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         resource = api.topic_publish(self.TOPIC_PATH, [MESSAGE])
 
@@ -245,7 +255,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         B64 = base64.b64encode(PAYLOAD)
         MESSAGE = {'data': B64, 'attributes': {'foo': 'bar'}}
         gax_api = _GAXPublisherAPI()
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.topic_publish(self.TOPIC_PATH, [MESSAGE])
@@ -264,7 +275,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         B64 = base64.b64encode(PAYLOAD).decode('ascii')
         MESSAGE = {'data': B64, 'attributes': {}}
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.topic_publish(self.TOPIC_PATH, [MESSAGE])
@@ -282,7 +294,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([
             {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}], None)
         gax_api = _GAXPublisherAPI(_list_topic_subscriptions_response=response)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         subscriptions, next_token = api.topic_list_subscriptions(
             self.TOPIC_PATH)
@@ -308,7 +321,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([
             {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}], NEW_TOKEN)
         gax_api = _GAXPublisherAPI(_list_topic_subscriptions_response=response)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         subscriptions, next_token = api.topic_list_subscriptions(
             self.TOPIC_PATH, page_size=SIZE, page_token=TOKEN)
@@ -330,7 +344,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         from google.gax import INITIAL_PAGE
         from google.cloud.exceptions import NotFound
         gax_api = _GAXPublisherAPI()
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.topic_list_subscriptions(self.TOPIC_PATH)
@@ -345,7 +360,8 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         from google.gax import INITIAL_PAGE
         from google.gax.errors import GaxError
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        client = _Client(self.PROJECT)
+        api = self._makeOne(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.topic_list_subscriptions(self.TOPIC_PATH)

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -74,8 +74,9 @@ class TestClient(unittest.TestCase):
 
         class _GaxPublisherAPI(object):
 
-            def __init__(self, _wrapped):
+            def __init__(self, _wrapped, client):
                 self._wrapped = _wrapped
+                self._client = client
 
         creds = _Credentials()
         client = self._makeOne(project=self.PROJECT, credentials=creds)
@@ -88,6 +89,7 @@ class TestClient(unittest.TestCase):
 
         self.assertIsInstance(api, _GaxPublisherAPI)
         self.assertIs(api._wrapped, wrapped)
+        self.assertIs(api._client, client)
         # API instance is cached
         again = client.publisher_api
         self.assertIs(again, api)

--- a/pubsub/unit_tests/test_connection.py
+++ b/pubsub/unit_tests/test_connection.py
@@ -101,7 +101,9 @@ class Test_PublisherAPI(_Base):
 
     def test_ctor(self):
         connection = _Connection()
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
+        self.assertIs(api._client, client)
         self.assertIs(api._connection, connection)
 
     def test_list_topics_no_paging(self):
@@ -109,11 +111,10 @@ class Test_PublisherAPI(_Base):
 
         returned = {'topics': [{'name': self.TOPIC_PATH}]}
         connection = _Connection(returned)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         iterator = api.list_topics(self.PROJECT)
-        # Add back the client to support API requests.
-        iterator.client = _Client(connection, self.PROJECT)
         topics = list(iterator)
         next_token = iterator.next_page_token
 
@@ -141,12 +142,11 @@ class Test_PublisherAPI(_Base):
             'nextPageToken': 'TOKEN2',
         }
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         iterator = api.list_topics(
             self.PROJECT, page_token=TOKEN1, page_size=SIZE)
-        # Add back the client to support API requests.
-        iterator.client = _Client(connection, self.PROJECT)
         page = six.next(iterator.pages)
         topics = list(page)
         next_token = iterator.next_page_token
@@ -167,11 +167,10 @@ class Test_PublisherAPI(_Base):
     def test_list_topics_missing_key(self):
         returned = {}
         connection = _Connection(returned)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         iterator = api.list_topics(self.PROJECT)
-        # Add back the client to support API requests.
-        iterator.client = _Client(connection, self.PROJECT)
         topics = list(iterator)
         next_token = iterator.next_page_token
 
@@ -186,7 +185,8 @@ class Test_PublisherAPI(_Base):
     def test_topic_create(self):
         RETURNED = {'name': self.TOPIC_PATH}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         resource = api.topic_create(self.TOPIC_PATH)
 
@@ -199,7 +199,8 @@ class Test_PublisherAPI(_Base):
         from google.cloud.exceptions import Conflict
         connection = _Connection()
         connection._no_response_error = Conflict
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         with self.assertRaises(Conflict):
             api.topic_create(self.TOPIC_PATH)
@@ -211,7 +212,8 @@ class Test_PublisherAPI(_Base):
     def test_topic_get_hit(self):
         RETURNED = {'name': self.TOPIC_PATH}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         resource = api.topic_get(self.TOPIC_PATH)
 
@@ -223,7 +225,8 @@ class Test_PublisherAPI(_Base):
     def test_topic_get_miss(self):
         from google.cloud.exceptions import NotFound
         connection = _Connection()
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         with self.assertRaises(NotFound):
             api.topic_get(self.TOPIC_PATH)
@@ -235,7 +238,8 @@ class Test_PublisherAPI(_Base):
     def test_topic_delete_hit(self):
         RETURNED = {}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         api.topic_delete(self.TOPIC_PATH)
 
@@ -246,7 +250,8 @@ class Test_PublisherAPI(_Base):
     def test_topic_delete_miss(self):
         from google.cloud.exceptions import NotFound
         connection = _Connection()
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         with self.assertRaises(NotFound):
             api.topic_delete(self.TOPIC_PATH)
@@ -264,7 +269,8 @@ class Test_PublisherAPI(_Base):
         B64MSG = {'data': B64_PAYLOAD, 'attributes': {}}
         RETURNED = {'messageIds': [MSGID]}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         resource = api.topic_publish(self.TOPIC_PATH, [MESSAGE])
 
@@ -282,7 +288,8 @@ class Test_PublisherAPI(_Base):
         PAYLOAD = b'This is the message text'
         MESSAGE = {'data': PAYLOAD, 'attributes': {}}
         connection = _Connection()
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         with self.assertRaises(NotFound):
             api.topic_publish(self.TOPIC_PATH, [MESSAGE])
@@ -297,7 +304,8 @@ class Test_PublisherAPI(_Base):
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         RETURNED = {'subscriptions': [SUB_INFO]}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         subscriptions, next_token = api.topic_list_subscriptions(
             self.TOPIC_PATH)
@@ -324,7 +332,8 @@ class Test_PublisherAPI(_Base):
             'nextPageToken': 'TOKEN2',
         }
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         subscriptions, next_token = api.topic_list_subscriptions(
             self.TOPIC_PATH, page_token=TOKEN1, page_size=SIZE)
@@ -345,7 +354,8 @@ class Test_PublisherAPI(_Base):
     def test_topic_list_subscriptions_missing_key(self):
         RETURNED = {}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         subscriptions, next_token = api.topic_list_subscriptions(
             self.TOPIC_PATH)
@@ -361,7 +371,8 @@ class Test_PublisherAPI(_Base):
     def test_topic_list_subscriptions_miss(self):
         from google.cloud.exceptions import NotFound
         connection = _Connection()
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         with self.assertRaises(NotFound):
             api.topic_list_subscriptions(self.TOPIC_PATH)


### PR DESCRIPTION
In the process, had to add custom support for the GAX page iterator in our core Iterator implementation.

@tseaver @jonparrott I am sending this out as-is hoping for some feedback (`list_subscriptions` and `topic_list_subscriptions` also need to be done). I don't feel that great about the way I did custom paging in `Iterator`, maybe it's worth defining a GAX subclass of `Iterator`?

Also, in order to avoid too many radical changes to the code, I punted on getting a `client` into the `Iterator` returned by the `_gax` / `connection` implementations. As can be seen by the unit tests, this effectively makes them useless (more-so in the HTTP case than in the GAX case). I'd be happy to send a follow-up PR to make `client` accessible in the `_PublisherAPI` implementation, but again, wanted to make this commit digestible.

~~**NOTE**: Has #2594 as diffbase.~~