### PR TITLE
Converting Pub/Sub topic->list_subscriptions to iterator.

### DIFF
--- a/docs/pubsub_snippets.py
+++ b/docs/pubsub_snippets.py
@@ -206,14 +206,8 @@ def topic_subscription(client, to_delete):
         sub_names.add(sub.full_name)
 
     # [START topic_list_subscriptions]
-    subscriptions, token = topic.list_subscriptions()   # API request
-    while True:
-        for subscription in subscriptions:
-            do_something_with(subscription)
-        if token is None:
-            break
-        subscriptions, token = topic.list_subscriptions(
-            page_token=token)                           # API request
+    for subscription in topic.list_subscriptions():   # API request(s)
+        do_something_with(subscription)
     # [END topic_list_subscriptions]
 
     assert sub_names.issuperset(expected_names)

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -30,6 +30,8 @@ from google.cloud._helpers import _pb_timestamp_to_rfc3339
 from google.cloud.exceptions import Conflict
 from google.cloud.exceptions import NotFound
 from google.cloud.iterator import GAXIterator
+from google.cloud.pubsub._helpers import subscription_name_from_path
+from google.cloud.pubsub.subscription import Subscription
 from google.cloud.pubsub.topic import Topic
 
 
@@ -175,16 +177,14 @@ class _PublisherAPI(object):
             raise
         return result.message_ids
 
-    def topic_list_subscriptions(self, topic_path, page_size=0,
-                                 page_token=None):
+    def topic_list_subscriptions(self, topic, page_size=0, page_token=None):
         """API call:  list subscriptions bound to a topic
 
         See:
         https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics.subscriptions/list
 
-        :type topic_path: str
-        :param topic_path: fully-qualified path of the topic, in format
-                            ``projects/<PROJECT>/topics/<TOPIC_NAME>``.
+        :type topic: :class:`~google.cloud.pubsub.topic.Topic`
+        :param topic: The topic that owns the subscriptions.
 
         :type page_size: int
         :param page_size: maximum number of subscriptions to return, If not
@@ -195,15 +195,17 @@ class _PublisherAPI(object):
                            If not passed, the API will return the first page
                            of subscriptions.
 
-        :rtype: list of strings
-        :returns: fully-qualified names of subscriptions for the supplied
-                topic.
-        :raises: :exc:`google.cloud.exceptions.NotFound` if the topic does not
-                    exist
+        :rtype: :class:`~google.cloud.iterator.Iterator`
+        :returns: Iterator of
+                  :class:`~google.cloud.pubsub.subscription.Subscription`
+                  accessible to the current API.
+        :raises: :exc:`~google.cloud.exceptions.NotFound` if the topic does
+                  not exist.
         """
         if page_token is None:
             page_token = INITIAL_PAGE
         options = CallOptions(page_token=page_token)
+        topic_path = topic.full_name
         try:
             page_iter = self._gax_api.list_topic_subscriptions(
                 topic_path, page_size=page_size, options=options)
@@ -211,9 +213,14 @@ class _PublisherAPI(object):
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(topic_path)
             raise
-        subs = page_iter.next()
-        token = page_iter.page_token or None
-        return subs, token
+
+        iter_kwargs = {}
+        if page_size:  # page_size can be 0 or explicit None.
+            iter_kwargs['max_results'] = page_size
+        iterator = GAXIterator(self._client, page_iter,
+                               _item_to_subscription, **iter_kwargs)
+        iterator.topic = topic
+        return iterator
 
 
 class _SubscriberAPI(object):
@@ -554,7 +561,7 @@ def make_gax_subscriber_api(connection):
 
 
 def _item_to_topic(iterator, resource):
-    """Convert a JSON job to the native object.
+    """Convert a protobuf topic to the native object.
 
     :type iterator: :class:`~google.cloud.iterator.Iterator`
     :param iterator: The iterator that is currently in use.
@@ -567,3 +574,20 @@ def _item_to_topic(iterator, resource):
     """
     return Topic.from_api_repr(
         {'name': resource.name}, iterator.client)
+
+
+def _item_to_subscription(iterator, subscription_path):
+    """Convert a subscription name to the native object.
+
+    :type iterator: :class:`~google.cloud.iterator.Iterator`
+    :param iterator: The iterator that is currently in use.
+
+    :type subscription_path: str
+    :param subscription_path: Subscription path returned from the API.
+
+    :rtype: :class:`~google.cloud.pubsub.subscription.Subscription`
+    :returns: The next subscription in the page.
+    """
+    subscription_name = subscription_name_from_path(
+        subscription_path, iterator.client.project)
+    return Subscription(subscription_name, iterator.topic)

--- a/pubsub/google/cloud/pubsub/topic.py
+++ b/pubsub/google/cloud/pubsub/topic.py
@@ -17,7 +17,6 @@
 from google.cloud._helpers import _datetime_to_rfc3339
 from google.cloud._helpers import _NOW
 from google.cloud.exceptions import NotFound
-from google.cloud.pubsub._helpers import subscription_name_from_path
 from google.cloud.pubsub._helpers import topic_name_from_path
 from google.cloud.pubsub.iam import Policy
 from google.cloud.pubsub.subscription import Subscription
@@ -306,21 +305,14 @@ class Topic(object):
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current topic.
 
-        :rtype: tuple, (list, str)
-        :returns: list of :class:`~.pubsub.subscription.Subscription`,
-                  plus a "next page token" string:  if not None, indicates that
-                  more topics can be retrieved with another call (pass that
-                  value as ``page_token``).
+        :rtype: :class:`~google.cloud.iterator.Iterator`
+        :returns: Iterator of
+                  :class:`~google.cloud.pubsub.subscription.Subscription`
+                  accessible to the current topic.
         """
         client = self._require_client(client)
         api = client.publisher_api
-        sub_paths, next_token = api.topic_list_subscriptions(
-            self.full_name, page_size, page_token)
-        subscriptions = []
-        for sub_path in sub_paths:
-            sub_name = subscription_name_from_path(sub_path, self.project)
-            subscriptions.append(Subscription(sub_name, self))
-        return subscriptions, next_token
+        return api.topic_list_subscriptions(self, page_size, page_token)
 
     def get_iam_policy(self, client=None):
         """Fetch the IAM policy for the topic.

--- a/system_tests/pubsub.py
+++ b/system_tests/pubsub.py
@@ -70,6 +70,18 @@ def _consume_topics(pubsub_client):
     return list(pubsub_client.list_topics())
 
 
+def _consume_subscriptions(topic):
+    """Consume entire iterator.
+
+    :type topic: :class:`~google.cloud.pubsub.topic.Topic`
+    :param topic: Topic to use to retrieve subscriptions.
+
+    :rtype: list
+    :returns: List of all subscriptions encountered.
+    """
+    return list(topic.list_subscriptions())
+
+
 class TestPubsub(unittest.TestCase):
 
     def setUp(self):
@@ -89,7 +101,7 @@ class TestPubsub(unittest.TestCase):
         self.assertEqual(topic.name, topic_name)
 
     def test_list_topics(self):
-        before = list(Config.CLIENT.list_topics())
+        before = _consume_topics(Config.CLIENT)
         topics_to_create = [
             'new' + unique_resource_id(),
             'newer' + unique_resource_id(),
@@ -148,7 +160,7 @@ class TestPubsub(unittest.TestCase):
         topic = Config.CLIENT.topic(TOPIC_NAME)
         topic.create()
         self.to_delete.append(topic)
-        empty, _ = topic.list_subscriptions()
+        empty = _consume_subscriptions(topic)
         self.assertEqual(len(empty), 0)
         subscriptions_to_create = [
             'new' + unique_resource_id(),
@@ -162,10 +174,10 @@ class TestPubsub(unittest.TestCase):
 
         # Retrieve the subscriptions.
         def _all_created(result):
-            return len(result[0]) == len(subscriptions_to_create)
+            return len(result) == len(subscriptions_to_create)
 
         retry = RetryResult(_all_created)
-        all_subscriptions, _ = retry(topic.list_subscriptions)()
+        all_subscriptions = retry(_consume_subscriptions)(topic)
 
         created = [subscription for subscription in all_subscriptions
                    if subscription.name in subscriptions_to_create]


### PR DESCRIPTION
~~**NOTE**: Has #2617 as diffbase, though has only one commit.~~

**NOTE**: `_item_to_subscription` is identically defined in `_gax` and `connection`, since in either case the API just returns strings.

Also worth noting that the mocks in the unit tests were returning values different from what the actual responses returned.