### PR TITLE
Converting Pub/Sub client->list_subscriptions to iterator.

### DIFF
--- a/docs/pubsub_snippets.py
+++ b/docs/pubsub_snippets.py
@@ -60,14 +60,8 @@ def client_list_subscriptions(client,
         pass
 
     # [START client_list_subscriptions]
-    subscriptions, token = client.list_subscriptions()   # API request
-    while True:
-        for subscription in subscriptions:
-            do_something_with(subscription)
-        if token is None:
-            break
-        subscriptions, token = client.list_subscriptions(
-            page_token=token)                           # API request
+    for subscription in client.list_subscriptions():  # API request(s)
+        do_something_with(subscription)
     # [END client_list_subscriptions]
 
 

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -218,8 +218,9 @@ class _PublisherAPI(object):
         iter_kwargs = {}
         if page_size:  # page_size can be 0 or explicit None.
             iter_kwargs['max_results'] = page_size
-        iterator = GAXIterator(self._client, page_iter,
-                               _item_to_subscription, **iter_kwargs)
+        iterator = GAXIterator(
+            self._client, page_iter,
+            _item_to_subscription_for_topic, **iter_kwargs)
         iterator.topic = topic
         return iterator
 
@@ -563,7 +564,7 @@ def _item_to_topic(iterator, resource):
         {'name': resource.name}, iterator.client)
 
 
-def _item_to_subscription(iterator, subscription_path):
+def _item_to_subscription_for_topic(iterator, subscription_path):
     """Convert a subscription name to the native object.
 
     :type iterator: :class:`~google.cloud.iterator.Iterator`

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -266,7 +266,7 @@ class _SubscriberAPI(object):
         # can be re-used by other subscriptions from the same topic.
         topics = {}
         item_to_value = functools.partial(
-            _item_to_subscription_for_client, topics=topics)
+            _item_to_sub_for_client, topics=topics)
         return GAXIterator(self._client, page_iter, item_to_value)
 
     def subscription_create(self, subscription_path, topic_path,
@@ -577,7 +577,7 @@ def _item_to_subscription_for_topic(iterator, subscription_path):
     return Subscription(subscription_name, iterator.topic)
 
 
-def _item_to_subscription_for_client(iterator, sub_pb, topics):
+def _item_to_sub_for_client(iterator, sub_pb, topics):
     """Convert a subscription protobuf to the native object.
 
     .. note::

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -98,9 +98,9 @@ class Client(JSONClient):
         if self._subscriber_api is None:
             if self._use_gax:
                 generated = make_gax_subscriber_api(self.connection)
-                self._subscriber_api = GAXSubscriberAPI(generated)
+                self._subscriber_api = GAXSubscriberAPI(generated, self)
             else:
-                self._subscriber_api = JSONSubscriberAPI(self.connection)
+                self._subscriber_api = JSONSubscriberAPI(self)
         return self._subscriber_api
 
     @property

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -22,7 +22,6 @@ from google.cloud.pubsub.connection import Connection
 from google.cloud.pubsub.connection import _PublisherAPI as JSONPublisherAPI
 from google.cloud.pubsub.connection import _SubscriberAPI as JSONSubscriberAPI
 from google.cloud.pubsub.connection import _IAMPolicyAPI
-from google.cloud.pubsub.subscription import Subscription
 from google.cloud.pubsub.topic import Topic
 
 try:

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -160,20 +160,14 @@ class Client(JSONClient):
                            passed, the API will return the first page of
                            topics.
 
-        :rtype: tuple, (list, str)
-        :returns: list of :class:`~.pubsub.subscription.Subscription`,
-                  plus a "next page token" string:  if not None, indicates that
-                  more topics can be retrieved with another call (pass that
-                  value as ``page_token``).
+        :rtype: :class:`~google.cloud.iterator.Iterator`
+        :returns: Iterator of
+                  :class:`~google.cloud.pubsub.subscription.Subscription`
+                  accessible to the current client.
         """
         api = self.subscriber_api
-        resources, next_token = api.list_subscriptions(
+        return api.list_subscriptions(
             self.project, page_size, page_token)
-        topics = {}
-        subscriptions = [Subscription.from_api_repr(resource, self,
-                                                    topics=topics)
-                         for resource in resources]
-        return subscriptions, next_token
 
     def topic(self, name, timestamp_messages=False):
         """Creates a topic bound to the current client.

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -238,7 +238,8 @@ class _PublisherAPI(object):
 
         iterator = HTTPIterator(
             client=self._client, path=path,
-            item_to_value=_item_to_subscription, items_key='subscriptions',
+            item_to_value=_item_to_subscription_for_topic,
+            items_key='subscriptions',
             page_token=page_token, extra_params=extra_params)
         iterator.topic = topic
         return iterator
@@ -591,7 +592,7 @@ def _item_to_topic(iterator, resource):
     return Topic.from_api_repr(resource, iterator.client)
 
 
-def _item_to_subscription(iterator, subscription_path):
+def _item_to_subscription_for_topic(iterator, subscription_path):
     """Convert a subscription name to the native object.
 
     :type iterator: :class:`~google.cloud.iterator.Iterator`

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -290,7 +290,7 @@ class _SubscriberAPI(object):
         # can be re-used by other subscriptions from the same topic.
         topics = {}
         item_to_value = functools.partial(
-            _item_to_subscription_for_client, topics=topics)
+            _item_to_sub_for_client, topics=topics)
         return HTTPIterator(
             client=self._client, path=path, item_to_value=item_to_value,
             items_key='subscriptions', page_token=page_token,
@@ -612,7 +612,7 @@ def _item_to_subscription_for_topic(iterator, subscription_path):
     return Subscription(subscription_name, iterator.topic)
 
 
-def _item_to_subscription_for_client(iterator, resource, topics):
+def _item_to_sub_for_client(iterator, resource, topics):
     """Convert a subscription to the native object.
 
     .. note::

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -15,6 +15,7 @@
 """Create / interact with Google Cloud Pub/Sub connections."""
 
 import base64
+import functools
 import os
 
 from google.cloud import connection as base_connection
@@ -274,24 +275,26 @@ class _SubscriberAPI(object):
                            If not passed, the API will return the first page
                            of subscriptions.
 
-        :rtype: tuple, (list, str)
-        :returns: list of ``Subscription`` resource dicts, plus a
-                  "next page token" string:  if not None, indicates that
-                  more subscriptions can be retrieved with another call (pass
-                  that value as ``page_token``).
+        :rtype: :class:`~google.cloud.iterator.Iterator`
+        :returns: Iterator of
+                  :class:`~google.cloud.pubsub.subscription.Subscription`
+                  accessible to the current API.
         """
-        conn = self._connection
-        params = {}
-
+        extra_params = {}
         if page_size is not None:
-            params['pageSize'] = page_size
-
-        if page_token is not None:
-            params['pageToken'] = page_token
-
+            extra_params['pageSize'] = page_size
         path = '/projects/%s/subscriptions' % (project,)
-        resp = conn.api_request(method='GET', path=path, query_params=params)
-        return resp.get('subscriptions', ()), resp.get('nextPageToken')
+
+        # We attach a mutable topics dictionary so that as topic
+        # objects are created by Subscription.from_api_repr, they
+        # can be re-used by other subscriptions from the same topic.
+        topics = {}
+        item_to_value = functools.partial(
+            _item_to_subscription_for_client, topics=topics)
+        return HTTPIterator(
+            client=self._client, path=path, item_to_value=item_to_value,
+            items_key='subscriptions', page_token=page_token,
+            extra_params=extra_params)
 
     def subscription_create(self, subscription_path, topic_path,
                             ack_deadline=None, push_endpoint=None):
@@ -607,3 +610,32 @@ def _item_to_subscription_for_topic(iterator, subscription_path):
     subscription_name = subscription_name_from_path(
         subscription_path, iterator.client.project)
     return Subscription(subscription_name, iterator.topic)
+
+
+def _item_to_subscription_for_client(iterator, resource, topics):
+    """Convert a subscription to the native object.
+
+    .. note::
+
+       This method does not have the correct signature to be used as
+       the ``item_to_value`` argument to
+       :class:`~google.cloud.iterator.Iterator`. It is intended to be
+       patched with a mutable topics argument that can be updated
+       on subsequent calls. For an example, see how the method is
+       used above in :meth:`_SubscriberAPI.list_subscriptions`.
+
+    :type iterator: :class:`~google.cloud.iterator.Iterator`
+    :param iterator: The iterator that is currently in use.
+
+    :type resource: dict
+    :param resource: A subscription returned from the API.
+
+    :type topics: dict
+    :param topics: A dictionary of topics to be used (and modified)
+                   as new subscriptions are created bound to topics.
+
+    :rtype: :class:`~google.cloud.pubsub.subscription.Subscription`
+    :returns: The next subscription in the page.
+    """
+    return Subscription.from_api_repr(
+        resource, iterator.client, topics=topics)

--- a/pubsub/google/cloud/pubsub/connection.py
+++ b/pubsub/google/cloud/pubsub/connection.py
@@ -247,12 +247,13 @@ class _PublisherAPI(object):
 class _SubscriberAPI(object):
     """Helper mapping subscriber-related APIs.
 
-    :type connection: :class:`Connection`
-    :param connection: the connection used to make API requests.
+    :type client: :class:`~google.cloud.pubsub.client.Client`
+    :param client: the client used to make API requests.
     """
 
-    def __init__(self, connection):
-        self._connection = connection
+    def __init__(self, client):
+        self._client = client
+        self._connection = client.connection
 
     def list_subscriptions(self, project, page_size=None, page_token=None):
         """API call:  list subscriptions for a given project

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -126,8 +126,9 @@ class TestClient(unittest.TestCase):
 
         class _GaxSubscriberAPI(object):
 
-            def __init__(self, _wrapped):
+            def __init__(self, _wrapped, client):
                 self._wrapped = _wrapped
+                self._client = client
 
         creds = _Credentials()
 
@@ -139,6 +140,7 @@ class TestClient(unittest.TestCase):
 
         self.assertIsInstance(api, _GaxSubscriberAPI)
         self.assertIs(api._wrapped, wrapped)
+        self.assertIs(api._client, client)
         # API instance is cached
         again = client.subscriber_api
         self.assertIs(again, api)

--- a/pubsub/unit_tests/test_connection.py
+++ b/pubsub/unit_tests/test_connection.py
@@ -417,14 +417,17 @@ class Test_SubscriberAPI(_Base):
 
     def test_ctor(self):
         connection = _Connection()
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
         self.assertIs(api._connection, connection)
+        self.assertIs(api._client, client)
 
     def test_list_subscriptions_no_paging(self):
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         RETURNED = {'subscriptions': [SUB_INFO]}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         subscriptions, next_token = api.list_subscriptions(self.PROJECT)
 
@@ -450,7 +453,8 @@ class Test_SubscriberAPI(_Base):
             'nextPageToken': 'TOKEN2',
         }
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         subscriptions, next_token = api.list_subscriptions(
             self.PROJECT, page_token=TOKEN1, page_size=SIZE)
@@ -471,7 +475,8 @@ class Test_SubscriberAPI(_Base):
     def test_list_subscriptions_missing_key(self):
         RETURNED = {}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         subscriptions, next_token = api.list_subscriptions(self.PROJECT)
 
@@ -488,7 +493,8 @@ class Test_SubscriberAPI(_Base):
         RETURNED = RESOURCE.copy()
         RETURNED['name'] = self.SUB_PATH
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         resource = api.subscription_create(self.SUB_PATH, self.TOPIC_PATH)
 
@@ -511,7 +517,8 @@ class Test_SubscriberAPI(_Base):
         RETURNED = RESOURCE.copy()
         RETURNED['name'] = self.SUB_PATH
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         resource = api.subscription_create(
             self.SUB_PATH, self.TOPIC_PATH,
@@ -533,7 +540,8 @@ class Test_SubscriberAPI(_Base):
             'pushConfig': {'pushEndpoint': PUSH_ENDPOINT},
         }
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         resource = api.subscription_get(self.SUB_PATH)
 
@@ -545,7 +553,8 @@ class Test_SubscriberAPI(_Base):
     def test_subscription_delete(self):
         RETURNED = {}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         api.subscription_delete(self.SUB_PATH)
 
@@ -560,7 +569,8 @@ class Test_SubscriberAPI(_Base):
         }
         RETURNED = {}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         api.subscription_modify_push_config(self.SUB_PATH, PUSH_ENDPOINT)
 
@@ -580,7 +590,8 @@ class Test_SubscriberAPI(_Base):
             'receivedMessages': [{'ackId': ACK_ID, 'message': MESSAGE}],
         }
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
         BODY = {
             'returnImmediately': False,
             'maxMessages': 1,
@@ -606,7 +617,8 @@ class Test_SubscriberAPI(_Base):
             'receivedMessages': [{'ackId': ACK_ID, 'message': MESSAGE}],
         }
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
         MAX_MESSAGES = 10
         BODY = {
             'returnImmediately': True,
@@ -630,7 +642,8 @@ class Test_SubscriberAPI(_Base):
         }
         RETURNED = {}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         api.subscription_acknowledge(self.SUB_PATH, [ACK_ID1, ACK_ID2])
 
@@ -649,7 +662,8 @@ class Test_SubscriberAPI(_Base):
         }
         RETURNED = {}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        client = _Client(connection, self.PROJECT)
+        api = self._makeOne(client)
 
         api.subscription_modify_ack_deadline(
             self.SUB_PATH, [ACK_ID1, ACK_ID2], NEW_DEADLINE)


### PR DESCRIPTION
There is surprisingly no system test for `Client.list_subscriptions()`. After seeing how different the implementations of `Client.list_subscriptions()` and `Topic.list_subscriptions()` are, I am strongly for adding such a system test.

~~Sending this out without fixing unit tests to get it in the hands of reviewers. The unit tests may take me a non-trivial time, but I am working on them.~~