### PR TITLE
Converting Logging client->list_entries to iterator.

### DIFF
--- a/core/google/cloud/iterator.py
+++ b/core/google/cloud/iterator.py
@@ -298,6 +298,7 @@ class HTTPIterator(Iterator):
     _PAGE_TOKEN = 'pageToken'
     _MAX_RESULTS = 'maxResults'
     _RESERVED_PARAMS = frozenset([_PAGE_TOKEN, _MAX_RESULTS])
+    _HTTP_METHOD = 'GET'
 
     def __init__(self, client, path, item_to_value,
                  items_key=DEFAULT_ITEMS_KEY,
@@ -378,9 +379,19 @@ class HTTPIterator(Iterator):
         :rtype: dict
         :returns: The parsed JSON response of the next page's contents.
         """
-        return self.client.connection.api_request(
-            method='GET', path=self.path,
-            query_params=self._get_query_params())
+        params = self._get_query_params()
+        if self._HTTP_METHOD == 'GET':
+            return self.client.connection.api_request(
+                method=self._HTTP_METHOD,
+                path=self.path,
+                query_params=params)
+        elif self._HTTP_METHOD == 'POST':
+            return self.client.connection.api_request(
+                method=self._HTTP_METHOD,
+                path=self.path,
+                data=params)
+        else:
+            raise ValueError('Unexpected HTTP method', self._HTTP_METHOD)
 
 
 class GAXIterator(Iterator):

--- a/core/unit_tests/test_iterator.py
+++ b/core/unit_tests/test_iterator.py
@@ -436,6 +436,32 @@ class TestHTTPIterator(unittest.TestCase):
         self.assertEqual(kw['path'], path)
         self.assertEqual(kw['query_params'], {})
 
+    def test__get_next_page_response_with_post(self):
+        path = '/foo'
+        returned = {'green': 'eggs', 'ham': 55}
+        connection = _Connection(returned)
+        client = _Client(connection)
+        iterator = self._makeOne(client, path, None)
+        iterator._HTTP_METHOD = 'POST'
+        response = iterator._get_next_page_response()
+        self.assertEqual(response, returned)
+
+        self.assertEqual(len(connection._requested), 1)
+        called_kwargs = connection._requested[0]
+        self.assertEqual(called_kwargs, {
+            'method': iterator._HTTP_METHOD,
+            'path': path,
+            'data': {},
+        })
+
+    def test__get_next_page_bad_http_method(self):
+        path = '/foo'
+        client = _Client(None)
+        iterator = self._makeOne(client, path, None)
+        iterator._HTTP_METHOD = 'NOT-A-VERB'
+        with self.assertRaises(ValueError):
+            iterator._get_next_page_response()
+
 
 class TestGAXIterator(unittest.TestCase):
 

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -68,8 +68,7 @@ Fetch entries for the default project.
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
-   >>> entries, token = client.list_entries()  # API call
-   >>> for entry in entries:
+   >>> for entry in client.list_entries():  # API call(s)
    ...    timestamp = entry.timestamp.isoformat()
    ...    print('%sZ: %s' %
    ...          (timestamp, entry.payload))
@@ -82,8 +81,9 @@ Fetch entries across multiple projects.
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
-   >>> entries, token = client.list_entries(
-   ...     project_ids=['one-project', 'another-project'])  # API call
+   >>> iterator = client.list_entries(
+   ...     project_ids=['one-project', 'another-project'])
+   >>> entries = list(iterator)  # API call(s)
 
 Filter entries retrieved using the `Advanced Logs Filters`_ syntax
 
@@ -94,7 +94,8 @@ Filter entries retrieved using the `Advanced Logs Filters`_ syntax
    >>> from google.cloud import logging
    >>> client = logging.Client()
    >>> FILTER = "log:log_name AND textPayload:simple"
-   >>> entries, token = client.list_entries(filter=FILTER)  # API call
+   >>> iterator = client.list_entries(filter=FILTER)
+   >>> entries = list(iterator)  # API call(s)
 
 Sort entries in descending timestamp order.
 
@@ -102,7 +103,8 @@ Sort entries in descending timestamp order.
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
-   >>> entries, token = client.list_entries(order_by=logging.DESCENDING)  # API call
+   >>> iterator = client.list_entries(order_by=logging.DESCENDING)
+   >>> entries = list(iterator)  # API call(s)
 
 Retrieve entries in batches of 10, iterating until done.
 
@@ -111,12 +113,15 @@ Retrieve entries in batches of 10, iterating until done.
    >>> from google.cloud import logging
    >>> client = logging.Client()
    >>> retrieved = []
-   >>> token = None
-   >>> while True:
-   ...     entries, token = client.list_entries(page_size=10, page_token=token)  # API call
-   ...     retrieved.extend(entries)
-   ...     if token is None:
-   ...         break
+   >>> iterator = client.list_entries(page_size=10, page_token=token)
+   >>> pages = iterator.pages
+   >>> page1 = next(pages)  # API call
+   >>> for entry in page1:
+   ...     do_something(entry)
+   ...
+   >>> page2 = next(pages)  # API call
+   >>> for entry in page2:
+   ...     do_something_else(entry)
 
 Retrieve entries for a single logger, sorting in descending timestamp order:
 
@@ -125,7 +130,8 @@ Retrieve entries for a single logger, sorting in descending timestamp order:
    >>> from google.cloud import logging
    >>> client = logging.Client()
    >>> logger = client.logger('log_name')
-   >>> entries, token = logger.list_entries(order_by=logging.DESCENDING)  # API call
+   >>> iterator = logger.list_entries(order_by=logging.DESCENDING)
+   >>> entries = list(iterator)  # API call(s)
 
 Delete all entries for a logger
 -------------------------------

--- a/logging/README.rst
+++ b/logging/README.rst
@@ -47,8 +47,7 @@ Example of fetching entries:
 
 .. code:: python
 
-    entries, token = logger.list_entries()
-    for entry in entries:
+    for entry in logger.list_entries():
         print(entry.payload)
 
 See the ``google-cloud-python`` API `logging documentation`_ to learn how to

--- a/logging/google/cloud/logging/_helpers.py
+++ b/logging/google/cloud/logging/_helpers.py
@@ -1,0 +1,48 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common logging helpers."""
+
+
+from google.cloud.logging.entries import ProtobufEntry
+from google.cloud.logging.entries import StructEntry
+from google.cloud.logging.entries import TextEntry
+
+
+def entry_from_resource(resource, client, loggers):
+    """Detect correct entry type from resource and instantiate.
+
+    :type resource: dict
+    :param resource: one entry resource from API response
+
+    :type client: :class:`~google.cloud.logging.client.Client`
+    :param client: Client that owns the log entry.
+
+    :type loggers: dict
+    :param loggers:
+        A mapping of logger fullnames -> loggers.  If the logger
+        that owns the entry is not in ``loggers``, the entry
+        will have a newly-created logger.
+
+    :rtype: :class:`~google.cloud.logging.entries._BaseEntry`
+    :returns: The entry instance, constructed via the resource
+    """
+    if 'textPayload' in resource:
+        return TextEntry.from_api_repr(resource, client, loggers)
+    elif 'jsonPayload' in resource:
+        return StructEntry.from_api_repr(resource, client, loggers)
+    elif 'protoPayload' in resource:
+        return ProtobufEntry.from_api_repr(resource, client, loggers)
+
+    raise ValueError('Cannot parse log entry resource')

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -285,8 +285,9 @@ class Logger(object):
                             defaults to the project bound to the client.
 
         :type filter_: str
-        :param filter_: a filter expression. See:
-                        https://cloud.google.com/logging/docs/view/advanced_filters
+        :param filter_:
+            a filter expression. See:
+            https://cloud.google.com/logging/docs/view/advanced_filters
 
         :type order_by: str
         :param order_by: One of :data:`~google.cloud.logging.ASCENDING`
@@ -301,11 +302,9 @@ class Logger(object):
                            passed, the API will return the first page of
                            entries.
 
-        :rtype: tuple, (list, str)
-        :returns: list of :class:`google.cloud.logging.entry.TextEntry`, plus a
-                  "next page token" string:  if not None, indicates that
-                  more entries can be retrieved with another call (pass that
-                  value as ``page_token``).
+        :rtype: :class:`~google.cloud.iterator.Iterator`
+        :returns: Iterator of :class:`~google.cloud.logging.entries._BaseEntry`
+                  accessible to the current logger.
         """
         log_filter = 'logName=%s' % (self.full_name,)
         if filter_ is not None:

--- a/logging/unit_tests/test__helpers.py
+++ b/logging/unit_tests/test__helpers.py
@@ -1,0 +1,62 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+
+
+class Test_entry_from_resource(unittest.TestCase):
+
+    @staticmethod
+    def _call_fut(resource, client, loggers):
+        from google.cloud.logging._helpers import entry_from_resource
+        return entry_from_resource(resource, client, loggers)
+
+    def test_unknown_type(self):
+        with self.assertRaises(ValueError):
+            self._call_fut({}, None, {})
+
+    def _payload_helper(self, key, class_name):
+        from google.cloud._testing import _Monkey
+        import google.cloud.logging._helpers as MUT
+
+        resource = {key: 'yup'}
+        client = object()
+        loggers = {}
+        mock_class = EntryMock()
+        with _Monkey(MUT, **{class_name: mock_class}):
+            result = self._call_fut(resource, client, loggers)
+
+        self.assertIs(result, mock_class.sentinel)
+        self.assertEqual(mock_class.called, (resource, client, loggers))
+
+    def test_text_payload(self):
+        self._payload_helper('textPayload', 'TextEntry')
+
+    def test_json_payload(self):
+        self._payload_helper('jsonPayload', 'StructEntry')
+
+    def test_proto_payload(self):
+        self._payload_helper('protoPayload', 'ProtobufEntry')
+
+
+class EntryMock(object):
+
+    def __init__(self):
+        self.sentinel = object()
+        self.called = None
+
+    def from_api_repr(self, resource, client, loggers):
+        self.called = (resource, client, loggers)
+        return self.sentinel

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -202,14 +202,6 @@ class TestClient(unittest.TestCase):
         self.assertIs(logger.client, client)
         self.assertEqual(logger.project, self.PROJECT)
 
-    def test__entry_from_resource_unknown_type(self):
-        PROJECT = 'PROJECT'
-        creds = _Credentials()
-        client = self._makeOne(PROJECT, creds)
-        loggers = {}
-        with self.assertRaises(ValueError):
-            client._entry_from_resource({'unknownPayload': {}}, loggers)
-
     def test_list_entries_defaults(self):
         from google.cloud.logging.entries import TextEntry
         IID = 'IID'


### PR DESCRIPTION
@waprin @jonparrott I just realized how weird the logging HTTP/JSON API is. For `/entries:list`, [POST is used](https://cloud.google.com/logging/docs/api/reference/rest/v2/entries/list) instead of GET, and the "query params" come in the payload instead of as query params.

~~Just as #2633 started, I'm sending this out without fixing unit tests to get it in the hands of reviewers. The unit tests may take me a non-trivial time, but I am working on them.~~
