### PR TITLE
Actual type_url URI is type.googleapis.com.

### DIFF
--- a/core/google/cloud/operation.py
+++ b/core/google/cloud/operation.py
@@ -17,7 +17,7 @@
 from google.longrunning import operations_pb2
 
 
-_GOOGLE_APIS_PREFIX = 'types.googleapis.com'
+_GOOGLE_APIS_PREFIX = 'type.googleapis.com'
 
 _TYPE_URL_MAP = {
 }


### PR DESCRIPTION
Usually `prefix` is passed to `def _compute_type_url(klass, prefix)` so this should be a low/no impact change.

However I don't see where Bigtable passes `prefix`...
