### PR TITLE
Clean up async docs and unify for future GAPIC async.

### DIFF
--- a/docs/speech-usage.rst
+++ b/docs/speech-usage.rst
@@ -69,9 +69,12 @@ See: `Speech Asynchronous Recognize`_
     ...     operation.poll()  # API call
     >>> operation.complete
     True
-    >>> operation.results[0].transcript
+    >>> for result in operation.results:
+    ...     print('=' * 20)
+    ...     print(result.transcript)
+    ...     print(result.confidence)
+    ====================
     'how old is the Brooklyn Bridge'
-    >>> operation.results[0].confidence
     0.98267895
 
 

--- a/speech/google/cloud/speech/operation.py
+++ b/speech/google/cloud/speech/operation.py
@@ -123,8 +123,9 @@ class Operation(operation.Operation):
         raw_results = response.get('response', {}).get('results', None)
         results = []
         if raw_results:
-            for result in raw_results[0]['alternatives']:
-                results.append(Transcript.from_api_repr(result))
+            for result in raw_results:
+                for alternative in result['alternatives']:
+                    results.append(Transcript.from_api_repr(alternative))
         if metadata:
             self._metadata = Metadata.from_api_repr(metadata)
 

--- a/speech/unit_tests/test_operation.py
+++ b/speech/unit_tests/test_operation.py
@@ -36,7 +36,7 @@ class OperationTests(unittest.TestCase):
 
     def test_from_api_repr(self):
         from unit_tests._fixtures import OPERATION_COMPLETE_RESPONSE
-        from google.cloud.speech.operation import Transcript
+        from google.cloud.speech.transcript import Transcript
         from google.cloud.speech.metadata import Metadata
         RESPONSE = OPERATION_COMPLETE_RESPONSE
 
@@ -46,10 +46,12 @@ class OperationTests(unittest.TestCase):
         self.assertEqual('123456789', operation.name)
         self.assertTrue(operation.complete)
 
+        self.assertEqual(len(operation.results), 1)
         self.assertIsInstance(operation.results[0], Transcript)
         self.assertEqual(operation.results[0].transcript,
                          'how old is the Brooklyn Bridge')
-        self.assertEqual(operation.results[0].confidence, 0.98267895)
+        self.assertEqual(operation.results[0].confidence,
+                         0.98267895)
         self.assertTrue(operation.complete)
         self.assertIsInstance(operation.metadata, Metadata)
         self.assertEqual(operation.metadata.progress_percent, 100)


### PR DESCRIPTION
@dhermes mentioned this in a previous review.
This is correct and I also cleaned up the docs.

In my testing with async, I haven't gotten more than one alternative to show up, even whith `max_alternatives=2`. So that's why there isn't two in the doc example.