### PR TITLE
Allow Transcript to handle missing 'confidence' fields

### DIFF
--- a/speech/google/cloud/speech/transcript.py
+++ b/speech/google/cloud/speech/transcript.py
@@ -38,7 +38,7 @@ class Transcript(object):
         :rtype: :class:`Transcript`
         :returns: Instance of ``Transcript``.
         """
-        return cls(transcript.get('transcript'), transcript.get('confidence'))
+        return cls(transcript['transcript'], transcript.get('confidence'))
 
     @classmethod
     def from_pb(cls, transcript):

--- a/speech/google/cloud/speech/transcript.py
+++ b/speech/google/cloud/speech/transcript.py
@@ -38,7 +38,7 @@ class Transcript(object):
         :rtype: :class:`Transcript`
         :returns: Instance of ``Transcript``.
         """
-        return cls(transcript['transcript'], transcript['confidence'])
+        return cls(transcript.get('transcript'), transcript.get('confidence'))
 
     @classmethod
     def from_pb(cls, transcript):

--- a/speech/unit_tests/test_transcript.py
+++ b/speech/unit_tests/test_transcript.py
@@ -31,3 +31,12 @@ class TestTranscript(unittest.TestCase):
         self.assertEqual('how old is the Brooklyn Bridge',
                          transcript.transcript)
         self.assertEqual(0.98267895, transcript.confidence)
+
+    def test_from_api_repr_with_no_confidence(self):
+        data = {
+            'transcript': 'testing 1 2 3'
+        }
+
+        transcript = self._getTargetClass().from_api_repr(data)
+        self.assertEqual(transcript.transcript, data['transcript'])
+        self.assertIsNone(transcript.confidence)


### PR DESCRIPTION
When `max_alternitives` > 1, the `confidence` field is omitted entirely. So `Transcript` needs to set `confidence` to `None`.

```
{
 "results": [
  {
   "alternatives": [
    {
     "transcript": "hello thank you for using Google Cloud platform",
     "confidence": 0.95869493
    },
    {
     "transcript": "thank you for using Google Cloud platform"
    },
    {
     "transcript": "hello thank you for using Google Cloud platforms"
    }
   ]
  }
 ]
}
```