### PR TITLE
Expose connection property on _JSONSpeechAPI.

### DIFF
--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -230,6 +230,15 @@ class _JSONSpeechAPI(object):
         self._client = client
         self._connection = client.connection
 
+    @property
+    def connection(self):
+        """Connection property.
+
+        :rtype: :class:`~google.cloud.core.connection.Connection`
+        :returns: Instance of ``Connection``
+        """
+        return self._connection
+
     def async_recognize(self, sample, language_code=None,
                         max_alternatives=None, profanity_filter=None,
                         speech_context=None):

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -294,12 +294,14 @@ class TestClient(unittest.TestCase):
             self.assertIsInstance(client.speech_api, GAPICSpeechAPI)
 
     def test_speech_api_without_gax(self):
+        from google.cloud.connection import Connection
         from google.cloud.speech.client import _JSONSpeechAPI
 
         creds = _Credentials()
         client = self._makeOne(credentials=creds, use_gax=False)
         self.assertIsNone(client._speech_api)
         self.assertIsInstance(client.speech_api, _JSONSpeechAPI)
+        self.assertIsInstance(client.speech_api.connection, Connection)
 
     def test_speech_api_preset(self):
         creds = _Credentials()


### PR DESCRIPTION
`Operation.poll` uses the `connection` to make the request.  This was missed in the tests since they set `connection` to `_Connection()`.