### PR TITLE
Passing Client through to low-level logging API objects.

### DIFF
--- a/logging/google/cloud/logging/_gax.py
+++ b/logging/google/cloud/logging/_gax.py
@@ -144,9 +144,13 @@ class _SinksAPI(object):
     :type gax_api:
         :class:`google.logging.v2.config_service_v2_api.ConfigServiceV2Api`
     :param gax_api: API object used to make GAX requests.
+
+    :type client: :class:`~google.cloud.logging.client.Client`
+    :param client: The client that owns this API object.
     """
-    def __init__(self, gax_api):
+    def __init__(self, gax_api, client):
         self._gax_api = gax_api
+        self._client = client
 
     def list_sinks(self, project, page_size=0, page_token=None):
         """List sinks for the project associated with this client.
@@ -291,9 +295,13 @@ class _MetricsAPI(object):
     :type gax_api:
         :class:`google.logging.v2.metrics_service_v2_api.MetricsServiceV2Api`
     :param gax_api: API object used to make GAX requests.
+
+    :type client: :class:`~google.cloud.logging.client.Client`
+    :param client: The client that owns this API object.
     """
-    def __init__(self, gax_api):
+    def __init__(self, gax_api, client):
         self._gax_api = gax_api
+        self._client = client
 
     def list_metrics(self, project, page_size=0, page_token=None):
         """List metrics for the project associated with this client.

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -113,9 +113,9 @@ class Client(JSONClient):
         if self._sinks_api is None:
             if _USE_GAX:
                 generated = GeneratedSinksAPI()
-                self._sinks_api = GAXSinksAPI(generated)
+                self._sinks_api = GAXSinksAPI(generated, self)
             else:
-                self._sinks_api = JSONSinksAPI(self.connection)
+                self._sinks_api = JSONSinksAPI(self)
         return self._sinks_api
 
     @property
@@ -128,9 +128,9 @@ class Client(JSONClient):
         if self._metrics_api is None:
             if _USE_GAX:
                 generated = GeneratedMetricsAPI()
-                self._metrics_api = GAXMetricsAPI(generated)
+                self._metrics_api = GAXMetricsAPI(generated, self)
             else:
-                self._metrics_api = JSONMetricsAPI(self.connection)
+                self._metrics_api = JSONMetricsAPI(self)
         return self._metrics_api
 
     def logger(self, name):

--- a/logging/google/cloud/logging/connection.py
+++ b/logging/google/cloud/logging/connection.py
@@ -184,11 +184,12 @@ class _SinksAPI(object):
     See:
     https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.sinks
 
-    :type connection: :class:`google.cloud.logging.connection.Connection`
-    :param connection: the connection used to make API requests.
+    :type client: :class:`~google.cloud.logging.client.Client`
+    :param client: The client used to make API requests.
     """
-    def __init__(self, connection):
-        self._connection = connection
+    def __init__(self, client):
+        self._client = client
+        self._connection = client.connection
 
     def list_sinks(self, project, page_size=None, page_token=None):
         """List sinks for the project associated with this client.
@@ -323,11 +324,12 @@ class _MetricsAPI(object):
     See:
     https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.metrics
 
-    :type connection: :class:`google.cloud.logging.connection.Connection`
-    :param connection: the connection used to make API requests.
+    :type client: :class:`~google.cloud.logging.client.Client`
+    :param client: The client used to make API requests.
     """
-    def __init__(self, connection):
-        self._connection = connection
+    def __init__(self, client):
+        self._client = client
+        self._connection = client.connection
 
     def list_metrics(self, project, page_size=None, page_token=None):
         """List metrics for the project associated with this client.

--- a/logging/unit_tests/test__gax.py
+++ b/logging/unit_tests/test__gax.py
@@ -606,8 +606,10 @@ class Test_SinksAPI(_Base, unittest.TestCase):
 
     def test_ctor(self):
         gax_api = _GAXSinksAPI()
-        api = self._makeOne(gax_api)
+        client = object()
+        api = self._makeOne(gax_api, client)
         self.assertIs(api._gax_api, gax_api)
+        self.assertIs(api._client, client)
 
     def test_list_sinks_no_paging(self):
         from google.gax import INITIAL_PAGE
@@ -625,7 +627,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
                           filter=self.FILTER)
         response = _GAXPageIterator([sink_pb], page_token=TOKEN)
         gax_api = _GAXSinksAPI(_list_sinks_response=response)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         sinks, token = api.list_sinks(self.PROJECT)
 
@@ -653,7 +655,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
                           filter=self.FILTER)
         response = _GAXPageIterator([sink_pb])
         gax_api = _GAXSinksAPI(_list_sinks_response=response)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         sinks, token = api.list_sinks(
             self.PROJECT, page_size=PAGE_SIZE, page_token=TOKEN)
@@ -669,7 +671,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_create_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXSinksAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.sink_create(
@@ -679,7 +681,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_create_conflict(self):
         from google.cloud.exceptions import Conflict
         gax_api = _GAXSinksAPI(_create_sink_conflict=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(Conflict):
             api.sink_create(
@@ -689,7 +691,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_create_ok(self):
         from google.logging.v2.logging_config_pb2 import LogSink
         gax_api = _GAXSinksAPI()
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         api.sink_create(
             self.PROJECT, self.SINK_NAME, self.FILTER, self.DESTINATION_URI)
@@ -706,7 +708,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_get_error(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXSinksAPI()
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.sink_get(self.PROJECT, self.SINK_NAME)
@@ -714,7 +716,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_get_miss(self):
         from google.gax.errors import GaxError
         gax_api = _GAXSinksAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.sink_get(self.PROJECT, self.SINK_NAME)
@@ -731,7 +733,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
                           destination=self.DESTINATION_URI,
                           filter=self.FILTER)
         gax_api = _GAXSinksAPI(_get_sink_response=sink_pb)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         response = api.sink_get(self.PROJECT, self.SINK_NAME)
 
@@ -744,7 +746,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_update_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXSinksAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.sink_update(
@@ -754,7 +756,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_update_miss(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXSinksAPI()
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.sink_update(
@@ -768,7 +770,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
                            destination=self.DESTINATION_URI,
                            filter=self.FILTER)
         gax_api = _GAXSinksAPI(_update_sink_response=response)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         api.sink_update(
             self.PROJECT, self.SINK_NAME, self.FILTER, self.DESTINATION_URI)
@@ -785,7 +787,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_delete_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXSinksAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.sink_delete(self.PROJECT, self.SINK_NAME)
@@ -793,14 +795,14 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_delete_miss(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXSinksAPI(_sink_not_found=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.sink_delete(self.PROJECT, self.SINK_NAME)
 
     def test_sink_delete_hit(self):
         gax_api = _GAXSinksAPI()
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         api.sink_delete(self.PROJECT, self.SINK_NAME)
 
@@ -821,7 +823,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
 
     def test_ctor(self):
         gax_api = _GAXMetricsAPI()
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
         self.assertIs(api._gax_api, gax_api)
 
     def test_list_metrics_no_paging(self):
@@ -840,7 +842,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
                               filter=self.FILTER)
         response = _GAXPageIterator([metric_pb], page_token=TOKEN)
         gax_api = _GAXMetricsAPI(_list_log_metrics_response=response)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         metrics, token = api.list_metrics(self.PROJECT)
 
@@ -868,7 +870,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
                               filter=self.FILTER)
         response = _GAXPageIterator([metric_pb])
         gax_api = _GAXMetricsAPI(_list_log_metrics_response=response)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         metrics, token = api.list_metrics(
             self.PROJECT, page_size=PAGE_SIZE, page_token=TOKEN)
@@ -884,7 +886,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_create_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXMetricsAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.metric_create(
@@ -894,7 +896,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_create_conflict(self):
         from google.cloud.exceptions import Conflict
         gax_api = _GAXMetricsAPI(_create_log_metric_conflict=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(Conflict):
             api.metric_create(
@@ -904,7 +906,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_create_ok(self):
         from google.logging.v2.logging_metrics_pb2 import LogMetric
         gax_api = _GAXMetricsAPI()
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         api.metric_create(
             self.PROJECT, self.METRIC_NAME, self.FILTER, self.DESCRIPTION)
@@ -921,7 +923,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_get_error(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXMetricsAPI()
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.metric_get(self.PROJECT, self.METRIC_NAME)
@@ -929,7 +931,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_get_miss(self):
         from google.gax.errors import GaxError
         gax_api = _GAXMetricsAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.metric_get(self.PROJECT, self.METRIC_NAME)
@@ -946,7 +948,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
                               description=self.DESCRIPTION,
                               filter=self.FILTER)
         gax_api = _GAXMetricsAPI(_get_log_metric_response=metric_pb)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         response = api.metric_get(self.PROJECT, self.METRIC_NAME)
 
@@ -959,7 +961,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_update_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXMetricsAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.metric_update(
@@ -969,7 +971,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_update_miss(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXMetricsAPI()
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.metric_update(
@@ -983,7 +985,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
                              description=self.DESCRIPTION,
                              filter=self.FILTER)
         gax_api = _GAXMetricsAPI(_update_log_metric_response=response)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         api.metric_update(
             self.PROJECT, self.METRIC_NAME, self.FILTER, self.DESCRIPTION)
@@ -1000,7 +1002,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_delete_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXMetricsAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.metric_delete(self.PROJECT, self.METRIC_NAME)
@@ -1008,14 +1010,14 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_delete_miss(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXMetricsAPI(_log_metric_not_found=True)
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.metric_delete(self.PROJECT, self.METRIC_NAME)
 
     def test_metric_delete_hit(self):
         gax_api = _GAXMetricsAPI()
-        api = self._makeOne(gax_api)
+        api = self._makeOne(gax_api, None)
 
         api.metric_delete(self.PROJECT, self.METRIC_NAME)
 

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -129,8 +129,9 @@ class TestClient(unittest.TestCase):
 
         class _GaxSinksAPI(object):
 
-            def __init__(self, _wrapped):
+            def __init__(self, _wrapped, client):
                 self._wrapped = _wrapped
+                self.client = client
 
         creds = _Credentials()
         client = self._makeOne(project=self.PROJECT, credentials=creds)
@@ -143,6 +144,7 @@ class TestClient(unittest.TestCase):
 
         self.assertIsInstance(api, _GaxSinksAPI)
         self.assertIs(api._wrapped, wrapped)
+        self.assertIs(api.client, client)
         # API instance is cached
         again = client.sinks_api
         self.assertIs(again, api)
@@ -176,8 +178,9 @@ class TestClient(unittest.TestCase):
 
         class _GaxMetricsAPI(object):
 
-            def __init__(self, _wrapped):
+            def __init__(self, _wrapped, client):
                 self._wrapped = _wrapped
+                self.client = client
 
         creds = _Credentials()
         client = self._makeOne(project=self.PROJECT, credentials=creds)
@@ -190,6 +193,7 @@ class TestClient(unittest.TestCase):
 
         self.assertIsInstance(api, _GaxMetricsAPI)
         self.assertIs(api._wrapped, wrapped)
+        self.assertIs(api.client, client)
         # API instance is cached
         again = client.metrics_api
         self.assertIs(again, api)

--- a/logging/unit_tests/test_connection.py
+++ b/logging/unit_tests/test_connection.py
@@ -300,8 +300,10 @@ class Test_SinksAPI(unittest.TestCase):
 
     def test_ctor(self):
         connection = object()
-        api = self._makeOne(connection)
+        client = _Client(connection)
+        api = self._makeOne(client)
         self.assertIs(api._connection, connection)
+        self.assertIs(api._client, client)
 
     def test_list_sinks_no_paging(self):
         TOKEN = 'TOKEN'
@@ -314,7 +316,8 @@ class Test_SinksAPI(unittest.TestCase):
             'nextPageToken': TOKEN,
         }
         conn = _Connection(RETURNED)
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         sinks, token = api.list_sinks(self.PROJECT)
 
@@ -337,7 +340,8 @@ class Test_SinksAPI(unittest.TestCase):
             }],
         }
         conn = _Connection(RETURNED)
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         sinks, token = api.list_sinks(
             self.PROJECT, page_size=PAGE_SIZE, page_token=TOKEN)
@@ -360,7 +364,8 @@ class Test_SinksAPI(unittest.TestCase):
         }
         conn = _Connection()
         conn._raise_conflict = True
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         with self.assertRaises(Conflict):
             api.sink_create(
@@ -379,7 +384,8 @@ class Test_SinksAPI(unittest.TestCase):
             'destination': self.DESTINATION_URI,
         }
         conn = _Connection({})
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         api.sink_create(
             self.PROJECT, self.SINK_NAME, self.FILTER, self.DESTINATION_URI)
@@ -392,7 +398,8 @@ class Test_SinksAPI(unittest.TestCase):
     def test_sink_get_miss(self):
         from google.cloud.exceptions import NotFound
         conn = _Connection()
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         with self.assertRaises(NotFound):
             api.sink_get(self.PROJECT, self.SINK_NAME)
@@ -408,7 +415,8 @@ class Test_SinksAPI(unittest.TestCase):
             'destination': self.DESTINATION_URI,
         }
         conn = _Connection(RESPONSE)
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         response = api.sink_get(self.PROJECT, self.SINK_NAME)
 
@@ -425,7 +433,8 @@ class Test_SinksAPI(unittest.TestCase):
             'destination': self.DESTINATION_URI,
         }
         conn = _Connection()
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         with self.assertRaises(NotFound):
             api.sink_update(
@@ -444,7 +453,8 @@ class Test_SinksAPI(unittest.TestCase):
             'destination': self.DESTINATION_URI,
         }
         conn = _Connection({})
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         api.sink_update(
             self.PROJECT, self.SINK_NAME, self.FILTER, self.DESTINATION_URI)
@@ -457,7 +467,8 @@ class Test_SinksAPI(unittest.TestCase):
     def test_sink_delete_miss(self):
         from google.cloud.exceptions import NotFound
         conn = _Connection()
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         with self.assertRaises(NotFound):
             api.sink_delete(self.PROJECT, self.SINK_NAME)
@@ -468,7 +479,8 @@ class Test_SinksAPI(unittest.TestCase):
 
     def test_sink_delete_hit(self):
         conn = _Connection({})
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         api.sink_delete(self.PROJECT, self.SINK_NAME)
 
@@ -503,7 +515,8 @@ class Test_MetricsAPI(unittest.TestCase):
             'nextPageToken': TOKEN,
         }
         conn = _Connection(RETURNED)
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         metrics, token = api.list_metrics(self.PROJECT)
 
@@ -524,7 +537,8 @@ class Test_MetricsAPI(unittest.TestCase):
             }],
         }
         conn = _Connection(RETURNED)
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         metrics, token = api.list_metrics(
             self.PROJECT, page_size=PAGE_SIZE, page_token=TOKEN)
@@ -547,7 +561,8 @@ class Test_MetricsAPI(unittest.TestCase):
         }
         conn = _Connection()
         conn._raise_conflict = True
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         with self.assertRaises(Conflict):
             api.metric_create(
@@ -566,7 +581,8 @@ class Test_MetricsAPI(unittest.TestCase):
             'description': self.DESCRIPTION,
         }
         conn = _Connection({})
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         api.metric_create(
             self.PROJECT, self.METRIC_NAME, self.FILTER, self.DESCRIPTION)
@@ -579,7 +595,8 @@ class Test_MetricsAPI(unittest.TestCase):
     def test_metric_get_miss(self):
         from google.cloud.exceptions import NotFound
         conn = _Connection()
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         with self.assertRaises(NotFound):
             api.metric_get(self.PROJECT, self.METRIC_NAME)
@@ -595,7 +612,8 @@ class Test_MetricsAPI(unittest.TestCase):
             'description': self.DESCRIPTION,
         }
         conn = _Connection(RESPONSE)
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         response = api.metric_get(self.PROJECT, self.METRIC_NAME)
 
@@ -612,7 +630,8 @@ class Test_MetricsAPI(unittest.TestCase):
             'description': self.DESCRIPTION,
         }
         conn = _Connection()
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         with self.assertRaises(NotFound):
             api.metric_update(
@@ -631,7 +650,8 @@ class Test_MetricsAPI(unittest.TestCase):
             'description': self.DESCRIPTION,
         }
         conn = _Connection({})
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         api.metric_update(
             self.PROJECT, self.METRIC_NAME, self.FILTER, self.DESCRIPTION)
@@ -644,7 +664,8 @@ class Test_MetricsAPI(unittest.TestCase):
     def test_metric_delete_miss(self):
         from google.cloud.exceptions import NotFound
         conn = _Connection()
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         with self.assertRaises(NotFound):
             api.metric_delete(self.PROJECT, self.METRIC_NAME)
@@ -655,7 +676,8 @@ class Test_MetricsAPI(unittest.TestCase):
 
     def test_metric_delete_hit(self):
         conn = _Connection({})
-        api = self._makeOne(conn)
+        client = _Client(conn)
+        api = self._makeOne(client)
 
         api.metric_delete(self.PROJECT, self.METRIC_NAME)
 


### PR DESCRIPTION
This is in preparation for making `list_sinks()` and `list_metrics()` use `Iterator`.