### PR TITLE
Using Logging client's use_gax attr. in API properties.

### DIFF
--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -111,7 +111,7 @@ class Client(JSONClient):
         https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.sinks
         """
         if self._sinks_api is None:
-            if _USE_GAX:
+            if self._use_gax:
                 generated = GeneratedSinksAPI()
                 self._sinks_api = GAXSinksAPI(generated, self)
             else:
@@ -126,7 +126,7 @@ class Client(JSONClient):
         https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.metrics
         """
         if self._metrics_api is None:
-            if _USE_GAX:
+            if self._use_gax:
                 generated = GeneratedMetricsAPI()
                 self._metrics_api = GAXMetricsAPI(generated, self)
             else:

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -104,11 +104,12 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging.connection import _SinksAPI
         from google.cloud.logging import client as MUT
         from google.cloud._testing import _Monkey
-        client = self._makeOne(self.PROJECT, credentials=_Credentials())
-        conn = client.connection = object()
 
         with _Monkey(MUT, _USE_GAX=False):
-            api = client.sinks_api
+            client = self._makeOne(self.PROJECT, credentials=_Credentials())
+
+        conn = client.connection = object()
+        api = client.sinks_api
 
         self.assertIsInstance(api, _SinksAPI)
         self.assertIs(api._connection, conn)
@@ -153,11 +154,12 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging.connection import _MetricsAPI
         from google.cloud.logging import client as MUT
         from google.cloud._testing import _Monkey
-        client = self._makeOne(self.PROJECT, credentials=_Credentials())
-        conn = client.connection = object()
 
         with _Monkey(MUT, _USE_GAX=False):
-            api = client.metrics_api
+            client = self._makeOne(self.PROJECT, credentials=_Credentials())
+
+        conn = client.connection = object()
+        api = client.metrics_api
 
         self.assertIsInstance(api, _MetricsAPI)
         self.assertIs(api._connection, conn)


### PR DESCRIPTION
These changes are also in #2652 (just so the tests would pass) but they are simple enough to stand on their own.

/cc @waprin 