### PR TITLE
Removing explicit (and implicit) doctest blocks from Sphinx docs.

### DIFF
--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -447,29 +447,35 @@ class Client(_BaseClient, _ClientProjectMixin):
 
         Passes our ``project``.
 
-        Using query to search a datastore::
+        Using query to search a datastore:
 
-        >>> from google.cloud import datastore
-        >>> client = datastore.Client()
-        >>> query = client.query(kind='MyKind')
-        >>> query.add_filter('property', '=', 'val')
+        .. code-block:: python
+
+          >>> from google.cloud import datastore
+          >>> client = datastore.Client()
+          >>> query = client.query(kind='MyKind')
+          >>> query.add_filter('property', '=', 'val')
 
         Using the query iterator's
         :meth:`~google.cloud.datastore.query.Iterator.next_page` method:
 
-        >>> query_iter = query.fetch()
-        >>> entities, more_results, cursor = query_iter.next_page()
-        >>> entities
-        [<list of Entity unmarshalled from protobuf>]
-        >>> more_results
-        <boolean of more results>
-        >>> cursor
-        <string containing cursor where fetch stopped>
+        .. code-block:: python
+
+          >>> query_iter = query.fetch()
+          >>> entities, more_results, cursor = query_iter.next_page()
+          >>> entities
+          [<list of Entity unmarshalled from protobuf>]
+          >>> more_results
+          <boolean of more results>
+          >>> cursor
+          <string containing cursor where fetch stopped>
 
         Under the hood this is doing:
 
-        >>> connection.run_query('project', query.to_protobuf())
-        [<list of Entity Protobufs>], cursor, more_results, skipped_results
+        .. code-block:: python
+
+          >>> connection.run_query('project', query.to_protobuf())
+          [<list of Entity Protobufs>], cursor, more_results, skipped_results
 
         :type kwargs: dict
         :param kwargs: Parameters for initializing and instance of

--- a/datastore/google/cloud/datastore/connection.py
+++ b/datastore/google/cloud/datastore/connection.py
@@ -474,16 +474,20 @@ class Connection(connection_module.Connection):
         as output). It is used under the hood in
         :meth:`Client.get() <.datastore.client.Client.get>`:
 
-        >>> from google.cloud import datastore
-        >>> client = datastore.Client(project='project')
-        >>> key = client.key('MyKind', 1234)
-        >>> client.get(key)
-        [<Entity object>]
+        .. code-block:: python
+
+          >>> from google.cloud import datastore
+          >>> client = datastore.Client(project='project')
+          >>> key = client.key('MyKind', 1234)
+          >>> client.get(key)
+          [<Entity object>]
 
         Using a :class:`Connection` directly:
 
-        >>> connection.lookup('project', [key.to_protobuf()])
-        [<Entity protobuf>]
+        .. code-block:: python
+
+          >>> connection.lookup('project', [key.to_protobuf()])
+          [<Entity protobuf>]
 
         :type project: str
         :param project: The project to look up the keys in.

--- a/datastore/google/cloud/datastore/entity.py
+++ b/datastore/google/cloud/datastore/entity.py
@@ -37,7 +37,10 @@ class Entity(dict):
     This means you could take an existing entity and change the key
     to duplicate the object.
 
-    Use :func:`google.cloud.datastore.get` to retrieve an existing entity.
+    Use :meth:`~google.cloud.datastore.client.Client.get` to retrieve an
+    existing entity:
+
+    .. code-block:: python
 
       >>> from google.cloud import datastore
       >>> client = datastore.Client()
@@ -47,16 +50,20 @@ class Entity(dict):
     You can the set values on the entity just like you would on any
     other dictionary.
 
-    >>> entity['age'] = 20
-    >>> entity['name'] = 'JJ'
-    >>> entity
-    <Entity[{'kind': 'EntityKind', id: 1234}] {'age': 20, 'name': 'JJ'}>
+    .. code-block:: python
+
+      >>> entity['age'] = 20
+      >>> entity['name'] = 'JJ'
+      >>> entity
+      <Entity[{'kind': 'EntityKind', id: 1234}] {'age': 20, 'name': 'JJ'}>
 
     And you can convert an entity to a regular Python dictionary with the
     ``dict`` builtin:
 
-    >>> dict(entity)
-    {'age': 20, 'name': 'JJ'}
+    .. code-block:: python
+
+      >>> dict(entity)
+      {'age': 20, 'name': 'JJ'}
 
     .. note::
 

--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -25,6 +25,8 @@ class Key(object):
 
     To create a basic key:
 
+    .. code-block:: python
+
       >>> Key('EntityKind', 1234)
       <Key[{'kind': 'EntityKind', 'id': 1234}]>
       >>> Key('EntityKind', 'foo')
@@ -32,12 +34,16 @@ class Key(object):
 
     To create a key with a parent:
 
+    .. code-block:: python
+
       >>> Key('Parent', 'foo', 'Child', 1234)
       <Key[{'kind': 'Parent', 'name': 'foo'}, {'kind': 'Child', 'id': 1234}]>
       >>> Key('Child', 1234, parent=parent_key)
       <Key[{'kind': 'Parent', 'name': 'foo'}, {'kind': 'Child', 'id': 1234}]>
 
     To create a partial key:
+
+    .. code-block:: python
 
       >>> Key('Parent', 'foo', 'Child')
       <Key[{'kind': 'Parent', 'name': 'foo'}, {'kind': 'Child'}]>

--- a/datastore/google/cloud/datastore/transaction.py
+++ b/datastore/google/cloud/datastore/transaction.py
@@ -25,22 +25,27 @@ class Transaction(Batch):
 
     For example, the following snippet of code will put the two ``save``
     operations (either ``insert`` or ``upsert``) into the same
-    mutation, and execute those within a transaction::
+    mutation, and execute those within a transaction:
 
-      >>> from google.cloud import datastore
+    .. code-block:: python
+
       >>> client = datastore.Client()
       >>> with client.transaction():
       ...     client.put_multi([entity1, entity2])
 
-    Because it derives from :class:`Batch <.datastore.batch.Batch>`,
-    :class:`Transaction` also provides :meth:`put` and :meth:`delete` methods::
+    Because it derives from :class:`~google.cloud.datastore.batch.Batch`,
+    :class:`Transaction` also provides :meth:`put` and :meth:`delete` methods:
+
+    .. code-block:: python
 
       >>> with client.transaction() as xact:
       ...     xact.put(entity1)
       ...     xact.delete(entity2.key)
 
     By default, the transaction is rolled back if the transaction block
-    exits with an error::
+    exits with an error:
+
+    .. code-block:: python
 
       >>> with client.transaction():
       ...     do_some_work()
@@ -49,9 +54,13 @@ class Transaction(Batch):
     If the transaction block exists without an exception, it will commit
     by default.
 
-    .. warning:: Inside a transaction, automatically assigned IDs for
+    .. warning::
+
+       Inside a transaction, automatically assigned IDs for
        entities will not be available at save time!  That means, if you
-       try::
+       try:
+
+       .. code-block:: python
 
          >>> with client.transaction():
          ...     entity = datastore.Entity(key=client.key('Thing'))
@@ -61,7 +70,9 @@ class Transaction(Batch):
        committed.
 
        Once you exit the transaction (or call :meth:`commit`), the
-       automatically generated ID will be assigned to the entity::
+       automatically generated ID will be assigned to the entity:
+
+       .. code-block:: python
 
          >>> with client.transaction():
          ...     entity = datastore.Entity(key=client.key('Thing'))
@@ -73,7 +84,9 @@ class Transaction(Batch):
          False
 
     If you don't want to use the context manager you can initialize a
-    transaction manually::
+    transaction manually:
+
+    .. code-block:: python
 
       >>> transaction = client.transaction()
       >>> transaction.begin()

--- a/docs/bigquery-usage.rst
+++ b/docs/bigquery-usage.rst
@@ -20,7 +20,7 @@ Authentication / Configuration
   :envvar:`GOOGLE_CLOUD_PROJECT` environment variables, create an instance of
   :class:`Client <google.cloud.bigquery.client.Client>`.
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import bigquery
      >>> client = bigquery.Client()
@@ -39,7 +39,7 @@ To override the project inferred from the environment, pass an explicit
 ``project`` to the constructor, or to either of the alternative
 ``classmethod`` factories:
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import bigquery
      >>> client = bigquery.Client(project='PROJECT_ID')
@@ -101,7 +101,7 @@ Patch metadata for a dataset:
 
 Replace the ACL for a dataset, and update all writeable fields:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import bigquery
    >>> client = bigquery.Client()
@@ -230,7 +230,7 @@ Querying data (asynchronous)
 
 Background a query, loading the results into a table:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import bigquery
    >>> client = bigquery.Client()
@@ -261,7 +261,7 @@ Background a query, loading the results into a table:
 
 Then, begin executing the job on the server:
 
-.. doctest::
+.. code-block:: python
 
    >>> job.begin()  # API call
    >>> job.created
@@ -271,7 +271,7 @@ Then, begin executing the job on the server:
 
 Poll until the job is complete:
 
-.. doctest::
+.. code-block:: python
 
    >>> import time
    >>> retry_count = 100
@@ -286,7 +286,7 @@ Poll until the job is complete:
 
 Retrieve the results:
 
-.. doctest::
+.. code-block:: python
 
    >>> results = job.results()
    >>> rows, total_count, token = query.fetch_data()  # API requet
@@ -305,7 +305,7 @@ Start a job loading data asynchronously from a set of CSV files, located on
 Google Cloud Storage, appending rows into an existing table.  First, create
 the job locally:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import bigquery
    >>> from google.cloud.bigquery import SchemaField
@@ -336,7 +336,7 @@ the job locally:
 
 Then, begin executing the job on the server:
 
-.. doctest::
+.. code-block:: python
 
    >>> job.begin()  # API call
    >>> job.created
@@ -346,7 +346,7 @@ Then, begin executing the job on the server:
 
 Poll until the job is complete:
 
-.. doctest::
+.. code-block:: python
 
    >>> import time
    >>> retry_count = 100
@@ -366,7 +366,7 @@ Exporting data (async)
 Start a job exporting a table's data asynchronously to a set of CSV files,
 located on Google Cloud Storage.  First, create the job locally:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import bigquery
    >>> client = bigquery.Client()
@@ -394,7 +394,7 @@ located on Google Cloud Storage.  First, create the job locally:
 
 Then, begin executing the job on the server:
 
-.. doctest::
+.. code-block:: python
 
    >>> job.begin()  # API call
    >>> job.created
@@ -404,7 +404,7 @@ Then, begin executing the job on the server:
 
 Poll until the job is complete:
 
-.. doctest::
+.. code-block:: python
 
    >>> import time
    >>> retry_count = 100
@@ -423,7 +423,7 @@ Copy tables (async)
 
 First, create the job locally:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import bigquery
    >>> client = bigquery.Client()
@@ -448,7 +448,7 @@ First, create the job locally:
 
 Then, begin executing the job on the server:
 
-.. doctest::
+.. code-block:: python
 
    >>> job.begin()  # API call
    >>> job.created
@@ -458,7 +458,7 @@ Then, begin executing the job on the server:
 
 Poll until the job is complete:
 
-.. doctest::
+.. code-block:: python
 
    >>> import time
    >>> retry_count = 100

--- a/docs/dns-usage.rst
+++ b/docs/dns-usage.rst
@@ -13,7 +13,7 @@ For an overview of authentication in ``google-cloud-python``, see :doc:`google-c
 Assuming your environment is set up as described in that document,
 create an instance of :class:`Client <google.cloud.dns.client.Client>`.
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import dns
      >>> client = dns.Client()
@@ -31,7 +31,7 @@ To override the project inferred from the environment, pass an explicit
 ``project`` to the constructor, or to either of the alternative
 ``classmethod`` factories:
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import dns
      >>> client = dns.Client(project='PROJECT_ID')
@@ -41,7 +41,7 @@ Project Quotas
 
 Query the quotas for a given project:
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import dns
      >>> client = dns.Client(project='PROJECT_ID')
@@ -70,7 +70,7 @@ Managed Zones
 A "managed zone" is the container for DNS records for the same DNS name
 suffix and has a set of name servers that accept and responds to queries:
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import dns
      >>> client = dns.Client(project='PROJECT_ID')
@@ -85,7 +85,7 @@ suffix and has a set of name servers that accept and responds to queries:
 
 List the zones for a given project:
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import dns
      >>> client = dns.Client(project='PROJECT_ID')
@@ -99,7 +99,7 @@ Resource Record Sets
 
 Each managed zone exposes a read-only set of resource records:
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import dns
      >>> client = dns.Client(project='PROJECT_ID')
@@ -117,7 +117,7 @@ Each managed zone exposes a read-only set of resource records:
    ``zone.list_resource_record_sets()``, passing the ``page_token``, until
    the token is ``None``.  E.g.
 
-   .. doctest::
+   .. code-block:: python
 
       >>> records, page_token = zone.list_resource_record_sets()  # API request
       >>> while page_token is not None:
@@ -132,7 +132,7 @@ Change requests
 Update the resource record set for a zone by creating a change request
 bundling additions to or deletions from the set.
 
-  .. doctest::
+  .. code-block:: python
 
      >>> import time
      >>> from google.cloud import dns
@@ -152,7 +152,7 @@ bundling additions to or deletions from the set.
 
 List changes made to the resource record set for a given zone:
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import dns
      >>> client = dns.Client(project='PROJECT_ID')
@@ -168,7 +168,7 @@ List changes made to the resource record set for a given zone:
    ``zone.list_changes()``, passing the ``page_token``, until the token
    is ``None``.  E.g.:
 
-   .. doctest::
+   .. code-block:: python
 
       >>> changes, page_token = zone.list_changes()  # API request
       >>> while page_token is not None:

--- a/docs/error-reporting-usage.rst
+++ b/docs/error-reporting-usage.rst
@@ -16,14 +16,14 @@ Authentication and Configuration
 - After configuring your environment, create a
   :class:`Client <google.cloud.error_reporting.client.Client>`
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import error_reporting
      >>> client = error_reporting.Client()
 
   or pass in ``credentials`` and ``project`` explicitly
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import error_reporting
      >>> client = error_reporting.Client(project='my-project', credentials=creds)
@@ -34,7 +34,7 @@ Authentication and Configuration
   which defaults to "default."
 
 
-    .. doctest::
+    .. code-block:: python
 
        >>> from google.cloud import error_reporting
        >>> client = error_reporting.Client(project='my-project',
@@ -46,7 +46,7 @@ Reporting an exception
 
 Report a stacktrace to Stackdriver Error Reporting after an exception
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import error_reporting
    >>> client = error_reporting.Client()
@@ -63,7 +63,7 @@ The user and HTTP context can also be included in the exception. The HTTP contex
 can be constructed using :class:`google.cloud.error_reporting.HTTPContext`. This will
 be used by Stackdriver Error Reporting to help group exceptions.
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import error_reporting
    >>> client = error_reporting.Client()
@@ -83,7 +83,7 @@ Errors can also be reported to Stackdriver Error Reporting outside the context o
 The library will include the file path, function name, and line number of the location where the
 error was reported.
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import error_reporting
    >>> client = error_reporting.Client()
@@ -91,7 +91,7 @@ error was reported.
 
 Similarly to reporting an exception, the user and HTTP context can be provided:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import error_reporting
    >>> client = error_reporting.Client()

--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -22,14 +22,14 @@ Authentication and Configuration
 - After configuring your environment, create a
   :class:`Client <google.cloud.logging.client.Client>`
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import logging
      >>> client = logging.Client()
 
   or pass in ``credentials`` and ``project`` explicitly
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import logging
      >>> client = logging.Client(project='my-project', credentials=creds)
@@ -40,7 +40,7 @@ Writing log entries
 
 Write a simple text entry to a logger.
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -49,7 +49,7 @@ Write a simple text entry to a logger.
 
 Write a dictionary entry to a logger.
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -64,7 +64,7 @@ Retrieving log entries
 
 Fetch entries for the default project.
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -77,7 +77,7 @@ Fetch entries for the default project.
 
 Fetch entries across multiple projects.
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -89,7 +89,7 @@ Filter entries retrieved using the `Advanced Logs Filters`_ syntax
 
 .. _Advanced Logs Filters: https://cloud.google.com/logging/docs/view/advanced_filters
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -99,7 +99,7 @@ Filter entries retrieved using the `Advanced Logs Filters`_ syntax
 
 Sort entries in descending timestamp order.
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -108,7 +108,7 @@ Sort entries in descending timestamp order.
 
 Retrieve entries in batches of 10, iterating until done.
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -125,7 +125,7 @@ Retrieve entries in batches of 10, iterating until done.
 
 Retrieve entries for a single logger, sorting in descending timestamp order:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -136,7 +136,7 @@ Retrieve entries for a single logger, sorting in descending timestamp order:
 Delete all entries for a logger
 -------------------------------
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -152,7 +152,7 @@ used within Stackdriver Monitoring to create charts and alerts.
 
 Create a metric:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -167,7 +167,7 @@ Create a metric:
 
 List all metrics for a project:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -180,7 +180,7 @@ List all metrics for a project:
 
 Refresh local information about a metric:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -193,7 +193,7 @@ Refresh local information about a metric:
 
 Update a metric:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -206,7 +206,7 @@ Update a metric:
 
 Delete a metric:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -231,7 +231,7 @@ Make sure that the storage bucket you want to export logs too has
 
 Add ``cloud-logs@google.com`` as the owner of ``my-bucket-name``:
 
-.. doctest::
+.. code-block:: python
 
     >>> from google.cloud import storage
     >>> client = storage.Client()
@@ -252,7 +252,7 @@ and add ``cloud-logs@google.com`` to a dataset.
 
 See: `Setting permissions for BigQuery`_
 
-.. doctest::
+.. code-block:: python
 
     >>> from google.cloud import bigquery
     >>> from google.cloud.bigquery.dataset import AccessGrant
@@ -276,7 +276,7 @@ and add ``cloud-logs@google.com`` to a topic.
 
 See: `Setting permissions for Pub/Sub`_
 
-.. doctest::
+.. code-block:: python
 
     >>> from google.cloud import pubsub
     >>> client = pubsub.Client()
@@ -289,7 +289,7 @@ See: `Setting permissions for Pub/Sub`_
 
 Create a Cloud Storage sink:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -305,7 +305,7 @@ Create a Cloud Storage sink:
 
 Create a BigQuery sink:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -321,7 +321,7 @@ Create a BigQuery sink:
 
 Create a Cloud Pub/Sub sink:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -338,7 +338,7 @@ Create a Cloud Pub/Sub sink:
 
 List all sinks for a project:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -350,7 +350,7 @@ List all sinks for a project:
 
 Refresh local information about a sink:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -365,7 +365,7 @@ Refresh local information about a sink:
 
 Update a sink:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -376,7 +376,7 @@ Update a sink:
 
 Delete a sink:
 
-.. doctest::
+.. code-block:: python
 
    >>> from google.cloud import logging
    >>> client = logging.Client()
@@ -397,7 +397,7 @@ It's possible to tie the Python :mod:`logging` module directly into Google Cloud
 create a :class:`CloudLoggingHandler <google.cloud.logging.CloudLoggingHandler>` instance from your
 Logging client.
 
-.. doctest::
+.. code-block:: python
 
     >>> import logging
     >>> import google.cloud.logging # Don't conflict with standard logging
@@ -419,7 +419,7 @@ All logs will go to a single custom log, which defaults to "python". The name of
 logger will be included in the structured log entry under the "python_logger" field. You can
 change it by providing a name to the handler:
 
-.. doctest::
+.. code-block:: python
 
     >>> handler = CloudLoggingHandler(client, name="mycustomlog")
 
@@ -429,7 +429,7 @@ you must avoid infinite recursion from the logging calls the client itself makes
 method :meth:`setup_logging <google.cloud.logging.handlers.setup_logging>` is provided to configure
 this automatically:
 
-.. doctest::
+.. code-block:: python
 
     >>> import logging
     >>> import google.cloud.logging # Don't conflict with standard logging
@@ -442,7 +442,7 @@ this automatically:
 
 You can also exclude certain loggers:
 
-.. doctest::
+.. code-block:: python
 
    >>> setup_logging(handler, excluded_loggers=('werkzeug',)))
 

--- a/docs/monitoring-usage.rst
+++ b/docs/monitoring-usage.rst
@@ -52,7 +52,9 @@ Most often the authentication credentials will be determined
 implicitly from your environment. See :doc:`google-cloud-auth` for
 more information.
 
-It is thus typical to create a client object as follows::
+It is thus typical to create a client object as follows:
+
+.. code-block:: python
 
     >>> from google.cloud import monitoring
     >>> client = monitoring.Client(project='target-project')
@@ -61,11 +63,15 @@ If you are running in Google Compute Engine or Google App Engine,
 the current project is the default target project. This default
 can be further overridden with the :envvar:`GOOGLE_CLOUD_PROJECT`
 environment variable. Using the default target project is
-even easier::
+even easier:
+
+.. code-block:: python
 
     >>> client = monitoring.Client()
 
-If necessary, you can pass in ``credentials`` and ``project`` explicitly::
+If necessary, you can pass in ``credentials`` and ``project`` explicitly:
+
+.. code-block:: python
 
     >>> client = monitoring.Client(project='target-project', credentials=...)
 
@@ -77,7 +83,9 @@ Monitored Resource Descriptors
 
 The available monitored resource types are defined by *monitored resource
 descriptors*. You can fetch a list of these with the
-:meth:`~google.cloud.monitoring.client.Client.list_resource_descriptors` method::
+:meth:`~google.cloud.monitoring.client.Client.list_resource_descriptors` method:
+
+.. code-block:: python
 
     >>> for descriptor in client.list_resource_descriptors():
     ...     print(descriptor.type)
@@ -98,7 +106,9 @@ Metric Descriptors
 The available metric types are defined by *metric descriptors*.
 They include `platform metrics`_, `agent metrics`_, and `custom metrics`_.
 You can list all of these with the
-:meth:`~google.cloud.monitoring.client.Client.list_metric_descriptors` method::
+:meth:`~google.cloud.monitoring.client.Client.list_metric_descriptors` method:
+
+.. code-block:: python
 
     >>> for descriptor in client.list_metric_descriptors():
     ...     print(descriptor.type)
@@ -111,7 +121,9 @@ the ``custom.googleapis.com`` namespace. You do this by creating a
 :class:`~google.cloud.monitoring.metric.MetricDescriptor` object using the
 client's :meth:`~google.cloud.monitoring.client.Client.metric_descriptor`
 factory and then calling the object's
-:meth:`~google.cloud.monitoring.metric.MetricDescriptor.create` method::
+:meth:`~google.cloud.monitoring.metric.MetricDescriptor.create` method:
+
+.. code-block:: python
 
     >>> from google.cloud.monitoring import MetricKind, ValueType
     >>> descriptor = client.metric_descriptor(
@@ -121,7 +133,9 @@ factory and then calling the object's
     ...     description='This is a simple example of a custom metric.')
     >>> descriptor.create()
 
-You can delete such a metric descriptor as follows::
+You can delete such a metric descriptor as follows:
+
+.. code-block:: python
 
     >>> descriptor = client.metric_descriptor(
     ...     'custom.googleapis.com/my_metric')
@@ -133,7 +147,9 @@ you must build the appropriate
 and include them in the
 :class:`~google.cloud.monitoring.metric.MetricDescriptor` object
 before you call
-:meth:`~google.cloud.monitoring.metric.MetricDescriptor.create`::
+:meth:`~google.cloud.monitoring.metric.MetricDescriptor.create`:
+
+.. code-block:: python
 
     >>> from google.cloud.monitoring import LabelDescriptor, LabelValueType
     >>> label = LabelDescriptor('response_code', LabelValueType.INT64,
@@ -160,7 +176,9 @@ Groups
 A group is a dynamic collection of *monitored resources* whose membership is
 defined by a `filter`_.  These groups are usually created via the
 `Stackdriver dashboard`_. You can list all the groups in a project with the
-:meth:`~google.cloud.monitoring.client.Client.list_groups` method::
+:meth:`~google.cloud.monitoring.client.Client.list_groups` method:
+
+.. code-block:: python
 
     >>> for group in client.list_groups():
     ...     print(group.id, group.display_name, group.parent_id)
@@ -171,12 +189,16 @@ defined by a `filter`_.  These groups are usually created via the
 See :class:`~google.cloud.monitoring.group.Group` and the API documentation for
 `Groups`_ and `Group members`_ for more information.
 
-You can get a specific group based on it's ID as follows::
+You can get a specific group based on it's ID as follows:
+
+.. code-block:: python
 
     >>> group = client.fetch_group('a001')
 
 You can get the current members of this group using the
-:meth:`~google.cloud.monitoring.group.Group.list_members` method::
+:meth:`~google.cloud.monitoring.group.Group.list_members` method:
+
+.. code-block:: python
 
     >>> for member in group.list_members():
     ...     print(member)
@@ -189,7 +211,9 @@ change properties.
 You can create new groups to define new collections of *monitored resources*.
 You do this by creating a :class:`~google.cloud.monitoring.group.Group` object using
 the client's :meth:`~google.cloud.monitoring.client.Client.group` factory and then
-calling the object's :meth:`~google.cloud.monitoring.group.Group.create` method::
+calling the object's :meth:`~google.cloud.monitoring.group.Group.create` method:
+
+.. code-block:: python
 
     >>> filter_string = 'resource.zone = "us-central1-a"'
     >>> group = client.group(
@@ -204,7 +228,9 @@ calling the object's :meth:`~google.cloud.monitoring.group.Group.create` method:
 You can further manipulate an existing group by first initializing a Group
 object with it's ID or name, and then calling various methods on it.
 
-Delete a group::
+Delete a group:
+
+.. code-block:: python
 
     >>> group = client.group('1234')
     >>> group.exists()
@@ -212,7 +238,9 @@ Delete a group::
     >>> group.delete()
 
 
-Update a group::
+Update a group:
+
+.. code-block:: python
 
     >>> group = client.group('1234')
     >>> group.exists()
@@ -250,7 +278,9 @@ single time series. For this, you must have :mod:`pandas` installed;
 it is not a required dependency of ``google-cloud-python``.
 
 You can display CPU utilization across your GCE instances over a five minute duration ending at
-the start of the current minute as follows::
+the start of the current minute as follows:
+
+.. code-block:: python
 
     >>> METRIC = 'compute.googleapis.com/instance/cpu/utilization'
     >>> query = client.query(METRIC, minutes=5)
@@ -266,7 +296,9 @@ information.
 For example, you can display CPU utilization during the last hour
 across GCE instances with names beginning with ``"mycluster-"``,
 averaged over five-minute intervals and aggregated per zone, as
-follows::
+follows:
+
+.. code-block:: python
 
     >>> from google.cloud.monitoring import Aligner, Reducer
     >>> METRIC = 'compute.googleapis.com/instance/cpu/utilization'
@@ -302,16 +334,18 @@ use the ``global`` monitored resource type.
 
 See `Monitored resource types`_ for more information about particular monitored resource types.
 
->>> from google.cloud import monitoring
->>> # Create a Resource object for the desired monitored resource type.
->>> resource = client.resource('gce_instance', labels={
-...     'instance_id': '1234567890123456789',
-...     'zone': 'us-central1-f'
-... })
->>> # Create a Metric object, specifying the metric type as well as values for any metric labels.
->>> metric = client.metric(type='custom.googleapis.com/my_metric', labels={
-...      'status': 'successful'
-... })
+.. code-block:: python
+
+  >>> from google.cloud import monitoring
+  >>> # Create a Resource object for the desired monitored resource type.
+  >>> resource = client.resource('gce_instance', labels={
+  ...     'instance_id': '1234567890123456789',
+  ...     'zone': 'us-central1-f'
+  ... })
+  >>> # Create a Metric object, specifying the metric type as well as values for any metric labels.
+  >>> metric = client.metric(type='custom.googleapis.com/my_metric', labels={
+  ...      'status': 'successful'
+  ... })
 
 With a ``Metric`` and ``Resource`` in hand, the :class:`~google.cloud.monitoring.client.Client`
 can be used to write :class:`~google.cloud.monitoring.timeseries.Point` values.
@@ -323,13 +357,17 @@ Stackdriver Monitoring supports several *metric kinds*: ``GAUGE``, ``CUMULATIVE`
 However, ``DELTA`` is not supported for custom metrics.
 
 ``GAUGE`` metrics represent only a single point in time, so only the ``end_time`` should be
-specified::
+specified:
+
+.. code-block:: python
 
     >>> client.write_point(metric=metric, resource=resource,
     ...                    value=3.14, end_time=end_time)  # API call
 
 By default, ``end_time`` defaults to :meth:`~datetime.datetime.utcnow()`, so metrics can be written
-to the current time as follows::
+to the current time as follows:
+
+.. code-block:: python
 
    >>> client.write_point(metric, resource, 3.14)  # API call
 
@@ -338,14 +376,18 @@ sometimes reset, such as after a process restart. Without cumulative metrics, th
 reset would otherwise show up as a huge negative spike. For cumulative metrics, the same start
 time should be re-used repeatedly as more points are written to the time series.
 
-In the examples below, the ``end_time`` again defaults to the current time::
+In the examples below, the ``end_time`` again defaults to the current time:
+
+.. code-block:: python
 
     >>> RESET = datetime.utcnow()
     >>> client.write_point(metric, resource, 3, start_time=RESET)  # API call
     >>> client.write_point(metric, resource, 6, start_time=RESET)  # API call
 
 To write multiple ``TimeSeries`` in a single batch, you can use
-:meth:`~google.cloud.monitoring.client.write_time_series`::
+:meth:`~google.cloud.monitoring.client.write_time_series`:
+
+.. code-block:: python
 
     >>> ts1 = client.time_series(metric1, resource, 3.14, end_time=end_time)
     >>> ts2 = client.time_series(metric2, resource, 42, end_time=end_time)

--- a/docs/pubsub-usage.rst
+++ b/docs/pubsub-usage.rst
@@ -30,7 +30,7 @@ Authentication / Configuration
 - After setting ``GOOGLE_APPLICATION_CREDENTIALS`` and ``GOOGLE_CLOUD_PROJECT``
   environment variables, create a :class:`Client <google.cloud.pubsub.client.Client>`
 
-  .. doctest::
+  .. code-block:: python
 
      >>> from google.cloud import pubsub
      >>> client = pubsub.Client()

--- a/error_reporting/google/cloud/error_reporting/client.py
+++ b/error_reporting/google/cloud/error_reporting/client.py
@@ -184,27 +184,30 @@ class Client(object):
 
     def report(self, message, http_context=None, user=None):
         """ Reports a message to Stackdriver Error Reporting
+
         https://cloud.google.com/error-reporting/docs/formatting-error-messages
 
-           :type message: str
-           :param message: A user-supplied message to report
+        :type message: str
+        :param message: A user-supplied message to report
 
+        :type http_context: :class`google.cloud.error_reporting.HTTPContext`
+        :param http_context: The HTTP request which was processed when the
+                             error was triggered.
 
-          :type http_context: :class`google.cloud.error_reporting.HTTPContext`
-          :param http_context: The HTTP request which was processed when the
-                               error was triggered.
+        :type user: str
+        :param user: The user who caused or was affected by the crash. This
+                     can be a user ID, an email address, or an arbitrary
+                     token that uniquely identifies the user. When sending
+                     an error report, leave this field empty if the user
+                     was not logged in. In this case the Error Reporting
+                     system will use other data, such as remote IP address,
+                     to distinguish affected users.
 
-          :type user: str
-          :param user: The user who caused or was affected by the crash. This
-                       can be a user ID, an email address, or an arbitrary
-                       token that uniquely identifies the user. When sending
-                       an error report, leave this field empty if the user
-                       was not logged in. In this case the Error Reporting
-                       system will use other data, such as remote IP address,
-                       to distinguish affected users.
+        Example:
 
-           Example::
-                >>>  client.report("Something went wrong!")
+        .. code-block:: python
+
+          >>>  client.report("Something went wrong!")
         """
         stack = traceback.extract_stack()
         last_call = stack[-2]

--- a/logging/google/cloud/logging/handlers/handlers.py
+++ b/logging/google/cloud/logging/handlers/handlers.py
@@ -55,7 +55,7 @@ class CloudLoggingHandler(logging.StreamHandler):
 
     Example:
 
-    .. doctest::
+    .. code-block:: python
 
         import google.cloud.logging
         from google.cloud.logging.handlers import CloudLoggingHandler
@@ -109,7 +109,7 @@ def setup_logging(handler, excluded_loggers=EXCLUDE_LOGGER_DEFAULTS):
 
     Example:
 
-    .. doctest::
+    .. code-block:: python
 
         import logging
         import google.cloud.logging

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -147,7 +147,9 @@ class Client(JSONClient):
         If the bucket isn't found, this will raise a
         :class:`google.cloud.storage.exceptions.NotFound`.
 
-        For example::
+        For example:
+
+        .. code-block:: python
 
           >>> try:
           >>>   bucket = client.get_bucket('my-bucket')
@@ -171,7 +173,9 @@ class Client(JSONClient):
         """Get a bucket by name, returning None if not found.
 
         You can use this if you would rather check for a None value
-        than catching an exception::
+        than catching an exception:
+
+        .. code-block:: python
 
           >>> bucket = client.lookup_bucket('doesnt-exist')
           >>> print(bucket)
@@ -194,7 +198,9 @@ class Client(JSONClient):
     def create_bucket(self, bucket_name):
         """Create a new bucket.
 
-        For example::
+        For example:
+
+        .. code-block:: python
 
           >>> bucket = client.create_bucket('my-bucket')
           >>> print(bucket)
@@ -221,6 +227,8 @@ class Client(JSONClient):
 
         This will not populate the list of blobs available in each
         bucket.
+
+        .. code-block:: python
 
           >>> for bucket in client.list_buckets():
           ...   print(bucket)


### PR DESCRIPTION
This way we can gradually turn them on with **doctest** and make sure they work piece by piece.

Also converted some implicit code blocks (`::`) and some implicit doctest blocks (`:` followed by `>>>`) into explicit code blocks.

Related to #2656.

-----

Aside: Where did these changes come from? I started a branch to run datastore doctests side-by-side with system tests. Before over-engineering some handrolled solution I just wanted to get `sphinx-build -b doctest` working. So, each of these changes came from modules that resulted in failed doctests. Not all of the changes were actually interpreted as doctests (e.g. implicit code blocks via `::`) however, isolating them / designating them as `.. code-block:: python` gives a clearer target to come back at a later time and convert into a `doctest`.