### PR TITLE
Fix pycodestyle failing when removing files from repo.

### DIFF
--- a/scripts/pycodestyle_on_repo.py
+++ b/scripts/pycodestyle_on_repo.py
@@ -37,6 +37,9 @@ def main():
     python_files = [
         candidate for candidate in candidates if candidate.endswith('.py')]
 
+    python_files = [
+        candidate for candidate in python_files if os.path.isfile(candidate)]
+
     if not python_files:
         print('No Python files to lint, exiting.')
     else:


### PR DESCRIPTION
I noticed this after removing some unneeded pb files for speech.

Example:
```bash
Using files changed relative to origin/master:
------------------------------------------------------------
docs/index.rst
docs/speech-metadata.rst
docs/speech-operation.rst
docs/speech-usage.rst
speech/google/cloud/speech/_gax.py
speech/google/cloud/speech/client.py
speech/google/cloud/speech/metadata.py
speech/google/cloud/speech/operation.py
speech/setup.py
speech/unit_tests/test_client.py
speech/unit_tests/test_metadata.py
speech/unit_tests/test_operation.py
system_tests/speech.py
------------------------------------------------------------
checking speech/google/cloud/speech/_gax.py
checking speech/google/cloud/speech/client.py
checking speech/google/cloud/speech/metadata.py
speech/google/cloud/speech/metadata.py:1:1: E902 IOError: [Errno 2] No such file or directory: 'speech/google/cloud/speech/metadata.py'
checking speech/google/cloud/speech/operation.py
speech/google/cloud/speech/operation.py:1:1: E902 IOError: [Errno 2] No such file or directory: 'speech/google/cloud/speech/operation.py'
checking speech/setup.py
checking speech/unit_tests/test_client.py
checking speech/unit_tests/test_metadata.py
speech/unit_tests/test_metadata.py:1:1: E902 IOError: [Errno 2] No such file or directory: 'speech/unit_tests/test_metadata.py'
checking speech/unit_tests/test_operation.py
speech/unit_tests/test_operation.py:1:1: E902 IOError: [Errno 2] No such file or directory: 'speech/unit_tests/test_operation.py'
checking system_tests/speech.py
ERROR: InvocationError: '/Users/daspecster/Documents/google/google-cloud-py-2/.tox/lint/bin/python /Users/daspecster/Documents/google/google-cloud-py-2/scripts/pycodestyle_on_repo.py'
__________________________________________________________________________________ summary __________________________________________________________________________________
ERROR:   lint: commands failed
```