### PR TITLE
Adding Python 3.5 on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: python
 sudo: false
 
+addons:
+  apt:
+    sources:
+    - deadsnakes
+    packages:
+    - python3.5
+
 install:
   - pip install --upgrade pip tox
 
 script:
   - python2.7 scripts/run_unit_tests.py
   - python3.4 scripts/run_unit_tests.py
+  - python3.5 scripts/run_unit_tests.py
   - python scripts/run_unit_tests.py --tox-env cover
   - tox -e lint
   - tox -e system-tests


### PR DESCRIPTION
~~Also removing unit tests on Travis for Python 3.4 (to keep the builds fast, if possible).~~