### PR TITLE
Adding PyPI badges to package READMEs.

### DIFF
--- a/bigquery/README.rst
+++ b/bigquery/README.rst
@@ -5,6 +5,8 @@ Python Client for Google BigQuery
 
 .. _Google BigQuery: https://cloud.google.com/bigquery/what-is-bigquery
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigquery-usage.html
@@ -85,3 +87,8 @@ See the ``google-cloud-python`` API `BigQuery documentation`_ to learn how
 to connect to BigQuery using this Client Library.
 
 .. _BigQuery documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigquery-usage.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-bigquery.svg
+   :target: https://pypi.python.org/pypi/google-cloud-bigquery
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery.svg
+   :target: https://pypi.python.org/pypi/google-cloud-bigquery

--- a/bigtable/README.rst
+++ b/bigtable/README.rst
@@ -5,6 +5,8 @@ Python Client for Google Cloud Bigtable
 
 .. _Google Cloud Bigtable: https://cloud.google.com/bigtable/docs/
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigtable-usage.html
@@ -40,3 +42,8 @@ See the ``google-cloud-python`` API `Bigtable documentation`_ to learn
 how to manage your data in Bigtable tables.
 
 .. _Bigtable documentation: https://google-cloud-python.readthedocs.io/en/stable/bigtable-usage.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-bigtable.svg
+   :target: https://pypi.python.org/pypi/google-cloud-bigtable
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigtable.svg
+   :target: https://pypi.python.org/pypi/google-cloud-bigtable

--- a/core/README.rst
+++ b/core/README.rst
@@ -5,6 +5,8 @@ This library is not meant to stand-alone. Instead it defines
 common helpers (e.g. base ``Client`` and ``Connection`` classes)
 used by all of the ``google-cloud-*``.
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/google-cloud-api.html
@@ -15,3 +17,8 @@ Quick Start
 .. code-block:: console
 
     $ pip install --upgrade google-cloud-core
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-core.svg
+   :target: https://pypi.python.org/pypi/google-cloud-core
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-core.svg
+   :target: https://pypi.python.org/pypi/google-cloud-core

--- a/datastore/README.rst
+++ b/datastore/README.rst
@@ -5,6 +5,8 @@ Python Client for Google Cloud Datastore
 
 .. _Google Cloud Datastore: https://cloud.google.com/datastore/docs
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/datastore-client.html
@@ -63,3 +65,8 @@ how to activate Cloud Datastore for your project.
     query = datastore.Query(kind='EntityKind')
     for result in query.fetch():
         print(result)
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg
+   :target: https://pypi.python.org/pypi/google-cloud-datastore
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datastore.svg
+   :target: https://pypi.python.org/pypi/google-cloud-datastore

--- a/dns/README.rst
+++ b/dns/README.rst
@@ -5,6 +5,8 @@ Python Client for Google Cloud DNS
 
 .. _Google Cloud DNS: https://cloud.google.com/dns/
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/dns-usage.html
@@ -40,3 +42,8 @@ See the ``google-cloud-python`` API `DNS documentation`_ to learn
 how to manage DNS records using this Client Library.
 
 .. _DNS documentation: https://google-cloud-python.readthedocs.io/en/stable/dns-usage.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-dns.svg
+   :target: https://pypi.python.org/pypi/google-cloud-dns
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dns.svg
+   :target: https://pypi.python.org/pypi/google-cloud-dns

--- a/error_reporting/README.rst
+++ b/error_reporting/README.rst
@@ -5,6 +5,8 @@ Python Client for Stackdriver Error Reporting
 
 .. _Stackdriver Error Reporting: https://cloud.google.com/error-reporting/
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/error-reporting-usage.html
@@ -45,3 +47,8 @@ See the ``google-cloud-python`` API `Error Reporting documentation`_ to learn
 how to get started using this library.
 
 .. _Error Reporting documentation: https://google-cloud-python.readthedocs.io/en/stable/error-reporting-usage.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-error-reporting.svg
+   :target: https://pypi.python.org/pypi/google-cloud-error-reporting
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-error-reporting.svg
+   :target: https://pypi.python.org/pypi/google-cloud-error-reporting

--- a/language/README.rst
+++ b/language/README.rst
@@ -5,6 +5,8 @@ Python Client for Google Cloud Natural Language
 
 .. _Google Cloud Natural Language: https://cloud.google.com/natural-language/
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/language-usage.html
@@ -44,3 +46,8 @@ See the ``google-cloud-python`` API `Natural Language documentation`_ to learn
 how to analyze text with this API.
 
 .. _Natural Language documentation: https://google-cloud-python.readthedocs.io/en/stable/language-usage.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-language.svg
+   :target: https://pypi.python.org/pypi/google-cloud-language
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-language.svg
+   :target: https://pypi.python.org/pypi/google-cloud-language

--- a/logging/README.rst
+++ b/logging/README.rst
@@ -5,6 +5,8 @@ Python Client for Stackdriver Logging
 
 .. _Stackdriver Logging: https://cloud.google.com/logging/
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/logging-usage.html
@@ -54,3 +56,8 @@ See the ``google-cloud-python`` API `logging documentation`_ to learn how to
 connect to Stackdriver Logging using this Client Library.
 
 .. _logging documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/logging-usage.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg
+   :target: https://pypi.python.org/pypi/google-cloud-logging
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-logging.svg
+   :target: https://pypi.python.org/pypi/google-cloud-logging

--- a/monitoring/README.rst
+++ b/monitoring/README.rst
@@ -5,6 +5,8 @@ Python Client for Stackdriver Monitoring
 
 .. _Stackdriver Monitoring: https://cloud.google.com/monitoring/
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/monitoring-usage.html
@@ -64,3 +66,8 @@ See the ``google-cloud-python`` API `monitoring documentation`_ to learn how
 to connect to Stackdriver Monitoring using this Client Library.
 
 .. _monitoring documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/monitoring-usage.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-monitoring.svg
+   :target: https://pypi.python.org/pypi/google-cloud-monitoring
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-monitoring.svg
+   :target: https://pypi.python.org/pypi/google-cloud-monitoring

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -5,6 +5,8 @@ Python Client for Google Cloud Pub / Sub
 
 .. _Google Cloud Pub / Sub: https://cloud.google.com/pubsub/docs
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/pubsub-usage.html
@@ -57,3 +59,8 @@ To get started with this API, you'll need to create
 
     topic.publish('this is the message_payload',
                   attr1='value1', attr2='value2')
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-pubsub.svg
+   :target: https://pypi.python.org/pypi/google-cloud-pubsub
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-pubsub.svg
+   :target: https://pypi.python.org/pypi/google-cloud-pubsub

--- a/resource_manager/README.rst
+++ b/resource_manager/README.rst
@@ -5,6 +5,8 @@ Python Client for Google Cloud Resource Manager
 
 .. _Google Cloud Resource Manager: https://cloud.google.com/resource-manager/
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/resource-manager-api.html
@@ -41,3 +43,8 @@ See the ``google-cloud-python`` API `Resource Manager documentation`_ to learn
 how to manage projects using this Client Library.
 
 .. _Resource Manager documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/resource-manager-api.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-resource-manager.svg
+   :target: https://pypi.python.org/pypi/google-cloud-resource-manager
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-resource-manager.svg
+   :target: https://pypi.python.org/pypi/google-cloud-resource-manager

--- a/storage/README.rst
+++ b/storage/README.rst
@@ -5,6 +5,8 @@ Python Client for Google Cloud Storage
 
 .. _Google Cloud Storage: https://cloud.google.com/storage/docs
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/storage-client.html
@@ -60,3 +62,8 @@ how to create a bucket.
     blob.upload_from_string('New contents!')
     blob2 = bucket.blob('remote/path/storage.txt')
     blob2.upload_from_filename(filename='/local/path.txt')
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-storage.svg
+   :target: https://pypi.python.org/pypi/google-cloud-storage
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storage.svg
+   :target: https://pypi.python.org/pypi/google-cloud-storage

--- a/translate/README.rst
+++ b/translate/README.rst
@@ -5,6 +5,8 @@ Python Client for Google Translate
 
 .. _Google Translate: https://cloud.google.com/translate/
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/translate-usage.html
@@ -40,3 +42,8 @@ See the ``google-cloud-python`` API `Translate documentation`_ to learn
 how to translate text using this library.
 
 .. _Translate documentation: https://google-cloud-python.readthedocs.io/en/stable/translate-usage.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-translate.svg
+   :target: https://pypi.python.org/pypi/google-cloud-translate
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-translate.svg
+   :target: https://pypi.python.org/pypi/google-cloud-translate

--- a/vision/README.rst
+++ b/vision/README.rst
@@ -5,6 +5,8 @@ Python Client for Google Cloud Vision
 
 .. _Google Cloud Vision: https://cloud.google.com/vision/
 
+|pypi| |versions|
+
 -  `Documentation`_
 
 .. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/vision-usage.html
@@ -48,3 +50,8 @@ See the ``google-cloud-python`` API `Vision documentation`_ to learn
 how to analyze images using this library.
 
 .. _Vision documentation: https://google-cloud-python.readthedocs.io/en/stable/vision-usage.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-vision.svg
+   :target: https://pypi.python.org/pypi/google-cloud-vision
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-vision.svg
+   :target: https://pypi.python.org/pypi/google-cloud-vision


### PR DESCRIPTION
`runtimeconfig` and `speech` don't get badges because they aren't on PyPI yet

- @tswast what is the plan for publishing `runtimeconfig`?
- @daspecster can you add the "add badge to README" to your release checklist for `speech`?