### PR TITLE
Adding docs for the Runtime Config API.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -183,6 +183,16 @@
 .. toctree::
   :maxdepth: 0
   :hidden:
+  :caption: Runtime Configuration
+
+  runtimeconfig-usage
+  Client <runtimeconfig-client>
+  runtimeconfig-config
+  runtimeconfig-variable
+
+.. toctree::
+  :maxdepth: 0
+  :hidden:
   :caption: External Links
 
   GitHub <https://github.com/GoogleCloudPlatform/google-cloud-python/>

--- a/docs/runtimeconfig-client.rst
+++ b/docs/runtimeconfig-client.rst
@@ -1,0 +1,13 @@
+Runtime Configuration Client
+============================
+
+.. automodule:: google.cloud.runtimeconfig.client
+  :members:
+  :show-inheritance:
+
+Connection
+~~~~~~~~~~
+
+.. automodule:: google.cloud.runtimeconfig.connection
+  :members:
+  :show-inheritance:

--- a/docs/runtimeconfig-config.rst
+++ b/docs/runtimeconfig-config.rst
@@ -1,0 +1,6 @@
+Configuration
+~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.runtimeconfig.config
+  :members:
+  :show-inheritance:

--- a/docs/runtimeconfig-usage.rst
+++ b/docs/runtimeconfig-usage.rst
@@ -1,0 +1,6 @@
+Using the API
+=============
+
+.. automodule:: google.cloud.runtimeconfig
+  :members:
+  :show-inheritance:

--- a/docs/runtimeconfig-variable.rst
+++ b/docs/runtimeconfig-variable.rst
@@ -1,0 +1,6 @@
+Variables
+~~~~~~~~~
+
+.. automodule:: google.cloud.runtimeconfig.variable
+  :members:
+  :show-inheritance:

--- a/scripts/verify_included_modules.py
+++ b/scripts/verify_included_modules.py
@@ -67,6 +67,7 @@ PACKAGES = (
     'monitoring',
     'pubsub',
     'resource_manager',
+    'runtimeconfig',
     'speech',
     'storage',
     'translate',

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     {toxinidir}/vision
     {toxinidir}/translate
     {toxinidir}/speech
+    {toxinidir}/runtimeconfig
     pytest
 covercmd =
     py.test --quiet \
@@ -110,6 +111,12 @@ covercmd =
       --cov-append \
       --cov-config {toxinidir}/.coveragerc \
       speech/unit_tests
+    py.test --quiet \
+      --cov=google.cloud \
+      --cov=unit_tests \
+      --cov-append \
+      --cov-config {toxinidir}/.coveragerc \
+      runtimeconfig/unit_tests
     coverage report --show-missing --fail-under=100
 
 [testenv]


### PR DESCRIPTION
The runtimeconfig-usage doc (or the `runtimeconfig/google/cloud/runtimeconfig/__init__.py` file) should add some examples of library usage.

@tswast once this is merged, care to take the reins on adding some usage examples?