### PR TITLE
Adding Runtime Config API to umbrella config.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ This client supports the following Google Cloud Platform services:
 -  `Google Translate`_ (`Translate README`_)
 -  `Google Cloud Vision`_ (`Vision README`_)
 -  `Google Cloud Bigtable - HappyBase`_ (`HappyBase README`_)
+-  `Google Cloud Runtime Configuration`_ (`Runtime Config README`_)
 
 .. _Google Cloud Datastore: https://pypi.python.org/pypi/google-cloud-datastore
 .. _Datastore README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/datastore
@@ -60,6 +61,8 @@ This client supports the following Google Cloud Platform services:
 .. _Vision README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/vision
 .. _Google Cloud Bigtable - HappyBase: https://pypi.python.org/pypi/google-cloud-happybase/
 .. _HappyBase README: https://github.com/GoogleCloudPlatform/google-cloud-python-happybase
+.. _Google Cloud Runtime Configuration: https://cloud.google.com/deployment-manager/runtime-configurator/
+.. _Runtime Config README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/runtimeconfig
 
 If you need support for other Google APIs, check out the
 `Google APIs Python Client library`_.

--- a/runtimeconfig/README.rst
+++ b/runtimeconfig/README.rst
@@ -5,7 +5,7 @@ Python Client for Google Cloud RuntimeConfig
 
 .. _Google Cloud RuntimeConfig: https://cloud.google.com/deployment-manager/runtime-configurator/
 
-|alpha|
+|alpha| |pypi| |versions|
 
 -  `Documentation`_
 
@@ -47,4 +47,9 @@ for changes to your data and return based on certain conditions.
 See the ``google-cloud-python`` API `runtimeconfig documentation`_ to learn
 how to interact with Cloud RuntimeConfig using this Client Library.
 
-.. _RuntimeConfig documentation: https://google-cloud-python.readthedocs.io/en/stable/runtimeconfig-usage.html
+.. _RuntimeConfig documentation: https://google-cloud-python.readthedocs.io/en/latest/runtimeconfig-usage.html
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-runtimeconfig.svg
+   :target: https://pypi.python.org/pypi/google-cloud-runtimeconfig
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-runtimeconfig.svg
+   :target: https://pypi.python.org/pypi/google-cloud-runtimeconfig

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ REQUIREMENTS = [
     'google-cloud-storage >= 0.20.0',
     'google-cloud-translate >= 0.20.0',
     'google-cloud-vision >= 0.20.0',
+    'google-cloud-runtimeconfig >= 0.20.0',
 ]
 
 setup(


### PR DESCRIPTION
Also updating Runtime Config README with badges and updating the main README to refer to the Runtime Config API.

Worth noting that I just manually push https://pypi.python.org/pypi/google-cloud-runtimeconfig from 7e2eb335346ff45ce972df0b051114dab23ac022 via:

```
$ cd runtimeconfig
$ python setup.py sdist bdist_wheel
$ twine upload dist/*
```