### PR TITLE
Attempt at making package builds **seem** like "setup.py develop"

### DIFF
--- a/datastore/make_pth.py
+++ b/datastore/make_pth.py
@@ -1,3 +1,19 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Make a hacked PTH file to simulate "setup.py develop"."""
+
 import argparse
 import json
 import os
@@ -31,6 +47,9 @@ def fake_core_dist_info(site_packages):
     """Fake the dist. info of google-cloud-core.
 
     It needs to be faked since we don't actually install it.
+
+    :type site_packages: str
+    :param site_packages: Path to a site packages directory.
     """
     dist_info = os.path.join(site_packages, CORE_DIST_INFO)
     if not os.path.isdir(dist_info):
@@ -42,7 +61,11 @@ def fake_core_dist_info(site_packages):
 
 
 def add_hacked_pth_file(site_packages):
-    """Add the hacked .PTH file to the site packages dir."""
+    """Add the hacked .PTH file to the site packages dir.
+
+    :type site_packages: str
+    :param site_packages: Path to a site packages directory.
+    """
     installer = namespaces.Installer()
     part1 = installer._gen_nspkg_line('google')
     part2 = EXTRA_PATH_TEMPLATE.format(
@@ -60,16 +83,18 @@ def add_hacked_pth_file(site_packages):
         file_obj.write(file_contents)
 
 
-def main(site_packages):
-    add_hacked_pth_file(site_packages)
-    fake_core_dist_info(site_packages)
-
-
-if __name__ == '__main__':
+def main():
+    """Main script for making a hacked PTH file."""
     parser = argparse.ArgumentParser(
         description='Make a hacked PTH file to emulate "setup.py develop"')
     help_txt = 'Site packages directory where .pth file will be added.'
     parser.add_argument('--site-packages', dest='site_packages',
                         required=True, help=help_txt)
     args = parser.parse_args()
-    main(args.site_packages)
+
+    add_hacked_pth_file(args.site_packages)
+    fake_core_dist_info(args.site_packages)
+
+
+if __name__ == '__main__':
+    main()

--- a/datastore/make_pth.py
+++ b/datastore/make_pth.py
@@ -1,0 +1,72 @@
+import argparse
+import json
+import os
+
+from setuptools import namespaces
+
+
+FILENAME = 'danny-hack-nspkg.pth'
+VERSION = '0.20.0'
+CORE_DIST_INFO = 'google_cloud_core-{}.dist-info'.format(VERSION)
+CORE_METADATA = {
+    'metadata_version': '2.0',
+    'name': 'google-cloud-core',
+    'version': VERSION,
+}
+CURR_DIR = os.path.abspath(os.path.dirname(__file__))
+CORE_DIR = os.path.abspath(
+    os.path.join(CURR_DIR, '..', 'core'))
+EXTRA_PATH_TEMPLATE = (
+    'import sys;'
+    'mp = sys.modules[{!r}].__path__;'
+    'p1 = {!r};'
+    '(p1 not in mp) and mp.append(p1);'
+    'p2 = {!r};'
+    '(p2 not in mp) and mp.append(p2)\n')
+
+
+def fake_core_dist_info(site_packages):
+    """Fake the dist. info of google-cloud-core.
+
+    It needs to be faked since we don't actually install it.
+    """
+    dist_info = os.path.join(site_packages, CORE_DIST_INFO)
+    if not os.path.isdir(dist_info):
+        os.mkdir(dist_info)
+    meta = os.path.join(dist_info, 'metadata.json')
+    if not os.path.exists(meta):
+        with open(meta, 'w') as file_obj:
+            json.dump(CORE_METADATA, file_obj)
+
+
+def add_hacked_pth_file(site_packages):
+    """Add the hacked .PTH file to the site packages dir."""
+    installer = namespaces.Installer()
+    part1 = installer._gen_nspkg_line('google')
+    part2 = EXTRA_PATH_TEMPLATE.format(
+        'google', os.path.join(CORE_DIR, 'google'),
+        os.path.join(CURR_DIR, 'google'))
+    part3 = installer._gen_nspkg_line('google.cloud')
+    part4 = EXTRA_PATH_TEMPLATE.format(
+        'google.cloud', os.path.join(CORE_DIR, 'google', 'cloud'),
+        os.path.join(CURR_DIR, 'google', 'cloud'))
+
+    file_contents = ''.join([part1, part2, part3, part4])
+    full_path = os.path.join(site_packages, FILENAME)
+    with open(full_path, 'w') as file_obj:
+        file_obj.write(file_contents)
+
+
+def main(site_packages):
+    add_hacked_pth_file(site_packages)
+    fake_core_dist_info(site_packages)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Make a hacked PTH file to emulate "setup.py develop"')
+    help_txt = 'Site packages directory where .pth file will be added.'
+    parser.add_argument('--site-packages', dest='site_packages',
+                        required=True, help=help_txt)
+    args = parser.parse_args()
+    main(args.site_packages)

--- a/datastore/make_pth.py
+++ b/datastore/make_pth.py
@@ -18,7 +18,9 @@ CORE_DIR = os.path.abspath(
     os.path.join(CURR_DIR, '..', 'core'))
 EXTRA_PATH_TEMPLATE = (
     'import sys;'
-    'mp = sys.modules[{!r}].__path__;'
+    'import types;'
+    'm = sys.modules.setdefault({!r}, types.ModuleType({!r}));'
+    "mp = m.__dict__.setdefault('__path__', []);"
     'p1 = {!r};'
     '(p1 not in mp) and mp.append(p1);'
     'p2 = {!r};'
@@ -44,11 +46,12 @@ def add_hacked_pth_file(site_packages):
     installer = namespaces.Installer()
     part1 = installer._gen_nspkg_line('google')
     part2 = EXTRA_PATH_TEMPLATE.format(
-        'google', os.path.join(CORE_DIR, 'google'),
+        'google', 'google', os.path.join(CORE_DIR, 'google'),
         os.path.join(CURR_DIR, 'google'))
     part3 = installer._gen_nspkg_line('google.cloud')
     part4 = EXTRA_PATH_TEMPLATE.format(
-        'google.cloud', os.path.join(CORE_DIR, 'google', 'cloud'),
+        'google.cloud', 'google.cloud',
+        os.path.join(CORE_DIR, 'google', 'cloud'),
         os.path.join(CURR_DIR, 'google', 'cloud'))
 
     file_contents = ''.join([part1, part2, part3, part4])

--- a/datastore/tox.ini
+++ b/datastore/tox.ini
@@ -1,12 +1,19 @@
 [tox]
+skipsdist=True
 envlist =
     py27,py34,py35,cover
 
 [testing]
-localdeps =
-    pip install --upgrade {toxinidir}/../core
 deps =
     pytest
+    httplib2 >= 0.9.1
+    googleapis-common-protos >= 1.3.4
+    oauth2client >= 3.0.0, < 4.0.0dev
+    protobuf >= 3.0.0
+    six
+    grpcio >= 1.0.0, < 2.0dev
+installcmd =
+    python {toxinidir}/make_pth.py --site-packages {envsitepackagesdir}
 covercmd =
     py.test --quiet \
       --cov=google.cloud.datastore \
@@ -16,7 +23,7 @@ covercmd =
 
 [testenv]
 commands =
-    {[testing]localdeps}
+    {[testing]installcmd}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -25,7 +32,7 @@ deps =
 basepython =
     python2.7
 commands =
-    {[testing]localdeps}
+    {[testing]installcmd}
     {[testing]covercmd}
 deps =
     {[testenv]deps}


### PR DESCRIPTION
@jonparrott Please weigh in here. I am mostly happy with this but unclear on a few sharp corners.

Things I wish were better:

- Having to hard-code package deps in `tox.ini` (would be nice to install the deps from `setup.py` without installing the source
- Having to fake the metadata for `google-cloud-core` (since we use `pkg_resources.get_distribution('google-cloud-core')` for the user agent)
- Hack to make `__path__` in Python 3 look like it does in Python 2 (unclear why the `pep420` bool is in place in `setuptools`)