### PR TITLE
Keeping local (filesystem) deps from going stale in tox.ini

### DIFF
--- a/bigquery/tox.ini
+++ b/bigquery/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/bigtable/tox.ini
+++ b/bigtable/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/datastore/tox.ini
+++ b/datastore/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/dns/tox.ini
+++ b/dns/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/error_reporting/tox.ini
+++ b/error_reporting/tox.ini
@@ -3,9 +3,11 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade \
+        {toxinidir}/../core \
+        {toxinidir}/../logging
 deps =
-    {toxinidir}/../core
-    {toxinidir}/../logging
     pytest
 covercmd =
     py.test --quiet \
@@ -16,6 +18,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -24,6 +27,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/language/tox.ini
+++ b/language/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/logging/tox.ini
+++ b/logging/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/monitoring/tox.ini
+++ b/monitoring/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover,{py27,py34,py35}-{pandas}
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -24,6 +26,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testing]deps}

--- a/pubsub/tox.ini
+++ b/pubsub/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/resource_manager/tox.ini
+++ b/resource_manager/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/runtimeconfig/tox.ini
+++ b/runtimeconfig/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/speech/tox.ini
+++ b/speech/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/storage/tox.ini
+++ b/storage/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -4,23 +4,25 @@ envlist =
 
 [testing]
 deps =
-    {toxinidir}/core
-    {toxinidir}/bigtable
-    {toxinidir}/storage
-    {toxinidir}/datastore
-    {toxinidir}/bigquery
-    {toxinidir}/pubsub
-    {toxinidir}/logging
-    {toxinidir}/dns
-    {toxinidir}/language
-    {toxinidir}/error_reporting
-    {toxinidir}/resource_manager
-    {toxinidir}/monitoring
-    {toxinidir}/vision
-    {toxinidir}/translate
-    {toxinidir}/speech
-    {toxinidir}/runtimeconfig
     pytest
+localdeps =
+    pip install --upgrade \
+        {toxinidir}/core \
+        {toxinidir}/bigtable \
+        {toxinidir}/storage \
+        {toxinidir}/datastore \
+        {toxinidir}/bigquery \
+        {toxinidir}/pubsub \
+        {toxinidir}/logging \
+        {toxinidir}/dns \
+        {toxinidir}/language \
+        {toxinidir}/error_reporting \
+        {toxinidir}/resource_manager \
+        {toxinidir}/monitoring \
+        {toxinidir}/vision \
+        {toxinidir}/translate \
+        {toxinidir}/speech \
+        {toxinidir}/runtimeconfig
 covercmd =
     py.test --quiet \
       --cov=google.cloud \
@@ -138,6 +140,7 @@ commands =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testing]deps}
@@ -147,6 +150,7 @@ deps =
 [testenv:coveralls]
 basepython = {[testenv:umbrella-cover]basepython}
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
     coveralls
 ignore_errors = True
@@ -159,6 +163,7 @@ passenv = {[testenv:system-tests]passenv}
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     python -c \
         "import shutil; shutil.rmtree('docs/_build/json', ignore_errors=True)"
     {toxinidir}/scripts/update_json_docs.sh
@@ -176,6 +181,7 @@ passenv =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     python -c \
         "import shutil; shutil.rmtree('docs/_build', ignore_errors=True)"
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
@@ -187,10 +193,9 @@ deps =
 passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE READTHEDOCS
 
 [testenv:docs-doc2dash]
-setenv =
-    PYTHONPATH = {toxinidir}/_testing
 basepython = {[testenv:docs]basepython}
 commands =
+    {[testing]localdeps}
     sphinx-build -W -b html -d docs/_build_doc2dash/doctrees \
         docs docs/_build_doc2dash/html
     doc2dash -vv --force -n google-cloud-python \
@@ -214,6 +219,7 @@ verbose = 1
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     python {toxinidir}/scripts/pycodestyle_on_repo.py
     python {toxinidir}/scripts/run_pylint.py
 deps =
@@ -226,6 +232,7 @@ passenv = {[testenv:system-tests]passenv}
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     python {toxinidir}/system_tests/attempt_system_tests.py {posargs}
 deps =
     {[testing]deps}
@@ -235,6 +242,7 @@ passenv = GOOGLE_* TRAVIS* encrypted_*
 basepython =
     python3.4
 commands =
+    {[testing]localdeps}
     python {toxinidir}/system_tests/attempt_system_tests.py {posargs}
 deps =
     {[testing]deps}

--- a/translate/tox.ini
+++ b/translate/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/vision/tox.ini
+++ b/vision/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27,py34,py35,cover
 
 [testing]
+localdeps =
+    pip install --upgrade {toxinidir}/../core
 deps =
-    {toxinidir}/../core
     pytest
 covercmd =
     py.test --quiet \
@@ -15,6 +16,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -23,6 +25,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}


### PR DESCRIPTION
This is done by manually installing via `pip install --upgrade` every time a command is run.

This is suboptimal for many reasons, but is a less contentious fix than #2698 and can at least be a stop-gap until #2698 is merged / agreed on.