### PR TITLE
Migrate datastore iterator to use base iterator class

### DIFF
--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -464,6 +464,23 @@ class Client(_BaseClient, _ClientProjectMixin):
           >>> for entity in query_iter:
           ...     do_something(entity)
 
+        or manually page through results
+
+        .. code-block:: python
+
+          >>> query_iter = query.fetch(start_cursor='2mdd223i944')
+          >>> pages = query_iter.pages
+          >>>
+          >>> first_page = next(pages)
+          >>> first_page_entities = list(first_page)
+          >>> query_iter.next_page_token
+          'abc-some-cursor'
+          >>>
+          >>> second_page = next(pages)
+          >>> second_page_entities = list(second_page)
+          >>> query_iter.next_page_token is None
+          True
+
         Under the hood this is doing:
 
         .. code-block:: python

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -456,19 +456,13 @@ class Client(_BaseClient, _ClientProjectMixin):
           >>> query = client.query(kind='MyKind')
           >>> query.add_filter('property', '=', 'val')
 
-        Using the query iterator's
-        :meth:`~google.cloud.datastore.query.Iterator.next_page` method:
+        Using the query iterator
 
         .. code-block:: python
 
           >>> query_iter = query.fetch()
-          >>> entities, more_results, cursor = query_iter.next_page()
-          >>> entities
-          [<list of Entity unmarshalled from protobuf>]
-          >>> more_results
-          <boolean of more results>
-          >>> cursor
-          <string containing cursor where fetch stopped>
+          >>> for entity in query_iter:
+          ...     do_something(entity)
 
         Under the hood this is doing:
 

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -17,6 +17,8 @@
 import base64
 
 from google.cloud._helpers import _ensure_tuple_or_list
+from google.cloud.iterator import Iterator as BaseIterator
+
 from google.cloud.datastore._generated import query_pb2 as _query_pb2
 from google.cloud.datastore import helpers
 from google.cloud.datastore.key import Key
@@ -365,6 +367,44 @@ class Query(object):
 
         return Iterator(
             self, client, limit, offset, start_cursor, end_cursor)
+
+
+class AltIterator(BaseIterator):
+    """Represent the state of a given execution of a Query.
+
+    :type query: :class:`~google.cloud.datastore.query.Query`
+    :param query: Query object holding permanent configuration (i.e.
+                  things that don't change on with each page in
+                  a results set).
+
+    :type client: :class:`~google.cloud.datastore.client.Client`
+    :param client: The client used to make a request.
+
+    :type limit: int
+    :param limit: (Optional) Limit the number of results returned.
+
+    :type offset: int
+    :param offset: (Optional) Offset used to begin a query.
+
+    :type start_cursor: bytes
+    :param start_cursor: (Optional) Cursor to begin paging through
+                         query results.
+
+    :type end_cursor: bytes
+    :param end_cursor: (Optional) Cursor to end paging through
+                       query results.
+    """
+
+    def __init__(self, query, client, limit=None, offset=None,
+                 start_cursor=None, end_cursor=None):
+        super(AltIterator, self).__init__(
+            client=client, item_to_value=None,
+            page_token=start_cursor, max_results=limit)
+        self._query = query
+        self._offset = offset
+        self._end_cursor = end_cursor
+        # The attributes below will change over the life of the iterator.
+        self._more_results = True
 
 
 class Iterator(object):

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -403,14 +403,14 @@ class Iterator(object):
         self._page = self._more_results = None
         self._skipped_results = None
 
-    def next_page(self):
-        """Fetch a single "page" of query results.
+    def _build_protobuf(self):
+        """Build a query protobuf.
 
-        Low-level API for fine control:  the more convenient API is
-        to iterate on the current Iterator.
+        Relies on the current state of the iterator.
 
-        :rtype: tuple, (entities, more_results, cursor)
-        :returns: The next page of results.
+        :rtype: `google.cloud.datastore._generated.query_pb2.Query`
+        :returns: The query protobuf object for the current
+                  state of the iterator.
         """
         pb = _pb_from_query(self._query)
 
@@ -428,6 +428,18 @@ class Iterator(object):
         if self._offset is not None:
             pb.offset = self._offset
 
+        return pb
+
+    def next_page(self):
+        """Fetch a single "page" of query results.
+
+        Low-level API for fine control:  the more convenient API is
+        to iterate on the current Iterator.
+
+        :rtype: tuple, (entities, more_results, cursor)
+        :returns: The next page of results.
+        """
+        pb = self._build_protobuf()
         transaction = self._client.current_transaction
 
         query_results = self._client.connection.run_query(

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -397,6 +397,8 @@ class Iterator(BaseIterator):
                        query results.
     """
 
+    next_page_token = None
+
     def __init__(self, query, client, limit=None, offset=None,
                  start_cursor=None, end_cursor=None):
         super(Iterator, self).__init__(

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -22,6 +22,15 @@ from google.cloud.datastore import helpers
 from google.cloud.datastore.key import Key
 
 
+_NOT_FINISHED = _query_pb2.QueryResultBatch.NOT_FINISHED
+
+_FINISHED = (
+    _query_pb2.QueryResultBatch.NO_MORE_RESULTS,
+    _query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_LIMIT,
+    _query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_CURSOR,
+)
+
+
 class Query(object):
     """A Query against the Cloud Datastore.
 
@@ -384,14 +393,6 @@ class Iterator(object):
                        query results.
     """
 
-    _NOT_FINISHED = _query_pb2.QueryResultBatch.NOT_FINISHED
-
-    _FINISHED = (
-        _query_pb2.QueryResultBatch.NO_MORE_RESULTS,
-        _query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_LIMIT,
-        _query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_CURSOR,
-    )
-
     def __init__(self, query, client, limit=None, offset=None,
                  start_cursor=None, end_cursor=None):
         self._query = query
@@ -459,9 +460,9 @@ class Iterator(object):
             self._start_cursor = base64.urlsafe_b64encode(cursor_as_bytes)
         self._end_cursor = None
 
-        if more_results_enum == self._NOT_FINISHED:
+        if more_results_enum == _NOT_FINISHED:
             self._more_results = True
-        elif more_results_enum in self._FINISHED:
+        elif more_results_enum in _FINISHED:
             self._more_results = False
         else:
             raise ValueError('Unexpected value returned for `more_results`.')

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -358,7 +358,7 @@ class Query(object):
         :param client: client used to connect to datastore.
                        If not supplied, uses the query's value.
 
-        :rtype: :class:`AltIterator`
+        :rtype: :class:`Iterator`
         :returns: The iterator for the query.
         :raises: ValueError if ``connection`` is not passed and no implicit
                  default has been set.
@@ -366,12 +366,12 @@ class Query(object):
         if client is None:
             client = self._client
 
-        return AltIterator(
+        return Iterator(
             self, client, limit=limit, offset=offset,
             start_cursor=start_cursor, end_cursor=end_cursor)
 
 
-class AltIterator(BaseIterator):
+class Iterator(BaseIterator):
     """Represent the state of a given execution of a Query.
 
     :type query: :class:`~google.cloud.datastore.query.Query`
@@ -399,7 +399,7 @@ class AltIterator(BaseIterator):
 
     def __init__(self, query, client, limit=None, offset=None,
                  start_cursor=None, end_cursor=None):
-        super(AltIterator, self).__init__(
+        super(Iterator, self).__init__(
             client=client, item_to_value=_item_to_entity,
             page_token=start_cursor, max_results=limit)
         self._query = query

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -398,7 +398,7 @@ class AltIterator(BaseIterator):
     def __init__(self, query, client, limit=None, offset=None,
                  start_cursor=None, end_cursor=None):
         super(AltIterator, self).__init__(
-            client=client, item_to_value=None,
+            client=client, item_to_value=_item_to_entity,
             page_token=start_cursor, max_results=limit)
         self._query = query
         self._offset = offset
@@ -616,3 +616,21 @@ def _pb_from_query(query):
         pb.distinct_on.add().name = distinct_on_name
 
     return pb
+
+
+# pylint: disable=unused-argument
+def _item_to_entity(iterator, entity_pb):
+    """Convert a raw protobuf entity to the native object.
+
+    :type iterator: :class:`~google.cloud.iterator.Iterator`
+    :param iterator: The iterator that is currently in use.
+
+    :type entity_pb:
+        :class:`google.cloud.datastore._generated.entity_pb2.Entity`
+    :param entity_pb: An entity protobuf to convert to a native entity.
+
+    :rtype: :class:`~google.cloud.datastore.entity.Entity`
+    :returns: The next entity in the page.
+    """
+    return helpers.entity_from_protobuf(entity_pb)
+# pylint: enable=unused-argument

--- a/datastore/unit_tests/test_query.py
+++ b/datastore/unit_tests/test_query.py
@@ -309,39 +309,39 @@ class TestQuery(unittest.TestCase):
         self.assertEqual(query.distinct_on, _DISTINCT_ON2)
 
     def test_fetch_defaults_w_client_attr(self):
-        from google.cloud.datastore.query import AltIterator
+        from google.cloud.datastore.query import Iterator
 
         connection = _Connection()
         client = self._makeClient(connection)
         query = self._makeOne(client)
         iterator = query.fetch()
 
-        self.assertIsInstance(iterator, AltIterator)
+        self.assertIsInstance(iterator, Iterator)
         self.assertIs(iterator._query, query)
         self.assertIs(iterator.client, client)
         self.assertIsNone(iterator.max_results)
         self.assertEqual(iterator._offset, 0)
 
     def test_fetch_w_explicit_client(self):
-        from google.cloud.datastore.query import AltIterator
+        from google.cloud.datastore.query import Iterator
 
         connection = _Connection()
         client = self._makeClient(connection)
         other_client = self._makeClient(connection)
         query = self._makeOne(client)
         iterator = query.fetch(limit=7, offset=8, client=other_client)
-        self.assertIsInstance(iterator, AltIterator)
+        self.assertIsInstance(iterator, Iterator)
         self.assertIs(iterator._query, query)
         self.assertIs(iterator.client, other_client)
         self.assertEqual(iterator.max_results, 7)
         self.assertEqual(iterator._offset, 8)
 
 
-class TestAltIterator(unittest.TestCase):
+class TestIterator(unittest.TestCase):
 
     def _getTargetClass(self):
-        from google.cloud.datastore.query import AltIterator
-        return AltIterator
+        from google.cloud.datastore.query import Iterator
+        return Iterator
 
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)

--- a/datastore/unit_tests/test_query.py
+++ b/datastore/unit_tests/test_query.py
@@ -627,7 +627,7 @@ class TestAltIterator(unittest.TestCase):
 
         self.assertFalse(iterator._started)
         self.assertIs(iterator.client, client)
-        self.assertIsNone(iterator._item_to_value)
+        self.assertIsNotNone(iterator._item_to_value)
         self.assertIsNone(iterator.max_results)
         self.assertEqual(iterator.page_number, 0)
         self.assertIsNone(iterator.next_page_token,)
@@ -650,7 +650,7 @@ class TestAltIterator(unittest.TestCase):
 
         self.assertFalse(iterator._started)
         self.assertIs(iterator.client, client)
-        self.assertIsNone(iterator._item_to_value)
+        self.assertIsNotNone(iterator._item_to_value)
         self.assertEqual(iterator.max_results, limit)
         self.assertEqual(iterator.page_number, 0)
         self.assertEqual(iterator.next_page_token, start_cursor)
@@ -659,6 +659,30 @@ class TestAltIterator(unittest.TestCase):
         self.assertEqual(iterator._offset, offset)
         self.assertEqual(iterator._end_cursor, end_cursor)
         self.assertTrue(iterator._more_results)
+
+
+class Test__item_to_entity(unittest.TestCase):
+
+    def _callFUT(self, iterator, entity_pb):
+        from google.cloud.datastore.query import _item_to_entity
+        return _item_to_entity(iterator, entity_pb)
+
+    def test_it(self):
+        from google.cloud._testing import _Monkey
+        from google.cloud.datastore import helpers
+
+        result = object()
+        entities = []
+
+        def mocked(entity_pb):
+            entities.append(entity_pb)
+            return result
+
+        entity_pb = object()
+        with _Monkey(helpers, entity_from_protobuf=mocked):
+            self.assertIs(result, self._callFUT(None, entity_pb))
+
+        self.assertEqual(entities, [entity_pb])
 
 
 class Test__pb_from_query(unittest.TestCase):

--- a/datastore/unit_tests/test_query.py
+++ b/datastore/unit_tests/test_query.py
@@ -468,8 +468,6 @@ class TestIterator(unittest.TestCase):
         self.assertFalse(iterator._more_results)
 
     def test__process_query_results_bad_enum(self):
-        from google.cloud.datastore._generated import query_pb2
-
         iterator = self._makeOne(None, None)
         more_results_enum = 999
         with self.assertRaises(ValueError):

--- a/datastore/unit_tests/test_query.py
+++ b/datastore/unit_tests/test_query.py
@@ -611,6 +611,56 @@ class TestIterator(unittest.TestCase):
         self.assertEqual(connection._called_with[2], EXPECTED3)
 
 
+class TestAltIterator(unittest.TestCase):
+
+    def _getTargetClass(self):
+        from google.cloud.datastore.query import AltIterator
+        return AltIterator
+
+    def _makeOne(self, *args, **kw):
+        return self._getTargetClass()(*args, **kw)
+
+    def test_constructor_defaults(self):
+        query = object()
+        client = object()
+        iterator = self._makeOne(query, client)
+
+        self.assertFalse(iterator._started)
+        self.assertIs(iterator.client, client)
+        self.assertIsNone(iterator._item_to_value)
+        self.assertIsNone(iterator.max_results)
+        self.assertEqual(iterator.page_number, 0)
+        self.assertIsNone(iterator.next_page_token,)
+        self.assertEqual(iterator.num_results, 0)
+        self.assertIs(iterator._query, query)
+        self.assertIsNone(iterator._offset)
+        self.assertIsNone(iterator._end_cursor)
+        self.assertTrue(iterator._more_results)
+
+    def test_constructor_explicit(self):
+        query = object()
+        client = object()
+        limit = 43
+        offset = 9
+        start_cursor = b'8290\xff'
+        end_cursor = b'so20rc\ta'
+        iterator = self._makeOne(
+            query, client, limit=limit, offset=offset,
+            start_cursor=start_cursor, end_cursor=end_cursor)
+
+        self.assertFalse(iterator._started)
+        self.assertIs(iterator.client, client)
+        self.assertIsNone(iterator._item_to_value)
+        self.assertEqual(iterator.max_results, limit)
+        self.assertEqual(iterator.page_number, 0)
+        self.assertEqual(iterator.next_page_token, start_cursor)
+        self.assertEqual(iterator.num_results, 0)
+        self.assertIs(iterator._query, query)
+        self.assertEqual(iterator._offset, offset)
+        self.assertEqual(iterator._end_cursor, end_cursor)
+        self.assertTrue(iterator._more_results)
+
+
 class Test__pb_from_query(unittest.TestCase):
 
     def _callFUT(self, query):

--- a/system_tests/clear_datastore.py
+++ b/system_tests/clear_datastore.py
@@ -45,9 +45,8 @@ def fetch_keys(kind, client, fetch_max=FETCH_MAX, query=None, cursor=None):
         query.keys_only()
 
     iterator = query.fetch(limit=fetch_max, start_cursor=cursor)
-
-    entities, _, cursor = iterator.next_page()
-    return query, entities, cursor
+    page = six.next(iterator.pages)
+    return query, list(page), iterator.next_page_token
 
 
 def get_ancestors(entities):


### PR DESCRIPTION
I considered

- Making `offset` and `end_cursor` read-only public properties on the subclass
- Making a `@property` alias `start_cursor` that just returns the value of `next_page_token`
- Making a `@property` alias `limit` that just returns the value of `max_results`

I elected not to make anything **new** public since the original implementation didn't.

@jonparrott PTAL as well (do you think this will be too jarring a change?).