### PR TITLE
Putting 2 empty lines after function definiton in logging snippets.

### DIFF
--- a/docs/logging_snippets.py
+++ b/docs/logging_snippets.py
@@ -365,5 +365,6 @@ def main():
         for item in to_delete:
             _backoff_not_found(item.delete)
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
See: https://travis-ci.org/GoogleCloudPlatform/google-cloud-python/builds/174057513#L1262

I'm going to merge ASAP to get the build green.