### PR TITLE
Use PEP8 names in test helper methods

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -174,7 +174,7 @@ Coding Style
 
 Exceptions to PEP8:
 
-- Many unit tests use a helper method, ``_callFUT`` ("FUT" is short for
+- Many unit tests use a helper method, ``_call_fut`` ("FUT" is short for
   "Function-Under-Test"), which is PEP8-incompliant, but more readable.
   Some also use a local variable, ``MUT`` (short for "Module-Under-Test").
 

--- a/bigquery/unit_tests/test__helpers.py
+++ b/bigquery/unit_tests/test__helpers.py
@@ -323,7 +323,7 @@ class Test_ConfigurationProperty(unittest.TestCase):
         from google.cloud.bigquery._helpers import _ConfigurationProperty
         return _ConfigurationProperty
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_it(self):
@@ -332,7 +332,7 @@ class Test_ConfigurationProperty(unittest.TestCase):
             _attr = None
 
         class Wrapper(object):
-            attr = self._makeOne('attr')
+            attr = self._make_one('attr')
 
             def __init__(self):
                 self._configuration = Configuration()
@@ -359,7 +359,7 @@ class Test_TypedProperty(unittest.TestCase):
         from google.cloud.bigquery._helpers import _TypedProperty
         return _TypedProperty
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_it(self):
@@ -368,7 +368,7 @@ class Test_TypedProperty(unittest.TestCase):
             _attr = None
 
         class Wrapper(object):
-            attr = self._makeOne('attr', int)
+            attr = self._make_one('attr', int)
 
             def __init__(self):
                 self._configuration = Configuration()
@@ -427,11 +427,11 @@ class Test_UDFResourcesProperty(unittest.TestCase):
         from google.cloud.bigquery._helpers import UDFResourcesProperty
         return UDFResourcesProperty
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _descriptor_and_klass(self):
-        descriptor = self._makeOne()
+        descriptor = self._make_one()
 
         class _Test(object):
             _udf_resources = ()

--- a/bigquery/unit_tests/test__helpers.py
+++ b/bigquery/unit_tests/test__helpers.py
@@ -17,111 +17,111 @@ import unittest
 
 class Test_not_null(unittest.TestCase):
 
-    def _callFUT(self, value, field):
+    def _call_fut(self, value, field):
         from google.cloud.bigquery._helpers import _not_null
         return _not_null(value, field)
 
     def test_w_none_nullable(self):
-        self.assertFalse(self._callFUT(None, _Field('NULLABLE')))
+        self.assertFalse(self._call_fut(None, _Field('NULLABLE')))
 
     def test_w_none_required(self):
-        self.assertTrue(self._callFUT(None, _Field('REQUIRED')))
+        self.assertTrue(self._call_fut(None, _Field('REQUIRED')))
 
     def test_w_value(self):
-        self.assertTrue(self._callFUT(object(), object()))
+        self.assertTrue(self._call_fut(object(), object()))
 
 
 class Test_int_from_json(unittest.TestCase):
 
-    def _callFUT(self, value, field):
+    def _call_fut(self, value, field):
         from google.cloud.bigquery._helpers import _int_from_json
         return _int_from_json(value, field)
 
     def test_w_none_nullable(self):
-        self.assertIsNone(self._callFUT(None, _Field('NULLABLE')))
+        self.assertIsNone(self._call_fut(None, _Field('NULLABLE')))
 
     def test_w_none_required(self):
         with self.assertRaises(TypeError):
-            self._callFUT(None, _Field('REQUIRED'))
+            self._call_fut(None, _Field('REQUIRED'))
 
     def test_w_string_value(self):
-        coerced = self._callFUT('42', object())
+        coerced = self._call_fut('42', object())
         self.assertEqual(coerced, 42)
 
     def test_w_float_value(self):
-        coerced = self._callFUT(42, object())
+        coerced = self._call_fut(42, object())
         self.assertEqual(coerced, 42)
 
 
 class Test_float_from_json(unittest.TestCase):
 
-    def _callFUT(self, value, field):
+    def _call_fut(self, value, field):
         from google.cloud.bigquery._helpers import _float_from_json
         return _float_from_json(value, field)
 
     def test_w_none_nullable(self):
-        self.assertIsNone(self._callFUT(None, _Field('NULLABLE')))
+        self.assertIsNone(self._call_fut(None, _Field('NULLABLE')))
 
     def test_w_none_required(self):
         with self.assertRaises(TypeError):
-            self._callFUT(None, _Field('REQUIRED'))
+            self._call_fut(None, _Field('REQUIRED'))
 
     def test_w_string_value(self):
-        coerced = self._callFUT('3.1415', object())
+        coerced = self._call_fut('3.1415', object())
         self.assertEqual(coerced, 3.1415)
 
     def test_w_float_value(self):
-        coerced = self._callFUT(3.1415, object())
+        coerced = self._call_fut(3.1415, object())
         self.assertEqual(coerced, 3.1415)
 
 
 class Test_bool_from_json(unittest.TestCase):
 
-    def _callFUT(self, value, field):
+    def _call_fut(self, value, field):
         from google.cloud.bigquery._helpers import _bool_from_json
         return _bool_from_json(value, field)
 
     def test_w_none_nullable(self):
-        self.assertIsNone(self._callFUT(None, _Field('NULLABLE')))
+        self.assertIsNone(self._call_fut(None, _Field('NULLABLE')))
 
     def test_w_none_required(self):
         with self.assertRaises(AttributeError):
-            self._callFUT(None, _Field('REQUIRED'))
+            self._call_fut(None, _Field('REQUIRED'))
 
     def test_w_value_t(self):
-        coerced = self._callFUT('T', object())
+        coerced = self._call_fut('T', object())
         self.assertTrue(coerced)
 
     def test_w_value_true(self):
-        coerced = self._callFUT('True', object())
+        coerced = self._call_fut('True', object())
         self.assertTrue(coerced)
 
     def test_w_value_1(self):
-        coerced = self._callFUT('1', object())
+        coerced = self._call_fut('1', object())
         self.assertTrue(coerced)
 
     def test_w_value_other(self):
-        coerced = self._callFUT('f', object())
+        coerced = self._call_fut('f', object())
         self.assertFalse(coerced)
 
 
 class Test_datetime_from_json(unittest.TestCase):
 
-    def _callFUT(self, value, field):
+    def _call_fut(self, value, field):
         from google.cloud.bigquery._helpers import _datetime_from_json
         return _datetime_from_json(value, field)
 
     def test_w_none_nullable(self):
-        self.assertIsNone(self._callFUT(None, _Field('NULLABLE')))
+        self.assertIsNone(self._call_fut(None, _Field('NULLABLE')))
 
     def test_w_none_required(self):
         with self.assertRaises(TypeError):
-            self._callFUT(None, _Field('REQUIRED'))
+            self._call_fut(None, _Field('REQUIRED'))
 
     def test_w_string_value(self):
         import datetime
         from google.cloud._helpers import _EPOCH
-        coerced = self._callFUT('1.234567', object())
+        coerced = self._call_fut('1.234567', object())
         self.assertEqual(
             coerced,
             _EPOCH + datetime.timedelta(seconds=1, microseconds=234567))
@@ -129,7 +129,7 @@ class Test_datetime_from_json(unittest.TestCase):
     def test_w_float_value(self):
         import datetime
         from google.cloud._helpers import _EPOCH
-        coerced = self._callFUT(1.234567, object())
+        coerced = self._call_fut(1.234567, object())
         self.assertEqual(
             coerced,
             _EPOCH + datetime.timedelta(seconds=1, microseconds=234567))
@@ -137,20 +137,20 @@ class Test_datetime_from_json(unittest.TestCase):
 
 class Test_date_from_json(unittest.TestCase):
 
-    def _callFUT(self, value, field):
+    def _call_fut(self, value, field):
         from google.cloud.bigquery._helpers import _date_from_json
         return _date_from_json(value, field)
 
     def test_w_none_nullable(self):
-        self.assertIsNone(self._callFUT(None, _Field('NULLABLE')))
+        self.assertIsNone(self._call_fut(None, _Field('NULLABLE')))
 
     def test_w_none_required(self):
         with self.assertRaises(TypeError):
-            self._callFUT(None, _Field('REQUIRED'))
+            self._call_fut(None, _Field('REQUIRED'))
 
     def test_w_string_value(self):
         import datetime
-        coerced = self._callFUT('1987-09-22', object())
+        coerced = self._call_fut('1987-09-22', object())
         self.assertEqual(
             coerced,
             datetime.date(1987, 9, 22))
@@ -158,36 +158,36 @@ class Test_date_from_json(unittest.TestCase):
 
 class Test_record_from_json(unittest.TestCase):
 
-    def _callFUT(self, value, field):
+    def _call_fut(self, value, field):
         from google.cloud.bigquery._helpers import _record_from_json
         return _record_from_json(value, field)
 
     def test_w_none_nullable(self):
-        self.assertIsNone(self._callFUT(None, _Field('NULLABLE')))
+        self.assertIsNone(self._call_fut(None, _Field('NULLABLE')))
 
     def test_w_none_required(self):
         with self.assertRaises(TypeError):
-            self._callFUT(None, _Field('REQUIRED'))
+            self._call_fut(None, _Field('REQUIRED'))
 
     def test_w_nullable_subfield_none(self):
         subfield = _Field('NULLABLE', 'age', 'INTEGER')
         field = _Field('REQUIRED', fields=[subfield])
         value = {'f': [{'v': None}]}
-        coerced = self._callFUT(value, field)
+        coerced = self._call_fut(value, field)
         self.assertEqual(coerced, {'age': None})
 
     def test_w_scalar_subfield(self):
         subfield = _Field('REQUIRED', 'age', 'INTEGER')
         field = _Field('REQUIRED', fields=[subfield])
         value = {'f': [{'v': 42}]}
-        coerced = self._callFUT(value, field)
+        coerced = self._call_fut(value, field)
         self.assertEqual(coerced, {'age': 42})
 
     def test_w_repeated_subfield(self):
         subfield = _Field('REPEATED', 'color', 'STRING')
         field = _Field('REQUIRED', fields=[subfield])
         value = {'f': [{'v': ['red', 'yellow', 'blue']}]}
-        coerced = self._callFUT(value, field)
+        coerced = self._call_fut(value, field)
         self.assertEqual(coerced, {'color': ['red', 'yellow', 'blue']})
 
     def test_w_record_subfield(self):
@@ -213,30 +213,30 @@ class Test_record_from_json(unittest.TestCase):
                 'rank': 1,
             }
         }
-        coerced = self._callFUT(value, person)
+        coerced = self._call_fut(value, person)
         self.assertEqual(coerced, expected)
 
 
 class Test_string_from_json(unittest.TestCase):
 
-    def _callFUT(self, value, field):
+    def _call_fut(self, value, field):
         from google.cloud.bigquery._helpers import _string_from_json
         return _string_from_json(value, field)
 
     def test_w_none_nullable(self):
-        self.assertIsNone(self._callFUT(None, _Field('NULLABLE')))
+        self.assertIsNone(self._call_fut(None, _Field('NULLABLE')))
 
     def test_w_none_required(self):
-        self.assertIsNone(self._callFUT(None, _Field('RECORD')))
+        self.assertIsNone(self._call_fut(None, _Field('RECORD')))
 
     def test_w_string_value(self):
-        coerced = self._callFUT('Wonderful!', object())
+        coerced = self._call_fut('Wonderful!', object())
         self.assertEqual(coerced, 'Wonderful!')
 
 
 class Test_rows_from_json(unittest.TestCase):
 
-    def _callFUT(self, value, field):
+    def _call_fut(self, value, field):
         from google.cloud.bigquery._helpers import _rows_from_json
         return _rows_from_json(value, field)
 
@@ -281,7 +281,7 @@ class Test_rows_from_json(unittest.TestCase):
             ('Bharney Rhubble', bharney_phone, ['brown']),
             ('Wylma Phlyntstone', None, []),
         ]
-        coerced = self._callFUT(rows, schema)
+        coerced = self._call_fut(rows, schema)
         self.assertEqual(coerced, expected)
 
     def test_w_int64_float64(self):
@@ -312,7 +312,7 @@ class Test_rows_from_json(unittest.TestCase):
             ('Bharney Rhubble', 4, 0.125),
             ('Wylma Phlyntstone', 20, 0.625),
         ]
-        coerced = self._callFUT(rows, schema)
+        coerced = self._call_fut(rows, schema)
         self.assertEqual(coerced, expected)
 
 

--- a/bigquery/unit_tests/test__helpers.py
+++ b/bigquery/unit_tests/test__helpers.py
@@ -324,7 +324,7 @@ class Test_ConfigurationProperty(unittest.TestCase):
         return _ConfigurationProperty
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_it(self):
 
@@ -360,7 +360,7 @@ class Test_TypedProperty(unittest.TestCase):
         return _TypedProperty
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_it(self):
 
@@ -395,7 +395,7 @@ class Test_EnumProperty(unittest.TestCase):
 
     def test_it(self):
 
-        class Sub(self._getTargetClass()):
+        class Sub(self._get_target_class()):
             ALLOWED = ('FOO', 'BAR', 'BAZ')
 
         class Configuration(object):
@@ -428,7 +428,7 @@ class Test_UDFResourcesProperty(unittest.TestCase):
         return UDFResourcesProperty
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _descriptor_and_klass(self):
         descriptor = self._makeOne()

--- a/bigquery/unit_tests/test__helpers.py
+++ b/bigquery/unit_tests/test__helpers.py
@@ -318,7 +318,8 @@ class Test_rows_from_json(unittest.TestCase):
 
 class Test_ConfigurationProperty(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery._helpers import _ConfigurationProperty
         return _ConfigurationProperty
 
@@ -353,7 +354,8 @@ class Test_ConfigurationProperty(unittest.TestCase):
 
 class Test_TypedProperty(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery._helpers import _TypedProperty
         return _TypedProperty
 
@@ -386,7 +388,8 @@ class Test_TypedProperty(unittest.TestCase):
 
 class Test_EnumProperty(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery._helpers import _EnumProperty
         return _EnumProperty
 
@@ -419,7 +422,8 @@ class Test_EnumProperty(unittest.TestCase):
 
 class Test_UDFResourcesProperty(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery._helpers import UDFResourcesProperty
         return UDFResourcesProperty
 

--- a/bigquery/unit_tests/test__http.py
+++ b/bigquery/unit_tests/test__http.py
@@ -23,7 +23,7 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
         conn = self._makeOne()

--- a/bigquery/unit_tests/test__http.py
+++ b/bigquery/unit_tests/test__http.py
@@ -22,11 +22,11 @@ class TestConnection(unittest.TestCase):
         from google.cloud.bigquery._http import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.API_BASE_URL,
             'bigquery',
@@ -38,7 +38,7 @@ class TestConnection(unittest.TestCase):
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
-        conn = self._makeOne()
+        conn = self._make_one()
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)

--- a/bigquery/unit_tests/test__http.py
+++ b/bigquery/unit_tests/test__http.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery._http import Connection
         return Connection
 

--- a/bigquery/unit_tests/test_client.py
+++ b/bigquery/unit_tests/test_client.py
@@ -22,7 +22,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigquery.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
@@ -30,7 +30,7 @@ class TestClient(unittest.TestCase):
         PROJECT = 'PROJECT'
         creds = _Credentials()
         http = object()
-        client = self._makeOne(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, http=http)
         self.assertIsInstance(client.connection, Connection)
         self.assertIs(client.connection.credentials, creds)
         self.assertIs(client.connection.http, http)
@@ -58,7 +58,7 @@ class TestClient(unittest.TestCase):
             ]
         }
         creds = _Credentials()
-        client = self._makeOne(PROJECT_1, creds)
+        client = self._make_one(PROJECT_1, creds)
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_projects()
@@ -87,7 +87,7 @@ class TestClient(unittest.TestCase):
         TOKEN = 'TOKEN'
         DATA = {}
         creds = _Credentials()
-        client = self._makeOne(PROJECT, creds)
+        client = self._make_one(PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_projects(max_results=3, page_token=TOKEN)
@@ -129,7 +129,7 @@ class TestClient(unittest.TestCase):
             ]
         }
         creds = _Credentials()
-        client = self._makeOne(PROJECT, creds)
+        client = self._make_one(PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_datasets()
@@ -157,7 +157,7 @@ class TestClient(unittest.TestCase):
         TOKEN = 'TOKEN'
         DATA = {}
         creds = _Credentials()
-        client = self._makeOne(PROJECT, creds)
+        client = self._make_one(PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_datasets(
@@ -182,7 +182,7 @@ class TestClient(unittest.TestCase):
         DATASET = 'dataset_name'
         creds = _Credentials()
         http = object()
-        client = self._makeOne(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, http=http)
         dataset = client.dataset(DATASET)
         self.assertIsInstance(dataset, Dataset)
         self.assertEqual(dataset.name, DATASET)
@@ -191,7 +191,7 @@ class TestClient(unittest.TestCase):
     def test_job_from_resource_unknown_type(self):
         PROJECT = 'PROJECT'
         creds = _Credentials()
-        client = self._makeOne(PROJECT, creds)
+        client = self._make_one(PROJECT, creds)
         with self.assertRaises(ValueError):
             client.job_from_resource({'configuration': {'nonesuch': {}}})
 
@@ -305,7 +305,7 @@ class TestClient(unittest.TestCase):
             ]
         }
         creds = _Credentials()
-        client = self._makeOne(PROJECT, creds)
+        client = self._make_one(PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_jobs()
@@ -361,7 +361,7 @@ class TestClient(unittest.TestCase):
             ]
         }
         creds = _Credentials()
-        client = self._makeOne(PROJECT, creds)
+        client = self._make_one(PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_jobs()
@@ -389,7 +389,7 @@ class TestClient(unittest.TestCase):
         DATA = {}
         TOKEN = 'TOKEN'
         creds = _Credentials()
-        client = self._makeOne(PROJECT, creds)
+        client = self._make_one(PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_jobs(max_results=1000, page_token=TOKEN,
@@ -421,7 +421,7 @@ class TestClient(unittest.TestCase):
         SOURCE_URI = 'http://example.com/source.csv'
         creds = _Credentials()
         http = object()
-        client = self._makeOne(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, http=http)
         dataset = client.dataset(DATASET)
         destination = dataset.table(DESTINATION)
         job = client.load_table_from_storage(JOB, destination, SOURCE_URI)
@@ -440,7 +440,7 @@ class TestClient(unittest.TestCase):
         DESTINATION = 'destination_table'
         creds = _Credentials()
         http = object()
-        client = self._makeOne(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, http=http)
         dataset = client.dataset(DATASET)
         source = dataset.table(SOURCE)
         destination = dataset.table(DESTINATION)
@@ -460,7 +460,7 @@ class TestClient(unittest.TestCase):
         DESTINATION = 'gs://bucket_name/object_name'
         creds = _Credentials()
         http = object()
-        client = self._makeOne(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, http=http)
         dataset = client.dataset(DATASET)
         source = dataset.table(SOURCE)
         job = client.extract_table_to_storage(JOB, source, DESTINATION)
@@ -477,7 +477,7 @@ class TestClient(unittest.TestCase):
         QUERY = 'select count(*) from persons'
         creds = _Credentials()
         http = object()
-        client = self._makeOne(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, http=http)
         job = client.run_async_query(JOB, QUERY)
         self.assertIsInstance(job, QueryJob)
         self.assertIs(job._client, client)
@@ -490,7 +490,7 @@ class TestClient(unittest.TestCase):
         QUERY = 'select count(*) from persons'
         creds = _Credentials()
         http = object()
-        client = self._makeOne(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, http=http)
         job = client.run_sync_query(QUERY)
         self.assertIsInstance(job, QueryResults)
         self.assertIs(job._client, client)

--- a/bigquery/unit_tests/test_client.py
+++ b/bigquery/unit_tests/test_client.py
@@ -23,7 +23,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         from google.cloud.bigquery._http import Connection

--- a/bigquery/unit_tests/test_client.py
+++ b/bigquery/unit_tests/test_client.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestClient(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery.client import Client
         return Client
 

--- a/bigquery/unit_tests/test_dataset.py
+++ b/bigquery/unit_tests/test_dataset.py
@@ -22,30 +22,30 @@ class TestAccessGrant(unittest.TestCase):
         from google.cloud.bigquery.dataset import AccessGrant
         return AccessGrant
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
-        grant = self._makeOne('OWNER', 'userByEmail', 'phred@example.com')
+        grant = self._make_one('OWNER', 'userByEmail', 'phred@example.com')
         self.assertEqual(grant.role, 'OWNER')
         self.assertEqual(grant.entity_type, 'userByEmail')
         self.assertEqual(grant.entity_id, 'phred@example.com')
 
     def test_ctor_bad_entity_type(self):
         with self.assertRaises(ValueError):
-            self._makeOne(None, 'unknown', None)
+            self._make_one(None, 'unknown', None)
 
     def test_ctor_view_with_role(self):
         role = 'READER'
         entity_type = 'view'
         with self.assertRaises(ValueError):
-            self._makeOne(role, entity_type, None)
+            self._make_one(role, entity_type, None)
 
     def test_ctor_view_success(self):
         role = None
         entity_type = 'view'
         entity_id = object()
-        grant = self._makeOne(role, entity_type, entity_id)
+        grant = self._make_one(role, entity_type, entity_id)
         self.assertEqual(grant.role, role)
         self.assertEqual(grant.entity_type, entity_type)
         self.assertEqual(grant.entity_id, entity_id)
@@ -54,26 +54,26 @@ class TestAccessGrant(unittest.TestCase):
         role = None
         entity_type = 'userByEmail'
         with self.assertRaises(ValueError):
-            self._makeOne(role, entity_type, None)
+            self._make_one(role, entity_type, None)
 
     def test___eq___role_mismatch(self):
-        grant = self._makeOne('OWNER', 'userByEmail', 'phred@example.com')
-        other = self._makeOne('WRITER', 'userByEmail', 'phred@example.com')
+        grant = self._make_one('OWNER', 'userByEmail', 'phred@example.com')
+        other = self._make_one('WRITER', 'userByEmail', 'phred@example.com')
         self.assertNotEqual(grant, other)
 
     def test___eq___entity_type_mismatch(self):
-        grant = self._makeOne('OWNER', 'userByEmail', 'phred@example.com')
-        other = self._makeOne('OWNER', 'groupByEmail', 'phred@example.com')
+        grant = self._make_one('OWNER', 'userByEmail', 'phred@example.com')
+        other = self._make_one('OWNER', 'groupByEmail', 'phred@example.com')
         self.assertNotEqual(grant, other)
 
     def test___eq___entity_id_mismatch(self):
-        grant = self._makeOne('OWNER', 'userByEmail', 'phred@example.com')
-        other = self._makeOne('OWNER', 'userByEmail', 'bharney@example.com')
+        grant = self._make_one('OWNER', 'userByEmail', 'phred@example.com')
+        other = self._make_one('OWNER', 'userByEmail', 'bharney@example.com')
         self.assertNotEqual(grant, other)
 
     def test___eq___hit(self):
-        grant = self._makeOne('OWNER', 'userByEmail', 'phred@example.com')
-        other = self._makeOne('OWNER', 'userByEmail', 'phred@example.com')
+        grant = self._make_one('OWNER', 'userByEmail', 'phred@example.com')
+        other = self._make_one('OWNER', 'userByEmail', 'phred@example.com')
         self.assertEqual(grant, other)
 
 
@@ -86,7 +86,7 @@ class TestDataset(unittest.TestCase):
         from google.cloud.bigquery.dataset import Dataset
         return Dataset
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _setUpConstants(self):
@@ -176,7 +176,7 @@ class TestDataset(unittest.TestCase):
 
     def test_ctor(self):
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         self.assertEqual(dataset.name, self.DS_NAME)
         self.assertIs(dataset._client, client)
         self.assertEqual(dataset.project, client.project)
@@ -198,14 +198,14 @@ class TestDataset(unittest.TestCase):
 
     def test_access_roles_setter_non_list(self):
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         with self.assertRaises(TypeError):
             dataset.access_grants = object()
 
     def test_access_roles_setter_invalid_field(self):
         from google.cloud.bigquery.dataset import AccessGrant
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         phred = AccessGrant('OWNER', 'userByEmail', 'phred@example.com')
         with self.assertRaises(ValueError):
             dataset.access_grants = [phred, object()]
@@ -213,7 +213,7 @@ class TestDataset(unittest.TestCase):
     def test_access_roles_setter(self):
         from google.cloud.bigquery.dataset import AccessGrant
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         phred = AccessGrant('OWNER', 'userByEmail', 'phred@example.com')
         bharney = AccessGrant('OWNER', 'userByEmail', 'bharney@example.com')
         dataset.access_grants = [phred, bharney]
@@ -221,49 +221,49 @@ class TestDataset(unittest.TestCase):
 
     def test_default_table_expiration_ms_setter_bad_value(self):
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         with self.assertRaises(ValueError):
             dataset.default_table_expiration_ms = 'bogus'
 
     def test_default_table_expiration_ms_setter(self):
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         dataset.default_table_expiration_ms = 12345
         self.assertEqual(dataset.default_table_expiration_ms, 12345)
 
     def test_description_setter_bad_value(self):
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         with self.assertRaises(ValueError):
             dataset.description = 12345
 
     def test_description_setter(self):
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         dataset.description = 'DESCRIPTION'
         self.assertEqual(dataset.description, 'DESCRIPTION')
 
     def test_friendly_name_setter_bad_value(self):
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         with self.assertRaises(ValueError):
             dataset.friendly_name = 12345
 
     def test_friendly_name_setter(self):
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         dataset.friendly_name = 'FRIENDLY'
         self.assertEqual(dataset.friendly_name, 'FRIENDLY')
 
     def test_location_setter_bad_value(self):
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         with self.assertRaises(ValueError):
             dataset.location = 12345
 
     def test_location_setter(self):
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client)
+        dataset = self._make_one(self.DS_NAME, client)
         dataset.location = 'LOCATION'
         self.assertEqual(dataset.location, 'LOCATION')
 
@@ -303,7 +303,7 @@ class TestDataset(unittest.TestCase):
             {'role': 'READER', 'unknown': 'UNKNOWN'},
         ]
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
         with self.assertRaises(ValueError):
             dataset._parse_access_grants(ACCESS)
 
@@ -317,7 +317,7 @@ class TestDataset(unittest.TestCase):
             },
         ]
         client = _Client(self.PROJECT)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
         with self.assertRaises(ValueError):
             dataset._parse_access_grants(ACCESS)
 
@@ -326,7 +326,7 @@ class TestDataset(unittest.TestCase):
         RESOURCE = self._makeResource()
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
 
         dataset.create()
 
@@ -355,7 +355,7 @@ class TestDataset(unittest.TestCase):
         CLIENT1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        dataset = self._makeOne(self.DS_NAME, client=CLIENT1)
+        dataset = self._make_one(self.DS_NAME, client=CLIENT1)
         dataset.friendly_name = TITLE
         dataset.description = DESCRIPTION
         VIEW = {
@@ -408,7 +408,7 @@ class TestDataset(unittest.TestCase):
         self.WHEN = None
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
 
         dataset.create()
 
@@ -427,7 +427,7 @@ class TestDataset(unittest.TestCase):
         PATH = 'projects/%s/datasets/%s' % (self.PROJECT, self.DS_NAME)
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
 
         self.assertFalse(dataset.exists())
 
@@ -443,7 +443,7 @@ class TestDataset(unittest.TestCase):
         CLIENT1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection({})
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        dataset = self._makeOne(self.DS_NAME, client=CLIENT1)
+        dataset = self._make_one(self.DS_NAME, client=CLIENT1)
 
         self.assertTrue(dataset.exists(client=CLIENT2))
 
@@ -459,7 +459,7 @@ class TestDataset(unittest.TestCase):
         RESOURCE = self._makeResource()
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
 
         dataset.reload()
 
@@ -476,7 +476,7 @@ class TestDataset(unittest.TestCase):
         CLIENT1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        dataset = self._makeOne(self.DS_NAME, client=CLIENT1)
+        dataset = self._make_one(self.DS_NAME, client=CLIENT1)
 
         dataset.reload(client=CLIENT2)
 
@@ -491,7 +491,7 @@ class TestDataset(unittest.TestCase):
         RESOURCE = self._makeResource()
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
 
         with self.assertRaises(ValueError):
             dataset.patch(default_table_expiration_ms='BOGUS')
@@ -505,7 +505,7 @@ class TestDataset(unittest.TestCase):
         RESOURCE['friendlyName'] = TITLE
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
 
         dataset.patch(description=DESCRIPTION, friendly_name=TITLE)
 
@@ -531,7 +531,7 @@ class TestDataset(unittest.TestCase):
         CLIENT1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        dataset = self._makeOne(self.DS_NAME, client=CLIENT1)
+        dataset = self._make_one(self.DS_NAME, client=CLIENT1)
 
         dataset.patch(client=CLIENT2,
                       default_table_expiration_ms=DEF_TABLE_EXP,
@@ -558,7 +558,7 @@ class TestDataset(unittest.TestCase):
         RESOURCE['friendlyName'] = TITLE
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
         dataset.description = DESCRIPTION
         dataset.friendly_name = TITLE
 
@@ -588,7 +588,7 @@ class TestDataset(unittest.TestCase):
         CLIENT1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        dataset = self._makeOne(self.DS_NAME, client=CLIENT1)
+        dataset = self._make_one(self.DS_NAME, client=CLIENT1)
         dataset.default_table_expiration_ms = DEF_TABLE_EXP
         dataset.location = LOCATION
 
@@ -612,7 +612,7 @@ class TestDataset(unittest.TestCase):
         PATH = 'projects/%s/datasets/%s' % (self.PROJECT, self.DS_NAME)
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
 
         dataset.delete()
 
@@ -627,7 +627,7 @@ class TestDataset(unittest.TestCase):
         CLIENT1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection({})
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        dataset = self._makeOne(self.DS_NAME, client=CLIENT1)
+        dataset = self._make_one(self.DS_NAME, client=CLIENT1)
 
         dataset.delete(client=CLIENT2)
 
@@ -642,7 +642,7 @@ class TestDataset(unittest.TestCase):
 
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
 
         iterator = dataset.list_tables()
         self.assertIs(iterator.dataset, dataset)
@@ -686,7 +686,7 @@ class TestDataset(unittest.TestCase):
 
         conn = _Connection(DATA)
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
 
         iterator = dataset.list_tables()
         self.assertIs(iterator.dataset, dataset)
@@ -733,7 +733,7 @@ class TestDataset(unittest.TestCase):
 
         conn = _Connection(DATA)
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
 
         iterator = dataset.list_tables(max_results=3, page_token=TOKEN)
         self.assertIs(iterator.dataset, dataset)
@@ -759,7 +759,7 @@ class TestDataset(unittest.TestCase):
         from google.cloud.bigquery.table import Table
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
         table = dataset.table('table_name')
         self.assertIsInstance(table, Table)
         self.assertEqual(table.name, 'table_name')
@@ -771,7 +771,7 @@ class TestDataset(unittest.TestCase):
         from google.cloud.bigquery.table import Table
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._makeOne(self.DS_NAME, client=client)
+        dataset = self._make_one(self.DS_NAME, client=client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = dataset.table('table_name', schema=[full_name, age])

--- a/bigquery/unit_tests/test_dataset.py
+++ b/bigquery/unit_tests/test_dataset.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestAccessGrant(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery.dataset import AccessGrant
         return AccessGrant
 
@@ -80,7 +81,8 @@ class TestDataset(unittest.TestCase):
     PROJECT = 'project'
     DS_NAME = 'dataset-name'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery.dataset import Dataset
         return Dataset
 

--- a/bigquery/unit_tests/test_dataset.py
+++ b/bigquery/unit_tests/test_dataset.py
@@ -23,7 +23,7 @@ class TestAccessGrant(unittest.TestCase):
         return AccessGrant
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         grant = self._makeOne('OWNER', 'userByEmail', 'phred@example.com')
@@ -87,7 +87,7 @@ class TestDataset(unittest.TestCase):
         return Dataset
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _setUpConstants(self):
         import datetime
@@ -271,7 +271,7 @@ class TestDataset(unittest.TestCase):
         self._setUpConstants()
         client = _Client(self.PROJECT)
         RESOURCE = {}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, client=client)
 
@@ -285,7 +285,7 @@ class TestDataset(unittest.TestCase):
                 'datasetId': self.DS_NAME,
             }
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         dataset = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(dataset._client, client)
         self._verifyResourceProperties(dataset, RESOURCE)
@@ -293,7 +293,7 @@ class TestDataset(unittest.TestCase):
     def test_from_api_repr_w_properties(self):
         client = _Client(self.PROJECT)
         RESOURCE = self._makeResource()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         dataset = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(dataset._client, client)
         self._verifyResourceProperties(dataset, RESOURCE)

--- a/bigquery/unit_tests/test_job.py
+++ b/bigquery/unit_tests/test_job.py
@@ -122,7 +122,8 @@ class _Base(object):
 class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
     JOB_TYPE = 'load'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery.job import LoadTableFromStorageJob
         return LoadTableFromStorageJob
 
@@ -642,7 +643,8 @@ class TestCopyJob(unittest.TestCase, _Base):
     SOURCE_TABLE = 'source_table'
     DESTINATION_TABLE = 'destination_table'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery.job import CopyJob
         return CopyJob
 
@@ -939,7 +941,8 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
     SOURCE_TABLE = 'source_table'
     DESTINATION_URI = 'gs://bucket_name/object_name'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery.job import ExtractTableToStorageJob
         return ExtractTableToStorageJob
 
@@ -1232,7 +1235,8 @@ class TestQueryJob(unittest.TestCase, _Base):
     QUERY = 'select count(*) from persons'
     DESTINATION_TABLE = 'destination_table'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery.job import QueryJob
         return QueryJob
 

--- a/bigquery/unit_tests/test_job.py
+++ b/bigquery/unit_tests/test_job.py
@@ -269,7 +269,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client,
-                            schema=[full_name, age])
+                             schema=[full_name, age])
         self.assertEqual(job.schema, [full_name, age])
 
     def test_schema_setter_non_list(self):
@@ -499,7 +499,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client1,
-                            schema=[full_name, age])
+                             schema=[full_name, age])
 
         job.allow_jagged_rows = True
         job.allow_quoted_newlines = True
@@ -998,7 +998,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         client = _Client(self.PROJECT)
         source = _Table(self.SOURCE_TABLE)
         job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
-                            client)
+                             client)
         self.assertEqual(job.source, source)
         self.assertEqual(job.destination_uris, [self.DESTINATION_URI])
         self.assertIs(job._client, client)
@@ -1082,7 +1082,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         client = _Client(project=self.PROJECT, connection=conn)
         source = _Table(self.SOURCE_TABLE)
         job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
-                            client)
+                             client)
 
         job.begin()
 
@@ -1131,7 +1131,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         client2 = _Client(project=self.PROJECT, connection=conn2)
         source = _Table(self.SOURCE_TABLE)
         job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
-                            client1)
+                             client1)
 
         job.compression = 'GZIP'
         job.destination_format = 'NEWLINE_DELIMITED_JSON'
@@ -1163,7 +1163,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         client = _Client(project=self.PROJECT, connection=conn)
         source = _Table(self.SOURCE_TABLE)
         job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
-                            client)
+                             client)
 
         self.assertFalse(job.exists())
 
@@ -1181,7 +1181,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         client2 = _Client(project=self.PROJECT, connection=conn2)
         source = _Table(self.SOURCE_TABLE)
         job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
-                            client1)
+                             client1)
 
         self.assertTrue(job.exists(client=client2))
 
@@ -1199,7 +1199,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         client = _Client(project=self.PROJECT, connection=conn)
         source = _Table(self.SOURCE_TABLE)
         job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
-                            client)
+                             client)
 
         job.reload()
 
@@ -1218,7 +1218,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         client2 = _Client(project=self.PROJECT, connection=conn2)
         source = _Table(self.SOURCE_TABLE)
         job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
-                            client1)
+                             client1)
 
         job.reload(client=client2)
 
@@ -1533,9 +1533,9 @@ class TestQueryJob(unittest.TestCase, _Base):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         job = self._make_one(self.JOB_NAME, self.QUERY, client,
-                            udf_resources=[
-                                UDFResource("resourceUri", RESOURCE_URI)
-                            ])
+                             udf_resources=[
+                                 UDFResource("resourceUri", RESOURCE_URI)
+                             ])
 
         job.begin()
 

--- a/bigquery/unit_tests/test_job.py
+++ b/bigquery/unit_tests/test_job.py
@@ -23,7 +23,7 @@ class _Base(object):
     JOB_NAME = 'job_name'
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _setUpConstants(self):
         import datetime
@@ -364,7 +364,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         self._setUpConstants()
         client = _Client(self.PROJECT)
         RESOURCE = {}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, client=client)
 
@@ -378,7 +378,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
                 'jobId': self.JOB_NAME,
             }
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, client=client)
 
@@ -402,7 +402,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
                 }
             },
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
         self._verifyResourceProperties(job, RESOURCE)
@@ -410,7 +410,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
     def test_from_api_repr_w_properties(self):
         client = _Client(self.PROJECT)
         RESOURCE = self._makeResource()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         dataset = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(dataset._client, client)
         self._verifyResourceProperties(dataset, RESOURCE)
@@ -717,7 +717,7 @@ class TestCopyJob(unittest.TestCase, _Base):
         self._setUpConstants()
         client = _Client(self.PROJECT)
         RESOURCE = {}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, client=client)
 
@@ -731,7 +731,7 @@ class TestCopyJob(unittest.TestCase, _Base):
                 'jobId': self.JOB_NAME,
             }
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, client=client)
 
@@ -759,7 +759,7 @@ class TestCopyJob(unittest.TestCase, _Base):
                 }
             },
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
         self._verifyResourceProperties(job, RESOURCE)
@@ -767,7 +767,7 @@ class TestCopyJob(unittest.TestCase, _Base):
     def test_from_api_repr_w_properties(self):
         client = _Client(self.PROJECT)
         RESOURCE = self._makeResource()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         dataset = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(dataset._client, client)
         self._verifyResourceProperties(dataset, RESOURCE)
@@ -1019,7 +1019,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         self._setUpConstants()
         client = _Client(self.PROJECT)
         RESOURCE = {}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, client=client)
 
@@ -1033,7 +1033,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
                 'jobId': self.JOB_NAME,
             }
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, client=client)
 
@@ -1057,7 +1057,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
                 }
             },
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
         self._verifyResourceProperties(job, RESOURCE)
@@ -1065,7 +1065,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
     def test_from_api_repr_w_properties(self):
         client = _Client(self.PROJECT)
         RESOURCE = self._makeResource()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         dataset = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(dataset._client, client)
         self._verifyResourceProperties(dataset, RESOURCE)
@@ -1360,7 +1360,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         self._setUpConstants()
         client = _Client(self.PROJECT)
         RESOURCE = {}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, client=client)
 
@@ -1374,7 +1374,7 @@ class TestQueryJob(unittest.TestCase, _Base):
                 'jobId': self.JOB_NAME,
             }
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, client=client)
 
@@ -1391,7 +1391,7 @@ class TestQueryJob(unittest.TestCase, _Base):
                 'query': {'query': self.QUERY}
             },
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
         self._verifyResourceProperties(job, RESOURCE)
@@ -1404,7 +1404,7 @@ class TestQueryJob(unittest.TestCase, _Base):
             'datasetId': self.DS_NAME,
             'tableId': self.DESTINATION_TABLE,
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         dataset = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(dataset._client, client)
         self._verifyResourceProperties(dataset, RESOURCE)

--- a/bigquery/unit_tests/test_job.py
+++ b/bigquery/unit_tests/test_job.py
@@ -22,7 +22,7 @@ class _Base(object):
     TABLE_NAME = 'table_name'
     JOB_NAME = 'job_name'
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _setUpConstants(self):
@@ -231,7 +231,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
     def test_ctor(self):
         client = _Client(self.PROJECT)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client)
         self.assertIs(job.destination, table)
         self.assertEqual(list(job.source_uris), [self.SOURCE1])
         self.assertIs(job._client, client)
@@ -268,14 +268,14 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         table = _Table()
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client,
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client,
                             schema=[full_name, age])
         self.assertEqual(job.schema, [full_name, age])
 
     def test_schema_setter_non_list(self):
         client = _Client(self.PROJECT)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client)
         with self.assertRaises(TypeError):
             job.schema = object()
 
@@ -283,7 +283,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         from google.cloud.bigquery.schema import SchemaField
         client = _Client(self.PROJECT)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         with self.assertRaises(ValueError):
             job.schema = [full_name, object()]
@@ -292,7 +292,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         from google.cloud.bigquery.schema import SchemaField
         client = _Client(self.PROJECT)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         job.schema = [full_name, age]
@@ -317,7 +317,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
 
         client = _Client(self.PROJECT)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client)
         job._properties['etag'] = 'ETAG'
         job._properties['id'] = JOB_ID
         job._properties['selfLink'] = URL
@@ -419,7 +419,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client)
         job._properties['status'] = {'state': 'RUNNING'}
 
         with self.assertRaises(ValueError):
@@ -436,7 +436,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client)
 
         job.begin()
 
@@ -498,7 +498,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         table = _Table()
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client1,
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client1,
                             schema=[full_name, age])
 
         job.allow_jagged_rows = True
@@ -537,7 +537,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client)
 
         self.assertFalse(job.exists())
 
@@ -554,7 +554,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         conn2 = _Connection({})
         client2 = _Client(project=self.PROJECT, connection=conn2)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client1)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client1)
 
         self.assertTrue(job.exists(client=client2))
 
@@ -571,7 +571,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client)
 
         job.reload()
 
@@ -589,7 +589,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client1)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client1)
 
         job.reload(client=client2)
 
@@ -607,7 +607,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         conn = _Connection(RESPONSE)
         client = _Client(project=self.PROJECT, connection=conn)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client)
 
         job.cancel()
 
@@ -626,7 +626,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         conn2 = _Connection(RESPONSE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         table = _Table()
-        job = self._makeOne(self.JOB_NAME, table, [self.SOURCE1], client1)
+        job = self._make_one(self.JOB_NAME, table, [self.SOURCE1], client1)
 
         job.cancel(client=client2)
 
@@ -698,7 +698,7 @@ class TestCopyJob(unittest.TestCase, _Base):
         client = _Client(self.PROJECT)
         source = _Table(self.SOURCE_TABLE)
         destination = _Table(self.DESTINATION_TABLE)
-        job = self._makeOne(self.JOB_NAME, destination, [source], client)
+        job = self._make_one(self.JOB_NAME, destination, [source], client)
         self.assertIs(job.destination, destination)
         self.assertEqual(job.sources, [source])
         self.assertIs(job._client, client)
@@ -784,7 +784,7 @@ class TestCopyJob(unittest.TestCase, _Base):
         client = _Client(project=self.PROJECT, connection=conn)
         source = _Table(self.SOURCE_TABLE)
         destination = _Table(self.DESTINATION_TABLE)
-        job = self._makeOne(self.JOB_NAME, destination, [source], client)
+        job = self._make_one(self.JOB_NAME, destination, [source], client)
 
         job.begin()
 
@@ -839,7 +839,7 @@ class TestCopyJob(unittest.TestCase, _Base):
         client2 = _Client(project=self.PROJECT, connection=conn2)
         source = _Table(self.SOURCE_TABLE)
         destination = _Table(self.DESTINATION_TABLE)
-        job = self._makeOne(self.JOB_NAME, destination, [source], client1)
+        job = self._make_one(self.JOB_NAME, destination, [source], client1)
 
         job.create_disposition = 'CREATE_NEVER'
         job.write_disposition = 'WRITE_TRUNCATE'
@@ -869,7 +869,7 @@ class TestCopyJob(unittest.TestCase, _Base):
         client = _Client(project=self.PROJECT, connection=conn)
         source = _Table(self.SOURCE_TABLE)
         destination = _Table(self.DESTINATION_TABLE)
-        job = self._makeOne(self.JOB_NAME, destination, [source], client)
+        job = self._make_one(self.JOB_NAME, destination, [source], client)
 
         self.assertFalse(job.exists())
 
@@ -887,7 +887,7 @@ class TestCopyJob(unittest.TestCase, _Base):
         client2 = _Client(project=self.PROJECT, connection=conn2)
         source = _Table(self.SOURCE_TABLE)
         destination = _Table(self.DESTINATION_TABLE)
-        job = self._makeOne(self.JOB_NAME, destination, [source], client1)
+        job = self._make_one(self.JOB_NAME, destination, [source], client1)
 
         self.assertTrue(job.exists(client=client2))
 
@@ -905,7 +905,7 @@ class TestCopyJob(unittest.TestCase, _Base):
         client = _Client(project=self.PROJECT, connection=conn)
         source = _Table(self.SOURCE_TABLE)
         destination = _Table(self.DESTINATION_TABLE)
-        job = self._makeOne(self.JOB_NAME, destination, [source], client)
+        job = self._make_one(self.JOB_NAME, destination, [source], client)
 
         job.reload()
 
@@ -924,7 +924,7 @@ class TestCopyJob(unittest.TestCase, _Base):
         client2 = _Client(project=self.PROJECT, connection=conn2)
         source = _Table(self.SOURCE_TABLE)
         destination = _Table(self.DESTINATION_TABLE)
-        job = self._makeOne(self.JOB_NAME, destination, [source], client1)
+        job = self._make_one(self.JOB_NAME, destination, [source], client1)
 
         job.reload(client=client2)
 
@@ -997,7 +997,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
     def test_ctor(self):
         client = _Client(self.PROJECT)
         source = _Table(self.SOURCE_TABLE)
-        job = self._makeOne(self.JOB_NAME, source, [self.DESTINATION_URI],
+        job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
                             client)
         self.assertEqual(job.source, source)
         self.assertEqual(job.destination_uris, [self.DESTINATION_URI])
@@ -1081,7 +1081,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         source = _Table(self.SOURCE_TABLE)
-        job = self._makeOne(self.JOB_NAME, source, [self.DESTINATION_URI],
+        job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
                             client)
 
         job.begin()
@@ -1130,7 +1130,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         source = _Table(self.SOURCE_TABLE)
-        job = self._makeOne(self.JOB_NAME, source, [self.DESTINATION_URI],
+        job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
                             client1)
 
         job.compression = 'GZIP'
@@ -1162,7 +1162,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
         source = _Table(self.SOURCE_TABLE)
-        job = self._makeOne(self.JOB_NAME, source, [self.DESTINATION_URI],
+        job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
                             client)
 
         self.assertFalse(job.exists())
@@ -1180,7 +1180,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         conn2 = _Connection({})
         client2 = _Client(project=self.PROJECT, connection=conn2)
         source = _Table(self.SOURCE_TABLE)
-        job = self._makeOne(self.JOB_NAME, source, [self.DESTINATION_URI],
+        job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
                             client1)
 
         self.assertTrue(job.exists(client=client2))
@@ -1198,7 +1198,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         source = _Table(self.SOURCE_TABLE)
-        job = self._makeOne(self.JOB_NAME, source, [self.DESTINATION_URI],
+        job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
                             client)
 
         job.reload()
@@ -1217,7 +1217,7 @@ class TestExtractTableToStorageJob(unittest.TestCase, _Base):
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         source = _Table(self.SOURCE_TABLE)
-        job = self._makeOne(self.JOB_NAME, source, [self.DESTINATION_URI],
+        job = self._make_one(self.JOB_NAME, source, [self.DESTINATION_URI],
                             client1)
 
         job.reload(client=client2)
@@ -1332,7 +1332,7 @@ class TestQueryJob(unittest.TestCase, _Base):
 
     def test_ctor(self):
         client = _Client(self.PROJECT)
-        job = self._makeOne(self.JOB_NAME, self.QUERY, client)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client)
         self.assertEqual(job.query, self.QUERY)
         self.assertIs(job._client, client)
         self.assertEqual(job.job_type, self.JOB_TYPE)
@@ -1412,7 +1412,7 @@ class TestQueryJob(unittest.TestCase, _Base):
     def test_results(self):
         from google.cloud.bigquery.query import QueryResults
         client = _Client(self.PROJECT)
-        job = self._makeOne(self.JOB_NAME, self.QUERY, client)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client)
         results = job.results()
         self.assertIsInstance(results, QueryResults)
         self.assertIs(results._job, job)
@@ -1427,7 +1427,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         del RESOURCE['user_email']
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        job = self._makeOne(self.JOB_NAME, self.QUERY, client)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client)
 
         job.begin()
         self.assertEqual(job.udf_resources, [])
@@ -1483,7 +1483,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        job = self._makeOne(self.JOB_NAME, self.QUERY, client1)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client1)
 
         dataset = Dataset(DS_NAME, client1)
         table = Table(TABLE, dataset)
@@ -1532,7 +1532,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         del RESOURCE['user_email']
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        job = self._makeOne(self.JOB_NAME, self.QUERY, client,
+        job = self._make_one(self.JOB_NAME, self.QUERY, client,
                             udf_resources=[
                                 UDFResource("resourceUri", RESOURCE_URI)
                             ])
@@ -1565,7 +1565,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         PATH = 'projects/%s/jobs/%s' % (self.PROJECT, self.JOB_NAME)
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
-        job = self._makeOne(self.JOB_NAME, self.QUERY, client)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client)
 
         self.assertFalse(job.exists())
 
@@ -1581,7 +1581,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection({})
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        job = self._makeOne(self.JOB_NAME, self.QUERY, client1)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client1)
 
         self.assertTrue(job.exists(client=client2))
 
@@ -1601,7 +1601,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         RESOURCE = self._makeResource()
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        job = self._makeOne(self.JOB_NAME, None, client)
+        job = self._make_one(self.JOB_NAME, None, client)
 
         dataset = Dataset(DS_NAME, client)
         table = Table(DEST_TABLE, dataset)
@@ -1632,7 +1632,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        job = self._makeOne(self.JOB_NAME, self.QUERY, client1)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client1)
 
         job.reload(client=client2)
 

--- a/bigquery/unit_tests/test_query.py
+++ b/bigquery/unit_tests/test_query.py
@@ -29,7 +29,7 @@ class TestQueryResults(unittest.TestCase):
         return QueryResults
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _makeResource(self, complete=False):
         resource = {
@@ -152,7 +152,7 @@ class TestQueryResults(unittest.TestCase):
         dataset = job.default_dataset = Dataset(DS_NAME, client)
         job.use_query_cache = True
         job.use_legacy_sql = True
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         query = klass.from_query_job(job)
 
@@ -173,7 +173,7 @@ class TestQueryResults(unittest.TestCase):
         job = QueryJob(
             self.JOB_NAME, self.QUERY, client,
             udf_resources=[UDFResource("resourceUri", RESOURCE_URI)])
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         query = klass.from_query_job(job)
 

--- a/bigquery/unit_tests/test_query.py
+++ b/bigquery/unit_tests/test_query.py
@@ -23,7 +23,8 @@ class TestQueryResults(unittest.TestCase):
     QUERY = 'select count(*) from persons'
     TOKEN = 'TOKEN'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery.query import QueryResults
         return QueryResults
 

--- a/bigquery/unit_tests/test_query.py
+++ b/bigquery/unit_tests/test_query.py
@@ -28,7 +28,7 @@ class TestQueryResults(unittest.TestCase):
         from google.cloud.bigquery.query import QueryResults
         return QueryResults
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _makeResource(self, complete=False):
@@ -119,7 +119,7 @@ class TestQueryResults(unittest.TestCase):
 
     def test_ctor(self):
         client = _Client(self.PROJECT)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         self.assertEqual(query.query, self.QUERY)
         self.assertIs(query._client, client)
 
@@ -187,14 +187,14 @@ class TestQueryResults(unittest.TestCase):
 
     def test_job_wo_jobid(self):
         client = _Client(self.PROJECT)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         self.assertIsNone(query.job)
 
     def test_job_w_jobid(self):
         from google.cloud.bigquery.job import QueryJob
         SERVER_GENERATED = 'SERVER_GENERATED'
         client = _Client(self.PROJECT)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         query._properties['jobReference'] = {
             'projectId': self.PROJECT,
             'jobId': SERVER_GENERATED,
@@ -209,7 +209,7 @@ class TestQueryResults(unittest.TestCase):
 
     def test_schema(self):
         client = _Client(self.PROJECT)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         self._verifyResourceProperties(query, {})
         resource = {
             'schema': {
@@ -225,7 +225,7 @@ class TestQueryResults(unittest.TestCase):
     def test_run_w_already_has_job(self):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         query._job = object()  # simulate already running
         with self.assertRaises(ValueError):
             query.run()
@@ -235,7 +235,7 @@ class TestQueryResults(unittest.TestCase):
         RESOURCE = self._makeResource(complete=False)
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         self.assertEqual(query.udf_resources, [])
         query.run()
 
@@ -255,7 +255,7 @@ class TestQueryResults(unittest.TestCase):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        query = self._makeOne(self.QUERY, client1)
+        query = self._make_one(self.QUERY, client1)
 
         query.default_dataset = client2.dataset(DATASET)
         query.max_results = 100
@@ -295,7 +295,7 @@ class TestQueryResults(unittest.TestCase):
         RESOURCE = self._makeResource(complete=False)
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         query.udf_resources = [UDFResource("inlineCode", INLINE_UDF_CODE)]
 
         query.run()
@@ -317,7 +317,7 @@ class TestQueryResults(unittest.TestCase):
         RESOURCE = self._makeResource(complete=False)
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         query.udf_resources = [UDFResource("resourceUri", RESOURCE_URI)]
 
         query.run()
@@ -340,7 +340,7 @@ class TestQueryResults(unittest.TestCase):
         RESOURCE = self._makeResource(complete=False)
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         query.udf_resources = [UDFResource("resourceUri", RESOURCE_URI),
                                UDFResource("inlineCode", INLINE_UDF_CODE)]
 
@@ -363,7 +363,7 @@ class TestQueryResults(unittest.TestCase):
     def test_fetch_data_query_not_yet_run(self):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         self.assertRaises(ValueError, query.fetch_data)
 
     def test_fetch_data_w_bound_client(self):
@@ -374,7 +374,7 @@ class TestQueryResults(unittest.TestCase):
 
         conn = _Connection(AFTER)
         client = _Client(project=self.PROJECT, connection=conn)
-        query = self._makeOne(self.QUERY, client)
+        query = self._make_one(self.QUERY, client)
         query._set_properties(BEFORE)
         self.assertFalse(query.complete)
 
@@ -407,7 +407,7 @@ class TestQueryResults(unittest.TestCase):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(AFTER)
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        query = self._makeOne(self.QUERY, client1)
+        query = self._make_one(self.QUERY, client1)
         query._set_properties(BEFORE)
         self.assertFalse(query.complete)
 

--- a/bigquery/unit_tests/test_schema.py
+++ b/bigquery/unit_tests/test_schema.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestSchemaField(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery.schema import SchemaField
         return SchemaField
 

--- a/bigquery/unit_tests/test_schema.py
+++ b/bigquery/unit_tests/test_schema.py
@@ -23,7 +23,7 @@ class TestSchemaField(unittest.TestCase):
         return SchemaField
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         field = self._makeOne('test', 'STRING')

--- a/bigquery/unit_tests/test_schema.py
+++ b/bigquery/unit_tests/test_schema.py
@@ -22,11 +22,11 @@ class TestSchemaField(unittest.TestCase):
         from google.cloud.bigquery.schema import SchemaField
         return SchemaField
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
-        field = self._makeOne('test', 'STRING')
+        field = self._make_one('test', 'STRING')
         self.assertEqual(field.name, 'test')
         self.assertEqual(field.field_type, 'STRING')
         self.assertEqual(field.mode, 'NULLABLE')
@@ -34,7 +34,7 @@ class TestSchemaField(unittest.TestCase):
         self.assertIsNone(field.fields)
 
     def test_ctor_explicit(self):
-        field = self._makeOne('test', 'STRING', mode='REQUIRED',
+        field = self._make_one('test', 'STRING', mode='REQUIRED',
                               description='Testing')
         self.assertEqual(field.name, 'test')
         self.assertEqual(field.field_type, 'STRING')
@@ -43,9 +43,9 @@ class TestSchemaField(unittest.TestCase):
         self.assertIsNone(field.fields)
 
     def test_ctor_subfields(self):
-        field = self._makeOne('phone_number', 'RECORD',
-                              fields=[self._makeOne('area_code', 'STRING'),
-                                      self._makeOne('local_number', 'STRING')])
+        field = self._make_one('phone_number', 'RECORD',
+                              fields=[self._make_one('area_code', 'STRING'),
+                                      self._make_one('local_number', 'STRING')])
         self.assertEqual(field.name, 'phone_number')
         self.assertEqual(field.field_type, 'RECORD')
         self.assertEqual(field.mode, 'NULLABLE')
@@ -63,49 +63,49 @@ class TestSchemaField(unittest.TestCase):
         self.assertIsNone(field.fields[1].fields)
 
     def test___eq___name_mismatch(self):
-        field = self._makeOne('test', 'STRING')
-        other = self._makeOne('other', 'STRING')
+        field = self._make_one('test', 'STRING')
+        other = self._make_one('other', 'STRING')
         self.assertNotEqual(field, other)
 
     def test___eq___field_type_mismatch(self):
-        field = self._makeOne('test', 'STRING')
-        other = self._makeOne('test', 'INTEGER')
+        field = self._make_one('test', 'STRING')
+        other = self._make_one('test', 'INTEGER')
         self.assertNotEqual(field, other)
 
     def test___eq___mode_mismatch(self):
-        field = self._makeOne('test', 'STRING', mode='REQUIRED')
-        other = self._makeOne('test', 'STRING', mode='NULLABLE')
+        field = self._make_one('test', 'STRING', mode='REQUIRED')
+        other = self._make_one('test', 'STRING', mode='NULLABLE')
         self.assertNotEqual(field, other)
 
     def test___eq___description_mismatch(self):
-        field = self._makeOne('test', 'STRING', description='Testing')
-        other = self._makeOne('test', 'STRING', description='Other')
+        field = self._make_one('test', 'STRING', description='Testing')
+        other = self._make_one('test', 'STRING', description='Other')
         self.assertNotEqual(field, other)
 
     def test___eq___fields_mismatch(self):
-        sub1 = self._makeOne('sub1', 'STRING')
-        sub2 = self._makeOne('sub2', 'STRING')
-        field = self._makeOne('test', 'RECORD', fields=[sub1])
-        other = self._makeOne('test', 'RECORD', fields=[sub2])
+        sub1 = self._make_one('sub1', 'STRING')
+        sub2 = self._make_one('sub2', 'STRING')
+        field = self._make_one('test', 'RECORD', fields=[sub1])
+        other = self._make_one('test', 'RECORD', fields=[sub2])
         self.assertNotEqual(field, other)
 
     def test___eq___hit(self):
-        field = self._makeOne('test', 'STRING', mode='REQUIRED',
+        field = self._make_one('test', 'STRING', mode='REQUIRED',
                               description='Testing')
-        other = self._makeOne('test', 'STRING', mode='REQUIRED',
+        other = self._make_one('test', 'STRING', mode='REQUIRED',
                               description='Testing')
         self.assertEqual(field, other)
 
     def test___eq___hit_case_diff_on_type(self):
-        field = self._makeOne('test', 'STRING', mode='REQUIRED',
+        field = self._make_one('test', 'STRING', mode='REQUIRED',
                               description='Testing')
-        other = self._makeOne('test', 'string', mode='REQUIRED',
+        other = self._make_one('test', 'string', mode='REQUIRED',
                               description='Testing')
         self.assertEqual(field, other)
 
     def test___eq___hit_w_fields(self):
-        sub1 = self._makeOne('sub1', 'STRING')
-        sub2 = self._makeOne('sub2', 'STRING')
-        field = self._makeOne('test', 'RECORD', fields=[sub1, sub2])
-        other = self._makeOne('test', 'RECORD', fields=[sub1, sub2])
+        sub1 = self._make_one('sub1', 'STRING')
+        sub2 = self._make_one('sub2', 'STRING')
+        field = self._make_one('test', 'RECORD', fields=[sub1, sub2])
+        other = self._make_one('test', 'RECORD', fields=[sub1, sub2])
         self.assertEqual(field, other)

--- a/bigquery/unit_tests/test_schema.py
+++ b/bigquery/unit_tests/test_schema.py
@@ -35,7 +35,7 @@ class TestSchemaField(unittest.TestCase):
 
     def test_ctor_explicit(self):
         field = self._make_one('test', 'STRING', mode='REQUIRED',
-                              description='Testing')
+                               description='Testing')
         self.assertEqual(field.name, 'test')
         self.assertEqual(field.field_type, 'STRING')
         self.assertEqual(field.mode, 'REQUIRED')
@@ -43,9 +43,10 @@ class TestSchemaField(unittest.TestCase):
         self.assertIsNone(field.fields)
 
     def test_ctor_subfields(self):
-        field = self._make_one('phone_number', 'RECORD',
-                              fields=[self._make_one('area_code', 'STRING'),
-                                      self._make_one('local_number', 'STRING')])
+        field = self._make_one(
+            'phone_number', 'RECORD',
+            fields=[self._make_one('area_code', 'STRING'),
+                    self._make_one('local_number', 'STRING')])
         self.assertEqual(field.name, 'phone_number')
         self.assertEqual(field.field_type, 'RECORD')
         self.assertEqual(field.mode, 'NULLABLE')
@@ -91,16 +92,16 @@ class TestSchemaField(unittest.TestCase):
 
     def test___eq___hit(self):
         field = self._make_one('test', 'STRING', mode='REQUIRED',
-                              description='Testing')
+                               description='Testing')
         other = self._make_one('test', 'STRING', mode='REQUIRED',
-                              description='Testing')
+                               description='Testing')
         self.assertEqual(field, other)
 
     def test___eq___hit_case_diff_on_type(self):
         field = self._make_one('test', 'STRING', mode='REQUIRED',
-                              description='Testing')
+                               description='Testing')
         other = self._make_one('test', 'string', mode='REQUIRED',
-                              description='Testing')
+                               description='Testing')
         self.assertEqual(field, other)
 
     def test___eq___hit_w_fields(self):

--- a/bigquery/unit_tests/test_table.py
+++ b/bigquery/unit_tests/test_table.py
@@ -1768,7 +1768,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
 
 class Test_parse_schema_resource(unittest.TestCase, _SchemaBase):
 
-    def _callFUT(self, resource):
+    def _call_fut(self, resource):
         from google.cloud.bigquery.table import _parse_schema_resource
         return _parse_schema_resource(resource)
 
@@ -1782,7 +1782,7 @@ class Test_parse_schema_resource(unittest.TestCase, _SchemaBase):
 
     def test__parse_schema_resource_defaults(self):
         RESOURCE = self._makeResource()
-        schema = self._callFUT(RESOURCE['schema'])
+        schema = self._call_fut(RESOURCE['schema'])
         self._verifySchema(schema, RESOURCE)
 
     def test__parse_schema_resource_subfields(self):
@@ -1797,7 +1797,7 @@ class Test_parse_schema_resource(unittest.TestCase, _SchemaBase):
                         {'name': 'number',
                          'type': 'STRING',
                          'mode': 'REQUIRED'}]})
-        schema = self._callFUT(RESOURCE['schema'])
+        schema = self._call_fut(RESOURCE['schema'])
         self._verifySchema(schema, RESOURCE)
 
     def test__parse_schema_resource_fields_without_mode(self):
@@ -1806,13 +1806,13 @@ class Test_parse_schema_resource(unittest.TestCase, _SchemaBase):
             {'name': 'phone',
              'type': 'STRING'})
 
-        schema = self._callFUT(RESOURCE['schema'])
+        schema = self._call_fut(RESOURCE['schema'])
         self._verifySchema(schema, RESOURCE)
 
 
 class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
 
-    def _callFUT(self, resource):
+    def _call_fut(self, resource):
         from google.cloud.bigquery.table import _build_schema_resource
         return _build_schema_resource(resource)
 
@@ -1820,7 +1820,7 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
         from google.cloud.bigquery.table import SchemaField
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        resource = self._callFUT([full_name, age])
+        resource = self._call_fut([full_name, age])
         self.assertEqual(len(resource), 2)
         self.assertEqual(resource[0],
                          {'name': 'full_name',
@@ -1837,7 +1837,7 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED',
                                 description=DESCRIPTION)
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        resource = self._callFUT([full_name, age])
+        resource = self._call_fut([full_name, age])
         self.assertEqual(len(resource), 2)
         self.assertEqual(resource[0],
                          {'name': 'full_name',
@@ -1856,7 +1856,7 @@ class Test_build_schema_resource(unittest.TestCase, _SchemaBase):
         ph_num = SchemaField('number', 'STRING', 'REQUIRED')
         phone = SchemaField('phone', 'RECORD', mode='REPEATABLE',
                             fields=[ph_type, ph_num])
-        resource = self._callFUT([full_name, phone])
+        resource = self._call_fut([full_name, phone])
         self.assertEqual(len(resource), 2)
         self.assertEqual(resource[0],
                          {'name': 'full_name',

--- a/bigquery/unit_tests/test_table.py
+++ b/bigquery/unit_tests/test_table.py
@@ -167,7 +167,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         self.assertEqual(table.schema, [full_name, age])
 
     def test_num_bytes_getter(self):
@@ -410,7 +410,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
 
         table.create()
 
@@ -440,7 +440,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
 
         self.assertIsNone(table.partitioning_type)
         table.partitioning_type = "DAY"
@@ -474,7 +474,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         self.assertIsNone(table.partition_expiration)
         table.partition_expiration = 100
         self.assertEqual(table.partitioning_type, "DAY")
@@ -507,7 +507,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         with self.assertRaises(ValueError):
             table.partitioning_type = 123
 
@@ -520,7 +520,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         with self.assertRaises(ValueError):
             table.partitioning_type = "HASH"
 
@@ -533,7 +533,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         self.assertIsNone(table.partitioning_type)
         table.partitioning_type = 'DAY'
         self.assertEqual(table.partitioning_type, 'DAY')
@@ -547,7 +547,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         table._properties['timePartitioning'] = {'type': 'DAY'}
         table.partitioning_type = None
         self.assertIsNone(table.partitioning_type)
@@ -562,7 +562,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         with self.assertRaises(ValueError):
             table.partition_expiration = "NEVER"
 
@@ -575,7 +575,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         self.assertIsNone(table.partition_expiration)
         table.partition_expiration = 100
         self.assertEqual(table.partitioning_type, "DAY")
@@ -590,7 +590,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         self.assertIsNone(table.partition_expiration)
         table._properties['timePartitioning'] = {
             'type': 'DAY',
@@ -609,7 +609,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         self.assertIsNone(table.partition_expiration)
         table.partition_expiration = None
         self.assertIsNone(table.partitioning_type)
@@ -624,7 +624,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         self.assertEqual(table.list_partitions(), [20160804, 20160805])
 
     def test_create_w_alternate_client(self):
@@ -654,7 +654,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         table.friendly_name = TITLE
         table.description = DESCRIPTION
         table.view_query = QUERY
@@ -693,7 +693,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
 
         table.create()
 
@@ -909,7 +909,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, age])
+                               schema=[full_name, age])
         table.description = DESCRIPTION
         table.friendly_name = TITLE
 
@@ -1068,7 +1068,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         age = SchemaField('age', 'INTEGER', mode='NULLABLE')
         joined = SchemaField('joined', 'TIMESTAMP', mode='NULLABLE')
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, age, joined])
+                               schema=[full_name, age, joined])
 
         iterator = table.fetch_data()
         page = six.next(iterator.pages)
@@ -1135,7 +1135,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         voter = SchemaField('voter', 'BOOLEAN', mode='NULLABLE')
         score = SchemaField('score', 'FLOAT', mode='NULLABLE')
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, age, voter, score])
+                               schema=[full_name, age, voter, score])
 
         iterator = table.fetch_data(
             client=client2, max_results=MAX, page_token=TOKEN)
@@ -1188,7 +1188,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         struct = SchemaField('struct', 'RECORD', mode='REPEATED',
                              fields=[index, score])
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, struct])
+                               schema=[full_name, struct])
 
         iterator = table.fetch_data()
         page = six.next(iterator.pages)
@@ -1244,7 +1244,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         phone = SchemaField('phone', 'RECORD', mode='NULLABLE',
                             fields=[area_code, local_number, rank])
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, phone])
+                               schema=[full_name, phone])
 
         iterator = table.fetch_data()
         page = six.next(iterator.pages)
@@ -1306,7 +1306,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         joined = SchemaField('joined', 'TIMESTAMP', mode='NULLABLE')
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, age, joined])
+                               schema=[full_name, age, joined])
         ROWS = [
             ('Phred Phlyntstone', 32, WHEN),
             ('Bharney Rhubble', 33, WHEN + datetime.timedelta(seconds=1)),
@@ -1358,7 +1358,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         voter = SchemaField('voter', 'BOOLEAN', mode='NULLABLE')
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, age, voter])
+                               schema=[full_name, age, voter])
         ROWS = [
             ('Phred Phlyntstone', 32, True),
             ('Bharney Rhubble', 33, False),
@@ -1412,7 +1412,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         struct = SchemaField('struct', 'RECORD', mode='REPEATED',
                              fields=[index, score])
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, struct])
+                               schema=[full_name, struct])
         ROWS = [
             (['red', 'green'], [{'index': [1, 2], 'score': [3.1415, 1.414]}]),
         ]
@@ -1448,7 +1448,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         phone = SchemaField('phone', 'RECORD', mode='NULLABLE',
                             fields=[area_code, local_number, rank])
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, phone])
+                               schema=[full_name, phone])
         ROWS = [
             ('Phred Phlyntstone', {'area_code': '800',
                                    'local_number': '555-1212',
@@ -1558,7 +1558,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         joined = SchemaField('joined', 'TIMESTAMP', mode='NULLABLE')
         table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                              schema=[full_name, age, joined])
+                               schema=[full_name, age, joined])
         ROWS = [
             ('Phred Phlyntstone', 32, WHEN),
             ('Bharney Rhubble', 33, WHEN + datetime.timedelta(seconds=1)),

--- a/bigquery/unit_tests/test_table.py
+++ b/bigquery/unit_tests/test_table.py
@@ -35,7 +35,8 @@ class TestTable(unittest.TestCase, _SchemaBase):
     DS_NAME = 'dataset-name'
     TABLE_NAME = 'table-name'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigquery.table import Table
         return Table
 

--- a/bigquery/unit_tests/test_table.py
+++ b/bigquery/unit_tests/test_table.py
@@ -40,7 +40,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         from google.cloud.bigquery.table import Table
         return Table
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _setUpConstants(self):
@@ -134,7 +134,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
     def test_ctor(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         self.assertEqual(table.name, self.TABLE_NAME)
         self.assertIs(table._dataset, dataset)
         self.assertEqual(table.project, self.PROJECT)
@@ -166,14 +166,14 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         self.assertEqual(table.schema, [full_name, age])
 
     def test_num_bytes_getter(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
 
         # Check with no value set.
         self.assertIsNone(table.num_bytes)
@@ -195,7 +195,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
     def test_num_rows_getter(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
 
         # Check with no value set.
         self.assertIsNone(table.num_rows)
@@ -217,7 +217,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
     def test_schema_setter_non_list(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         with self.assertRaises(TypeError):
             table.schema = object()
 
@@ -225,7 +225,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         from google.cloud.bigquery.table import SchemaField
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         with self.assertRaises(ValueError):
             table.schema = [full_name, object()]
@@ -234,7 +234,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         from google.cloud.bigquery.table import SchemaField
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         table.schema = [full_name, age]
@@ -253,7 +253,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
             self.PROJECT, self.DS_NAME, self.TABLE_NAME)
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         table._properties['creationTime'] = _millis(CREATED)
         table._properties['etag'] = 'ETAG'
         table._properties['lastModifiedTime'] = _millis(MODIFIED)
@@ -275,21 +275,21 @@ class TestTable(unittest.TestCase, _SchemaBase):
     def test_description_setter_bad_value(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         with self.assertRaises(ValueError):
             table.description = 12345
 
     def test_description_setter(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         table.description = 'DESCRIPTION'
         self.assertEqual(table.description, 'DESCRIPTION')
 
     def test_expires_setter_bad_value(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         with self.assertRaises(ValueError):
             table.expires = object()
 
@@ -300,56 +300,56 @@ class TestTable(unittest.TestCase, _SchemaBase):
         WHEN = datetime.datetime(2015, 7, 28, 16, 39, tzinfo=UTC)
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         table.expires = WHEN
         self.assertEqual(table.expires, WHEN)
 
     def test_friendly_name_setter_bad_value(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         with self.assertRaises(ValueError):
             table.friendly_name = 12345
 
     def test_friendly_name_setter(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         table.friendly_name = 'FRIENDLY'
         self.assertEqual(table.friendly_name, 'FRIENDLY')
 
     def test_location_setter_bad_value(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         with self.assertRaises(ValueError):
             table.location = 12345
 
     def test_location_setter(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         table.location = 'LOCATION'
         self.assertEqual(table.location, 'LOCATION')
 
     def test_view_query_setter_bad_value(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         with self.assertRaises(ValueError):
             table.view_query = 12345
 
     def test_view_query_setter(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         table.view_query = 'select * from foo'
         self.assertEqual(table.view_query, 'select * from foo')
 
     def test_view_query_deleter(self):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
         table.view_query = 'select * from foo'
         del table.view_query
         self.assertIsNone(table.view_query)
@@ -395,7 +395,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset)
+        table = self._make_one(self.TABLE_NAME, dataset)
 
         with self.assertRaises(ValueError):
             table.create()
@@ -409,7 +409,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
 
         table.create()
@@ -439,7 +439,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
 
         self.assertIsNone(table.partitioning_type)
@@ -473,7 +473,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         self.assertIsNone(table.partition_expiration)
         table.partition_expiration = 100
@@ -506,7 +506,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         with self.assertRaises(ValueError):
             table.partitioning_type = 123
@@ -519,7 +519,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         with self.assertRaises(ValueError):
             table.partitioning_type = "HASH"
@@ -532,7 +532,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         self.assertIsNone(table.partitioning_type)
         table.partitioning_type = 'DAY'
@@ -546,7 +546,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         table._properties['timePartitioning'] = {'type': 'DAY'}
         table.partitioning_type = None
@@ -561,7 +561,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         with self.assertRaises(ValueError):
             table.partition_expiration = "NEVER"
@@ -574,7 +574,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         self.assertIsNone(table.partition_expiration)
         table.partition_expiration = 100
@@ -589,7 +589,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         self.assertIsNone(table.partition_expiration)
         table._properties['timePartitioning'] = {
@@ -608,7 +608,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         self.assertIsNone(table.partition_expiration)
         table.partition_expiration = None
@@ -623,7 +623,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
         self.assertEqual(table.list_partitions(), [20160804, 20160805])
 
@@ -653,7 +653,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client=client1)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age])
         table.friendly_name = TITLE
         table.description = DESCRIPTION
@@ -692,7 +692,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset,
+        table = self._make_one(self.TABLE_NAME, dataset,
                               schema=[full_name, age])
 
         table.create()
@@ -719,7 +719,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         self.assertFalse(table.exists())
 
@@ -737,7 +737,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn2 = _Connection({})
         client2 = _Client(project=self.PROJECT, connection=conn2)
         dataset = _Dataset(client1)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         self.assertTrue(table.exists(client=client2))
 
@@ -755,7 +755,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         table.reload()
 
@@ -774,7 +774,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         dataset = _Dataset(client1)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         table.reload(client=client2)
 
@@ -790,7 +790,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         with self.assertRaises(ValueError):
             table.patch(expires='BOGUS')
@@ -806,7 +806,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         table.patch(description=DESCRIPTION,
                     friendly_name=TITLE,
@@ -846,7 +846,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         dataset = _Dataset(client1)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='NULLABLE')
 
@@ -882,7 +882,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         table.patch(schema=None)
 
@@ -908,7 +908,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age])
         table.description = DESCRIPTION
         table.friendly_name = TITLE
@@ -956,7 +956,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         dataset = _Dataset(client1)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
         table.default_table_expiration_ms = DEF_TABLE_EXP
         table.location = LOCATION
         table.expires = self.EXP_TIME
@@ -987,7 +987,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         table.delete()
 
@@ -1004,7 +1004,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn2 = _Connection({})
         client2 = _Client(project=self.PROJECT, connection=conn2)
         dataset = _Dataset(client1)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         table.delete(client=client2)
 
@@ -1067,7 +1067,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='NULLABLE')
         joined = SchemaField('joined', 'TIMESTAMP', mode='NULLABLE')
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, joined])
 
         iterator = table.fetch_data()
@@ -1134,7 +1134,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         voter = SchemaField('voter', 'BOOLEAN', mode='NULLABLE')
         score = SchemaField('score', 'FLOAT', mode='NULLABLE')
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, voter, score])
 
         iterator = table.fetch_data(
@@ -1187,7 +1187,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         score = SchemaField('score', 'FLOAT', 'REPEATED')
         struct = SchemaField('struct', 'RECORD', mode='REPEATED',
                              fields=[index, score])
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, struct])
 
         iterator = table.fetch_data()
@@ -1243,7 +1243,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         rank = SchemaField('rank', 'INTEGER', 'REQUIRED')
         phone = SchemaField('phone', 'RECORD', mode='NULLABLE',
                             fields=[area_code, local_number, rank])
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, phone])
 
         iterator = table.fetch_data()
@@ -1275,7 +1275,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         from google.cloud.bigquery.table import _TABLE_HAS_NO_SCHEMA
         client = _Client(project=self.PROJECT)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
         ROWS = [
             ('Phred Phlyntstone', 32),
             ('Bharney Rhubble', 33),
@@ -1305,7 +1305,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         joined = SchemaField('joined', 'TIMESTAMP', mode='NULLABLE')
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, joined])
         ROWS = [
             ('Phred Phlyntstone', 32, WHEN),
@@ -1357,7 +1357,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         voter = SchemaField('voter', 'BOOLEAN', mode='NULLABLE')
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, voter])
         ROWS = [
             ('Phred Phlyntstone', 32, True),
@@ -1411,7 +1411,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         score = SchemaField('score', 'FLOAT', 'REPEATED')
         struct = SchemaField('struct', 'RECORD', mode='REPEATED',
                              fields=[index, score])
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, struct])
         ROWS = [
             (['red', 'green'], [{'index': [1, 2], 'score': [3.1415, 1.414]}]),
@@ -1447,7 +1447,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         rank = SchemaField('rank', 'INTEGER', 'REQUIRED')
         phone = SchemaField('phone', 'RECORD', mode='NULLABLE',
                             fields=[area_code, local_number, rank])
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, phone])
         ROWS = [
             ('Phred Phlyntstone', {'area_code': '800',
@@ -1485,7 +1485,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
         file_obj = TextModeFile()
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
         with self.assertRaises(ValueError):
             table.upload_from_file(file_obj, 'CSV', size=1234)
 
@@ -1497,7 +1497,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
         file_obj = object()
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
         with self.assertRaises(ValueError):
             table.upload_from_file(file_obj, 'CSV', size=None)
 
@@ -1517,7 +1517,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         )
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         with _NamedTemporaryFile() as temp:
             with open(temp.name, 'w') as file_obj:
@@ -1557,7 +1557,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
         age = SchemaField('age', 'INTEGER', mode='REQUIRED')
         joined = SchemaField('joined', 'TIMESTAMP', mode='NULLABLE')
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset,
+        table = self._make_one(self.TABLE_NAME, dataset=dataset,
                               schema=[full_name, age, joined])
         ROWS = [
             ('Phred Phlyntstone', 32, WHEN),
@@ -1663,7 +1663,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
             simple_multipart = True
             simple_path = u''  # force resumable
         dataset = _Dataset(client)
-        table = self._makeOne(self.TABLE_NAME, dataset=dataset)
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
         with _Monkey(MUT, _UploadConfig=_UploadConfig):
             with _NamedTemporaryFile() as temp:

--- a/bigquery/unit_tests/test_table.py
+++ b/bigquery/unit_tests/test_table.py
@@ -41,7 +41,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         return Table
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _setUpConstants(self):
         import datetime
@@ -359,7 +359,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
         RESOURCE = {}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, dataset)
 
@@ -376,7 +376,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
             },
             'type': 'TABLE',
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         table = klass.from_api_repr(RESOURCE, dataset)
         self.assertEqual(table.name, self.TABLE_NAME)
         self.assertIs(table._dataset, dataset)
@@ -386,7 +386,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         client = _Client(self.PROJECT)
         dataset = _Dataset(client)
         RESOURCE = self._makeResource()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         table = klass.from_api_repr(RESOURCE, dataset)
         self.assertIs(table._dataset._client, client)
         self._verifyResourceProperties(table, RESOURCE)

--- a/bigtable/unit_tests/test_client.py
+++ b/bigtable/unit_tests/test_client.py
@@ -18,7 +18,7 @@ import unittest
 
 class Test__make_data_stub(unittest.TestCase):
 
-    def _callFUT(self, client):
+    def _call_fut(self, client):
         from google.cloud.bigtable.client import _make_data_stub
         return _make_data_stub(client)
 
@@ -38,7 +38,7 @@ class Test__make_data_stub(unittest.TestCase):
             return fake_stub
 
         with _Monkey(MUT, make_secure_stub=mock_make_secure_stub):
-            result = self._callFUT(client)
+            result = self._call_fut(client)
 
         self.assertIs(result, fake_stub)
         self.assertEqual(make_secure_stub_args, [
@@ -65,7 +65,7 @@ class Test__make_data_stub(unittest.TestCase):
             return fake_stub
 
         with _Monkey(MUT, make_insecure_stub=mock_make_insecure_stub):
-            result = self._callFUT(client)
+            result = self._call_fut(client)
 
         self.assertIs(result, fake_stub)
         self.assertEqual(make_insecure_stub_args, [
@@ -78,7 +78,7 @@ class Test__make_data_stub(unittest.TestCase):
 
 class Test__make_instance_stub(unittest.TestCase):
 
-    def _callFUT(self, client):
+    def _call_fut(self, client):
         from google.cloud.bigtable.client import _make_instance_stub
         return _make_instance_stub(client)
 
@@ -98,7 +98,7 @@ class Test__make_instance_stub(unittest.TestCase):
             return fake_stub
 
         with _Monkey(MUT, make_secure_stub=mock_make_secure_stub):
-            result = self._callFUT(client)
+            result = self._call_fut(client)
 
         self.assertIs(result, fake_stub)
         self.assertEqual(make_secure_stub_args, [
@@ -125,7 +125,7 @@ class Test__make_instance_stub(unittest.TestCase):
             return fake_stub
 
         with _Monkey(MUT, make_insecure_stub=mock_make_insecure_stub):
-            result = self._callFUT(client)
+            result = self._call_fut(client)
 
         self.assertIs(result, fake_stub)
         self.assertEqual(make_insecure_stub_args, [
@@ -138,7 +138,7 @@ class Test__make_instance_stub(unittest.TestCase):
 
 class Test__make_operations_stub(unittest.TestCase):
 
-    def _callFUT(self, client):
+    def _call_fut(self, client):
         from google.cloud.bigtable.client import _make_operations_stub
         return _make_operations_stub(client)
 
@@ -160,7 +160,7 @@ class Test__make_operations_stub(unittest.TestCase):
             return fake_stub
 
         with _Monkey(MUT, make_secure_stub=mock_make_secure_stub):
-            result = self._callFUT(client)
+            result = self._call_fut(client)
 
         self.assertIs(result, fake_stub)
         self.assertEqual(make_secure_stub_args, [
@@ -189,7 +189,7 @@ class Test__make_operations_stub(unittest.TestCase):
             return fake_stub
 
         with _Monkey(MUT, make_insecure_stub=mock_make_insecure_stub):
-            result = self._callFUT(client)
+            result = self._call_fut(client)
 
         self.assertIs(result, fake_stub)
         self.assertEqual(make_insecure_stub_args, [
@@ -202,7 +202,7 @@ class Test__make_operations_stub(unittest.TestCase):
 
 class Test__make_table_stub(unittest.TestCase):
 
-    def _callFUT(self, client):
+    def _call_fut(self, client):
         from google.cloud.bigtable.client import _make_table_stub
         return _make_table_stub(client)
 
@@ -222,7 +222,7 @@ class Test__make_table_stub(unittest.TestCase):
             return fake_stub
 
         with _Monkey(MUT, make_secure_stub=mock_make_secure_stub):
-            result = self._callFUT(client)
+            result = self._call_fut(client)
 
         self.assertIs(result, fake_stub)
         self.assertEqual(make_secure_stub_args, [
@@ -249,7 +249,7 @@ class Test__make_table_stub(unittest.TestCase):
             return fake_stub
 
         with _Monkey(MUT, make_insecure_stub=mock_make_insecure_stub):
-            result = self._callFUT(client)
+            result = self._call_fut(client)
 
         self.assertIs(result, fake_stub)
         self.assertEqual(make_insecure_stub_args, [

--- a/bigtable/unit_tests/test_client.py
+++ b/bigtable/unit_tests/test_client.py
@@ -273,7 +273,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def _makeOneWithMocks(self, *args, **kwargs):
         from google.cloud._testing import _Monkey

--- a/bigtable/unit_tests/test_client.py
+++ b/bigtable/unit_tests/test_client.py
@@ -272,10 +272,10 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigtable.client import Client
         return Client
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
-    def _makeOneWithMocks(self, *args, **kwargs):
+    def _make_oneWithMocks(self, *args, **kwargs):
         from google.cloud._testing import _Monkey
         from google.cloud.bigtable import client as MUT
 
@@ -287,7 +287,7 @@ class TestClient(unittest.TestCase):
                      _make_instance_stub=mock_make_instance_stub,
                      _make_operations_stub=mock_make_operations_stub,
                      _make_table_stub=mock_make_table_stub):
-            return self._makeOne(*args, **kwargs)
+            return self._make_one(*args, **kwargs)
 
     def _constructor_test_helper(self, expected_scopes, creds,
                                  read_only=False, admin=False,
@@ -305,7 +305,7 @@ class TestClient(unittest.TestCase):
                      _make_instance_stub=mock_make_instance_stub,
                      _make_operations_stub=mock_make_operations_stub,
                      _make_table_stub=mock_make_table_stub):
-            client = self._makeOne(project=self.PROJECT, credentials=creds,
+            client = self._make_one(project=self.PROJECT, credentials=creds,
                                    read_only=read_only, admin=admin,
                                    user_agent=user_agent)
 
@@ -401,7 +401,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigtable import client as MUT
 
         credentials = _Credentials('value')
-        client = self._makeOneWithMocks(
+        client = self._make_oneWithMocks(
             project=self.PROJECT,
             credentials=credentials,
             read_only=read_only,
@@ -449,14 +449,14 @@ class TestClient(unittest.TestCase):
     def test_credentials_getter(self):
         credentials = _Credentials()
         project = 'PROJECT'
-        client = self._makeOneWithMocks(project=project,
+        client = self._make_oneWithMocks(project=project,
                                         credentials=credentials)
         self.assertIs(client.credentials, credentials)
 
     def test_project_name_property(self):
         credentials = _Credentials()
         project = 'PROJECT'
-        client = self._makeOneWithMocks(project=project,
+        client = self._make_oneWithMocks(project=project,
                                         credentials=credentials)
         project_name = 'projects/' + project
         self.assertEqual(client.project_name, project_name)
@@ -464,14 +464,14 @@ class TestClient(unittest.TestCase):
     def test_instance_stub_getter(self):
         credentials = _Credentials()
         project = 'PROJECT'
-        client = self._makeOneWithMocks(project=project,
+        client = self._make_oneWithMocks(project=project,
                                         credentials=credentials, admin=True)
         self.assertIs(client._instance_stub, client._instance_stub_internal)
 
     def test_instance_stub_non_admin_failure(self):
         credentials = _Credentials()
         project = 'PROJECT'
-        client = self._makeOneWithMocks(project=project,
+        client = self._make_oneWithMocks(project=project,
                                         credentials=credentials, admin=False)
         with self.assertRaises(ValueError):
             getattr(client, '_instance_stub')
@@ -479,7 +479,7 @@ class TestClient(unittest.TestCase):
     def test_operations_stub_getter(self):
         credentials = _Credentials()
         project = 'PROJECT'
-        client = self._makeOneWithMocks(project=project,
+        client = self._make_oneWithMocks(project=project,
                                         credentials=credentials, admin=True)
         self.assertIs(client._operations_stub,
                       client._operations_stub_internal)
@@ -487,7 +487,7 @@ class TestClient(unittest.TestCase):
     def test_operations_stub_non_admin_failure(self):
         credentials = _Credentials()
         project = 'PROJECT'
-        client = self._makeOneWithMocks(project=project,
+        client = self._make_oneWithMocks(project=project,
                                         credentials=credentials, admin=False)
         with self.assertRaises(ValueError):
             getattr(client, '_operations_stub')
@@ -495,14 +495,14 @@ class TestClient(unittest.TestCase):
     def test_table_stub_getter(self):
         credentials = _Credentials()
         project = 'PROJECT'
-        client = self._makeOneWithMocks(project=project,
+        client = self._make_oneWithMocks(project=project,
                                         credentials=credentials, admin=True)
         self.assertIs(client._table_stub, client._table_stub_internal)
 
     def test_table_stub_non_admin_failure(self):
         credentials = _Credentials()
         project = 'PROJECT'
-        client = self._makeOneWithMocks(project=project,
+        client = self._make_oneWithMocks(project=project,
                                         credentials=credentials, admin=False)
         with self.assertRaises(ValueError):
             getattr(client, '_table_stub')
@@ -517,7 +517,7 @@ class TestClient(unittest.TestCase):
         INSTANCE_ID = 'instance-id'
         DISPLAY_NAME = 'display-name'
         credentials = _Credentials()
-        client = self._makeOneWithMocks(project=PROJECT,
+        client = self._make_oneWithMocks(project=PROJECT,
                                         credentials=credentials)
 
         instance = client.instance(INSTANCE_ID, display_name=DISPLAY_NAME)
@@ -539,7 +539,7 @@ class TestClient(unittest.TestCase):
         LOCATION_ID = 'locname'
         SERVE_NODES = 5
         credentials = _Credentials()
-        client = self._makeOneWithMocks(project=PROJECT,
+        client = self._make_oneWithMocks(project=PROJECT,
                                         credentials=credentials)
 
         instance = client.instance(
@@ -570,7 +570,7 @@ class TestClient(unittest.TestCase):
             'projects/' + self.PROJECT + '/instances/' + INSTANCE_ID2)
 
         credentials = _Credentials()
-        client = self._makeOneWithMocks(
+        client = self._make_oneWithMocks(
             project=self.PROJECT,
             credentials=credentials,
             admin=True,

--- a/bigtable/unit_tests/test_client.py
+++ b/bigtable/unit_tests/test_client.py
@@ -267,7 +267,8 @@ class TestClient(unittest.TestCase):
     DISPLAY_NAME = 'display-name'
     USER_AGENT = 'you-sir-age-int'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.client import Client
         return Client
 

--- a/bigtable/unit_tests/test_client.py
+++ b/bigtable/unit_tests/test_client.py
@@ -306,8 +306,8 @@ class TestClient(unittest.TestCase):
                      _make_operations_stub=mock_make_operations_stub,
                      _make_table_stub=mock_make_table_stub):
             client = self._make_one(project=self.PROJECT, credentials=creds,
-                                   read_only=read_only, admin=admin,
-                                   user_agent=user_agent)
+                                    read_only=read_only, admin=admin,
+                                    user_agent=user_agent)
 
         # Verify the mocks.
         self.assertEqual(mock_make_data_stub.calls, [client])
@@ -450,14 +450,14 @@ class TestClient(unittest.TestCase):
         credentials = _Credentials()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
-                                        credentials=credentials)
+                                         credentials=credentials)
         self.assertIs(client.credentials, credentials)
 
     def test_project_name_property(self):
         credentials = _Credentials()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
-                                        credentials=credentials)
+                                         credentials=credentials)
         project_name = 'projects/' + project
         self.assertEqual(client.project_name, project_name)
 
@@ -465,14 +465,14 @@ class TestClient(unittest.TestCase):
         credentials = _Credentials()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
-                                        credentials=credentials, admin=True)
+                                         credentials=credentials, admin=True)
         self.assertIs(client._instance_stub, client._instance_stub_internal)
 
     def test_instance_stub_non_admin_failure(self):
         credentials = _Credentials()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
-                                        credentials=credentials, admin=False)
+                                         credentials=credentials, admin=False)
         with self.assertRaises(ValueError):
             getattr(client, '_instance_stub')
 
@@ -480,7 +480,7 @@ class TestClient(unittest.TestCase):
         credentials = _Credentials()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
-                                        credentials=credentials, admin=True)
+                                         credentials=credentials, admin=True)
         self.assertIs(client._operations_stub,
                       client._operations_stub_internal)
 
@@ -488,7 +488,7 @@ class TestClient(unittest.TestCase):
         credentials = _Credentials()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
-                                        credentials=credentials, admin=False)
+                                         credentials=credentials, admin=False)
         with self.assertRaises(ValueError):
             getattr(client, '_operations_stub')
 
@@ -496,14 +496,14 @@ class TestClient(unittest.TestCase):
         credentials = _Credentials()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
-                                        credentials=credentials, admin=True)
+                                         credentials=credentials, admin=True)
         self.assertIs(client._table_stub, client._table_stub_internal)
 
     def test_table_stub_non_admin_failure(self):
         credentials = _Credentials()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
-                                        credentials=credentials, admin=False)
+                                         credentials=credentials, admin=False)
         with self.assertRaises(ValueError):
             getattr(client, '_table_stub')
 
@@ -518,7 +518,7 @@ class TestClient(unittest.TestCase):
         DISPLAY_NAME = 'display-name'
         credentials = _Credentials()
         client = self._make_oneWithMocks(project=PROJECT,
-                                        credentials=credentials)
+                                         credentials=credentials)
 
         instance = client.instance(INSTANCE_ID, display_name=DISPLAY_NAME)
 
@@ -540,7 +540,7 @@ class TestClient(unittest.TestCase):
         SERVE_NODES = 5
         credentials = _Credentials()
         client = self._make_oneWithMocks(project=PROJECT,
-                                        credentials=credentials)
+                                         credentials=credentials)
 
         instance = client.instance(
             INSTANCE_ID, display_name=DISPLAY_NAME,

--- a/bigtable/unit_tests/test_cluster.py
+++ b/bigtable/unit_tests/test_cluster.py
@@ -374,7 +374,7 @@ class TestCluster(unittest.TestCase):
 
 class Test__prepare_create_request(unittest.TestCase):
 
-    def _callFUT(self, cluster):
+    def _call_fut(self, cluster):
         from google.cloud.bigtable.cluster import _prepare_create_request
         return _prepare_create_request(cluster)
 
@@ -391,7 +391,7 @@ class Test__prepare_create_request(unittest.TestCase):
         cluster = Cluster(CLUSTER_ID, instance,
                           serve_nodes=SERVE_NODES)
 
-        request_pb = self._callFUT(cluster)
+        request_pb = self._call_fut(cluster)
 
         self.assertEqual(request_pb.cluster_id, CLUSTER_ID)
         self.assertEqual(request_pb.parent, instance.name)

--- a/bigtable/unit_tests/test_cluster.py
+++ b/bigtable/unit_tests/test_cluster.py
@@ -25,7 +25,8 @@ class TestCluster(unittest.TestCase):
                     '/instances/' + INSTANCE_ID +
                     '/clusters/' + CLUSTER_ID)
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.cluster import Cluster
         return Cluster
 

--- a/bigtable/unit_tests/test_cluster.py
+++ b/bigtable/unit_tests/test_cluster.py
@@ -49,7 +49,7 @@ class TestCluster(unittest.TestCase):
         instance = _Instance(self.INSTANCE_ID, client)
 
         cluster = self._make_one(self.CLUSTER_ID, instance,
-                                serve_nodes=SERVE_NODES)
+                                 serve_nodes=SERVE_NODES)
         self.assertEqual(cluster.cluster_id, self.CLUSTER_ID)
         self.assertIs(cluster._instance, instance)
         self.assertEqual(cluster.serve_nodes, SERVE_NODES)
@@ -60,7 +60,7 @@ class TestCluster(unittest.TestCase):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
         cluster = self._make_one(self.CLUSTER_ID, instance,
-                                serve_nodes=SERVE_NODES)
+                                 serve_nodes=SERVE_NODES)
         new_cluster = cluster.copy()
 
         # Make sure the client copy succeeded.
@@ -293,7 +293,7 @@ class TestCluster(unittest.TestCase):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
         cluster = self._make_one(self.CLUSTER_ID, instance,
-                                serve_nodes=SERVE_NODES)
+                                 serve_nodes=SERVE_NODES)
 
         # Create request_pb
         request_pb = _ClusterPB(

--- a/bigtable/unit_tests/test_cluster.py
+++ b/bigtable/unit_tests/test_cluster.py
@@ -30,7 +30,7 @@ class TestCluster(unittest.TestCase):
         from google.cloud.bigtable.cluster import Cluster
         return Cluster
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
@@ -38,7 +38,7 @@ class TestCluster(unittest.TestCase):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
 
-        cluster = self._makeOne(self.CLUSTER_ID, instance)
+        cluster = self._make_one(self.CLUSTER_ID, instance)
         self.assertEqual(cluster.cluster_id, self.CLUSTER_ID)
         self.assertIs(cluster._instance, instance)
         self.assertEqual(cluster.serve_nodes, DEFAULT_SERVE_NODES)
@@ -48,7 +48,7 @@ class TestCluster(unittest.TestCase):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
 
-        cluster = self._makeOne(self.CLUSTER_ID, instance,
+        cluster = self._make_one(self.CLUSTER_ID, instance,
                                 serve_nodes=SERVE_NODES)
         self.assertEqual(cluster.cluster_id, self.CLUSTER_ID)
         self.assertIs(cluster._instance, instance)
@@ -59,7 +59,7 @@ class TestCluster(unittest.TestCase):
 
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
-        cluster = self._makeOne(self.CLUSTER_ID, instance,
+        cluster = self._make_one(self.CLUSTER_ID, instance,
                                 serve_nodes=SERVE_NODES)
         new_cluster = cluster.copy()
 
@@ -80,7 +80,7 @@ class TestCluster(unittest.TestCase):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
 
-        cluster = self._makeOne(self.CLUSTER_ID, instance)
+        cluster = self._make_one(self.CLUSTER_ID, instance)
         self.assertEqual(cluster.serve_nodes, DEFAULT_SERVE_NODES)
         cluster._update_from_pb(cluster_pb)
         self.assertEqual(cluster.serve_nodes, SERVE_NODES)
@@ -92,7 +92,7 @@ class TestCluster(unittest.TestCase):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
 
-        cluster = self._makeOne(self.CLUSTER_ID, instance)
+        cluster = self._make_one(self.CLUSTER_ID, instance)
         self.assertEqual(cluster.serve_nodes, DEFAULT_SERVE_NODES)
         with self.assertRaises(ValueError):
             cluster._update_from_pb(cluster_pb)
@@ -155,36 +155,36 @@ class TestCluster(unittest.TestCase):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
 
-        cluster = self._makeOne(self.CLUSTER_ID, instance)
+        cluster = self._make_one(self.CLUSTER_ID, instance)
         self.assertEqual(cluster.name, self.CLUSTER_NAME)
 
     def test___eq__(self):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
-        cluster1 = self._makeOne(self.CLUSTER_ID, instance)
-        cluster2 = self._makeOne(self.CLUSTER_ID, instance)
+        cluster1 = self._make_one(self.CLUSTER_ID, instance)
+        cluster2 = self._make_one(self.CLUSTER_ID, instance)
         self.assertEqual(cluster1, cluster2)
 
     def test___eq__type_differ(self):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
-        cluster1 = self._makeOne(self.CLUSTER_ID, instance)
+        cluster1 = self._make_one(self.CLUSTER_ID, instance)
         cluster2 = object()
         self.assertNotEqual(cluster1, cluster2)
 
     def test___ne__same_value(self):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
-        cluster1 = self._makeOne(self.CLUSTER_ID, instance)
-        cluster2 = self._makeOne(self.CLUSTER_ID, instance)
+        cluster1 = self._make_one(self.CLUSTER_ID, instance)
+        cluster2 = self._make_one(self.CLUSTER_ID, instance)
         comparison_val = (cluster1 != cluster2)
         self.assertFalse(comparison_val)
 
     def test___ne__(self):
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
-        cluster1 = self._makeOne('cluster_id1', instance)
-        cluster2 = self._makeOne('cluster_id2', instance)
+        cluster1 = self._make_one('cluster_id1', instance)
+        cluster2 = self._make_one('cluster_id2', instance)
         self.assertNotEqual(cluster1, cluster2)
 
     def test_reload(self):
@@ -195,7 +195,7 @@ class TestCluster(unittest.TestCase):
         LOCATION = 'LOCATION'
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
-        cluster = self._makeOne(self.CLUSTER_ID, instance)
+        cluster = self._make_one(self.CLUSTER_ID, instance)
 
         # Create request_pb
         request_pb = _GetClusterRequestPB(name=self.CLUSTER_NAME)
@@ -238,7 +238,7 @@ class TestCluster(unittest.TestCase):
         SERVE_NODES = 4
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
-        cluster = self._makeOne(
+        cluster = self._make_one(
             self.CLUSTER_ID, instance, serve_nodes=SERVE_NODES)
 
         # Create response_pb
@@ -292,7 +292,7 @@ class TestCluster(unittest.TestCase):
 
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
-        cluster = self._makeOne(self.CLUSTER_ID, instance,
+        cluster = self._make_one(self.CLUSTER_ID, instance,
                                 serve_nodes=SERVE_NODES)
 
         # Create request_pb
@@ -347,7 +347,7 @@ class TestCluster(unittest.TestCase):
 
         client = _Client(self.PROJECT)
         instance = _Instance(self.INSTANCE_ID, client)
-        cluster = self._makeOne(self.CLUSTER_ID, instance)
+        cluster = self._make_one(self.CLUSTER_ID, instance)
 
         # Create request_pb
         request_pb = _DeleteClusterRequestPB(name=self.CLUSTER_NAME)

--- a/bigtable/unit_tests/test_cluster.py
+++ b/bigtable/unit_tests/test_cluster.py
@@ -31,7 +31,7 @@ class TestCluster(unittest.TestCase):
         return Cluster
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
         from google.cloud.bigtable.cluster import DEFAULT_SERVE_NODES
@@ -108,7 +108,7 @@ class TestCluster(unittest.TestCase):
             serve_nodes=SERVE_NODES,
         )
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         cluster = klass.from_pb(cluster_pb, instance)
         self.assertIsInstance(cluster, klass)
         self.assertIs(cluster._instance, instance)
@@ -121,7 +121,7 @@ class TestCluster(unittest.TestCase):
         instance = _Instance(self.INSTANCE_ID, client)
         cluster_pb = _ClusterPB(name=BAD_CLUSTER_NAME)
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(ValueError):
             klass.from_pb(cluster_pb, instance)
 
@@ -134,7 +134,7 @@ class TestCluster(unittest.TestCase):
 
         cluster_pb = _ClusterPB(name=self.CLUSTER_NAME)
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(ValueError):
             klass.from_pb(cluster_pb, instance)
 
@@ -147,7 +147,7 @@ class TestCluster(unittest.TestCase):
 
         cluster_pb = _ClusterPB(name=self.CLUSTER_NAME)
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(ValueError):
             klass.from_pb(cluster_pb, instance)
 

--- a/bigtable/unit_tests/test_column_family.py
+++ b/bigtable/unit_tests/test_column_family.py
@@ -85,7 +85,8 @@ class Test__duration_pb_to_timedelta(unittest.TestCase):
 
 class TestMaxVersionsGCRule(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.column_family import MaxVersionsGCRule
         return MaxVersionsGCRule
 
@@ -118,7 +119,8 @@ class TestMaxVersionsGCRule(unittest.TestCase):
 
 class TestMaxAgeGCRule(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.column_family import MaxAgeGCRule
         return MaxAgeGCRule
 
@@ -157,7 +159,8 @@ class TestMaxAgeGCRule(unittest.TestCase):
 
 class TestGCRuleUnion(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.column_family import GCRuleUnion
         return GCRuleUnion
 
@@ -243,7 +246,8 @@ class TestGCRuleUnion(unittest.TestCase):
 
 class TestGCRuleIntersection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.column_family import GCRuleIntersection
         return GCRuleIntersection
 
@@ -332,7 +336,8 @@ class TestGCRuleIntersection(unittest.TestCase):
 
 class TestColumnFamily(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.column_family import ColumnFamily
         return ColumnFamily
 

--- a/bigtable/unit_tests/test_column_family.py
+++ b/bigtable/unit_tests/test_column_family.py
@@ -18,7 +18,7 @@ import unittest
 
 class Test__timedelta_to_duration_pb(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud.bigtable.column_family import (
             _timedelta_to_duration_pb)
         return _timedelta_to_duration_pb(*args, **kwargs)
@@ -30,7 +30,7 @@ class Test__timedelta_to_duration_pb(unittest.TestCase):
         seconds = microseconds = 1
         timedelta_val = datetime.timedelta(seconds=seconds,
                                            microseconds=microseconds)
-        result = self._callFUT(timedelta_val)
+        result = self._call_fut(timedelta_val)
         self.assertIsInstance(result, duration_pb2.Duration)
         self.assertEqual(result.seconds, seconds)
         self.assertEqual(result.nanos, 1000 * microseconds)
@@ -43,7 +43,7 @@ class Test__timedelta_to_duration_pb(unittest.TestCase):
         microseconds = -5
         timedelta_val = datetime.timedelta(seconds=seconds,
                                            microseconds=microseconds)
-        result = self._callFUT(timedelta_val)
+        result = self._call_fut(timedelta_val)
         self.assertIsInstance(result, duration_pb2.Duration)
         self.assertEqual(result.seconds, seconds - 1)
         self.assertEqual(result.nanos, 10**9 + 1000 * microseconds)
@@ -56,7 +56,7 @@ class Test__timedelta_to_duration_pb(unittest.TestCase):
         microseconds = 5
         timedelta_val = datetime.timedelta(seconds=seconds,
                                            microseconds=microseconds)
-        result = self._callFUT(timedelta_val)
+        result = self._call_fut(timedelta_val)
         self.assertIsInstance(result, duration_pb2.Duration)
         self.assertEqual(result.seconds, seconds + 1)
         self.assertEqual(result.nanos, -(10**9 - 1000 * microseconds))
@@ -64,7 +64,7 @@ class Test__timedelta_to_duration_pb(unittest.TestCase):
 
 class Test__duration_pb_to_timedelta(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud.bigtable.column_family import (
             _duration_pb_to_timedelta)
         return _duration_pb_to_timedelta(*args, **kwargs)
@@ -78,7 +78,7 @@ class Test__duration_pb_to_timedelta(unittest.TestCase):
                                             nanos=1000 * microseconds)
         timedelta_val = datetime.timedelta(seconds=seconds,
                                            microseconds=microseconds)
-        result = self._callFUT(duration_pb)
+        result = self._call_fut(duration_pb)
         self.assertIsInstance(result, datetime.timedelta)
         self.assertEqual(result, timedelta_val)
 
@@ -575,21 +575,21 @@ class TestColumnFamily(unittest.TestCase):
 
 class Test__gc_rule_from_pb(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud.bigtable.column_family import _gc_rule_from_pb
         return _gc_rule_from_pb(*args, **kwargs)
 
     def test_empty(self):
 
         gc_rule_pb = _GcRulePB()
-        self.assertIsNone(self._callFUT(gc_rule_pb))
+        self.assertIsNone(self._call_fut(gc_rule_pb))
 
     def test_max_num_versions(self):
         from google.cloud.bigtable.column_family import MaxVersionsGCRule
 
         orig_rule = MaxVersionsGCRule(1)
         gc_rule_pb = orig_rule.to_pb()
-        result = self._callFUT(gc_rule_pb)
+        result = self._call_fut(gc_rule_pb)
         self.assertIsInstance(result, MaxVersionsGCRule)
         self.assertEqual(result, orig_rule)
 
@@ -599,7 +599,7 @@ class Test__gc_rule_from_pb(unittest.TestCase):
 
         orig_rule = MaxAgeGCRule(datetime.timedelta(seconds=1))
         gc_rule_pb = orig_rule.to_pb()
-        result = self._callFUT(gc_rule_pb)
+        result = self._call_fut(gc_rule_pb)
         self.assertIsInstance(result, MaxAgeGCRule)
         self.assertEqual(result, orig_rule)
 
@@ -613,7 +613,7 @@ class Test__gc_rule_from_pb(unittest.TestCase):
         rule2 = MaxAgeGCRule(datetime.timedelta(seconds=1))
         orig_rule = GCRuleUnion([rule1, rule2])
         gc_rule_pb = orig_rule.to_pb()
-        result = self._callFUT(gc_rule_pb)
+        result = self._call_fut(gc_rule_pb)
         self.assertIsInstance(result, GCRuleUnion)
         self.assertEqual(result, orig_rule)
 
@@ -627,7 +627,7 @@ class Test__gc_rule_from_pb(unittest.TestCase):
         rule2 = MaxAgeGCRule(datetime.timedelta(seconds=1))
         orig_rule = GCRuleIntersection([rule1, rule2])
         gc_rule_pb = orig_rule.to_pb()
-        result = self._callFUT(gc_rule_pb)
+        result = self._call_fut(gc_rule_pb)
         self.assertIsInstance(result, GCRuleIntersection)
         self.assertEqual(result, orig_rule)
 
@@ -642,7 +642,7 @@ class Test__gc_rule_from_pb(unittest.TestCase):
                 return 'unknown'
 
         self.assertEqual(MockProto.names, [])
-        self.assertRaises(ValueError, self._callFUT, MockProto)
+        self.assertRaises(ValueError, self._call_fut, MockProto)
         self.assertEqual(MockProto.names, ['rule'])
 
 

--- a/bigtable/unit_tests/test_column_family.py
+++ b/bigtable/unit_tests/test_column_family.py
@@ -91,7 +91,7 @@ class TestMaxVersionsGCRule(unittest.TestCase):
         return MaxVersionsGCRule
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test___eq__type_differ(self):
         gc_rule1 = self._makeOne(10)
@@ -125,7 +125,7 @@ class TestMaxAgeGCRule(unittest.TestCase):
         return MaxAgeGCRule
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test___eq__type_differ(self):
         max_age = object()
@@ -165,7 +165,7 @@ class TestGCRuleUnion(unittest.TestCase):
         return GCRuleUnion
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         rules = object()
@@ -252,7 +252,7 @@ class TestGCRuleIntersection(unittest.TestCase):
         return GCRuleIntersection
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         rules = object()
@@ -342,7 +342,7 @@ class TestColumnFamily(unittest.TestCase):
         return ColumnFamily
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         column_family_id = u'column-family-id'

--- a/bigtable/unit_tests/test_column_family.py
+++ b/bigtable/unit_tests/test_column_family.py
@@ -90,28 +90,28 @@ class TestMaxVersionsGCRule(unittest.TestCase):
         from google.cloud.bigtable.column_family import MaxVersionsGCRule
         return MaxVersionsGCRule
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test___eq__type_differ(self):
-        gc_rule1 = self._makeOne(10)
+        gc_rule1 = self._make_one(10)
         gc_rule2 = object()
         self.assertNotEqual(gc_rule1, gc_rule2)
 
     def test___eq__same_value(self):
-        gc_rule1 = self._makeOne(2)
-        gc_rule2 = self._makeOne(2)
+        gc_rule1 = self._make_one(2)
+        gc_rule2 = self._make_one(2)
         self.assertEqual(gc_rule1, gc_rule2)
 
     def test___ne__same_value(self):
-        gc_rule1 = self._makeOne(99)
-        gc_rule2 = self._makeOne(99)
+        gc_rule1 = self._make_one(99)
+        gc_rule2 = self._make_one(99)
         comparison_val = (gc_rule1 != gc_rule2)
         self.assertFalse(comparison_val)
 
     def test_to_pb(self):
         max_num_versions = 1337
-        gc_rule = self._makeOne(max_num_versions=max_num_versions)
+        gc_rule = self._make_one(max_num_versions=max_num_versions)
         pb_val = gc_rule.to_pb()
         expected = _GcRulePB(max_num_versions=max_num_versions)
         self.assertEqual(pb_val, expected)
@@ -124,25 +124,25 @@ class TestMaxAgeGCRule(unittest.TestCase):
         from google.cloud.bigtable.column_family import MaxAgeGCRule
         return MaxAgeGCRule
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test___eq__type_differ(self):
         max_age = object()
-        gc_rule1 = self._makeOne(max_age=max_age)
+        gc_rule1 = self._make_one(max_age=max_age)
         gc_rule2 = object()
         self.assertNotEqual(gc_rule1, gc_rule2)
 
     def test___eq__same_value(self):
         max_age = object()
-        gc_rule1 = self._makeOne(max_age=max_age)
-        gc_rule2 = self._makeOne(max_age=max_age)
+        gc_rule1 = self._make_one(max_age=max_age)
+        gc_rule2 = self._make_one(max_age=max_age)
         self.assertEqual(gc_rule1, gc_rule2)
 
     def test___ne__same_value(self):
         max_age = object()
-        gc_rule1 = self._makeOne(max_age=max_age)
-        gc_rule2 = self._makeOne(max_age=max_age)
+        gc_rule1 = self._make_one(max_age=max_age)
+        gc_rule2 = self._make_one(max_age=max_age)
         comparison_val = (gc_rule1 != gc_rule2)
         self.assertFalse(comparison_val)
 
@@ -152,7 +152,7 @@ class TestMaxAgeGCRule(unittest.TestCase):
 
         max_age = datetime.timedelta(seconds=1)
         duration = duration_pb2.Duration(seconds=1)
-        gc_rule = self._makeOne(max_age=max_age)
+        gc_rule = self._make_one(max_age=max_age)
         pb_val = gc_rule.to_pb()
         self.assertEqual(pb_val, _GcRulePB(max_age=duration))
 
@@ -164,30 +164,30 @@ class TestGCRuleUnion(unittest.TestCase):
         from google.cloud.bigtable.column_family import GCRuleUnion
         return GCRuleUnion
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         rules = object()
-        rule_union = self._makeOne(rules)
+        rule_union = self._make_one(rules)
         self.assertIs(rule_union.rules, rules)
 
     def test___eq__(self):
         rules = object()
-        gc_rule1 = self._makeOne(rules)
-        gc_rule2 = self._makeOne(rules)
+        gc_rule1 = self._make_one(rules)
+        gc_rule2 = self._make_one(rules)
         self.assertEqual(gc_rule1, gc_rule2)
 
     def test___eq__type_differ(self):
         rules = object()
-        gc_rule1 = self._makeOne(rules)
+        gc_rule1 = self._make_one(rules)
         gc_rule2 = object()
         self.assertNotEqual(gc_rule1, gc_rule2)
 
     def test___ne__same_value(self):
         rules = object()
-        gc_rule1 = self._makeOne(rules)
-        gc_rule2 = self._makeOne(rules)
+        gc_rule1 = self._make_one(rules)
+        gc_rule2 = self._make_one(rules)
         comparison_val = (gc_rule1 != gc_rule2)
         self.assertFalse(comparison_val)
 
@@ -206,7 +206,7 @@ class TestGCRuleUnion(unittest.TestCase):
         pb_rule2 = _GcRulePB(
             max_age=duration_pb2.Duration(seconds=1))
 
-        rule3 = self._makeOne(rules=[rule1, rule2])
+        rule3 = self._make_one(rules=[rule1, rule2])
         pb_rule3 = _GcRulePB(
             union=_GcRuleUnionPB(rules=[pb_rule1, pb_rule2]))
 
@@ -228,7 +228,7 @@ class TestGCRuleUnion(unittest.TestCase):
         pb_rule2 = _GcRulePB(
             max_age=duration_pb2.Duration(seconds=1))
 
-        rule3 = self._makeOne(rules=[rule1, rule2])
+        rule3 = self._make_one(rules=[rule1, rule2])
         pb_rule3 = _GcRulePB(
             union=_GcRuleUnionPB(rules=[pb_rule1, pb_rule2]))
 
@@ -236,7 +236,7 @@ class TestGCRuleUnion(unittest.TestCase):
         rule4 = MaxVersionsGCRule(max_num_versions2)
         pb_rule4 = _GcRulePB(max_num_versions=max_num_versions2)
 
-        rule5 = self._makeOne(rules=[rule3, rule4])
+        rule5 = self._make_one(rules=[rule3, rule4])
         pb_rule5 = _GcRulePB(
             union=_GcRuleUnionPB(rules=[pb_rule3, pb_rule4]))
 
@@ -251,30 +251,30 @@ class TestGCRuleIntersection(unittest.TestCase):
         from google.cloud.bigtable.column_family import GCRuleIntersection
         return GCRuleIntersection
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         rules = object()
-        rule_intersection = self._makeOne(rules)
+        rule_intersection = self._make_one(rules)
         self.assertIs(rule_intersection.rules, rules)
 
     def test___eq__(self):
         rules = object()
-        gc_rule1 = self._makeOne(rules)
-        gc_rule2 = self._makeOne(rules)
+        gc_rule1 = self._make_one(rules)
+        gc_rule2 = self._make_one(rules)
         self.assertEqual(gc_rule1, gc_rule2)
 
     def test___eq__type_differ(self):
         rules = object()
-        gc_rule1 = self._makeOne(rules)
+        gc_rule1 = self._make_one(rules)
         gc_rule2 = object()
         self.assertNotEqual(gc_rule1, gc_rule2)
 
     def test___ne__same_value(self):
         rules = object()
-        gc_rule1 = self._makeOne(rules)
-        gc_rule2 = self._makeOne(rules)
+        gc_rule1 = self._make_one(rules)
+        gc_rule2 = self._make_one(rules)
         comparison_val = (gc_rule1 != gc_rule2)
         self.assertFalse(comparison_val)
 
@@ -293,7 +293,7 @@ class TestGCRuleIntersection(unittest.TestCase):
         pb_rule2 = _GcRulePB(
             max_age=duration_pb2.Duration(seconds=1))
 
-        rule3 = self._makeOne(rules=[rule1, rule2])
+        rule3 = self._make_one(rules=[rule1, rule2])
         pb_rule3 = _GcRulePB(
             intersection=_GcRuleIntersectionPB(
                 rules=[pb_rule1, pb_rule2]))
@@ -316,7 +316,7 @@ class TestGCRuleIntersection(unittest.TestCase):
         pb_rule2 = _GcRulePB(
             max_age=duration_pb2.Duration(seconds=1))
 
-        rule3 = self._makeOne(rules=[rule1, rule2])
+        rule3 = self._make_one(rules=[rule1, rule2])
         pb_rule3 = _GcRulePB(
             intersection=_GcRuleIntersectionPB(
                 rules=[pb_rule1, pb_rule2]))
@@ -325,7 +325,7 @@ class TestGCRuleIntersection(unittest.TestCase):
         rule4 = MaxVersionsGCRule(max_num_versions2)
         pb_rule4 = _GcRulePB(max_num_versions=max_num_versions2)
 
-        rule5 = self._makeOne(rules=[rule3, rule4])
+        rule5 = self._make_one(rules=[rule3, rule4])
         pb_rule5 = _GcRulePB(
             intersection=_GcRuleIntersectionPB(
                 rules=[pb_rule3, pb_rule4]))
@@ -341,14 +341,14 @@ class TestColumnFamily(unittest.TestCase):
         from google.cloud.bigtable.column_family import ColumnFamily
         return ColumnFamily
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         column_family_id = u'column-family-id'
         table = object()
         gc_rule = object()
-        column_family = self._makeOne(
+        column_family = self._make_one(
             column_family_id, table, gc_rule=gc_rule)
 
         self.assertEqual(column_family.column_family_id, column_family_id)
@@ -359,7 +359,7 @@ class TestColumnFamily(unittest.TestCase):
         column_family_id = u'column-family-id'
         table_name = 'table_name'
         table = _Table(table_name)
-        column_family = self._makeOne(column_family_id, table)
+        column_family = self._make_one(column_family_id, table)
 
         expected_name = table_name + '/columnFamilies/' + column_family_id
         self.assertEqual(column_family.name, expected_name)
@@ -368,14 +368,14 @@ class TestColumnFamily(unittest.TestCase):
         column_family_id = 'column_family_id'
         table = object()
         gc_rule = object()
-        column_family1 = self._makeOne(column_family_id, table,
+        column_family1 = self._make_one(column_family_id, table,
                                        gc_rule=gc_rule)
-        column_family2 = self._makeOne(column_family_id, table,
+        column_family2 = self._make_one(column_family_id, table,
                                        gc_rule=gc_rule)
         self.assertEqual(column_family1, column_family2)
 
     def test___eq__type_differ(self):
-        column_family1 = self._makeOne('column_family_id', None)
+        column_family1 = self._make_one('column_family_id', None)
         column_family2 = object()
         self.assertNotEqual(column_family1, column_family2)
 
@@ -383,20 +383,20 @@ class TestColumnFamily(unittest.TestCase):
         column_family_id = 'column_family_id'
         table = object()
         gc_rule = object()
-        column_family1 = self._makeOne(column_family_id, table,
+        column_family1 = self._make_one(column_family_id, table,
                                        gc_rule=gc_rule)
-        column_family2 = self._makeOne(column_family_id, table,
+        column_family2 = self._make_one(column_family_id, table,
                                        gc_rule=gc_rule)
         comparison_val = (column_family1 != column_family2)
         self.assertFalse(comparison_val)
 
     def test___ne__(self):
-        column_family1 = self._makeOne('column_family_id1', None)
-        column_family2 = self._makeOne('column_family_id2', None)
+        column_family1 = self._make_one('column_family_id1', None)
+        column_family2 = self._make_one('column_family_id2', None)
         self.assertNotEqual(column_family1, column_family2)
 
     def test_to_pb_no_rules(self):
-        column_family = self._makeOne('column_family_id', None)
+        column_family = self._make_one('column_family_id', None)
         pb_val = column_family.to_pb()
         expected = _ColumnFamilyPB()
         self.assertEqual(pb_val, expected)
@@ -405,7 +405,7 @@ class TestColumnFamily(unittest.TestCase):
         from google.cloud.bigtable.column_family import MaxVersionsGCRule
 
         gc_rule = MaxVersionsGCRule(1)
-        column_family = self._makeOne('column_family_id', None,
+        column_family = self._make_one('column_family_id', None,
                                       gc_rule=gc_rule)
         pb_val = column_family.to_pb()
         expected = _ColumnFamilyPB(gc_rule=gc_rule.to_pb())
@@ -426,7 +426,7 @@ class TestColumnFamily(unittest.TestCase):
 
         client = _Client()
         table = _Table(table_name, client=client)
-        column_family = self._makeOne(
+        column_family = self._make_one(
             column_family_id, table, gc_rule=gc_rule)
 
         # Create request_pb
@@ -484,7 +484,7 @@ class TestColumnFamily(unittest.TestCase):
 
         client = _Client()
         table = _Table(table_name, client=client)
-        column_family = self._makeOne(
+        column_family = self._make_one(
             column_family_id, table, gc_rule=gc_rule)
 
         # Create request_pb
@@ -543,7 +543,7 @@ class TestColumnFamily(unittest.TestCase):
 
         client = _Client()
         table = _Table(table_name, client=client)
-        column_family = self._makeOne(column_family_id, table)
+        column_family = self._make_one(column_family_id, table)
 
         # Create request_pb
         request_pb = table_admin_v2_pb2.ModifyColumnFamiliesRequest(

--- a/bigtable/unit_tests/test_column_family.py
+++ b/bigtable/unit_tests/test_column_family.py
@@ -369,9 +369,9 @@ class TestColumnFamily(unittest.TestCase):
         table = object()
         gc_rule = object()
         column_family1 = self._make_one(column_family_id, table,
-                                       gc_rule=gc_rule)
+                                        gc_rule=gc_rule)
         column_family2 = self._make_one(column_family_id, table,
-                                       gc_rule=gc_rule)
+                                        gc_rule=gc_rule)
         self.assertEqual(column_family1, column_family2)
 
     def test___eq__type_differ(self):
@@ -384,9 +384,9 @@ class TestColumnFamily(unittest.TestCase):
         table = object()
         gc_rule = object()
         column_family1 = self._make_one(column_family_id, table,
-                                       gc_rule=gc_rule)
+                                        gc_rule=gc_rule)
         column_family2 = self._make_one(column_family_id, table,
-                                       gc_rule=gc_rule)
+                                        gc_rule=gc_rule)
         comparison_val = (column_family1 != column_family2)
         self.assertFalse(comparison_val)
 
@@ -406,7 +406,7 @@ class TestColumnFamily(unittest.TestCase):
 
         gc_rule = MaxVersionsGCRule(1)
         column_family = self._make_one('column_family_id', None,
-                                      gc_rule=gc_rule)
+                                       gc_rule=gc_rule)
         pb_val = column_family.to_pb()
         expected = _ColumnFamilyPB(gc_rule=gc_rule.to_pb())
         self.assertEqual(pb_val, expected)

--- a/bigtable/unit_tests/test_instance.py
+++ b/bigtable/unit_tests/test_instance.py
@@ -514,7 +514,7 @@ class Test__prepare_create_request(unittest.TestCase):
     INSTANCE_NAME = PARENT + '/instances/' + INSTANCE_ID
     CLUSTER_NAME = INSTANCE_NAME + '/clusters/' + INSTANCE_ID
 
-    def _callFUT(self, instance, **kw):
+    def _call_fut(self, instance, **kw):
         from google.cloud.bigtable.instance import _prepare_create_request
         return _prepare_create_request(instance, **kw)
 
@@ -529,7 +529,7 @@ class Test__prepare_create_request(unittest.TestCase):
         client = _Client(self.PROJECT)
 
         instance = Instance(self.INSTANCE_ID, client, self.LOCATION_ID)
-        request_pb = self._callFUT(instance)
+        request_pb = self._call_fut(instance)
         self.assertIsInstance(request_pb,
                               messages_v2_pb.CreateInstanceRequest)
         self.assertEqual(request_pb.instance_id, self.INSTANCE_ID)
@@ -558,7 +558,7 @@ class Test__prepare_create_request(unittest.TestCase):
                             display_name=DISPLAY_NAME,
                             serve_nodes=SERVE_NODES)
 
-        request_pb = self._callFUT(instance)
+        request_pb = self._call_fut(instance)
 
         self.assertIsInstance(request_pb,
                               messages_v2_pb.CreateInstanceRequest)

--- a/bigtable/unit_tests/test_instance.py
+++ b/bigtable/unit_tests/test_instance.py
@@ -30,7 +30,8 @@ class TestInstance(unittest.TestCase):
     TABLE_ID = 'table_id'
     TABLE_NAME = INSTANCE_NAME + '/tables/' + TABLE_ID
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.instance import Instance
         return Instance
 

--- a/bigtable/unit_tests/test_instance.py
+++ b/bigtable/unit_tests/test_instance.py
@@ -36,7 +36,7 @@ class TestInstance(unittest.TestCase):
         return Instance
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
         from google.cloud.bigtable.cluster import DEFAULT_SERVE_NODES
@@ -122,7 +122,7 @@ class TestInstance(unittest.TestCase):
             display_name=self.INSTANCE_ID,
         )
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         instance = klass.from_pb(instance_pb, client)
         self.assertIsInstance(instance, klass)
         self.assertEqual(instance._client, client)
@@ -137,7 +137,7 @@ class TestInstance(unittest.TestCase):
         instance_name = 'INCORRECT_FORMAT'
         instance_pb = data_v2_pb2.Instance(name=instance_name)
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(ValueError):
             klass.from_pb(instance_pb, None)
 
@@ -152,7 +152,7 @@ class TestInstance(unittest.TestCase):
 
         instance_pb = data_v2_pb2.Instance(name=self.INSTANCE_NAME)
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(ValueError):
             klass.from_pb(instance_pb, client)
 

--- a/bigtable/unit_tests/test_instance.py
+++ b/bigtable/unit_tests/test_instance.py
@@ -35,14 +35,14 @@ class TestInstance(unittest.TestCase):
         from google.cloud.bigtable.instance import Instance
         return Instance
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
         from google.cloud.bigtable.cluster import DEFAULT_SERVE_NODES
 
         client = object()
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
         self.assertEqual(instance.display_name, self.INSTANCE_ID)
         self.assertIs(instance._client, client)
@@ -53,7 +53,7 @@ class TestInstance(unittest.TestCase):
         display_name = 'display_name'
         client = object()
 
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID,
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
                                  display_name=display_name)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
         self.assertEqual(instance.display_name, display_name)
@@ -63,7 +63,7 @@ class TestInstance(unittest.TestCase):
         display_name = 'display_name'
 
         client = _Client(self.PROJECT)
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID,
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
                                  display_name=display_name)
         new_instance = instance.copy()
 
@@ -77,7 +77,7 @@ class TestInstance(unittest.TestCase):
     def test_table_factory(self):
         from google.cloud.bigtable.table import Table
 
-        instance = self._makeOne(self.INSTANCE_ID, None, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, None, self.LOCATION_ID)
 
         table = instance.table(self.TABLE_ID)
         self.assertIsInstance(table, Table)
@@ -93,7 +93,7 @@ class TestInstance(unittest.TestCase):
             display_name=display_name,
         )
 
-        instance = self._makeOne(None, None, None, None)
+        instance = self._make_one(None, None, None, None)
         self.assertIsNone(instance.display_name)
         instance._update_from_pb(instance_pb)
         self.assertEqual(instance.display_name, display_name)
@@ -103,7 +103,7 @@ class TestInstance(unittest.TestCase):
             instance_pb2 as data_v2_pb2)
 
         instance_pb = data_v2_pb2.Instance()
-        instance = self._makeOne(None, None, None, None)
+        instance = self._make_one(None, None, None, None)
         self.assertIsNone(instance.display_name)
         with self.assertRaises(ValueError):
             instance._update_from_pb(instance_pb)
@@ -159,31 +159,31 @@ class TestInstance(unittest.TestCase):
     def test_name_property(self):
         client = _Client(project=self.PROJECT)
 
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
         self.assertEqual(instance.name, self.INSTANCE_NAME)
 
     def test___eq__(self):
         client = object()
-        instance1 = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
-        instance2 = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance1 = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance2 = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
         self.assertEqual(instance1, instance2)
 
     def test___eq__type_differ(self):
         client = object()
-        instance1 = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance1 = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
         instance2 = object()
         self.assertNotEqual(instance1, instance2)
 
     def test___ne__same_value(self):
         client = object()
-        instance1 = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
-        instance2 = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance1 = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance2 = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
         comparison_val = (instance1 != instance2)
         self.assertFalse(comparison_val)
 
     def test___ne__(self):
-        instance1 = self._makeOne('instance_id1', 'client1', self.LOCATION_ID)
-        instance2 = self._makeOne('instance_id2', 'client2', self.LOCATION_ID)
+        instance1 = self._make_one('instance_id1', 'client1', self.LOCATION_ID)
+        instance2 = self._make_one('instance_id2', 'client2', self.LOCATION_ID)
         self.assertNotEqual(instance1, instance2)
 
     def test_reload(self):
@@ -194,7 +194,7 @@ class TestInstance(unittest.TestCase):
         from unit_tests._testing import _FakeStub
 
         client = _Client(self.PROJECT)
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
 
         # Create request_pb
         request_pb = messages_v2_pb.GetInstanceRequest(
@@ -241,7 +241,7 @@ class TestInstance(unittest.TestCase):
         NOW = datetime.datetime.utcnow()
         NOW_PB = _datetime_to_pb_timestamp(NOW)
         client = _Client(self.PROJECT)
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID,
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
                                  display_name=self.DISPLAY_NAME)
 
         # Create response_pb
@@ -295,7 +295,7 @@ class TestInstance(unittest.TestCase):
         SERVE_NODES = 5
 
         client = _Client(self.PROJECT)
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID,
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
                                  serve_nodes=SERVE_NODES)
 
         # Create response_pb
@@ -331,7 +331,7 @@ class TestInstance(unittest.TestCase):
         from unit_tests._testing import _FakeStub
 
         client = _Client(self.PROJECT)
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID,
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
                                  display_name=self.DISPLAY_NAME)
 
         # Create request_pb
@@ -366,7 +366,7 @@ class TestInstance(unittest.TestCase):
         from unit_tests._testing import _FakeStub
 
         client = _Client(self.PROJECT)
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
 
         # Create request_pb
         request_pb = messages_v2_pb.DeleteInstanceRequest(
@@ -405,7 +405,7 @@ class TestInstance(unittest.TestCase):
         SERVE_NODES = 4
 
         client = _Client(self.PROJECT)
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
 
         CLUSTER_NAME1 = (instance.name + '/clusters/' + CLUSTER_ID1)
         CLUSTER_NAME2 = (instance.name + '/clusters/' + CLUSTER_ID2)
@@ -456,7 +456,7 @@ class TestInstance(unittest.TestCase):
         from unit_tests._testing import _FakeStub
 
         client = _Client(self.PROJECT)
-        instance = self._makeOne(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
 
         # Create request_
         request_pb = table_messages_v1_pb2.ListTablesRequest(

--- a/bigtable/unit_tests/test_instance.py
+++ b/bigtable/unit_tests/test_instance.py
@@ -54,7 +54,7 @@ class TestInstance(unittest.TestCase):
         client = object()
 
         instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
-                                 display_name=display_name)
+                                  display_name=display_name)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
         self.assertEqual(instance.display_name, display_name)
         self.assertIs(instance._client, client)
@@ -64,7 +64,7 @@ class TestInstance(unittest.TestCase):
 
         client = _Client(self.PROJECT)
         instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
-                                 display_name=display_name)
+                                  display_name=display_name)
         new_instance = instance.copy()
 
         # Make sure the client copy succeeded.
@@ -242,7 +242,7 @@ class TestInstance(unittest.TestCase):
         NOW_PB = _datetime_to_pb_timestamp(NOW)
         client = _Client(self.PROJECT)
         instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
-                                 display_name=self.DISPLAY_NAME)
+                                  display_name=self.DISPLAY_NAME)
 
         # Create response_pb
         metadata = messages_v2_pb2.CreateInstanceMetadata(request_time=NOW_PB)
@@ -296,7 +296,7 @@ class TestInstance(unittest.TestCase):
 
         client = _Client(self.PROJECT)
         instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
-                                 serve_nodes=SERVE_NODES)
+                                  serve_nodes=SERVE_NODES)
 
         # Create response_pb
         response_pb = operations_pb2.Operation(name=self.OP_NAME)
@@ -332,7 +332,7 @@ class TestInstance(unittest.TestCase):
 
         client = _Client(self.PROJECT)
         instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
-                                 display_name=self.DISPLAY_NAME)
+                                  display_name=self.DISPLAY_NAME)
 
         # Create request_pb
         request_pb = data_v2_pb2.Instance(

--- a/bigtable/unit_tests/test_row.py
+++ b/bigtable/unit_tests/test_row.py
@@ -24,7 +24,7 @@ class Test_SetDeleteRow(unittest.TestCase):
         return _SetDeleteRow
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test__get_mutations_virtual(self):
         row = self._makeOne(b'row-key', None)
@@ -40,7 +40,7 @@ class TestDirectRow(unittest.TestCase):
         return DirectRow
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         row_key = b'row_key'
@@ -145,7 +145,7 @@ class TestDirectRow(unittest.TestCase):
         self.assertEqual(row._pb_mutations, [expected_pb])
 
     def test_delete_cell(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         class MockRow(klass):
 
@@ -196,7 +196,7 @@ class TestDirectRow(unittest.TestCase):
         table = object()
 
         row = self._makeOne(row_key, table)
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         self.assertEqual(row._pb_mutations, [])
         row.delete_cells(column_family_id, klass.ALL_COLUMNS)
 
@@ -384,7 +384,7 @@ class TestConditionalRow(unittest.TestCase):
         return ConditionalRow
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         row_key = b'row_key'
@@ -526,7 +526,7 @@ class TestAppendRow(unittest.TestCase):
         return AppendRow
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         row_key = b'row_key'

--- a/bigtable/unit_tests/test_row.py
+++ b/bigtable/unit_tests/test_row.py
@@ -23,11 +23,11 @@ class Test_SetDeleteRow(unittest.TestCase):
         from google.cloud.bigtable.row import _SetDeleteRow
         return _SetDeleteRow
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test__get_mutations_virtual(self):
-        row = self._makeOne(b'row-key', None)
+        row = self._make_one(b'row-key', None)
         with self.assertRaises(NotImplementedError):
             row._get_mutations(None)
 
@@ -39,14 +39,14 @@ class TestDirectRow(unittest.TestCase):
         from google.cloud.bigtable.row import DirectRow
         return DirectRow
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         row_key = b'row_key'
         table = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         self.assertEqual(row._row_key, row_key)
         self.assertIs(row._table, table)
         self.assertEqual(row._pb_mutations, [])
@@ -56,18 +56,18 @@ class TestDirectRow(unittest.TestCase):
         row_key_bytes = b'row_key'
         table = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         self.assertEqual(row._row_key, row_key_bytes)
         self.assertIs(row._table, table)
 
     def test_constructor_with_non_bytes(self):
         row_key = object()
         with self.assertRaises(TypeError):
-            self._makeOne(row_key, None)
+            self._make_one(row_key, None)
 
     def test__get_mutations(self):
         row_key = b'row_key'
-        row = self._makeOne(row_key, None)
+        row = self._make_one(row_key, None)
 
         row._pb_mutations = mutations = object()
         self.assertIs(mutations, row._get_mutations(None))
@@ -82,7 +82,7 @@ class TestDirectRow(unittest.TestCase):
         if column is None:
             column = b'column'
         table = object()
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         self.assertEqual(row._pb_mutations, [])
         row.set_cell(column_family_id, column,
                      value, timestamp=timestamp)
@@ -118,7 +118,7 @@ class TestDirectRow(unittest.TestCase):
         column_family_id = u'column_family_id'
         table = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         value = object()  # Not bytes
         with self.assertRaises(TypeError):
             row.set_cell(column_family_id, column, value)
@@ -135,7 +135,7 @@ class TestDirectRow(unittest.TestCase):
 
     def test_delete(self):
         row_key = b'row_key'
-        row = self._makeOne(row_key, object())
+        row = self._make_one(row_key, object())
         self.assertEqual(row._pb_mutations, [])
         row.delete()
 
@@ -185,7 +185,7 @@ class TestDirectRow(unittest.TestCase):
         column_family_id = u'column_family_id'
         table = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         columns = object()  # Not iterable
         with self.assertRaises(TypeError):
             row.delete_cells(column_family_id, columns)
@@ -195,7 +195,7 @@ class TestDirectRow(unittest.TestCase):
         column_family_id = u'column_family_id'
         table = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         klass = self._get_target_class()
         self.assertEqual(row._pb_mutations, [])
         row.delete_cells(column_family_id, klass.ALL_COLUMNS)
@@ -212,7 +212,7 @@ class TestDirectRow(unittest.TestCase):
         column_family_id = u'column_family_id'
         table = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         columns = []
         self.assertEqual(row._pb_mutations, [])
         row.delete_cells(column_family_id, columns)
@@ -224,7 +224,7 @@ class TestDirectRow(unittest.TestCase):
         column_family_id = u'column_family_id'
         table = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         columns = [column]
         self.assertEqual(row._pb_mutations, [])
         row.delete_cells(column_family_id, columns, time_range=time_range)
@@ -261,7 +261,7 @@ class TestDirectRow(unittest.TestCase):
         column_family_id = u'column_family_id'
         table = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         columns = [column, object()]
         self.assertEqual(row._pb_mutations, [])
         with self.assertRaises(TypeError):
@@ -277,7 +277,7 @@ class TestDirectRow(unittest.TestCase):
         column2_bytes = b'column2'
         table = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         columns = [column1, column2]
         self.assertEqual(row._pb_mutations, [])
         row.delete_cells(column_family_id, columns)
@@ -306,7 +306,7 @@ class TestDirectRow(unittest.TestCase):
         column = b'column'
         client = _Client()
         table = _Table(table_name, client=client)
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
 
         # Create request_pb
         value = b'bytes-value'
@@ -350,7 +350,7 @@ class TestDirectRow(unittest.TestCase):
 
         row_key = b'row_key'
         table = object()
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         row._pb_mutations = [1, 2, 3]
         num_mutations = len(row._pb_mutations)
         with _Monkey(MUT, MAX_MUTATIONS=num_mutations - 1):
@@ -363,7 +363,7 @@ class TestDirectRow(unittest.TestCase):
         row_key = b'row_key'
         client = _Client()
         table = _Table(None, client=client)
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         self.assertEqual(row._pb_mutations, [])
 
         # Patch the stub used by the API method.
@@ -383,7 +383,7 @@ class TestConditionalRow(unittest.TestCase):
         from google.cloud.bigtable.row import ConditionalRow
         return ConditionalRow
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
@@ -391,7 +391,7 @@ class TestConditionalRow(unittest.TestCase):
         table = object()
         filter_ = object()
 
-        row = self._makeOne(row_key, table, filter_=filter_)
+        row = self._make_one(row_key, table, filter_=filter_)
         self.assertEqual(row._row_key, row_key)
         self.assertIs(row._table, table)
         self.assertIs(row._filter, filter_)
@@ -401,7 +401,7 @@ class TestConditionalRow(unittest.TestCase):
     def test__get_mutations(self):
         row_key = b'row_key'
         filter_ = object()
-        row = self._makeOne(row_key, None, filter_=filter_)
+        row = self._make_one(row_key, None, filter_=filter_)
 
         row._true_pb_mutations = true_mutations = object()
         row._false_pb_mutations = false_mutations = object()
@@ -423,7 +423,7 @@ class TestConditionalRow(unittest.TestCase):
         client = _Client()
         table = _Table(table_name, client=client)
         row_filter = RowSampleFilter(0.33)
-        row = self._makeOne(row_key, table, filter_=row_filter)
+        row = self._make_one(row_key, table, filter_=row_filter)
 
         # Create request_pb
         value1 = b'bytes-value'
@@ -490,7 +490,7 @@ class TestConditionalRow(unittest.TestCase):
         row_key = b'row_key'
         table = object()
         filter_ = object()
-        row = self._makeOne(row_key, table, filter_=filter_)
+        row = self._make_one(row_key, table, filter_=filter_)
         row._true_pb_mutations = [1, 2, 3]
         num_mutations = len(row._true_pb_mutations)
         with _Monkey(MUT, MAX_MUTATIONS=num_mutations - 1):
@@ -504,7 +504,7 @@ class TestConditionalRow(unittest.TestCase):
         client = _Client()
         table = _Table(None, client=client)
         filter_ = object()
-        row = self._makeOne(row_key, table, filter_=filter_)
+        row = self._make_one(row_key, table, filter_=filter_)
         self.assertEqual(row._true_pb_mutations, [])
         self.assertEqual(row._false_pb_mutations, [])
 
@@ -525,14 +525,14 @@ class TestAppendRow(unittest.TestCase):
         from google.cloud.bigtable.row import AppendRow
         return AppendRow
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         row_key = b'row_key'
         table = object()
 
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         self.assertEqual(row._row_key, row_key)
         self.assertIs(row._table, table)
         self.assertEqual(row._rule_pb_list, [])
@@ -540,7 +540,7 @@ class TestAppendRow(unittest.TestCase):
     def test_clear(self):
         row_key = b'row_key'
         table = object()
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         row._rule_pb_list = [1, 2, 3]
         row.clear()
         self.assertEqual(row._rule_pb_list, [])
@@ -548,7 +548,7 @@ class TestAppendRow(unittest.TestCase):
     def test_append_cell_value(self):
         table = object()
         row_key = b'row_key'
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         self.assertEqual(row._rule_pb_list, [])
 
         column = b'column'
@@ -563,7 +563,7 @@ class TestAppendRow(unittest.TestCase):
     def test_increment_cell_value(self):
         table = object()
         row_key = b'row_key'
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         self.assertEqual(row._rule_pb_list, [])
 
         column = b'column'
@@ -586,7 +586,7 @@ class TestAppendRow(unittest.TestCase):
         column = b'column'
         client = _Client()
         table = _Table(table_name, client=client)
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
 
         # Create request_pb
         value = b'bytes-value'
@@ -637,7 +637,7 @@ class TestAppendRow(unittest.TestCase):
         row_key = b'row_key'
         client = _Client()
         table = _Table(None, client=client)
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         self.assertEqual(row._rule_pb_list, [])
 
         # Patch the stub used by the API method.
@@ -655,7 +655,7 @@ class TestAppendRow(unittest.TestCase):
 
         row_key = b'row_key'
         table = object()
-        row = self._makeOne(row_key, table)
+        row = self._make_one(row_key, table)
         row._rule_pb_list = [1, 2, 3]
         num_mutations = len(row._rule_pb_list)
         with _Monkey(MUT, MAX_MUTATIONS=num_mutations - 1):

--- a/bigtable/unit_tests/test_row.py
+++ b/bigtable/unit_tests/test_row.py
@@ -665,7 +665,7 @@ class TestAppendRow(unittest.TestCase):
 
 class Test__parse_rmw_row_response(unittest.TestCase):
 
-    def _callFUT(self, row_response):
+    def _call_fut(self, row_response):
         from google.cloud.bigtable.row import _parse_rmw_row_response
         return _parse_rmw_row_response(row_response)
 
@@ -745,12 +745,12 @@ class Test__parse_rmw_row_response(unittest.TestCase):
             ],
         )
         sample_input = _ReadModifyWriteRowResponsePB(row=response_row)
-        self.assertEqual(expected_output, self._callFUT(sample_input))
+        self.assertEqual(expected_output, self._call_fut(sample_input))
 
 
 class Test__parse_family_pb(unittest.TestCase):
 
-    def _callFUT(self, family_pb):
+    def _call_fut(self, family_pb):
         from google.cloud.bigtable.row import _parse_family_pb
         return _parse_family_pb(family_pb)
 
@@ -802,7 +802,7 @@ class Test__parse_family_pb(unittest.TestCase):
                 ),
             ],
         )
-        self.assertEqual(expected_output, self._callFUT(sample_input))
+        self.assertEqual(expected_output, self._call_fut(sample_input))
 
 
 def _CheckAndMutateRowRequestPB(*args, **kw):

--- a/bigtable/unit_tests/test_row.py
+++ b/bigtable/unit_tests/test_row.py
@@ -18,7 +18,8 @@ import unittest
 
 class Test_SetDeleteRow(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row import _SetDeleteRow
         return _SetDeleteRow
 
@@ -33,7 +34,8 @@ class Test_SetDeleteRow(unittest.TestCase):
 
 class TestDirectRow(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row import DirectRow
         return DirectRow
 
@@ -376,7 +378,8 @@ class TestDirectRow(unittest.TestCase):
 
 class TestConditionalRow(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row import ConditionalRow
         return ConditionalRow
 
@@ -517,7 +520,8 @@ class TestConditionalRow(unittest.TestCase):
 
 class TestAppendRow(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row import AppendRow
         return AppendRow
 

--- a/bigtable/unit_tests/test_row_data.py
+++ b/bigtable/unit_tests/test_row_data.py
@@ -24,7 +24,7 @@ class TestCell(unittest.TestCase):
         return Cell
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def _from_pb_test_helper(self, labels=None):
         import datetime
@@ -45,7 +45,7 @@ class TestCell(unittest.TestCase):
                 value=value, timestamp_micros=timestamp_micros, labels=labels)
             cell_expected = self._makeOne(value, timestamp, labels=labels)
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         result = klass.from_pb(cell_pb)
         self.assertEqual(result, cell_expected)
 
@@ -100,7 +100,7 @@ class TestPartialRowData(unittest.TestCase):
         return PartialRowData
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         row_key = object()
@@ -192,7 +192,7 @@ class TestPartialRowsData(unittest.TestCase):
         return PartialRowsData
 
     def _getDoNothingClass(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         class FakePartialRowsData(klass):
 
@@ -208,7 +208,7 @@ class TestPartialRowsData(unittest.TestCase):
         return FakePartialRowsData
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         response_iterator = object()
@@ -435,7 +435,7 @@ class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
         return PartialRowsData
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def _load_json_test(self, test_name):
         import os

--- a/bigtable/unit_tests/test_row_data.py
+++ b/bigtable/unit_tests/test_row_data.py
@@ -23,7 +23,7 @@ class TestCell(unittest.TestCase):
         from google.cloud.bigtable.row_data import Cell
         return Cell
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def _from_pb_test_helper(self, labels=None):
@@ -39,11 +39,11 @@ class TestCell(unittest.TestCase):
         if labels is None:
             cell_pb = data_v2_pb2.Cell(
                 value=value, timestamp_micros=timestamp_micros)
-            cell_expected = self._makeOne(value, timestamp)
+            cell_expected = self._make_one(value, timestamp)
         else:
             cell_pb = data_v2_pb2.Cell(
                 value=value, timestamp_micros=timestamp_micros, labels=labels)
-            cell_expected = self._makeOne(value, timestamp, labels=labels)
+            cell_expected = self._make_one(value, timestamp, labels=labels)
 
         klass = self._get_target_class()
         result = klass.from_pb(cell_pb)
@@ -59,27 +59,27 @@ class TestCell(unittest.TestCase):
     def test_constructor(self):
         value = object()
         timestamp = object()
-        cell = self._makeOne(value, timestamp)
+        cell = self._make_one(value, timestamp)
         self.assertEqual(cell.value, value)
         self.assertEqual(cell.timestamp, timestamp)
 
     def test___eq__(self):
         value = object()
         timestamp = object()
-        cell1 = self._makeOne(value, timestamp)
-        cell2 = self._makeOne(value, timestamp)
+        cell1 = self._make_one(value, timestamp)
+        cell2 = self._make_one(value, timestamp)
         self.assertEqual(cell1, cell2)
 
     def test___eq__type_differ(self):
-        cell1 = self._makeOne(None, None)
+        cell1 = self._make_one(None, None)
         cell2 = object()
         self.assertNotEqual(cell1, cell2)
 
     def test___ne__same_value(self):
         value = object()
         timestamp = object()
-        cell1 = self._makeOne(value, timestamp)
-        cell2 = self._makeOne(value, timestamp)
+        cell1 = self._make_one(value, timestamp)
+        cell2 = self._make_one(value, timestamp)
         comparison_val = (cell1 != cell2)
         self.assertFalse(comparison_val)
 
@@ -87,8 +87,8 @@ class TestCell(unittest.TestCase):
         value1 = 'value1'
         value2 = 'value2'
         timestamp = object()
-        cell1 = self._makeOne(value1, timestamp)
-        cell2 = self._makeOne(value2, timestamp)
+        cell1 = self._make_one(value1, timestamp)
+        cell2 = self._make_one(value2, timestamp)
         self.assertNotEqual(cell1, cell2)
 
 
@@ -99,45 +99,45 @@ class TestPartialRowData(unittest.TestCase):
         from google.cloud.bigtable.row_data import PartialRowData
         return PartialRowData
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         row_key = object()
-        partial_row_data = self._makeOne(row_key)
+        partial_row_data = self._make_one(row_key)
         self.assertIs(partial_row_data._row_key, row_key)
         self.assertEqual(partial_row_data._cells, {})
 
     def test___eq__(self):
         row_key = object()
-        partial_row_data1 = self._makeOne(row_key)
-        partial_row_data2 = self._makeOne(row_key)
+        partial_row_data1 = self._make_one(row_key)
+        partial_row_data2 = self._make_one(row_key)
         self.assertEqual(partial_row_data1, partial_row_data2)
 
     def test___eq__type_differ(self):
-        partial_row_data1 = self._makeOne(None)
+        partial_row_data1 = self._make_one(None)
         partial_row_data2 = object()
         self.assertNotEqual(partial_row_data1, partial_row_data2)
 
     def test___ne__same_value(self):
         row_key = object()
-        partial_row_data1 = self._makeOne(row_key)
-        partial_row_data2 = self._makeOne(row_key)
+        partial_row_data1 = self._make_one(row_key)
+        partial_row_data2 = self._make_one(row_key)
         comparison_val = (partial_row_data1 != partial_row_data2)
         self.assertFalse(comparison_val)
 
     def test___ne__(self):
         row_key1 = object()
-        partial_row_data1 = self._makeOne(row_key1)
+        partial_row_data1 = self._make_one(row_key1)
         row_key2 = object()
-        partial_row_data2 = self._makeOne(row_key2)
+        partial_row_data2 = self._make_one(row_key2)
         self.assertNotEqual(partial_row_data1, partial_row_data2)
 
     def test___ne__cells(self):
         row_key = object()
-        partial_row_data1 = self._makeOne(row_key)
+        partial_row_data1 = self._make_one(row_key)
         partial_row_data1._cells = object()
-        partial_row_data2 = self._makeOne(row_key)
+        partial_row_data2 = self._make_one(row_key)
         self.assertNotEqual(partial_row_data1, partial_row_data2)
 
     def test_to_dict(self):
@@ -151,7 +151,7 @@ class TestPartialRowData(unittest.TestCase):
         qual2 = b'col2'
         qual3 = b'col3'
 
-        partial_row_data = self._makeOne(None)
+        partial_row_data = self._make_one(None)
         partial_row_data._cells = {
             family_name1: {
                 qual1: cell1,
@@ -171,7 +171,7 @@ class TestPartialRowData(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_cells_property(self):
-        partial_row_data = self._makeOne(None)
+        partial_row_data = self._make_one(None)
         cells = {1: 2}
         partial_row_data._cells = cells
         # Make sure we get a copy, not the original.
@@ -180,7 +180,7 @@ class TestPartialRowData(unittest.TestCase):
 
     def test_row_key_getter(self):
         row_key = object()
-        partial_row_data = self._makeOne(row_key)
+        partial_row_data = self._make_one(row_key)
         self.assertIs(partial_row_data.row_key, row_key)
 
 
@@ -207,59 +207,59 @@ class TestPartialRowsData(unittest.TestCase):
 
         return FakePartialRowsData
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         response_iterator = object()
-        partial_rows_data = self._makeOne(response_iterator)
+        partial_rows_data = self._make_one(response_iterator)
         self.assertIs(partial_rows_data._response_iterator,
                       response_iterator)
         self.assertEqual(partial_rows_data._rows, {})
 
     def test___eq__(self):
         response_iterator = object()
-        partial_rows_data1 = self._makeOne(response_iterator)
-        partial_rows_data2 = self._makeOne(response_iterator)
+        partial_rows_data1 = self._make_one(response_iterator)
+        partial_rows_data2 = self._make_one(response_iterator)
         self.assertEqual(partial_rows_data1, partial_rows_data2)
 
     def test___eq__type_differ(self):
-        partial_rows_data1 = self._makeOne(None)
+        partial_rows_data1 = self._make_one(None)
         partial_rows_data2 = object()
         self.assertNotEqual(partial_rows_data1, partial_rows_data2)
 
     def test___ne__same_value(self):
         response_iterator = object()
-        partial_rows_data1 = self._makeOne(response_iterator)
-        partial_rows_data2 = self._makeOne(response_iterator)
+        partial_rows_data1 = self._make_one(response_iterator)
+        partial_rows_data2 = self._make_one(response_iterator)
         comparison_val = (partial_rows_data1 != partial_rows_data2)
         self.assertFalse(comparison_val)
 
     def test___ne__(self):
         response_iterator1 = object()
-        partial_rows_data1 = self._makeOne(response_iterator1)
+        partial_rows_data1 = self._make_one(response_iterator1)
         response_iterator2 = object()
-        partial_rows_data2 = self._makeOne(response_iterator2)
+        partial_rows_data2 = self._make_one(response_iterator2)
         self.assertNotEqual(partial_rows_data1, partial_rows_data2)
 
     def test_state_start(self):
-        prd = self._makeOne([])
+        prd = self._make_one([])
         self.assertEqual(prd.state, prd.START)
 
     def test_state_new_row_w_row(self):
-        prd = self._makeOne([])
+        prd = self._make_one([])
         prd._last_scanned_row_key = ''
         prd._row = object()
         self.assertEqual(prd.state, prd.NEW_ROW)
 
     def test_rows_getter(self):
-        partial_rows_data = self._makeOne(None)
+        partial_rows_data = self._make_one(None)
         partial_rows_data._rows = value = object()
         self.assertIs(partial_rows_data.rows, value)
 
     def test_cancel(self):
         response_iterator = _MockCancellableIterator()
-        partial_rows_data = self._makeOne(response_iterator)
+        partial_rows_data = self._make_one(response_iterator)
         self.assertEqual(response_iterator.cancel_calls, 0)
         partial_rows_data.cancel()
         self.assertEqual(response_iterator.cancel_calls, 1)
@@ -291,7 +291,7 @@ class TestPartialRowsData(unittest.TestCase):
             list(response_iterator.iter_values), [value2, value3])
 
     def test__copy_from_current_unset(self):
-        prd = self._makeOne([])
+        prd = self._make_one([])
         chunks = _generate_cell_chunks([''])
         chunk = chunks[0]
         prd._copy_from_current(chunk)
@@ -307,7 +307,7 @@ class TestPartialRowsData(unittest.TestCase):
         QUALIFIER = b'C'
         TIMESTAMP_MICROS = 100
         LABELS = ['L1', 'L2']
-        prd = self._makeOne([])
+        prd = self._make_one([])
         prd._cell = _PartialCellData()
         chunks = _generate_cell_chunks([''])
         chunk = chunks[0]
@@ -324,7 +324,7 @@ class TestPartialRowsData(unittest.TestCase):
         self.assertEqual(chunk.labels, LABELS)
 
     def test__copy_from_previous_unset(self):
-        prd = self._makeOne([])
+        prd = self._make_one([])
         cell = _PartialCellData()
         prd._copy_from_previous(cell)
         self.assertEqual(cell.row_key, '')
@@ -339,7 +339,7 @@ class TestPartialRowsData(unittest.TestCase):
         QUALIFIER = b'C'
         TIMESTAMP_MICROS = 100
         LABELS = ['L1', 'L2']
-        prd = self._makeOne([])
+        prd = self._make_one([])
         cell = _PartialCellData(
             row_key=ROW_KEY,
             family_name=FAMILY_NAME,
@@ -361,7 +361,7 @@ class TestPartialRowsData(unittest.TestCase):
         QUALIFIER = b'C'
         TIMESTAMP_MICROS = 100
         LABELS = ['L1', 'L2']
-        prd = self._makeOne([])
+        prd = self._make_one([])
         prd._previous_cell = _PartialCellData(
             row_key=ROW_KEY,
             family_name=FAMILY_NAME,
@@ -379,7 +379,7 @@ class TestPartialRowsData(unittest.TestCase):
 
     def test__save_row_no_cell(self):
         ROW_KEY = 'RK'
-        prd = self._makeOne([])
+        prd = self._make_one([])
         row = prd._row = _Dummy(row_key=ROW_KEY)
         prd._cell = None
         prd._save_current_row()
@@ -389,7 +389,7 @@ class TestPartialRowsData(unittest.TestCase):
         from google.cloud.bigtable.row_data import InvalidReadRowsResponse
         response = _ReadRowsResponseV2(chunks=(), last_scanned_row_key='ABC')
         iterator = _MockCancellableIterator(response)
-        prd = self._makeOne(iterator)
+        prd = self._make_one(iterator)
         with self.assertRaises(InvalidReadRowsResponse):
             prd.consume_next()
 
@@ -397,7 +397,7 @@ class TestPartialRowsData(unittest.TestCase):
         response = _ReadRowsResponseV2(
             chunks=(), last_scanned_row_key='AFTER')
         iterator = _MockCancellableIterator(response)
-        prd = self._makeOne(iterator)
+        prd = self._make_one(iterator)
         prd._last_scanned_row_key = 'BEFORE'
         prd.consume_next()
         self.assertEqual(prd._last_scanned_row_key, 'AFTER')
@@ -407,7 +407,7 @@ class TestPartialRowsData(unittest.TestCase):
         chunks = _generate_cell_chunks([''])
         response = _ReadRowsResponseV2(chunks)
         iterator = _MockCancellableIterator(response)
-        prd = self._makeOne(iterator)
+        prd = self._make_one(iterator)
         with self.assertRaises(InvalidChunk):
             prd.consume_next()
 
@@ -420,7 +420,7 @@ class TestPartialRowsData(unittest.TestCase):
         first.qualifier.value = b'C'
         response = _ReadRowsResponseV2(chunks)
         iterator = _MockCancellableIterator(response)
-        prd = self._makeOne(iterator)
+        prd = self._make_one(iterator)
         with self.assertRaises(InvalidChunk):
             prd.consume_next()
 
@@ -434,7 +434,7 @@ class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
         from google.cloud.bigtable.row_data import PartialRowsData
         return PartialRowsData
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def _load_json_test(self, test_name):
@@ -455,7 +455,7 @@ class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
         chunks, results = self._load_json_test(testcase_name)
         response = _ReadRowsResponseV2(chunks)
         iterator = _MockCancellableIterator(response)
-        prd = self._makeOne(iterator)
+        prd = self._make_one(iterator)
         with self.assertRaises(InvalidChunk):
             prd.consume_next()
         expected_result = self._sort_flattend_cells(
@@ -511,7 +511,7 @@ class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
         chunks, results = self._load_json_test(testcase_name)
         response = _ReadRowsResponseV2(chunks)
         iterator = _MockCancellableIterator(response)
-        prd = self._makeOne(iterator)
+        prd = self._make_one(iterator)
         prd.consume_next()
         self.assertEqual(prd.state, prd.ROW_IN_PROGRESS)
         expected_result = self._sort_flattend_cells(
@@ -533,7 +533,7 @@ class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
         chunks, results = self._load_json_test(testcase_name)
         response = _ReadRowsResponseV2(chunks)
         iterator = _MockCancellableIterator(response)
-        prd = self._makeOne(iterator)
+        prd = self._make_one(iterator)
         prd.consume_next()
         flattened = self._sort_flattend_cells(_flatten_cells(prd))
         if expected_result is self._marker:

--- a/bigtable/unit_tests/test_row_data.py
+++ b/bigtable/unit_tests/test_row_data.py
@@ -18,7 +18,8 @@ import unittest
 
 class TestCell(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_data import Cell
         return Cell
 
@@ -93,7 +94,8 @@ class TestCell(unittest.TestCase):
 
 class TestPartialRowData(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_data import PartialRowData
         return PartialRowData
 
@@ -184,7 +186,8 @@ class TestPartialRowData(unittest.TestCase):
 
 class TestPartialRowsData(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_data import PartialRowsData
         return PartialRowsData
 
@@ -426,7 +429,8 @@ class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
 
     _json_tests = None
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_data import PartialRowsData
         return PartialRowsData
 

--- a/bigtable/unit_tests/test_row_filters.py
+++ b/bigtable/unit_tests/test_row_filters.py
@@ -23,30 +23,30 @@ class Test_BoolFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import _BoolFilter
         return _BoolFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         flag = object()
-        row_filter = self._makeOne(flag)
+        row_filter = self._make_one(flag)
         self.assertIs(row_filter.flag, flag)
 
     def test___eq__type_differ(self):
         flag = object()
-        row_filter1 = self._makeOne(flag)
+        row_filter1 = self._make_one(flag)
         row_filter2 = object()
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test___eq__same_value(self):
         flag = object()
-        row_filter1 = self._makeOne(flag)
-        row_filter2 = self._makeOne(flag)
+        row_filter1 = self._make_one(flag)
+        row_filter2 = self._make_one(flag)
         self.assertEqual(row_filter1, row_filter2)
 
     def test___ne__same_value(self):
         flag = object()
-        row_filter1 = self._makeOne(flag)
-        row_filter2 = self._makeOne(flag)
+        row_filter1 = self._make_one(flag)
+        row_filter2 = self._make_one(flag)
         comparison_val = (row_filter1 != row_filter2)
         self.assertFalse(comparison_val)
 
@@ -58,12 +58,12 @@ class TestSinkFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import SinkFilter
         return SinkFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         flag = True
-        row_filter = self._makeOne(flag)
+        row_filter = self._make_one(flag)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(sink=flag)
         self.assertEqual(pb_val, expected_pb)
@@ -76,12 +76,12 @@ class TestPassAllFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import PassAllFilter
         return PassAllFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         flag = True
-        row_filter = self._makeOne(flag)
+        row_filter = self._make_one(flag)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(pass_all_filter=flag)
         self.assertEqual(pb_val, expected_pb)
@@ -94,12 +94,12 @@ class TestBlockAllFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import BlockAllFilter
         return BlockAllFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         flag = True
-        row_filter = self._makeOne(flag)
+        row_filter = self._make_one(flag)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(block_all_filter=flag)
         self.assertEqual(pb_val, expected_pb)
@@ -112,35 +112,35 @@ class Test_RegexFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import _RegexFilter
         return _RegexFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         regex = b'abc'
-        row_filter = self._makeOne(regex)
+        row_filter = self._make_one(regex)
         self.assertIs(row_filter.regex, regex)
 
     def test_constructor_non_bytes(self):
         regex = u'abc'
-        row_filter = self._makeOne(regex)
+        row_filter = self._make_one(regex)
         self.assertEqual(row_filter.regex, b'abc')
 
     def test___eq__type_differ(self):
         regex = b'def-rgx'
-        row_filter1 = self._makeOne(regex)
+        row_filter1 = self._make_one(regex)
         row_filter2 = object()
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test___eq__same_value(self):
         regex = b'trex-regex'
-        row_filter1 = self._makeOne(regex)
-        row_filter2 = self._makeOne(regex)
+        row_filter1 = self._make_one(regex)
+        row_filter2 = self._make_one(regex)
         self.assertEqual(row_filter1, row_filter2)
 
     def test___ne__same_value(self):
         regex = b'abc'
-        row_filter1 = self._makeOne(regex)
-        row_filter2 = self._makeOne(regex)
+        row_filter1 = self._make_one(regex)
+        row_filter2 = self._make_one(regex)
         comparison_val = (row_filter1 != row_filter2)
         self.assertFalse(comparison_val)
 
@@ -152,12 +152,12 @@ class TestRowKeyRegexFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import RowKeyRegexFilter
         return RowKeyRegexFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         regex = b'row-key-regex'
-        row_filter = self._makeOne(regex)
+        row_filter = self._make_one(regex)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(row_key_regex_filter=regex)
         self.assertEqual(pb_val, expected_pb)
@@ -170,29 +170,29 @@ class TestRowSampleFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import RowSampleFilter
         return RowSampleFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         sample = object()
-        row_filter = self._makeOne(sample)
+        row_filter = self._make_one(sample)
         self.assertIs(row_filter.sample, sample)
 
     def test___eq__type_differ(self):
         sample = object()
-        row_filter1 = self._makeOne(sample)
+        row_filter1 = self._make_one(sample)
         row_filter2 = object()
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test___eq__same_value(self):
         sample = object()
-        row_filter1 = self._makeOne(sample)
-        row_filter2 = self._makeOne(sample)
+        row_filter1 = self._make_one(sample)
+        row_filter2 = self._make_one(sample)
         self.assertEqual(row_filter1, row_filter2)
 
     def test_to_pb(self):
         sample = 0.25
-        row_filter = self._makeOne(sample)
+        row_filter = self._make_one(sample)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(row_sample_filter=sample)
         self.assertEqual(pb_val, expected_pb)
@@ -205,12 +205,12 @@ class TestFamilyNameRegexFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import FamilyNameRegexFilter
         return FamilyNameRegexFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         regex = u'family-regex'
-        row_filter = self._makeOne(regex)
+        row_filter = self._make_one(regex)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(family_name_regex_filter=regex)
         self.assertEqual(pb_val, expected_pb)
@@ -224,12 +224,12 @@ class TestColumnQualifierRegexFilter(unittest.TestCase):
             ColumnQualifierRegexFilter)
         return ColumnQualifierRegexFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         regex = b'column-regex'
-        row_filter = self._makeOne(regex)
+        row_filter = self._make_one(regex)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(
             column_qualifier_regex_filter=regex)
@@ -243,35 +243,35 @@ class TestTimestampRange(unittest.TestCase):
         from google.cloud.bigtable.row_filters import TimestampRange
         return TimestampRange
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         start = object()
         end = object()
-        time_range = self._makeOne(start=start, end=end)
+        time_range = self._make_one(start=start, end=end)
         self.assertIs(time_range.start, start)
         self.assertIs(time_range.end, end)
 
     def test___eq__(self):
         start = object()
         end = object()
-        time_range1 = self._makeOne(start=start, end=end)
-        time_range2 = self._makeOne(start=start, end=end)
+        time_range1 = self._make_one(start=start, end=end)
+        time_range2 = self._make_one(start=start, end=end)
         self.assertEqual(time_range1, time_range2)
 
     def test___eq__type_differ(self):
         start = object()
         end = object()
-        time_range1 = self._makeOne(start=start, end=end)
+        time_range1 = self._make_one(start=start, end=end)
         time_range2 = object()
         self.assertNotEqual(time_range1, time_range2)
 
     def test___ne__same_value(self):
         start = object()
         end = object()
-        time_range1 = self._makeOne(start=start, end=end)
-        time_range2 = self._makeOne(start=start, end=end)
+        time_range1 = self._make_one(start=start, end=end)
+        time_range2 = self._make_one(start=start, end=end)
         comparison_val = (time_range1 != time_range2)
         self.assertFalse(comparison_val)
 
@@ -288,7 +288,7 @@ class TestTimestampRange(unittest.TestCase):
         if end_micros is not None:
             end = _EPOCH + datetime.timedelta(microseconds=end_micros)
             pb_kwargs['end_timestamp_micros'] = end_micros
-        time_range = self._makeOne(start=start, end=end)
+        time_range = self._make_one(start=start, end=end)
 
         expected_pb = _TimestampRangePB(**pb_kwargs)
         self.assertEqual(time_range.to_pb(), expected_pb)
@@ -318,31 +318,31 @@ class TestTimestampRangeFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import TimestampRangeFilter
         return TimestampRangeFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         range_ = object()
-        row_filter = self._makeOne(range_)
+        row_filter = self._make_one(range_)
         self.assertIs(row_filter.range_, range_)
 
     def test___eq__type_differ(self):
         range_ = object()
-        row_filter1 = self._makeOne(range_)
+        row_filter1 = self._make_one(range_)
         row_filter2 = object()
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test___eq__same_value(self):
         range_ = object()
-        row_filter1 = self._makeOne(range_)
-        row_filter2 = self._makeOne(range_)
+        row_filter1 = self._make_one(range_)
+        row_filter2 = self._make_one(range_)
         self.assertEqual(row_filter1, row_filter2)
 
     def test_to_pb(self):
         from google.cloud.bigtable.row_filters import TimestampRange
 
         range_ = TimestampRange()
-        row_filter = self._makeOne(range_)
+        row_filter = self._make_one(range_)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(
             timestamp_range_filter=_TimestampRangePB())
@@ -356,12 +356,12 @@ class TestColumnRangeFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import ColumnRangeFilter
         return ColumnRangeFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
         column_family_id = object()
-        row_filter = self._makeOne(column_family_id)
+        row_filter = self._make_one(column_family_id)
         self.assertIs(row_filter.column_family_id, column_family_id)
         self.assertIsNone(row_filter.start_column)
         self.assertIsNone(row_filter.end_column)
@@ -374,7 +374,7 @@ class TestColumnRangeFilter(unittest.TestCase):
         end_column = object()
         inclusive_start = object()
         inclusive_end = object()
-        row_filter = self._makeOne(
+        row_filter = self._make_one(
             column_family_id,
             start_column=start_column,
             end_column=end_column,
@@ -388,12 +388,12 @@ class TestColumnRangeFilter(unittest.TestCase):
 
     def test_constructor_bad_start(self):
         column_family_id = object()
-        self.assertRaises(ValueError, self._makeOne,
+        self.assertRaises(ValueError, self._make_one,
                           column_family_id, inclusive_start=True)
 
     def test_constructor_bad_end(self):
         column_family_id = object()
-        self.assertRaises(ValueError, self._makeOne,
+        self.assertRaises(ValueError, self._make_one,
                           column_family_id, inclusive_end=True)
 
     def test___eq__(self):
@@ -402,12 +402,12 @@ class TestColumnRangeFilter(unittest.TestCase):
         end_column = object()
         inclusive_start = object()
         inclusive_end = object()
-        row_filter1 = self._makeOne(column_family_id,
+        row_filter1 = self._make_one(column_family_id,
                                     start_column=start_column,
                                     end_column=end_column,
                                     inclusive_start=inclusive_start,
                                     inclusive_end=inclusive_end)
-        row_filter2 = self._makeOne(column_family_id,
+        row_filter2 = self._make_one(column_family_id,
                                     start_column=start_column,
                                     end_column=end_column,
                                     inclusive_start=inclusive_start,
@@ -416,13 +416,13 @@ class TestColumnRangeFilter(unittest.TestCase):
 
     def test___eq__type_differ(self):
         column_family_id = object()
-        row_filter1 = self._makeOne(column_family_id)
+        row_filter1 = self._make_one(column_family_id)
         row_filter2 = object()
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test_to_pb(self):
         column_family_id = u'column-family-id'
-        row_filter = self._makeOne(column_family_id)
+        row_filter = self._make_one(column_family_id)
         col_range_pb = _ColumnRangePB(family_name=column_family_id)
         expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
@@ -430,7 +430,7 @@ class TestColumnRangeFilter(unittest.TestCase):
     def test_to_pb_inclusive_start(self):
         column_family_id = u'column-family-id'
         column = b'column'
-        row_filter = self._makeOne(column_family_id, start_column=column)
+        row_filter = self._make_one(column_family_id, start_column=column)
         col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
             start_qualifier_closed=column,
@@ -441,7 +441,7 @@ class TestColumnRangeFilter(unittest.TestCase):
     def test_to_pb_exclusive_start(self):
         column_family_id = u'column-family-id'
         column = b'column'
-        row_filter = self._makeOne(column_family_id, start_column=column,
+        row_filter = self._make_one(column_family_id, start_column=column,
                                    inclusive_start=False)
         col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
@@ -453,7 +453,7 @@ class TestColumnRangeFilter(unittest.TestCase):
     def test_to_pb_inclusive_end(self):
         column_family_id = u'column-family-id'
         column = b'column'
-        row_filter = self._makeOne(column_family_id, end_column=column)
+        row_filter = self._make_one(column_family_id, end_column=column)
         col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
             end_qualifier_closed=column,
@@ -464,7 +464,7 @@ class TestColumnRangeFilter(unittest.TestCase):
     def test_to_pb_exclusive_end(self):
         column_family_id = u'column-family-id'
         column = b'column'
-        row_filter = self._makeOne(column_family_id, end_column=column,
+        row_filter = self._make_one(column_family_id, end_column=column,
                                    inclusive_end=False)
         col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
@@ -481,12 +481,12 @@ class TestValueRegexFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import ValueRegexFilter
         return ValueRegexFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         regex = b'value-regex'
-        row_filter = self._makeOne(regex)
+        row_filter = self._make_one(regex)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(value_regex_filter=regex)
         self.assertEqual(pb_val, expected_pb)
@@ -499,11 +499,11 @@ class TestValueRangeFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import ValueRangeFilter
         return ValueRangeFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
-        row_filter = self._makeOne()
+        row_filter = self._make_one()
         self.assertIsNone(row_filter.start_value)
         self.assertIsNone(row_filter.end_value)
         self.assertTrue(row_filter.inclusive_start)
@@ -514,7 +514,7 @@ class TestValueRangeFilter(unittest.TestCase):
         end_value = object()
         inclusive_start = object()
         inclusive_end = object()
-        row_filter = self._makeOne(start_value=start_value,
+        row_filter = self._make_one(start_value=start_value,
                                    end_value=end_value,
                                    inclusive_start=inclusive_start,
                                    inclusive_end=inclusive_end)
@@ -524,61 +524,61 @@ class TestValueRangeFilter(unittest.TestCase):
         self.assertIs(row_filter.inclusive_end, inclusive_end)
 
     def test_constructor_bad_start(self):
-        self.assertRaises(ValueError, self._makeOne, inclusive_start=True)
+        self.assertRaises(ValueError, self._make_one, inclusive_start=True)
 
     def test_constructor_bad_end(self):
-        self.assertRaises(ValueError, self._makeOne, inclusive_end=True)
+        self.assertRaises(ValueError, self._make_one, inclusive_end=True)
 
     def test___eq__(self):
         start_value = object()
         end_value = object()
         inclusive_start = object()
         inclusive_end = object()
-        row_filter1 = self._makeOne(start_value=start_value,
+        row_filter1 = self._make_one(start_value=start_value,
                                     end_value=end_value,
                                     inclusive_start=inclusive_start,
                                     inclusive_end=inclusive_end)
-        row_filter2 = self._makeOne(start_value=start_value,
+        row_filter2 = self._make_one(start_value=start_value,
                                     end_value=end_value,
                                     inclusive_start=inclusive_start,
                                     inclusive_end=inclusive_end)
         self.assertEqual(row_filter1, row_filter2)
 
     def test___eq__type_differ(self):
-        row_filter1 = self._makeOne()
+        row_filter1 = self._make_one()
         row_filter2 = object()
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test_to_pb(self):
-        row_filter = self._makeOne()
+        row_filter = self._make_one()
         expected_pb = _RowFilterPB(
             value_range_filter=_ValueRangePB())
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_inclusive_start(self):
         value = b'some-value'
-        row_filter = self._makeOne(start_value=value)
+        row_filter = self._make_one(start_value=value)
         val_range_pb = _ValueRangePB(start_value_closed=value)
         expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_exclusive_start(self):
         value = b'some-value'
-        row_filter = self._makeOne(start_value=value, inclusive_start=False)
+        row_filter = self._make_one(start_value=value, inclusive_start=False)
         val_range_pb = _ValueRangePB(start_value_open=value)
         expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_inclusive_end(self):
         value = b'some-value'
-        row_filter = self._makeOne(end_value=value)
+        row_filter = self._make_one(end_value=value)
         val_range_pb = _ValueRangePB(end_value_closed=value)
         expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
 
     def test_to_pb_exclusive_end(self):
         value = b'some-value'
-        row_filter = self._makeOne(end_value=value, inclusive_end=False)
+        row_filter = self._make_one(end_value=value, inclusive_end=False)
         val_range_pb = _ValueRangePB(end_value_open=value)
         expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
         self.assertEqual(row_filter.to_pb(), expected_pb)
@@ -591,30 +591,30 @@ class Test_CellCountFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import _CellCountFilter
         return _CellCountFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         num_cells = object()
-        row_filter = self._makeOne(num_cells)
+        row_filter = self._make_one(num_cells)
         self.assertIs(row_filter.num_cells, num_cells)
 
     def test___eq__type_differ(self):
         num_cells = object()
-        row_filter1 = self._makeOne(num_cells)
+        row_filter1 = self._make_one(num_cells)
         row_filter2 = object()
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test___eq__same_value(self):
         num_cells = object()
-        row_filter1 = self._makeOne(num_cells)
-        row_filter2 = self._makeOne(num_cells)
+        row_filter1 = self._make_one(num_cells)
+        row_filter2 = self._make_one(num_cells)
         self.assertEqual(row_filter1, row_filter2)
 
     def test___ne__same_value(self):
         num_cells = object()
-        row_filter1 = self._makeOne(num_cells)
-        row_filter2 = self._makeOne(num_cells)
+        row_filter1 = self._make_one(num_cells)
+        row_filter2 = self._make_one(num_cells)
         comparison_val = (row_filter1 != row_filter2)
         self.assertFalse(comparison_val)
 
@@ -626,12 +626,12 @@ class TestCellsRowOffsetFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import CellsRowOffsetFilter
         return CellsRowOffsetFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         num_cells = 76
-        row_filter = self._makeOne(num_cells)
+        row_filter = self._make_one(num_cells)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(
             cells_per_row_offset_filter=num_cells)
@@ -645,12 +645,12 @@ class TestCellsRowLimitFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import CellsRowLimitFilter
         return CellsRowLimitFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         num_cells = 189
-        row_filter = self._makeOne(num_cells)
+        row_filter = self._make_one(num_cells)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(
             cells_per_row_limit_filter=num_cells)
@@ -664,12 +664,12 @@ class TestCellsColumnLimitFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import CellsColumnLimitFilter
         return CellsColumnLimitFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         num_cells = 10
-        row_filter = self._makeOne(num_cells)
+        row_filter = self._make_one(num_cells)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(
             cells_per_column_limit_filter=num_cells)
@@ -684,12 +684,12 @@ class TestStripValueTransformerFilter(unittest.TestCase):
             StripValueTransformerFilter)
         return StripValueTransformerFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         flag = True
-        row_filter = self._makeOne(flag)
+        row_filter = self._make_one(flag)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(strip_value_transformer=flag)
         self.assertEqual(pb_val, expected_pb)
@@ -702,29 +702,29 @@ class TestApplyLabelFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import ApplyLabelFilter
         return ApplyLabelFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         label = object()
-        row_filter = self._makeOne(label)
+        row_filter = self._make_one(label)
         self.assertIs(row_filter.label, label)
 
     def test___eq__type_differ(self):
         label = object()
-        row_filter1 = self._makeOne(label)
+        row_filter1 = self._make_one(label)
         row_filter2 = object()
         self.assertNotEqual(row_filter1, row_filter2)
 
     def test___eq__same_value(self):
         label = object()
-        row_filter1 = self._makeOne(label)
-        row_filter2 = self._makeOne(label)
+        row_filter1 = self._make_one(label)
+        row_filter2 = self._make_one(label)
         self.assertEqual(row_filter1, row_filter2)
 
     def test_to_pb(self):
         label = u'label'
-        row_filter = self._makeOne(label)
+        row_filter = self._make_one(label)
         pb_val = row_filter.to_pb()
         expected_pb = _RowFilterPB(apply_label_transformer=label)
         self.assertEqual(pb_val, expected_pb)
@@ -737,27 +737,27 @@ class Test_FilterCombination(unittest.TestCase):
         from google.cloud.bigtable.row_filters import _FilterCombination
         return _FilterCombination
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
-        row_filter = self._makeOne()
+        row_filter = self._make_one()
         self.assertEqual(row_filter.filters, [])
 
     def test_constructor_explicit(self):
         filters = object()
-        row_filter = self._makeOne(filters=filters)
+        row_filter = self._make_one(filters=filters)
         self.assertIs(row_filter.filters, filters)
 
     def test___eq__(self):
         filters = object()
-        row_filter1 = self._makeOne(filters=filters)
-        row_filter2 = self._makeOne(filters=filters)
+        row_filter1 = self._make_one(filters=filters)
+        row_filter2 = self._make_one(filters=filters)
         self.assertEqual(row_filter1, row_filter2)
 
     def test___eq__type_differ(self):
         filters = object()
-        row_filter1 = self._makeOne(filters=filters)
+        row_filter1 = self._make_one(filters=filters)
         row_filter2 = object()
         self.assertNotEqual(row_filter1, row_filter2)
 
@@ -769,7 +769,7 @@ class TestRowFilterChain(unittest.TestCase):
         from google.cloud.bigtable.row_filters import RowFilterChain
         return RowFilterChain
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
@@ -783,7 +783,7 @@ class TestRowFilterChain(unittest.TestCase):
         row_filter2 = RowSampleFilter(0.25)
         row_filter2_pb = row_filter2.to_pb()
 
-        row_filter3 = self._makeOne(filters=[row_filter1, row_filter2])
+        row_filter3 = self._make_one(filters=[row_filter1, row_filter2])
         filter_pb = row_filter3.to_pb()
 
         expected_pb = _RowFilterPB(
@@ -802,13 +802,13 @@ class TestRowFilterChain(unittest.TestCase):
         row_filter1 = StripValueTransformerFilter(True)
         row_filter2 = RowSampleFilter(0.25)
 
-        row_filter3 = self._makeOne(filters=[row_filter1, row_filter2])
+        row_filter3 = self._make_one(filters=[row_filter1, row_filter2])
         row_filter3_pb = row_filter3.to_pb()
 
         row_filter4 = CellsRowLimitFilter(11)
         row_filter4_pb = row_filter4.to_pb()
 
-        row_filter5 = self._makeOne(filters=[row_filter3, row_filter4])
+        row_filter5 = self._make_one(filters=[row_filter3, row_filter4])
         filter_pb = row_filter5.to_pb()
 
         expected_pb = _RowFilterPB(
@@ -826,7 +826,7 @@ class TestRowFilterUnion(unittest.TestCase):
         from google.cloud.bigtable.row_filters import RowFilterUnion
         return RowFilterUnion
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
@@ -840,7 +840,7 @@ class TestRowFilterUnion(unittest.TestCase):
         row_filter2 = RowSampleFilter(0.25)
         row_filter2_pb = row_filter2.to_pb()
 
-        row_filter3 = self._makeOne(filters=[row_filter1, row_filter2])
+        row_filter3 = self._make_one(filters=[row_filter1, row_filter2])
         filter_pb = row_filter3.to_pb()
 
         expected_pb = _RowFilterPB(
@@ -859,13 +859,13 @@ class TestRowFilterUnion(unittest.TestCase):
         row_filter1 = StripValueTransformerFilter(True)
         row_filter2 = RowSampleFilter(0.25)
 
-        row_filter3 = self._makeOne(filters=[row_filter1, row_filter2])
+        row_filter3 = self._make_one(filters=[row_filter1, row_filter2])
         row_filter3_pb = row_filter3.to_pb()
 
         row_filter4 = CellsRowLimitFilter(11)
         row_filter4_pb = row_filter4.to_pb()
 
-        row_filter5 = self._makeOne(filters=[row_filter3, row_filter4])
+        row_filter5 = self._make_one(filters=[row_filter3, row_filter4])
         filter_pb = row_filter5.to_pb()
 
         expected_pb = _RowFilterPB(
@@ -883,14 +883,14 @@ class TestConditionalRowFilter(unittest.TestCase):
         from google.cloud.bigtable.row_filters import ConditionalRowFilter
         return ConditionalRowFilter
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         base_filter = object()
         true_filter = object()
         false_filter = object()
-        cond_filter = self._makeOne(base_filter,
+        cond_filter = self._make_one(base_filter,
                                     true_filter=true_filter,
                                     false_filter=false_filter)
         self.assertIs(cond_filter.base_filter, base_filter)
@@ -901,10 +901,10 @@ class TestConditionalRowFilter(unittest.TestCase):
         base_filter = object()
         true_filter = object()
         false_filter = object()
-        cond_filter1 = self._makeOne(base_filter,
+        cond_filter1 = self._make_one(base_filter,
                                      true_filter=true_filter,
                                      false_filter=false_filter)
-        cond_filter2 = self._makeOne(base_filter,
+        cond_filter2 = self._make_one(base_filter,
                                      true_filter=true_filter,
                                      false_filter=false_filter)
         self.assertEqual(cond_filter1, cond_filter2)
@@ -913,7 +913,7 @@ class TestConditionalRowFilter(unittest.TestCase):
         base_filter = object()
         true_filter = object()
         false_filter = object()
-        cond_filter1 = self._makeOne(base_filter,
+        cond_filter1 = self._make_one(base_filter,
                                      true_filter=true_filter,
                                      false_filter=false_filter)
         cond_filter2 = object()
@@ -934,7 +934,7 @@ class TestConditionalRowFilter(unittest.TestCase):
         row_filter3 = CellsRowOffsetFilter(11)
         row_filter3_pb = row_filter3.to_pb()
 
-        row_filter4 = self._makeOne(row_filter1, true_filter=row_filter2,
+        row_filter4 = self._make_one(row_filter1, true_filter=row_filter2,
                                     false_filter=row_filter3)
         filter_pb = row_filter4.to_pb()
 
@@ -958,7 +958,7 @@ class TestConditionalRowFilter(unittest.TestCase):
         row_filter2 = RowSampleFilter(0.25)
         row_filter2_pb = row_filter2.to_pb()
 
-        row_filter3 = self._makeOne(row_filter1, true_filter=row_filter2)
+        row_filter3 = self._make_one(row_filter1, true_filter=row_filter2)
         filter_pb = row_filter3.to_pb()
 
         expected_pb = _RowFilterPB(
@@ -980,7 +980,7 @@ class TestConditionalRowFilter(unittest.TestCase):
         row_filter2 = RowSampleFilter(0.25)
         row_filter2_pb = row_filter2.to_pb()
 
-        row_filter3 = self._makeOne(row_filter1, false_filter=row_filter2)
+        row_filter3 = self._make_one(row_filter1, false_filter=row_filter2)
         filter_pb = row_filter3.to_pb()
 
         expected_pb = _RowFilterPB(

--- a/bigtable/unit_tests/test_row_filters.py
+++ b/bigtable/unit_tests/test_row_filters.py
@@ -403,15 +403,15 @@ class TestColumnRangeFilter(unittest.TestCase):
         inclusive_start = object()
         inclusive_end = object()
         row_filter1 = self._make_one(column_family_id,
-                                    start_column=start_column,
-                                    end_column=end_column,
-                                    inclusive_start=inclusive_start,
-                                    inclusive_end=inclusive_end)
+                                     start_column=start_column,
+                                     end_column=end_column,
+                                     inclusive_start=inclusive_start,
+                                     inclusive_end=inclusive_end)
         row_filter2 = self._make_one(column_family_id,
-                                    start_column=start_column,
-                                    end_column=end_column,
-                                    inclusive_start=inclusive_start,
-                                    inclusive_end=inclusive_end)
+                                     start_column=start_column,
+                                     end_column=end_column,
+                                     inclusive_start=inclusive_start,
+                                     inclusive_end=inclusive_end)
         self.assertEqual(row_filter1, row_filter2)
 
     def test___eq__type_differ(self):
@@ -442,7 +442,7 @@ class TestColumnRangeFilter(unittest.TestCase):
         column_family_id = u'column-family-id'
         column = b'column'
         row_filter = self._make_one(column_family_id, start_column=column,
-                                   inclusive_start=False)
+                                    inclusive_start=False)
         col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
             start_qualifier_open=column,
@@ -465,7 +465,7 @@ class TestColumnRangeFilter(unittest.TestCase):
         column_family_id = u'column-family-id'
         column = b'column'
         row_filter = self._make_one(column_family_id, end_column=column,
-                                   inclusive_end=False)
+                                    inclusive_end=False)
         col_range_pb = _ColumnRangePB(
             family_name=column_family_id,
             end_qualifier_open=column,
@@ -515,9 +515,9 @@ class TestValueRangeFilter(unittest.TestCase):
         inclusive_start = object()
         inclusive_end = object()
         row_filter = self._make_one(start_value=start_value,
-                                   end_value=end_value,
-                                   inclusive_start=inclusive_start,
-                                   inclusive_end=inclusive_end)
+                                    end_value=end_value,
+                                    inclusive_start=inclusive_start,
+                                    inclusive_end=inclusive_end)
         self.assertIs(row_filter.start_value, start_value)
         self.assertIs(row_filter.end_value, end_value)
         self.assertIs(row_filter.inclusive_start, inclusive_start)
@@ -535,13 +535,13 @@ class TestValueRangeFilter(unittest.TestCase):
         inclusive_start = object()
         inclusive_end = object()
         row_filter1 = self._make_one(start_value=start_value,
-                                    end_value=end_value,
-                                    inclusive_start=inclusive_start,
-                                    inclusive_end=inclusive_end)
+                                     end_value=end_value,
+                                     inclusive_start=inclusive_start,
+                                     inclusive_end=inclusive_end)
         row_filter2 = self._make_one(start_value=start_value,
-                                    end_value=end_value,
-                                    inclusive_start=inclusive_start,
-                                    inclusive_end=inclusive_end)
+                                     end_value=end_value,
+                                     inclusive_start=inclusive_start,
+                                     inclusive_end=inclusive_end)
         self.assertEqual(row_filter1, row_filter2)
 
     def test___eq__type_differ(self):
@@ -891,8 +891,8 @@ class TestConditionalRowFilter(unittest.TestCase):
         true_filter = object()
         false_filter = object()
         cond_filter = self._make_one(base_filter,
-                                    true_filter=true_filter,
-                                    false_filter=false_filter)
+                                     true_filter=true_filter,
+                                     false_filter=false_filter)
         self.assertIs(cond_filter.base_filter, base_filter)
         self.assertIs(cond_filter.true_filter, true_filter)
         self.assertIs(cond_filter.false_filter, false_filter)
@@ -902,11 +902,11 @@ class TestConditionalRowFilter(unittest.TestCase):
         true_filter = object()
         false_filter = object()
         cond_filter1 = self._make_one(base_filter,
-                                     true_filter=true_filter,
-                                     false_filter=false_filter)
+                                      true_filter=true_filter,
+                                      false_filter=false_filter)
         cond_filter2 = self._make_one(base_filter,
-                                     true_filter=true_filter,
-                                     false_filter=false_filter)
+                                      true_filter=true_filter,
+                                      false_filter=false_filter)
         self.assertEqual(cond_filter1, cond_filter2)
 
     def test___eq__type_differ(self):
@@ -914,8 +914,8 @@ class TestConditionalRowFilter(unittest.TestCase):
         true_filter = object()
         false_filter = object()
         cond_filter1 = self._make_one(base_filter,
-                                     true_filter=true_filter,
-                                     false_filter=false_filter)
+                                      true_filter=true_filter,
+                                      false_filter=false_filter)
         cond_filter2 = object()
         self.assertNotEqual(cond_filter1, cond_filter2)
 
@@ -935,7 +935,7 @@ class TestConditionalRowFilter(unittest.TestCase):
         row_filter3_pb = row_filter3.to_pb()
 
         row_filter4 = self._make_one(row_filter1, true_filter=row_filter2,
-                                    false_filter=row_filter3)
+                                     false_filter=row_filter3)
         filter_pb = row_filter4.to_pb()
 
         expected_pb = _RowFilterPB(

--- a/bigtable/unit_tests/test_row_filters.py
+++ b/bigtable/unit_tests/test_row_filters.py
@@ -18,7 +18,8 @@ import unittest
 
 class Test_BoolFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import _BoolFilter
         return _BoolFilter
 
@@ -52,7 +53,8 @@ class Test_BoolFilter(unittest.TestCase):
 
 class TestSinkFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import SinkFilter
         return SinkFilter
 
@@ -69,7 +71,8 @@ class TestSinkFilter(unittest.TestCase):
 
 class TestPassAllFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import PassAllFilter
         return PassAllFilter
 
@@ -86,7 +89,8 @@ class TestPassAllFilter(unittest.TestCase):
 
 class TestBlockAllFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import BlockAllFilter
         return BlockAllFilter
 
@@ -103,7 +107,8 @@ class TestBlockAllFilter(unittest.TestCase):
 
 class Test_RegexFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import _RegexFilter
         return _RegexFilter
 
@@ -142,7 +147,8 @@ class Test_RegexFilter(unittest.TestCase):
 
 class TestRowKeyRegexFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import RowKeyRegexFilter
         return RowKeyRegexFilter
 
@@ -159,7 +165,8 @@ class TestRowKeyRegexFilter(unittest.TestCase):
 
 class TestRowSampleFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import RowSampleFilter
         return RowSampleFilter
 
@@ -193,7 +200,8 @@ class TestRowSampleFilter(unittest.TestCase):
 
 class TestFamilyNameRegexFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import FamilyNameRegexFilter
         return FamilyNameRegexFilter
 
@@ -210,7 +218,8 @@ class TestFamilyNameRegexFilter(unittest.TestCase):
 
 class TestColumnQualifierRegexFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import (
             ColumnQualifierRegexFilter)
         return ColumnQualifierRegexFilter
@@ -229,7 +238,8 @@ class TestColumnQualifierRegexFilter(unittest.TestCase):
 
 class TestTimestampRange(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import TimestampRange
         return TimestampRange
 
@@ -303,7 +313,8 @@ class TestTimestampRange(unittest.TestCase):
 
 class TestTimestampRangeFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import TimestampRangeFilter
         return TimestampRangeFilter
 
@@ -340,7 +351,8 @@ class TestTimestampRangeFilter(unittest.TestCase):
 
 class TestColumnRangeFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import ColumnRangeFilter
         return ColumnRangeFilter
 
@@ -464,7 +476,8 @@ class TestColumnRangeFilter(unittest.TestCase):
 
 class TestValueRegexFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import ValueRegexFilter
         return ValueRegexFilter
 
@@ -481,7 +494,8 @@ class TestValueRegexFilter(unittest.TestCase):
 
 class TestValueRangeFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import ValueRangeFilter
         return ValueRangeFilter
 
@@ -572,7 +586,8 @@ class TestValueRangeFilter(unittest.TestCase):
 
 class Test_CellCountFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import _CellCountFilter
         return _CellCountFilter
 
@@ -606,7 +621,8 @@ class Test_CellCountFilter(unittest.TestCase):
 
 class TestCellsRowOffsetFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import CellsRowOffsetFilter
         return CellsRowOffsetFilter
 
@@ -624,7 +640,8 @@ class TestCellsRowOffsetFilter(unittest.TestCase):
 
 class TestCellsRowLimitFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import CellsRowLimitFilter
         return CellsRowLimitFilter
 
@@ -642,7 +659,8 @@ class TestCellsRowLimitFilter(unittest.TestCase):
 
 class TestCellsColumnLimitFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import CellsColumnLimitFilter
         return CellsColumnLimitFilter
 
@@ -660,7 +678,8 @@ class TestCellsColumnLimitFilter(unittest.TestCase):
 
 class TestStripValueTransformerFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import (
             StripValueTransformerFilter)
         return StripValueTransformerFilter
@@ -678,7 +697,8 @@ class TestStripValueTransformerFilter(unittest.TestCase):
 
 class TestApplyLabelFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import ApplyLabelFilter
         return ApplyLabelFilter
 
@@ -712,7 +732,8 @@ class TestApplyLabelFilter(unittest.TestCase):
 
 class Test_FilterCombination(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import _FilterCombination
         return _FilterCombination
 
@@ -743,7 +764,8 @@ class Test_FilterCombination(unittest.TestCase):
 
 class TestRowFilterChain(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import RowFilterChain
         return RowFilterChain
 
@@ -799,7 +821,8 @@ class TestRowFilterChain(unittest.TestCase):
 
 class TestRowFilterUnion(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import RowFilterUnion
         return RowFilterUnion
 
@@ -855,7 +878,8 @@ class TestRowFilterUnion(unittest.TestCase):
 
 class TestConditionalRowFilter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.row_filters import ConditionalRowFilter
         return ConditionalRowFilter
 

--- a/bigtable/unit_tests/test_row_filters.py
+++ b/bigtable/unit_tests/test_row_filters.py
@@ -24,7 +24,7 @@ class Test_BoolFilter(unittest.TestCase):
         return _BoolFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         flag = object()
@@ -59,7 +59,7 @@ class TestSinkFilter(unittest.TestCase):
         return SinkFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         flag = True
@@ -77,7 +77,7 @@ class TestPassAllFilter(unittest.TestCase):
         return PassAllFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         flag = True
@@ -95,7 +95,7 @@ class TestBlockAllFilter(unittest.TestCase):
         return BlockAllFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         flag = True
@@ -113,7 +113,7 @@ class Test_RegexFilter(unittest.TestCase):
         return _RegexFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         regex = b'abc'
@@ -153,7 +153,7 @@ class TestRowKeyRegexFilter(unittest.TestCase):
         return RowKeyRegexFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         regex = b'row-key-regex'
@@ -171,7 +171,7 @@ class TestRowSampleFilter(unittest.TestCase):
         return RowSampleFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         sample = object()
@@ -206,7 +206,7 @@ class TestFamilyNameRegexFilter(unittest.TestCase):
         return FamilyNameRegexFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         regex = u'family-regex'
@@ -225,7 +225,7 @@ class TestColumnQualifierRegexFilter(unittest.TestCase):
         return ColumnQualifierRegexFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         regex = b'column-regex'
@@ -244,7 +244,7 @@ class TestTimestampRange(unittest.TestCase):
         return TimestampRange
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         start = object()
@@ -319,7 +319,7 @@ class TestTimestampRangeFilter(unittest.TestCase):
         return TimestampRangeFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         range_ = object()
@@ -357,7 +357,7 @@ class TestColumnRangeFilter(unittest.TestCase):
         return ColumnRangeFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
         column_family_id = object()
@@ -482,7 +482,7 @@ class TestValueRegexFilter(unittest.TestCase):
         return ValueRegexFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         regex = b'value-regex'
@@ -500,7 +500,7 @@ class TestValueRangeFilter(unittest.TestCase):
         return ValueRangeFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
         row_filter = self._makeOne()
@@ -592,7 +592,7 @@ class Test_CellCountFilter(unittest.TestCase):
         return _CellCountFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         num_cells = object()
@@ -627,7 +627,7 @@ class TestCellsRowOffsetFilter(unittest.TestCase):
         return CellsRowOffsetFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         num_cells = 76
@@ -646,7 +646,7 @@ class TestCellsRowLimitFilter(unittest.TestCase):
         return CellsRowLimitFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         num_cells = 189
@@ -665,7 +665,7 @@ class TestCellsColumnLimitFilter(unittest.TestCase):
         return CellsColumnLimitFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         num_cells = 10
@@ -685,7 +685,7 @@ class TestStripValueTransformerFilter(unittest.TestCase):
         return StripValueTransformerFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         flag = True
@@ -703,7 +703,7 @@ class TestApplyLabelFilter(unittest.TestCase):
         return ApplyLabelFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         label = object()
@@ -738,7 +738,7 @@ class Test_FilterCombination(unittest.TestCase):
         return _FilterCombination
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor_defaults(self):
         row_filter = self._makeOne()
@@ -770,7 +770,7 @@ class TestRowFilterChain(unittest.TestCase):
         return RowFilterChain
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         from google.cloud.bigtable.row_filters import RowSampleFilter
@@ -827,7 +827,7 @@ class TestRowFilterUnion(unittest.TestCase):
         return RowFilterUnion
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_to_pb(self):
         from google.cloud.bigtable.row_filters import RowSampleFilter
@@ -884,7 +884,7 @@ class TestConditionalRowFilter(unittest.TestCase):
         return ConditionalRowFilter
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         base_filter = object()

--- a/bigtable/unit_tests/test_table.py
+++ b/bigtable/unit_tests/test_table.py
@@ -29,7 +29,8 @@ class TestTable(unittest.TestCase):
     TIMESTAMP_MICROS = 100
     VALUE = b'value'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.bigtable.table import Table
         return Table
 

--- a/bigtable/unit_tests/test_table.py
+++ b/bigtable/unit_tests/test_table.py
@@ -430,7 +430,7 @@ class TestTable(unittest.TestCase):
 class Test__create_row_request(unittest.TestCase):
 
     def _call_fut(self, table_name, row_key=None, start_key=None, end_key=None,
-                 filter_=None, limit=None):
+                  filter_=None, limit=None):
         from google.cloud.bigtable.table import _create_row_request
         return _create_row_request(
             table_name, row_key=row_key, start_key=start_key, end_key=end_key,
@@ -478,7 +478,7 @@ class Test__create_row_request(unittest.TestCase):
         start_key = b'start_key'
         end_key = b'end_key'
         result = self._call_fut(table_name, start_key=start_key,
-                               end_key=end_key)
+                                end_key=end_key)
         expected_result = _ReadRowsRequestPB(table_name=table_name)
         expected_result.rows.row_ranges.add(
             start_key_closed=start_key, end_key_open=end_key)

--- a/bigtable/unit_tests/test_table.py
+++ b/bigtable/unit_tests/test_table.py
@@ -35,7 +35,7 @@ class TestTable(unittest.TestCase):
         return Table
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         table_id = 'table-id'

--- a/bigtable/unit_tests/test_table.py
+++ b/bigtable/unit_tests/test_table.py
@@ -429,7 +429,7 @@ class TestTable(unittest.TestCase):
 
 class Test__create_row_request(unittest.TestCase):
 
-    def _callFUT(self, table_name, row_key=None, start_key=None, end_key=None,
+    def _call_fut(self, table_name, row_key=None, start_key=None, end_key=None,
                  filter_=None, limit=None):
         from google.cloud.bigtable.table import _create_row_request
         return _create_row_request(
@@ -438,19 +438,19 @@ class Test__create_row_request(unittest.TestCase):
 
     def test_table_name_only(self):
         table_name = 'table_name'
-        result = self._callFUT(table_name)
+        result = self._call_fut(table_name)
         expected_result = _ReadRowsRequestPB(
             table_name=table_name)
         self.assertEqual(result, expected_result)
 
     def test_row_key_row_range_conflict(self):
         with self.assertRaises(ValueError):
-            self._callFUT(None, row_key=object(), end_key=object())
+            self._call_fut(None, row_key=object(), end_key=object())
 
     def test_row_key(self):
         table_name = 'table_name'
         row_key = b'row_key'
-        result = self._callFUT(table_name, row_key=row_key)
+        result = self._call_fut(table_name, row_key=row_key)
         expected_result = _ReadRowsRequestPB(
             table_name=table_name,
         )
@@ -460,7 +460,7 @@ class Test__create_row_request(unittest.TestCase):
     def test_row_range_start_key(self):
         table_name = 'table_name'
         start_key = b'start_key'
-        result = self._callFUT(table_name, start_key=start_key)
+        result = self._call_fut(table_name, start_key=start_key)
         expected_result = _ReadRowsRequestPB(table_name=table_name)
         expected_result.rows.row_ranges.add(start_key_closed=start_key)
         self.assertEqual(result, expected_result)
@@ -468,7 +468,7 @@ class Test__create_row_request(unittest.TestCase):
     def test_row_range_end_key(self):
         table_name = 'table_name'
         end_key = b'end_key'
-        result = self._callFUT(table_name, end_key=end_key)
+        result = self._call_fut(table_name, end_key=end_key)
         expected_result = _ReadRowsRequestPB(table_name=table_name)
         expected_result.rows.row_ranges.add(end_key_open=end_key)
         self.assertEqual(result, expected_result)
@@ -477,7 +477,7 @@ class Test__create_row_request(unittest.TestCase):
         table_name = 'table_name'
         start_key = b'start_key'
         end_key = b'end_key'
-        result = self._callFUT(table_name, start_key=start_key,
+        result = self._call_fut(table_name, start_key=start_key,
                                end_key=end_key)
         expected_result = _ReadRowsRequestPB(table_name=table_name)
         expected_result.rows.row_ranges.add(
@@ -488,7 +488,7 @@ class Test__create_row_request(unittest.TestCase):
         from google.cloud.bigtable.row_filters import RowSampleFilter
         table_name = 'table_name'
         row_filter = RowSampleFilter(0.33)
-        result = self._callFUT(table_name, filter_=row_filter)
+        result = self._call_fut(table_name, filter_=row_filter)
         expected_result = _ReadRowsRequestPB(
             table_name=table_name,
             filter=row_filter.to_pb(),
@@ -498,7 +498,7 @@ class Test__create_row_request(unittest.TestCase):
     def test_with_limit(self):
         table_name = 'table_name'
         limit = 1337
-        result = self._callFUT(table_name, limit=limit)
+        result = self._call_fut(table_name, limit=limit)
         expected_result = _ReadRowsRequestPB(
             table_name=table_name,
             rows_limit=limit,

--- a/bigtable/unit_tests/test_table.py
+++ b/bigtable/unit_tests/test_table.py
@@ -34,14 +34,14 @@ class TestTable(unittest.TestCase):
         from google.cloud.bigtable.table import Table
         return Table
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         table_id = 'table-id'
         instance = object()
 
-        table = self._makeOne(table_id, instance)
+        table = self._make_one(table_id, instance)
         self.assertEqual(table.table_id, table_id)
         self.assertIs(table._instance, instance)
 
@@ -50,7 +50,7 @@ class TestTable(unittest.TestCase):
         instance_name = 'instance_name'
 
         instance = _Instance(instance_name)
-        table = self._makeOne(table_id, instance)
+        table = self._make_one(table_id, instance)
         expected_name = instance_name + '/tables/' + table_id
         self.assertEqual(table.name, expected_name)
 
@@ -59,7 +59,7 @@ class TestTable(unittest.TestCase):
 
         table_id = 'table-id'
         gc_rule = object()
-        table = self._makeOne(table_id, None)
+        table = self._make_one(table_id, None)
         column_family_id = 'column_family_id'
         column_family = table.column_family(column_family_id, gc_rule=gc_rule)
 
@@ -72,7 +72,7 @@ class TestTable(unittest.TestCase):
         from google.cloud.bigtable.row import DirectRow
 
         table_id = 'table-id'
-        table = self._makeOne(table_id, None)
+        table = self._make_one(table_id, None)
         row_key = b'row_key'
         row = table.row(row_key)
 
@@ -84,7 +84,7 @@ class TestTable(unittest.TestCase):
         from google.cloud.bigtable.row import ConditionalRow
 
         table_id = 'table-id'
-        table = self._makeOne(table_id, None)
+        table = self._make_one(table_id, None)
         row_key = b'row_key'
         filter_ = object()
         row = table.row(row_key, filter_=filter_)
@@ -97,7 +97,7 @@ class TestTable(unittest.TestCase):
         from google.cloud.bigtable.row import AppendRow
 
         table_id = 'table-id'
-        table = self._makeOne(table_id, None)
+        table = self._make_one(table_id, None)
         row_key = b'row_key'
         row = table.row(row_key, append=True)
 
@@ -106,31 +106,31 @@ class TestTable(unittest.TestCase):
         self.assertEqual(row._table, table)
 
     def test_row_factory_failure(self):
-        table = self._makeOne(self.TABLE_ID, None)
+        table = self._make_one(self.TABLE_ID, None)
         with self.assertRaises(ValueError):
             table.row(b'row_key', filter_=object(), append=True)
 
     def test___eq__(self):
         instance = object()
-        table1 = self._makeOne(self.TABLE_ID, instance)
-        table2 = self._makeOne(self.TABLE_ID, instance)
+        table1 = self._make_one(self.TABLE_ID, instance)
+        table2 = self._make_one(self.TABLE_ID, instance)
         self.assertEqual(table1, table2)
 
     def test___eq__type_differ(self):
-        table1 = self._makeOne(self.TABLE_ID, None)
+        table1 = self._make_one(self.TABLE_ID, None)
         table2 = object()
         self.assertNotEqual(table1, table2)
 
     def test___ne__same_value(self):
         instance = object()
-        table1 = self._makeOne(self.TABLE_ID, instance)
-        table2 = self._makeOne(self.TABLE_ID, instance)
+        table1 = self._make_one(self.TABLE_ID, instance)
+        table2 = self._make_one(self.TABLE_ID, instance)
         comparison_val = (table1 != table2)
         self.assertFalse(comparison_val)
 
     def test___ne__(self):
-        table1 = self._makeOne('table_id1', 'instance1')
-        table2 = self._makeOne('table_id2', 'instance2')
+        table1 = self._make_one('table_id1', 'instance1')
+        table2 = self._make_one('table_id2', 'instance2')
         self.assertNotEqual(table1, table2)
 
     def _create_test_helper(self, initial_split_keys, column_families=()):
@@ -139,7 +139,7 @@ class TestTable(unittest.TestCase):
 
         client = _Client()
         instance = _Instance(self.INSTANCE_NAME, client=client)
-        table = self._makeOne(self.TABLE_ID, instance)
+        table = self._make_one(self.TABLE_ID, instance)
 
         # Create request_pb
         splits_pb = [
@@ -206,7 +206,7 @@ class TestTable(unittest.TestCase):
 
         client = _Client()
         instance = _Instance(self.INSTANCE_NAME, client=client)
-        table = self._makeOne(self.TABLE_ID, instance)
+        table = self._make_one(self.TABLE_ID, instance)
 
         # Create request_pb
         request_pb = _GetTableRequestPB(name=self.TABLE_NAME)
@@ -244,7 +244,7 @@ class TestTable(unittest.TestCase):
 
         client = _Client()
         instance = _Instance(self.INSTANCE_NAME, client=client)
-        table = self._makeOne(self.TABLE_ID, instance)
+        table = self._make_one(self.TABLE_ID, instance)
 
         # Create request_pb
         request_pb = _DeleteTableRequestPB(name=self.TABLE_NAME)
@@ -274,7 +274,7 @@ class TestTable(unittest.TestCase):
 
         client = _Client()
         instance = _Instance(self.INSTANCE_NAME, client=client)
-        table = self._makeOne(self.TABLE_ID, instance)
+        table = self._make_one(self.TABLE_ID, instance)
 
         # Create request_pb
         request_pb = object()  # Returned by our mock.
@@ -355,7 +355,7 @@ class TestTable(unittest.TestCase):
 
         client = _Client()
         instance = _Instance(self.INSTANCE_NAME, client=client)
-        table = self._makeOne(self.TABLE_ID, instance)
+        table = self._make_one(self.TABLE_ID, instance)
 
         # Create request_pb
         request_pb = object()  # Returned by our mock.
@@ -403,7 +403,7 @@ class TestTable(unittest.TestCase):
 
         client = _Client()
         instance = _Instance(self.INSTANCE_NAME, client=client)
-        table = self._makeOne(self.TABLE_ID, instance)
+        table = self._make_one(self.TABLE_ID, instance)
 
         # Create request_pb
         request_pb = _SampleRowKeysRequestPB(table_name=self.TABLE_NAME)

--- a/core/unit_tests/streaming/test_buffered_stream.py
+++ b/core/unit_tests/streaming/test_buffered_stream.py
@@ -23,7 +23,7 @@ class Test_BufferedStream(unittest.TestCase):
         return BufferedStream
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_closed_stream(self):
         class _Stream(object):

--- a/core/unit_tests/streaming/test_buffered_stream.py
+++ b/core/unit_tests/streaming/test_buffered_stream.py
@@ -17,7 +17,8 @@ import unittest
 
 class Test_BufferedStream(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.streaming.buffered_stream import BufferedStream
         return BufferedStream
 

--- a/core/unit_tests/streaming/test_buffered_stream.py
+++ b/core/unit_tests/streaming/test_buffered_stream.py
@@ -22,7 +22,7 @@ class Test_BufferedStream(unittest.TestCase):
         from google.cloud.streaming.buffered_stream import BufferedStream
         return BufferedStream
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_closed_stream(self):
@@ -31,7 +31,7 @@ class Test_BufferedStream(unittest.TestCase):
 
         start = 0
         bufsize = 4
-        bufstream = self._makeOne(_Stream, start, bufsize)
+        bufstream = self._make_one(_Stream, start, bufsize)
         self.assertIs(bufstream._stream, _Stream)
         self.assertEqual(bufstream._start_pos, start)
         self.assertEqual(bufstream._buffer_pos, 0)
@@ -45,7 +45,7 @@ class Test_BufferedStream(unittest.TestCase):
         START = 0
         BUFSIZE = 4
         stream = BytesIO(CONTENT)
-        bufstream = self._makeOne(stream, START, BUFSIZE)
+        bufstream = self._make_one(stream, START, BUFSIZE)
         self.assertIs(bufstream._stream, stream)
         self.assertEqual(bufstream._start_pos, START)
         self.assertEqual(bufstream._buffer_pos, 0)
@@ -61,7 +61,7 @@ class Test_BufferedStream(unittest.TestCase):
         BUFSIZE = 10
         stream = BytesIO(CONTENT)
         stream.read(START)  # already consumed
-        bufstream = self._makeOne(stream, START, BUFSIZE)
+        bufstream = self._make_one(stream, START, BUFSIZE)
         self.assertIs(bufstream._stream, stream)
         self.assertEqual(bufstream._start_pos, START)
         self.assertEqual(bufstream._buffer_pos, 0)
@@ -76,7 +76,7 @@ class Test_BufferedStream(unittest.TestCase):
         START = 0
         BUFSIZE = 4
         stream = BytesIO(CONTENT)
-        bufstream = self._makeOne(stream, START, BUFSIZE)
+        bufstream = self._make_one(stream, START, BUFSIZE)
         self.assertEqual(bufstream._bytes_remaining, BUFSIZE)
 
     def test__bytes_remaining_start_zero_shorter_than_buffer(self):
@@ -86,7 +86,7 @@ class Test_BufferedStream(unittest.TestCase):
         BUFSIZE = 10
         stream = BytesIO(CONTENT)
         stream.read(START)  # already consumed
-        bufstream = self._makeOne(stream, START, BUFSIZE)
+        bufstream = self._make_one(stream, START, BUFSIZE)
         self.assertEqual(bufstream._bytes_remaining, len(CONTENT) - START)
 
     def test_read_w_none(self):
@@ -95,7 +95,7 @@ class Test_BufferedStream(unittest.TestCase):
         START = 0
         BUFSIZE = 4
         stream = BytesIO(CONTENT)
-        bufstream = self._makeOne(stream, START, BUFSIZE)
+        bufstream = self._make_one(stream, START, BUFSIZE)
         with self.assertRaises(ValueError):
             bufstream.read(None)
 
@@ -105,7 +105,7 @@ class Test_BufferedStream(unittest.TestCase):
         START = 0
         BUFSIZE = 4
         stream = BytesIO(CONTENT)
-        bufstream = self._makeOne(stream, START, BUFSIZE)
+        bufstream = self._make_one(stream, START, BUFSIZE)
         with self.assertRaises(ValueError):
             bufstream.read(-2)
 
@@ -115,7 +115,7 @@ class Test_BufferedStream(unittest.TestCase):
         START = 0
         BUFSIZE = 4
         stream = BytesIO(CONTENT)
-        bufstream = self._makeOne(stream, START, BUFSIZE)
+        bufstream = self._make_one(stream, START, BUFSIZE)
         self.assertEqual(bufstream.read(4), CONTENT[:4])
 
     def test_read_exhausted(self):
@@ -125,7 +125,7 @@ class Test_BufferedStream(unittest.TestCase):
         BUFSIZE = 10
         stream = BytesIO(CONTENT)
         stream.read(START)  # already consumed
-        bufstream = self._makeOne(stream, START, BUFSIZE)
+        bufstream = self._make_one(stream, START, BUFSIZE)
         self.assertTrue(bufstream.stream_exhausted)
         self.assertEqual(bufstream.stream_end_position, len(CONTENT))
         self.assertEqual(bufstream._bytes_remaining, 0)

--- a/core/unit_tests/streaming/test_exceptions.py
+++ b/core/unit_tests/streaming/test_exceptions.py
@@ -22,14 +22,14 @@ class Test_HttpError(unittest.TestCase):
         from google.cloud.streaming.exceptions import HttpError
         return HttpError
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         RESPONSE = {'status': '404'}
         CONTENT = b'CONTENT'
         URL = 'http://www.example.com'
-        exception = self._makeOne(RESPONSE, CONTENT, URL)
+        exception = self._make_one(RESPONSE, CONTENT, URL)
         self.assertEqual(exception.response, RESPONSE)
         self.assertEqual(exception.content, CONTENT)
         self.assertEqual(exception.url, URL)
@@ -64,7 +64,7 @@ class Test_RetryAfterError(unittest.TestCase):
         from google.cloud.streaming.exceptions import RetryAfterError
         return RetryAfterError
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
@@ -72,7 +72,7 @@ class Test_RetryAfterError(unittest.TestCase):
         CONTENT = b'CONTENT'
         URL = 'http://www.example.com'
         RETRY_AFTER = 60
-        exception = self._makeOne(RESPONSE, CONTENT, URL, RETRY_AFTER)
+        exception = self._make_one(RESPONSE, CONTENT, URL, RETRY_AFTER)
         self.assertEqual(exception.response, RESPONSE)
         self.assertEqual(exception.content, CONTENT)
         self.assertEqual(exception.url, URL)

--- a/core/unit_tests/streaming/test_exceptions.py
+++ b/core/unit_tests/streaming/test_exceptions.py
@@ -17,7 +17,8 @@ import unittest
 
 class Test_HttpError(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.streaming.exceptions import HttpError
         return HttpError
 
@@ -58,7 +59,8 @@ class Test_HttpError(unittest.TestCase):
 
 class Test_RetryAfterError(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.streaming.exceptions import RetryAfterError
         return RetryAfterError
 

--- a/core/unit_tests/streaming/test_exceptions.py
+++ b/core/unit_tests/streaming/test_exceptions.py
@@ -23,7 +23,7 @@ class Test_HttpError(unittest.TestCase):
         return HttpError
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         RESPONSE = {'status': '404'}
@@ -49,7 +49,7 @@ class Test_HttpError(unittest.TestCase):
             content = CONTENT
             request_url = URL
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         exception = klass.from_response(_Response())
         self.assertIsInstance(exception, klass)
         self.assertEqual(exception.response, RESPONSE)
@@ -65,7 +65,7 @@ class Test_RetryAfterError(unittest.TestCase):
         return RetryAfterError
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         RESPONSE = {'status': '404'}
@@ -94,7 +94,7 @@ class Test_RetryAfterError(unittest.TestCase):
             request_url = URL
             retry_after = RETRY_AFTER
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         exception = klass.from_response(_Response())
         self.assertIsInstance(exception, klass)
         self.assertEqual(exception.response, RESPONSE)

--- a/core/unit_tests/streaming/test_http_wrapper.py
+++ b/core/unit_tests/streaming/test_http_wrapper.py
@@ -215,62 +215,62 @@ class Test_Response(unittest.TestCase):
 
 class Test__check_response(unittest.TestCase):
 
-    def _callFUT(self, *args, **kw):
+    def _call_fut(self, *args, **kw):
         from google.cloud.streaming.http_wrapper import _check_response
         return _check_response(*args, **kw)
 
     def test_w_none(self):
         from google.cloud.streaming.exceptions import RequestError
         with self.assertRaises(RequestError):
-            self._callFUT(None)
+            self._call_fut(None)
 
     def test_w_TOO_MANY_REQUESTS(self):
         from google.cloud.streaming.exceptions import BadStatusCodeError
         from google.cloud.streaming.http_wrapper import TOO_MANY_REQUESTS
 
         with self.assertRaises(BadStatusCodeError):
-            self._callFUT(_Response(TOO_MANY_REQUESTS))
+            self._call_fut(_Response(TOO_MANY_REQUESTS))
 
     def test_w_50x(self):
         from google.cloud.streaming.exceptions import BadStatusCodeError
 
         with self.assertRaises(BadStatusCodeError):
-            self._callFUT(_Response(500))
+            self._call_fut(_Response(500))
 
         with self.assertRaises(BadStatusCodeError):
-            self._callFUT(_Response(503))
+            self._call_fut(_Response(503))
 
     def test_w_retry_after(self):
         from google.cloud.streaming.exceptions import RetryAfterError
 
         with self.assertRaises(RetryAfterError):
-            self._callFUT(_Response(200, 20))
+            self._call_fut(_Response(200, 20))
 
     def test_pass(self):
-        self._callFUT(_Response(200))
+        self._call_fut(_Response(200))
 
 
 class Test__reset_http_connections(unittest.TestCase):
 
-    def _callFUT(self, *args, **kw):
+    def _call_fut(self, *args, **kw):
         from google.cloud.streaming.http_wrapper import _reset_http_connections
         return _reset_http_connections(*args, **kw)
 
     def test_wo_connections(self):
         http = object()
-        self._callFUT(http)
+        self._call_fut(http)
 
     def test_w_connections(self):
         connections = {'delete:me': object(), 'skip_me': object()}
         http = _Dummy(connections=connections)
-        self._callFUT(http)
+        self._call_fut(http)
         self.assertFalse('delete:me' in connections)
         self.assertTrue('skip_me' in connections)
 
 
 class Test___make_api_request_no_retry(unittest.TestCase):
 
-    def _callFUT(self, *args, **kw):
+    def _call_fut(self, *args, **kw):
         from google.cloud.streaming.http_wrapper import (
             _make_api_request_no_retry)
         return _make_api_request_no_retry(*args, **kw)
@@ -297,7 +297,7 @@ class Test___make_api_request_no_retry(unittest.TestCase):
         _checked = []
         with _Monkey(MUT, httplib2=_httplib2,
                      _check_response=_checked.append):
-            response = self._callFUT(_http, _request)
+            response = self._call_fut(_http, _request)
 
         self.assertIsInstance(response, MUT.Response)
         self.assertEqual(response.info, INFO)
@@ -319,7 +319,7 @@ class Test___make_api_request_no_retry(unittest.TestCase):
         _checked = []
         with _Monkey(MUT, httplib2=_httplib2,
                      _check_response=_checked.append):
-            response = self._callFUT(_http, _request)
+            response = self._call_fut(_http, _request)
 
         self.assertIsInstance(response, MUT.Response)
         self.assertEqual(response.info, INFO)
@@ -341,7 +341,7 @@ class Test___make_api_request_no_retry(unittest.TestCase):
         _checked = []
         with _Monkey(MUT, httplib2=_httplib2,
                      _check_response=_checked.append):
-            response = self._callFUT(_http, _request)
+            response = self._call_fut(_http, _request)
 
         self.assertIsInstance(response, MUT.Response)
         self.assertEqual(response.info, INFO)
@@ -363,13 +363,13 @@ class Test___make_api_request_no_retry(unittest.TestCase):
         _request = _Request()
         with _Monkey(MUT, httplib2=_httplib2):
             with self.assertRaises(RequestError):
-                self._callFUT(_http, _request)
+                self._call_fut(_http, _request)
         self._verify_requested(_http, _request, connection_type=CONN_TYPE)
 
 
 class Test_make_api_request(unittest.TestCase):
 
-    def _callFUT(self, *args, **kw):
+    def _call_fut(self, *args, **kw):
         from google.cloud.streaming.http_wrapper import make_api_request
         return make_api_request(*args, **kw)
 
@@ -386,7 +386,7 @@ class Test_make_api_request(unittest.TestCase):
 
         with _Monkey(MUT, _make_api_request_no_retry=_wo_exception,
                      _check_response=_checked.append):
-            response = self._callFUT(HTTP, REQUEST)
+            response = self._call_fut(HTTP, REQUEST)
 
         self.assertIs(response, RESPONSE)
         expected_kw = {'redirections': MUT._REDIRECTIONS}
@@ -412,7 +412,7 @@ class Test_make_api_request(unittest.TestCase):
 
         with _Monkey(MUT, _make_api_request_no_retry=_wo_exception,
                      _check_response=_checked.append):
-            response = self._callFUT(HTTP, REQUEST, retries=5)
+            response = self._call_fut(HTTP, REQUEST, retries=5)
 
         self.assertIs(response, RESPONSE)
         self.assertEqual(len(_created), 5)
@@ -436,7 +436,7 @@ class Test_make_api_request(unittest.TestCase):
                      _make_api_request_no_retry=_wo_exception,
                      _check_response=_checked.append):
             with self.assertRaises(ValueError):
-                self._callFUT(HTTP, REQUEST, retries=3)
+                self._call_fut(HTTP, REQUEST, retries=3)
 
         self.assertEqual(len(_created), 3)
         expected_kw = {'redirections': MUT._REDIRECTIONS}

--- a/core/unit_tests/streaming/test_http_wrapper.py
+++ b/core/unit_tests/streaming/test_http_wrapper.py
@@ -23,7 +23,7 @@ class Test__httplib2_debug_level(unittest.TestCase):
         return _httplib2_debug_level
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_wo_loggable_body_wo_http(self):
         from google.cloud._testing import _Monkey
@@ -83,7 +83,7 @@ class Test_Request(unittest.TestCase):
         return Request
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         request = self._makeOne()
@@ -124,7 +124,7 @@ class Test_Response(unittest.TestCase):
         return Response
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         CONTENT = 'CONTENT'

--- a/core/unit_tests/streaming/test_http_wrapper.py
+++ b/core/unit_tests/streaming/test_http_wrapper.py
@@ -17,7 +17,8 @@ import unittest
 
 class Test__httplib2_debug_level(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.streaming.http_wrapper import _httplib2_debug_level
         return _httplib2_debug_level
 
@@ -76,7 +77,8 @@ class Test__httplib2_debug_level(unittest.TestCase):
 
 class Test_Request(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.streaming.http_wrapper import Request
         return Request
 
@@ -116,7 +118,8 @@ class Test_Request(unittest.TestCase):
 
 class Test_Response(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.streaming.http_wrapper import Response
         return Response
 

--- a/core/unit_tests/streaming/test_http_wrapper.py
+++ b/core/unit_tests/streaming/test_http_wrapper.py
@@ -22,7 +22,7 @@ class Test__httplib2_debug_level(unittest.TestCase):
         from google.cloud.streaming.http_wrapper import _httplib2_debug_level
         return _httplib2_debug_level
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_wo_loggable_body_wo_http(self):
@@ -33,7 +33,7 @@ class Test__httplib2_debug_level(unittest.TestCase):
         LEVEL = 1
         _httplib2 = _Dummy(debuglevel=0)
         with _Monkey(MUT, httplib2=_httplib2):
-            with self._makeOne(request, LEVEL):
+            with self._make_one(request, LEVEL):
                 self.assertEqual(_httplib2.debuglevel, 0)
 
     def test_w_loggable_body_wo_http(self):
@@ -44,7 +44,7 @@ class Test__httplib2_debug_level(unittest.TestCase):
         LEVEL = 1
         _httplib2 = _Dummy(debuglevel=0)
         with _Monkey(MUT, httplib2=_httplib2):
-            with self._makeOne(request, LEVEL):
+            with self._make_one(request, LEVEL):
                 self.assertEqual(_httplib2.debuglevel, LEVEL)
         self.assertEqual(_httplib2.debuglevel, 0)
 
@@ -66,7 +66,7 @@ class Test__httplib2_debug_level(unittest.TestCase):
         connections = {'update:me': update_me, 'skip_me': skip_me}
         _http = _Dummy(connections=connections)
         with _Monkey(MUT, httplib2=_httplib2):
-            with self._makeOne(request, LEVEL, _http):
+            with self._make_one(request, LEVEL, _http):
                 self.assertEqual(_httplib2.debuglevel, LEVEL)
                 self.assertEqual(update_me.debuglevel, LEVEL)
                 self.assertEqual(skip_me.debuglevel, 0)
@@ -82,11 +82,11 @@ class Test_Request(unittest.TestCase):
         from google.cloud.streaming.http_wrapper import Request
         return Request
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
-        request = self._makeOne()
+        request = self._make_one()
         self.assertEqual(request.url, '')
         self.assertEqual(request.http_method, 'GET')
         self.assertEqual(request.headers, {'content-length': '0'})
@@ -95,12 +95,12 @@ class Test_Request(unittest.TestCase):
 
     def test_loggable_body_setter_w_body_None(self):
         from google.cloud.streaming.exceptions import RequestError
-        request = self._makeOne(body=None)
+        request = self._make_one(body=None)
         with self.assertRaises(RequestError):
             request.loggable_body = 'abc'
 
     def test_body_setter_w_None(self):
-        request = self._makeOne()
+        request = self._make_one()
         request.loggable_body = 'abc'
         request.body = None
         self.assertEqual(request.headers, {})
@@ -108,7 +108,7 @@ class Test_Request(unittest.TestCase):
         self.assertEqual(request.loggable_body, 'abc')
 
     def test_body_setter_w_non_string(self):
-        request = self._makeOne()
+        request = self._make_one()
         request.loggable_body = 'abc'
         request.body = body = _Dummy(length=123)
         self.assertEqual(request.headers, {'content-length': '123'})
@@ -123,14 +123,14 @@ class Test_Response(unittest.TestCase):
         from google.cloud.streaming.http_wrapper import Response
         return Response
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         CONTENT = 'CONTENT'
         URL = 'http://example.com/api'
         info = {'status': '200'}
-        response = self._makeOne(info, CONTENT, URL)
+        response = self._make_one(info, CONTENT, URL)
         self.assertEqual(len(response), len(CONTENT))
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.retry_after)
@@ -146,7 +146,7 @@ class Test_Response(unittest.TestCase):
             'content-encoding': 'testing',
             'content-range': RANGE,
         }
-        response = self._makeOne(info, CONTENT, URL)
+        response = self._make_one(info, CONTENT, URL)
         self.assertEqual(len(response), 123)
 
     def test_length_w_content_encoding_wo_content_range(self):
@@ -157,7 +157,7 @@ class Test_Response(unittest.TestCase):
             'content-length': len(CONTENT),
             'content-encoding': 'testing',
         }
-        response = self._makeOne(info, CONTENT, URL)
+        response = self._make_one(info, CONTENT, URL)
         self.assertEqual(len(response), len(CONTENT))
 
     def test_length_w_content_length_w_content_range(self):
@@ -169,7 +169,7 @@ class Test_Response(unittest.TestCase):
             'content-length': len(CONTENT) * 2,
             'content-range': RANGE,
         }
-        response = self._makeOne(info, CONTENT, URL)
+        response = self._make_one(info, CONTENT, URL)
         self.assertEqual(len(response), len(CONTENT) * 2)
 
     def test_length_wo_content_length_w_content_range(self):
@@ -180,7 +180,7 @@ class Test_Response(unittest.TestCase):
             'status': '200',
             'content-range': RANGE,
         }
-        response = self._makeOne(info, CONTENT, URL)
+        response = self._make_one(info, CONTENT, URL)
         self.assertEqual(len(response), 123)
 
     def test_retry_after_w_header(self):
@@ -190,7 +190,7 @@ class Test_Response(unittest.TestCase):
             'status': '200',
             'retry-after': '123',
         }
-        response = self._makeOne(info, CONTENT, URL)
+        response = self._make_one(info, CONTENT, URL)
         self.assertEqual(response.retry_after, 123)
 
     def test_is_redirect_w_code_wo_location(self):
@@ -199,7 +199,7 @@ class Test_Response(unittest.TestCase):
         info = {
             'status': '301',
         }
-        response = self._makeOne(info, CONTENT, URL)
+        response = self._make_one(info, CONTENT, URL)
         self.assertFalse(response.is_redirect)
 
     def test_is_redirect_w_code_w_location(self):
@@ -209,7 +209,7 @@ class Test_Response(unittest.TestCase):
             'status': '301',
             'location': 'http://example.com/other',
         }
-        response = self._makeOne(info, CONTENT, URL)
+        response = self._make_one(info, CONTENT, URL)
         self.assertTrue(response.is_redirect)
 
 

--- a/core/unit_tests/streaming/test_stream_slice.py
+++ b/core/unit_tests/streaming/test_stream_slice.py
@@ -23,7 +23,7 @@ class Test_StreamSlice(unittest.TestCase):
         return StreamSlice
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         from io import BytesIO

--- a/core/unit_tests/streaming/test_stream_slice.py
+++ b/core/unit_tests/streaming/test_stream_slice.py
@@ -22,7 +22,7 @@ class Test_StreamSlice(unittest.TestCase):
         from google.cloud.streaming.stream_slice import StreamSlice
         return StreamSlice
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
@@ -30,7 +30,7 @@ class Test_StreamSlice(unittest.TestCase):
         CONTENT = b'CONTENT GOES HERE'
         MAXSIZE = 4
         stream = BytesIO(CONTENT)
-        stream_slice = self._makeOne(stream, MAXSIZE)
+        stream_slice = self._make_one(stream, MAXSIZE)
         self.assertIs(stream_slice._stream, stream)
         self.assertEqual(stream_slice._remaining_bytes, MAXSIZE)
         self.assertEqual(stream_slice._max_bytes, MAXSIZE)
@@ -42,7 +42,7 @@ class Test_StreamSlice(unittest.TestCase):
         CONTENT = b''
         MAXSIZE = 0
         stream = BytesIO(CONTENT)
-        stream_slice = self._makeOne(stream, MAXSIZE)
+        stream_slice = self._make_one(stream, MAXSIZE)
         self.assertFalse(stream_slice)
 
     def test___nonzero___nonempty(self):
@@ -50,7 +50,7 @@ class Test_StreamSlice(unittest.TestCase):
         CONTENT = b'CONTENT GOES HERE'
         MAXSIZE = 4
         stream = BytesIO(CONTENT)
-        stream_slice = self._makeOne(stream, MAXSIZE)
+        stream_slice = self._make_one(stream, MAXSIZE)
         self.assertTrue(stream_slice)
 
     def test_read_exhausted(self):
@@ -59,7 +59,7 @@ class Test_StreamSlice(unittest.TestCase):
         CONTENT = b''
         MAXSIZE = 4
         stream = BytesIO(CONTENT)
-        stream_slice = self._makeOne(stream, MAXSIZE)
+        stream_slice = self._make_one(stream, MAXSIZE)
         with self.assertRaises(http_client.IncompleteRead):
             stream_slice.read()
 
@@ -68,7 +68,7 @@ class Test_StreamSlice(unittest.TestCase):
         CONTENT = b'CONTENT GOES HERE'
         MAXSIZE = 4
         stream = BytesIO(CONTENT)
-        stream_slice = self._makeOne(stream, MAXSIZE)
+        stream_slice = self._make_one(stream, MAXSIZE)
         self.assertEqual(stream_slice.read(), CONTENT[:MAXSIZE])
         self.assertEqual(stream_slice._remaining_bytes, 0)
 
@@ -78,6 +78,6 @@ class Test_StreamSlice(unittest.TestCase):
         MAXSIZE = 4
         SIZE = 3
         stream = BytesIO(CONTENT)
-        stream_slice = self._makeOne(stream, MAXSIZE)
+        stream_slice = self._make_one(stream, MAXSIZE)
         self.assertEqual(stream_slice.read(SIZE), CONTENT[:SIZE])
         self.assertEqual(stream_slice._remaining_bytes, MAXSIZE - SIZE)

--- a/core/unit_tests/streaming/test_stream_slice.py
+++ b/core/unit_tests/streaming/test_stream_slice.py
@@ -17,7 +17,8 @@ import unittest
 
 class Test_StreamSlice(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.streaming.stream_slice import StreamSlice
         return StreamSlice
 

--- a/core/unit_tests/streaming/test_transfer.py
+++ b/core/unit_tests/streaming/test_transfer.py
@@ -24,7 +24,7 @@ class Test__Transfer(unittest.TestCase):
         return _Transfer
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         from google.cloud.streaming.transfer import _DEFAULT_CHUNKSIZE
@@ -169,7 +169,7 @@ class Test_Download(unittest.TestCase):
         return Download
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         stream = _Stream()
@@ -196,7 +196,7 @@ class Test_Download(unittest.TestCase):
 
     def test_from_file_w_existing_file_no_override(self):
         import os
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with _tempdir() as tempdir:
             filename = os.path.join(tempdir, 'file.out')
             with open(filename, 'w') as fileobj:
@@ -206,7 +206,7 @@ class Test_Download(unittest.TestCase):
 
     def test_from_file_w_existing_file_w_override_wo_auto_transfer(self):
         import os
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with _tempdir() as tempdir:
             filename = os.path.join(tempdir, 'file.out')
             with open(filename, 'w') as fileobj:
@@ -220,7 +220,7 @@ class Test_Download(unittest.TestCase):
 
     def test_from_stream_defaults(self):
         stream = _Stream()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         download = klass.from_stream(stream)
         self.assertIs(download.stream, stream)
         self.assertTrue(download.auto_transfer)
@@ -230,7 +230,7 @@ class Test_Download(unittest.TestCase):
         CHUNK_SIZE = 1 << 18
         SIZE = 123
         stream = _Stream()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         download = klass.from_stream(stream, auto_transfer=False,
                                      total_size=SIZE, chunksize=CHUNK_SIZE)
         self.assertIs(download.stream, stream)
@@ -805,7 +805,7 @@ class Test_Upload(unittest.TestCase):
         return Upload
 
     def _makeOne(self, stream, mime_type=MIME_TYPE, *args, **kw):
-        return self._getTargetClass()(stream, mime_type, *args, **kw)
+        return self._get_target_class()(stream, mime_type, *args, **kw)
 
     def test_ctor_defaults(self):
         from google.cloud.streaming.transfer import _DEFAULT_CHUNKSIZE
@@ -830,14 +830,14 @@ class Test_Upload(unittest.TestCase):
         self.assertEqual(upload.chunksize, CHUNK_SIZE)
 
     def test_from_file_w_nonesuch_file(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         filename = '~nosuchuser/file.txt'
         with self.assertRaises(OSError):
             klass.from_file(filename)
 
     def test_from_file_wo_mimetype_w_unguessable_filename(self):
         import os
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         CONTENT = b'EXISTING FILE W/ UNGUESSABLE MIMETYPE'
         with _tempdir() as tempdir:
             filename = os.path.join(tempdir, 'file.unguessable')
@@ -848,7 +848,7 @@ class Test_Upload(unittest.TestCase):
 
     def test_from_file_wo_mimetype_w_guessable_filename(self):
         import os
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         CONTENT = b'EXISTING FILE W/ GUESSABLE MIMETYPE'
         with _tempdir() as tempdir:
             filename = os.path.join(tempdir, 'file.txt')
@@ -862,7 +862,7 @@ class Test_Upload(unittest.TestCase):
 
     def test_from_file_w_mimetype_w_auto_transfer_w_kwds(self):
         import os
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         CONTENT = b'EXISTING FILE W/ GUESSABLE MIMETYPE'
         CHUNK_SIZE = 3
         with _tempdir() as tempdir:
@@ -881,13 +881,13 @@ class Test_Upload(unittest.TestCase):
             upload._stream.close()
 
     def test_from_stream_wo_mimetype(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         stream = _Stream()
         with self.assertRaises(ValueError):
             klass.from_stream(stream, mime_type=None)
 
     def test_from_stream_defaults(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         stream = _Stream()
         upload = klass.from_stream(stream, mime_type=self.MIME_TYPE)
         self.assertEqual(upload.mime_type, self.MIME_TYPE)
@@ -895,7 +895,7 @@ class Test_Upload(unittest.TestCase):
         self.assertIsNone(upload.total_size)
 
     def test_from_stream_explicit(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         stream = _Stream()
         SIZE = 10
         CHUNK_SIZE = 3

--- a/core/unit_tests/streaming/test_transfer.py
+++ b/core/unit_tests/streaming/test_transfer.py
@@ -46,11 +46,11 @@ class Test__Transfer(unittest.TestCase):
         CHUNK_SIZE = 1 << 18
         NUM_RETRIES = 8
         xfer = self._make_one(stream,
-                             close_stream=True,
-                             chunksize=CHUNK_SIZE,
-                             auto_transfer=False,
-                             http=HTTP,
-                             num_retries=NUM_RETRIES)
+                              close_stream=True,
+                              chunksize=CHUNK_SIZE,
+                              auto_transfer=False,
+                              http=HTTP,
+                              num_retries=NUM_RETRIES)
         self.assertIs(xfer.stream, stream)
         self.assertTrue(xfer.close_stream)
         self.assertEqual(xfer.chunksize, CHUNK_SIZE)

--- a/core/unit_tests/streaming/test_transfer.py
+++ b/core/unit_tests/streaming/test_transfer.py
@@ -18,7 +18,8 @@ import unittest
 class Test__Transfer(unittest.TestCase):
     URL = 'http://example.com/api'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.streaming.transfer import _Transfer
         return _Transfer
 
@@ -162,7 +163,8 @@ class Test__Transfer(unittest.TestCase):
 class Test_Download(unittest.TestCase):
     URL = "http://example.com/api"
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.streaming.transfer import Download
         return Download
 
@@ -797,7 +799,8 @@ class Test_Upload(unittest.TestCase):
     MIME_TYPE = 'application/octet-stream'
     UPLOAD_URL = 'http://example.com/upload/id=foobar'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.streaming.transfer import Upload
         return Upload
 

--- a/core/unit_tests/streaming/test_transfer.py
+++ b/core/unit_tests/streaming/test_transfer.py
@@ -23,13 +23,13 @@ class Test__Transfer(unittest.TestCase):
         from google.cloud.streaming.transfer import _Transfer
         return _Transfer
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         from google.cloud.streaming.transfer import _DEFAULT_CHUNKSIZE
         stream = _Stream()
-        xfer = self._makeOne(stream)
+        xfer = self._make_one(stream)
         self.assertIs(xfer.stream, stream)
         self.assertFalse(xfer.close_stream)
         self.assertEqual(xfer.chunksize, _DEFAULT_CHUNKSIZE)
@@ -45,7 +45,7 @@ class Test__Transfer(unittest.TestCase):
         HTTP = object()
         CHUNK_SIZE = 1 << 18
         NUM_RETRIES = 8
-        xfer = self._makeOne(stream,
+        xfer = self._make_one(stream,
                              close_stream=True,
                              chunksize=CHUNK_SIZE,
                              auto_transfer=False,
@@ -62,33 +62,33 @@ class Test__Transfer(unittest.TestCase):
     def test_bytes_http_fallback_to_http(self):
         stream = _Stream()
         HTTP = object()
-        xfer = self._makeOne(stream, http=HTTP)
+        xfer = self._make_one(stream, http=HTTP)
         self.assertIs(xfer.bytes_http, HTTP)
 
     def test_bytes_http_setter(self):
         stream = _Stream()
         HTTP = object()
         BYTES_HTTP = object()
-        xfer = self._makeOne(stream, http=HTTP)
+        xfer = self._make_one(stream, http=HTTP)
         xfer.bytes_http = BYTES_HTTP
         self.assertIs(xfer.bytes_http, BYTES_HTTP)
 
     def test_num_retries_setter_invalid(self):
         stream = _Stream()
-        xfer = self._makeOne(stream)
+        xfer = self._make_one(stream)
         with self.assertRaises(ValueError):
             xfer.num_retries = object()
 
     def test_num_retries_setter_negative(self):
         stream = _Stream()
-        xfer = self._makeOne(stream)
+        xfer = self._make_one(stream)
         with self.assertRaises(ValueError):
             xfer.num_retries = -1
 
     def test__initialize_not_already_initialized_w_http(self):
         HTTP = object()
         stream = _Stream()
-        xfer = self._makeOne(stream)
+        xfer = self._make_one(stream)
         xfer._initialize(HTTP, self.URL)
         self.assertTrue(xfer.initialized)
         self.assertIs(xfer.http, HTTP)
@@ -97,7 +97,7 @@ class Test__Transfer(unittest.TestCase):
     def test__initialize_not_already_initialized_wo_http(self):
         from httplib2 import Http
         stream = _Stream()
-        xfer = self._makeOne(stream)
+        xfer = self._make_one(stream)
         xfer._initialize(None, self.URL)
         self.assertTrue(xfer.initialized)
         self.assertIsInstance(xfer.http, Http)
@@ -106,7 +106,7 @@ class Test__Transfer(unittest.TestCase):
     def test__initialize_w_existing_http(self):
         HTTP_1, HTTP_2 = object(), object()
         stream = _Stream()
-        xfer = self._makeOne(stream, http=HTTP_1)
+        xfer = self._make_one(stream, http=HTTP_1)
         xfer._initialize(HTTP_2, self.URL)
         self.assertTrue(xfer.initialized)
         self.assertIs(xfer.http, HTTP_1)
@@ -117,7 +117,7 @@ class Test__Transfer(unittest.TestCase):
         URL_2 = 'http://example.com/other'
         HTTP_1, HTTP_2 = object(), object()
         stream = _Stream()
-        xfer = self._makeOne(stream)
+        xfer = self._make_one(stream)
         xfer._initialize(HTTP_1, self.URL)
         with self.assertRaises(TransferInvalidError):
             xfer._initialize(HTTP_2, URL_2)
@@ -125,27 +125,27 @@ class Test__Transfer(unittest.TestCase):
     def test__ensure_initialized_hit(self):
         HTTP = object()
         stream = _Stream()
-        xfer = self._makeOne(stream)
+        xfer = self._make_one(stream)
         xfer._initialize(HTTP, self.URL)
         xfer._ensure_initialized()  # no raise
 
     def test__ensure_initialized_miss(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
         stream = _Stream()
-        xfer = self._makeOne(stream)
+        xfer = self._make_one(stream)
         with self.assertRaises(TransferInvalidError):
             xfer._ensure_initialized()
 
     def test__ensure_uninitialized_hit(self):
         stream = _Stream()
-        xfer = self._makeOne(stream)
+        xfer = self._make_one(stream)
         xfer._ensure_uninitialized()  # no raise
 
     def test__ensure_uninitialized_miss(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
         stream = _Stream()
         HTTP = object()
-        xfer = self._makeOne(stream)
+        xfer = self._make_one(stream)
         xfer._initialize(HTTP, self.URL)
         with self.assertRaises(TransferInvalidError):
             xfer._ensure_uninitialized()
@@ -153,7 +153,7 @@ class Test__Transfer(unittest.TestCase):
     def test___del___closes_stream(self):
 
         stream = _Stream()
-        xfer = self._makeOne(stream, close_stream=True)
+        xfer = self._make_one(stream, close_stream=True)
 
         self.assertFalse(stream._closed)
         del xfer
@@ -168,12 +168,12 @@ class Test_Download(unittest.TestCase):
         from google.cloud.streaming.transfer import Download
         return Download
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         stream = _Stream()
-        download = self._makeOne(stream)
+        download = self._make_one(stream)
         self.assertIs(download.stream, stream)
         self.assertIsNone(download._initial_response)
         self.assertEqual(download.progress, 0)
@@ -183,14 +183,14 @@ class Test_Download(unittest.TestCase):
     def test_ctor_w_kwds(self):
         stream = _Stream()
         CHUNK_SIZE = 123
-        download = self._makeOne(stream, chunksize=CHUNK_SIZE)
+        download = self._make_one(stream, chunksize=CHUNK_SIZE)
         self.assertIs(download.stream, stream)
         self.assertEqual(download.chunksize, CHUNK_SIZE)
 
     def test_ctor_w_total_size(self):
         stream = _Stream()
         SIZE = 123
-        download = self._makeOne(stream, total_size=SIZE)
+        download = self._make_one(stream, total_size=SIZE)
         self.assertIs(download.stream, stream)
         self.assertEqual(download.total_size, SIZE)
 
@@ -240,7 +240,7 @@ class Test_Download(unittest.TestCase):
 
     def test_configure_request(self):
         CHUNK_SIZE = 100
-        download = self._makeOne(_Stream(), chunksize=CHUNK_SIZE)
+        download = self._make_one(_Stream(), chunksize=CHUNK_SIZE)
         request = _Dummy(headers={})
         url_builder = _Dummy(query_params={})
         download.configure_request(request, url_builder)
@@ -249,34 +249,34 @@ class Test_Download(unittest.TestCase):
 
     def test__set_total_wo_content_range_wo_existing_total(self):
         info = {}
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._set_total(info)
         self.assertEqual(download.total_size, 0)
 
     def test__set_total_wo_content_range_w_existing_total(self):
         SIZE = 123
         info = {}
-        download = self._makeOne(_Stream(), total_size=SIZE)
+        download = self._make_one(_Stream(), total_size=SIZE)
         download._set_total(info)
         self.assertEqual(download.total_size, SIZE)
 
     def test__set_total_w_content_range_w_existing_total(self):
         SIZE = 123
         info = {'content-range': 'bytes 123-234/4567'}
-        download = self._makeOne(_Stream(), total_size=SIZE)
+        download = self._make_one(_Stream(), total_size=SIZE)
         download._set_total(info)
         self.assertEqual(download.total_size, 4567)
 
     def test__set_total_w_content_range_w_asterisk_total(self):
         info = {'content-range': 'bytes 123-234/*'}
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._set_total(info)
         self.assertEqual(download.total_size, 0)
 
     def test_initialize_download_already_initialized(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
         request = _Request()
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._initialize(None, self.URL)
         with self.assertRaises(TransferInvalidError):
             download.initialize_download(request, http=object())
@@ -284,7 +284,7 @@ class Test_Download(unittest.TestCase):
     def test_initialize_download_wo_autotransfer(self):
         request = _Request()
         http = object()
-        download = self._makeOne(_Stream(), auto_transfer=False)
+        download = self._make_one(_Stream(), auto_transfer=False)
         download.initialize_download(request, http)
         self.assertIs(download.http, http)
         self.assertEqual(download.url, request.url)
@@ -296,7 +296,7 @@ class Test_Download(unittest.TestCase):
         from google.cloud.streaming.exceptions import HttpError
         request = _Request()
         http = object()
-        download = self._makeOne(_Stream(), auto_transfer=True)
+        download = self._make_one(_Stream(), auto_transfer=True)
 
         response = _makeResponse(http_client.BAD_REQUEST)
         requester = _MakeRequest(response)
@@ -316,7 +316,7 @@ class Test_Download(unittest.TestCase):
         request = _Request()
         http = object()
         info = {'content-location': REDIRECT_URL}
-        download = self._makeOne(_Stream(), auto_transfer=True)
+        download = self._make_one(_Stream(), auto_transfer=True)
 
         response = _makeResponse(http_client.NO_CONTENT, info)
         requester = _MakeRequest(response)
@@ -333,14 +333,14 @@ class Test_Download(unittest.TestCase):
 
     def test__normalize_start_end_w_end_w_start_lt_0(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
 
         with self.assertRaises(TransferInvalidError):
             download._normalize_start_end(-1, 0)
 
     def test__normalize_start_end_w_end_w_start_gt_total(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._set_total({'content-range': 'bytes 0-1/2'})
 
         with self.assertRaises(TransferInvalidError):
@@ -348,65 +348,65 @@ class Test_Download(unittest.TestCase):
 
     def test__normalize_start_end_w_end_lt_start(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._set_total({'content-range': 'bytes 0-1/2'})
 
         with self.assertRaises(TransferInvalidError):
             download._normalize_start_end(1, 0)
 
     def test__normalize_start_end_w_end_gt_start(self):
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._set_total({'content-range': 'bytes 0-1/2'})
         self.assertEqual(download._normalize_start_end(1, 2), (1, 1))
 
     def test__normalize_start_end_wo_end_w_start_lt_0(self):
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._set_total({'content-range': 'bytes 0-1/2'})
         self.assertEqual(download._normalize_start_end(-2), (0, 1))
         self.assertEqual(download._normalize_start_end(-1), (1, 1))
 
     def test__normalize_start_end_wo_end_w_start_ge_0(self):
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._set_total({'content-range': 'bytes 0-1/100'})
         self.assertEqual(download._normalize_start_end(0), (0, 99))
         self.assertEqual(download._normalize_start_end(1), (1, 99))
 
     def test__set_range_header_w_start_lt_0(self):
         request = _Request()
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._set_range_header(request, -1)
         self.assertEqual(request.headers['range'], 'bytes=-1')
 
     def test__set_range_header_w_start_ge_0_wo_end(self):
         request = _Request()
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._set_range_header(request, 0)
         self.assertEqual(request.headers['range'], 'bytes=0-')
 
     def test__set_range_header_w_start_ge_0_w_end(self):
         request = _Request()
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._set_range_header(request, 0, 1)
         self.assertEqual(request.headers['range'], 'bytes=0-1')
 
     def test__compute_end_byte_w_start_lt_0_w_end(self):
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         self.assertEqual(download._compute_end_byte(-1, 1), 1)
 
     def test__compute_end_byte_w_start_ge_0_wo_end_w_use_chunks(self):
         CHUNK_SIZE = 5
-        download = self._makeOne(_Stream(), chunksize=CHUNK_SIZE)
+        download = self._make_one(_Stream(), chunksize=CHUNK_SIZE)
         self.assertEqual(download._compute_end_byte(0, use_chunks=True), 4)
 
     def test__compute_end_byte_w_start_ge_0_w_end_w_use_chunks(self):
         CHUNK_SIZE = 5
-        download = self._makeOne(_Stream(), chunksize=CHUNK_SIZE)
+        download = self._make_one(_Stream(), chunksize=CHUNK_SIZE)
         self.assertEqual(download._compute_end_byte(0, 3, use_chunks=True), 3)
         self.assertEqual(download._compute_end_byte(0, 5, use_chunks=True), 4)
 
     def test__compute_end_byte_w_start_ge_0_w_end_w_total_size(self):
         CHUNK_SIZE = 50
-        download = self._makeOne(_Stream(), chunksize=CHUNK_SIZE)
+        download = self._make_one(_Stream(), chunksize=CHUNK_SIZE)
         download._set_total({'content-range': 'bytes 0-1/10'})
         self.assertEqual(download._compute_end_byte(0, 100, use_chunks=False),
                          9)
@@ -414,13 +414,13 @@ class Test_Download(unittest.TestCase):
 
     def test__compute_end_byte_w_start_ge_0_wo_end_w_total_size(self):
         CHUNK_SIZE = 50
-        download = self._makeOne(_Stream(), chunksize=CHUNK_SIZE)
+        download = self._make_one(_Stream(), chunksize=CHUNK_SIZE)
         download._set_total({'content-range': 'bytes 0-1/10'})
         self.assertEqual(download._compute_end_byte(0, use_chunks=False), 9)
 
     def test__get_chunk_not_initialized(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
 
         with self.assertRaises(TransferInvalidError):
             download._get_chunk(0, 10)
@@ -430,7 +430,7 @@ class Test_Download(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud.streaming import transfer as MUT
         http = object()
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         download._initialize(http, self.URL)
         response = _makeResponse(http_client.OK)
         requester = _MakeRequest(response)
@@ -448,7 +448,7 @@ class Test_Download(unittest.TestCase):
     def test__process_response_w_FORBIDDEN(self):
         from google.cloud.streaming.exceptions import HttpError
         from six.moves import http_client
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         response = _makeResponse(http_client.FORBIDDEN)
         with self.assertRaises(HttpError):
             download._process_response(response)
@@ -456,7 +456,7 @@ class Test_Download(unittest.TestCase):
     def test__process_response_w_NOT_FOUND(self):
         from google.cloud.streaming.exceptions import HttpError
         from six.moves import http_client
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         response = _makeResponse(http_client.NOT_FOUND)
         with self.assertRaises(HttpError):
             download._process_response(response)
@@ -464,7 +464,7 @@ class Test_Download(unittest.TestCase):
     def test__process_response_w_other_error(self):
         from google.cloud.streaming.exceptions import TransferRetryError
         from six.moves import http_client
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         response = _makeResponse(http_client.BAD_REQUEST)
         with self.assertRaises(TransferRetryError):
             download._process_response(response)
@@ -472,7 +472,7 @@ class Test_Download(unittest.TestCase):
     def test__process_response_w_OK_wo_encoding(self):
         from six.moves import http_client
         stream = _Stream()
-        download = self._makeOne(stream)
+        download = self._make_one(stream)
         response = _makeResponse(http_client.OK, content='OK')
         found = download._process_response(response)
         self.assertIs(found, response)
@@ -483,7 +483,7 @@ class Test_Download(unittest.TestCase):
     def test__process_response_w_PARTIAL_CONTENT_w_encoding(self):
         from six.moves import http_client
         stream = _Stream()
-        download = self._makeOne(stream)
+        download = self._make_one(stream)
         info = {'content-encoding': 'blah'}
         response = _makeResponse(http_client.OK, info, 'PARTIAL')
         found = download._process_response(response)
@@ -495,7 +495,7 @@ class Test_Download(unittest.TestCase):
     def test__process_response_w_REQUESTED_RANGE_NOT_SATISFIABLE(self):
         from six.moves import http_client
         stream = _Stream()
-        download = self._makeOne(stream)
+        download = self._make_one(stream)
         response = _makeResponse(
             http_client.REQUESTED_RANGE_NOT_SATISFIABLE)
         found = download._process_response(response)
@@ -507,7 +507,7 @@ class Test_Download(unittest.TestCase):
     def test__process_response_w_NO_CONTENT(self):
         from six.moves import http_client
         stream = _Stream()
-        download = self._makeOne(stream)
+        download = self._make_one(stream)
         response = _makeResponse(status_code=http_client.NO_CONTENT)
         found = download._process_response(response)
         self.assertIs(found, response)
@@ -517,7 +517,7 @@ class Test_Download(unittest.TestCase):
 
     def test_get_range_not_initialized(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
         with self.assertRaises(TransferInvalidError):
             download.get_range(0, 10)
 
@@ -531,7 +531,7 @@ class Test_Download(unittest.TestCase):
         RESP_RANGE = 'bytes 0-%d/%d' % (LEN - 1, LEN)
         http = object()
         stream = _Stream()
-        download = self._makeOne(stream)
+        download = self._make_one(stream)
         download._initialize(http, self.URL)
         info = {'content-range': RESP_RANGE}
         response = _makeResponse(http_client.OK, info, CONTENT)
@@ -560,7 +560,7 @@ class Test_Download(unittest.TestCase):
         RESP_RANGE = 'bytes %d-%d/%d' % (START, LEN - 1, LEN)
         http = object()
         stream = _Stream()
-        download = self._makeOne(stream, chunksize=CHUNK_SIZE)
+        download = self._make_one(stream, chunksize=CHUNK_SIZE)
         download._initialize(http, self.URL)
         info = {'content-range': RESP_RANGE}
         response = _makeResponse(http_client.OK, info, CONTENT[START:])
@@ -588,7 +588,7 @@ class Test_Download(unittest.TestCase):
         RESP_RANGE = 'bytes 0-%d/%d' % (PARTIAL_LEN, LEN,)
         http = object()
         stream = _Stream()
-        download = self._makeOne(stream, total_size=LEN)
+        download = self._make_one(stream, total_size=LEN)
         download._initialize(http, self.URL)
         info = {'content-range': RESP_RANGE}
         response = _makeResponse(http_client.OK, info, CONTENT[:PARTIAL_LEN])
@@ -619,7 +619,7 @@ class Test_Download(unittest.TestCase):
         RESP_RANGE = 'bytes %d-%d/%d' % (START, LEN - 1, LEN)
         http = object()
         stream = _Stream()
-        download = self._makeOne(stream, chunksize=CHUNK_SIZE)
+        download = self._make_one(stream, chunksize=CHUNK_SIZE)
         download._initialize(http, self.URL)
         info = {'content-range': RESP_RANGE}
         response = _makeResponse(http_client.OK, info)
@@ -648,7 +648,7 @@ class Test_Download(unittest.TestCase):
         RESP_RANGE = 'bytes 0-%d/%d' % (LEN - 1, LEN,)
         http = object()
         stream = _Stream()
-        download = self._makeOne(stream, total_size=LEN, chunksize=CHUNK_SIZE)
+        download = self._make_one(stream, total_size=LEN, chunksize=CHUNK_SIZE)
         download._initialize(http, self.URL)
         info = {'content-range': RESP_RANGE}
         response = _makeResponse(http_client.OK, info, CONTENT)
@@ -678,7 +678,7 @@ class Test_Download(unittest.TestCase):
         RESP_RANGE_2 = 'bytes %d-%d/%d' % (CHUNK_SIZE, LEN - 1, LEN)
         http = object()
         stream = _Stream()
-        download = self._makeOne(stream, chunksize=CHUNK_SIZE)
+        download = self._make_one(stream, chunksize=CHUNK_SIZE)
         download._initialize(http, self.URL)
         info_1 = {'content-range': RESP_RANGE_1}
         response_1 = _makeResponse(http_client.PARTIAL_CONTENT, info_1,
@@ -703,7 +703,7 @@ class Test_Download(unittest.TestCase):
 
     def test_stream_file_not_initialized(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
-        download = self._makeOne(_Stream())
+        download = self._make_one(_Stream())
 
         with self.assertRaises(TransferInvalidError):
             download.stream_file()
@@ -714,7 +714,7 @@ class Test_Download(unittest.TestCase):
         LEN = len(CONTENT)
         RESP_RANGE = 'bytes 0-%d/%d' % (LEN - 1, LEN,)
         stream = _Stream()
-        download = self._makeOne(stream, total_size=LEN)
+        download = self._make_one(stream, total_size=LEN)
         info = {'content-range': RESP_RANGE}
         download._initial_response = _makeResponse(
             http_client.OK, info, CONTENT)
@@ -738,7 +738,7 @@ class Test_Download(unittest.TestCase):
         RESP_RANGE_2 = 'bytes %d-%d/%d' % (CHUNK_SIZE, LEN - 1, LEN,)
         stream = _Stream()
         http = object()
-        download = self._makeOne(stream, chunksize=CHUNK_SIZE)
+        download = self._make_one(stream, chunksize=CHUNK_SIZE)
         info_1 = {'content-range': RESP_RANGE_1}
         download._initial_response = _makeResponse(
             http_client.PARTIAL_CONTENT, info_1, CONTENT[:CHUNK_SIZE])
@@ -774,7 +774,7 @@ class Test_Download(unittest.TestCase):
         RESP_RANGE = 'bytes 0-%d/%d' % (LEN - 1, LEN,)
         stream = _Stream()
         http = object()
-        download = self._makeOne(stream, chunksize=CHUNK_SIZE)
+        download = self._make_one(stream, chunksize=CHUNK_SIZE)
         info = {'content-range': RESP_RANGE}
         response = _makeResponse(http_client.OK, info, CONTENT)
         requester = _MakeRequest(response)
@@ -804,13 +804,13 @@ class Test_Upload(unittest.TestCase):
         from google.cloud.streaming.transfer import Upload
         return Upload
 
-    def _makeOne(self, stream, mime_type=MIME_TYPE, *args, **kw):
+    def _make_one(self, stream, mime_type=MIME_TYPE, *args, **kw):
         return self._get_target_class()(stream, mime_type, *args, **kw)
 
     def test_ctor_defaults(self):
         from google.cloud.streaming.transfer import _DEFAULT_CHUNKSIZE
         stream = _Stream()
-        upload = self._makeOne(stream)
+        upload = self._make_one(stream)
         self.assertIs(upload.stream, stream)
         self.assertIsNone(upload._final_response)
         self.assertIsNone(upload._server_chunk_granularity)
@@ -824,7 +824,7 @@ class Test_Upload(unittest.TestCase):
     def test_ctor_w_kwds(self):
         stream = _Stream()
         CHUNK_SIZE = 123
-        upload = self._makeOne(stream, chunksize=CHUNK_SIZE)
+        upload = self._make_one(stream, chunksize=CHUNK_SIZE)
         self.assertIs(upload.stream, stream)
         self.assertEqual(upload.mime_type, self.MIME_TYPE)
         self.assertEqual(upload.chunksize, CHUNK_SIZE)
@@ -911,7 +911,7 @@ class Test_Upload(unittest.TestCase):
         self.assertEqual(upload.chunksize, CHUNK_SIZE)
 
     def test_strategy_setter_invalid(self):
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         with self.assertRaises(ValueError):
             upload.strategy = object()
         with self.assertRaises(ValueError):
@@ -919,20 +919,20 @@ class Test_Upload(unittest.TestCase):
 
     def test_strategy_setter_SIMPLE_UPLOAD(self):
         from google.cloud.streaming.transfer import SIMPLE_UPLOAD
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload.strategy = SIMPLE_UPLOAD
         self.assertEqual(upload.strategy, SIMPLE_UPLOAD)
 
     def test_strategy_setter_RESUMABLE_UPLOAD(self):
         from google.cloud.streaming.transfer import RESUMABLE_UPLOAD
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload.strategy = RESUMABLE_UPLOAD
         self.assertEqual(upload.strategy, RESUMABLE_UPLOAD)
 
     def test_total_size_setter_initialized(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
         SIZE = 123
-        upload = self._makeOne(_Stream)
+        upload = self._make_one(_Stream)
         http = object()
         upload._initialize(http, _Request.URL)
         with self.assertRaises(TransferInvalidError):
@@ -940,7 +940,7 @@ class Test_Upload(unittest.TestCase):
 
     def test_total_size_setter_not_initialized(self):
         SIZE = 123
-        upload = self._makeOne(_Stream)
+        upload = self._make_one(_Stream)
         upload.total_size = SIZE
         self.assertEqual(upload.total_size, SIZE)
 
@@ -952,7 +952,7 @@ class Test_Upload(unittest.TestCase):
             simple_path='/upload/endpoint',
         )
         request = _Request()
-        upload = self._makeOne(_Stream)
+        upload = self._make_one(_Stream)
         upload.strategy = RESUMABLE_UPLOAD
         upload._set_default_strategy(config, request)
         self.assertEqual(upload.strategy, RESUMABLE_UPLOAD)
@@ -965,7 +965,7 @@ class Test_Upload(unittest.TestCase):
             simple_path='/upload/endpoint',
         )
         request = _Request()
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload._set_default_strategy(config, request)
         self.assertEqual(upload.strategy, SIMPLE_UPLOAD)
 
@@ -974,7 +974,7 @@ class Test_Upload(unittest.TestCase):
         from google.cloud.streaming.transfer import RESUMABLE_UPLOAD
         config = _UploadConfig()
         request = _Request()
-        upload = self._makeOne(
+        upload = self._make_one(
             _Stream(), total_size=RESUMABLE_UPLOAD_THRESHOLD + 1)
         upload._set_default_strategy(config, request)
         self.assertEqual(upload.strategy, RESUMABLE_UPLOAD)
@@ -985,7 +985,7 @@ class Test_Upload(unittest.TestCase):
         config = _UploadConfig()
         config.simple_multipart = False
         request = _Request(body=CONTENT)
-        upload = self._makeOne(_Stream(), total_size=len(CONTENT))
+        upload = self._make_one(_Stream(), total_size=len(CONTENT))
         upload._set_default_strategy(config, request)
         self.assertEqual(upload.strategy, RESUMABLE_UPLOAD)
 
@@ -995,7 +995,7 @@ class Test_Upload(unittest.TestCase):
         config = _UploadConfig()
         config.simple_path = None
         request = _Request(body=CONTENT)
-        upload = self._makeOne(_Stream(), total_size=len(CONTENT))
+        upload = self._make_one(_Stream(), total_size=len(CONTENT))
         upload._set_default_strategy(config, request)
         self.assertEqual(upload.strategy, RESUMABLE_UPLOAD)
 
@@ -1004,7 +1004,7 @@ class Test_Upload(unittest.TestCase):
         CONTENT = b'ABCDEFGHIJ'
         config = _UploadConfig()
         request = _Request(body=CONTENT)
-        upload = self._makeOne(_Stream(), total_size=len(CONTENT))
+        upload = self._make_one(_Stream(), total_size=len(CONTENT))
         upload._set_default_strategy(config, request)
         self.assertEqual(upload.strategy, SIMPLE_UPLOAD)
 
@@ -1014,7 +1014,7 @@ class Test_Upload(unittest.TestCase):
         config.max_size = MAX_SIZE
         request = _Request()
         url_builder = _Dummy()
-        upload = self._makeOne(_Stream(), total_size=MAX_SIZE + 1)
+        upload = self._make_one(_Stream(), total_size=MAX_SIZE + 1)
         with self.assertRaises(ValueError):
             upload.configure_request(config, request, url_builder)
 
@@ -1023,7 +1023,7 @@ class Test_Upload(unittest.TestCase):
         config.accept = ('text/*',)
         request = _Request()
         url_builder = _Dummy()
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         with self.assertRaises(ValueError):
             upload.configure_request(config, request, url_builder)
 
@@ -1033,7 +1033,7 @@ class Test_Upload(unittest.TestCase):
         config = _UploadConfig()
         request = _Request()
         url_builder = _Dummy(query_params={})
-        upload = self._makeOne(_Stream(CONTENT))
+        upload = self._make_one(_Stream(CONTENT))
         upload.strategy = SIMPLE_UPLOAD
 
         upload.configure_request(config, request, url_builder)
@@ -1054,7 +1054,7 @@ class Test_Upload(unittest.TestCase):
         request = _Request(body=BODY)
         request.headers['content-type'] = 'text/plain'
         url_builder = _Dummy(query_params={})
-        upload = self._makeOne(_Stream(CONTENT))
+        upload = self._make_one(_Stream(CONTENT))
         upload.strategy = SIMPLE_UPLOAD
 
         upload.configure_request(config, request, url_builder)
@@ -1094,7 +1094,7 @@ class Test_Upload(unittest.TestCase):
         config = _UploadConfig()
         request = _Request()
         url_builder = _Dummy(query_params={})
-        upload = self._makeOne(_Stream(CONTENT))
+        upload = self._make_one(_Stream(CONTENT))
         upload.strategy = RESUMABLE_UPLOAD
 
         upload.configure_request(config, request, url_builder)
@@ -1112,7 +1112,7 @@ class Test_Upload(unittest.TestCase):
         config = _UploadConfig()
         request = _Request()
         url_builder = _Dummy(query_params={})
-        upload = self._makeOne(_Stream(CONTENT))
+        upload = self._make_one(_Stream(CONTENT))
         upload.total_size = LEN
         upload.strategy = RESUMABLE_UPLOAD
 
@@ -1127,14 +1127,14 @@ class Test_Upload(unittest.TestCase):
 
     def test_refresh_upload_state_w_simple_strategy(self):
         from google.cloud.streaming.transfer import SIMPLE_UPLOAD
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload.strategy = SIMPLE_UPLOAD
         upload.refresh_upload_state()  # no-op
 
     def test_refresh_upload_state_not_initialized(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
         from google.cloud.streaming.transfer import RESUMABLE_UPLOAD
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload.strategy = RESUMABLE_UPLOAD
         with self.assertRaises(TransferInvalidError):
             upload.refresh_upload_state()
@@ -1149,7 +1149,7 @@ class Test_Upload(unittest.TestCase):
         RESP_RANGE = 'bytes 0-%d/%d' % (LEN - 1, LEN,)
         http = object()
         stream = _Stream()
-        upload = self._makeOne(stream, total_size=LEN)
+        upload = self._make_one(stream, total_size=LEN)
         upload.strategy = RESUMABLE_UPLOAD
         upload._initialize(http, _Request.URL)
         info = {'content-range': RESP_RANGE}
@@ -1176,7 +1176,7 @@ class Test_Upload(unittest.TestCase):
         RESP_RANGE = 'bytes 0-%d/%d' % (LEN - 1, LEN,)
         http = object()
         stream = _Stream()
-        upload = self._makeOne(stream, total_size=LEN)
+        upload = self._make_one(stream, total_size=LEN)
         upload.strategy = RESUMABLE_UPLOAD
         upload._initialize(http, _Request.URL)
         info = {'content-range': RESP_RANGE}
@@ -1203,7 +1203,7 @@ class Test_Upload(unittest.TestCase):
         LAST = 5
         http = object()
         stream = _Stream()
-        upload = self._makeOne(stream, total_size=LEN)
+        upload = self._make_one(stream, total_size=LEN)
         upload.strategy = RESUMABLE_UPLOAD
         upload._initialize(http, _Request.URL)
         info = {'range': '0-%d' % (LAST - 1,)}
@@ -1229,7 +1229,7 @@ class Test_Upload(unittest.TestCase):
         LEN = len(CONTENT)
         http = object()
         stream = _Stream()
-        upload = self._makeOne(stream, total_size=LEN)
+        upload = self._make_one(stream, total_size=LEN)
         upload.strategy = RESUMABLE_UPLOAD
         upload._initialize(http, _Request.URL)
         response = _makeResponse(RESUME_INCOMPLETE, content=CONTENT)
@@ -1255,7 +1255,7 @@ class Test_Upload(unittest.TestCase):
         LEN = len(CONTENT)
         http = object()
         stream = _Stream()
-        upload = self._makeOne(stream, total_size=LEN)
+        upload = self._make_one(stream, total_size=LEN)
         upload.strategy = RESUMABLE_UPLOAD
         upload._initialize(http, _Request.URL)
         response = _makeResponse(http_client.FORBIDDEN)
@@ -1268,30 +1268,30 @@ class Test_Upload(unittest.TestCase):
                 upload.refresh_upload_state()
 
     def test__get_range_header_miss(self):
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         response = _makeResponse(None)
         self.assertIsNone(upload._get_range_header(response))
 
     def test__get_range_header_w_Range(self):
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         response = _makeResponse(None, {'Range': '123'})
         self.assertEqual(upload._get_range_header(response), '123')
 
     def test__get_range_header_w_range(self):
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         response = _makeResponse(None, {'range': '123'})
         self.assertEqual(upload._get_range_header(response), '123')
 
     def test_initialize_upload_no_strategy(self):
         request = _Request()
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         with self.assertRaises(ValueError):
             upload.initialize_upload(request, http=object())
 
     def test_initialize_upload_simple_w_http(self):
         from google.cloud.streaming.transfer import SIMPLE_UPLOAD
         request = _Request()
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload.strategy = SIMPLE_UPLOAD
         upload.initialize_upload(request, http=object())  # no-op
 
@@ -1299,7 +1299,7 @@ class Test_Upload(unittest.TestCase):
         from google.cloud.streaming.exceptions import TransferInvalidError
         from google.cloud.streaming.transfer import RESUMABLE_UPLOAD
         request = _Request()
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload.strategy = RESUMABLE_UPLOAD
         upload._initialize(None, self.URL)
         with self.assertRaises(TransferInvalidError):
@@ -1312,7 +1312,7 @@ class Test_Upload(unittest.TestCase):
         from google.cloud.streaming.exceptions import HttpError
         from google.cloud.streaming.transfer import RESUMABLE_UPLOAD
         request = _Request()
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload.strategy = RESUMABLE_UPLOAD
         response = _makeResponse(http_client.FORBIDDEN)
         requester = _MakeRequest(response)
@@ -1327,7 +1327,7 @@ class Test_Upload(unittest.TestCase):
         from google.cloud.streaming import transfer as MUT
         from google.cloud.streaming.transfer import RESUMABLE_UPLOAD
         request = _Request()
-        upload = self._makeOne(_Stream(), auto_transfer=False)
+        upload = self._make_one(_Stream(), auto_transfer=False)
         upload.strategy = RESUMABLE_UPLOAD
         info = {'location': self.UPLOAD_URL}
         response = _makeResponse(http_client.OK, info)
@@ -1350,7 +1350,7 @@ class Test_Upload(unittest.TestCase):
         CONTENT = b'ABCDEFGHIJ'
         http = object()
         request = _Request()
-        upload = self._makeOne(_Stream(CONTENT), chunksize=1000)
+        upload = self._make_one(_Stream(CONTENT), chunksize=1000)
         upload.strategy = RESUMABLE_UPLOAD
         info = {'X-Goog-Upload-Chunk-Granularity': '100',
                 'location': self.UPLOAD_URL}
@@ -1375,34 +1375,34 @@ class Test_Upload(unittest.TestCase):
         self.assertEqual(chunk_request.body, CONTENT)
 
     def test__last_byte(self):
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         self.assertEqual(upload._last_byte('123-456'), 456)
 
     def test__validate_chunksize_wo__server_chunk_granularity(self):
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload._validate_chunksize(123)  # no-op
 
     def test__validate_chunksize_w__server_chunk_granularity_miss(self):
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload._server_chunk_granularity = 100
         with self.assertRaises(ValueError):
             upload._validate_chunksize(123)
 
     def test__validate_chunksize_w__server_chunk_granularity_hit(self):
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload._server_chunk_granularity = 100
         upload._validate_chunksize(400)
 
     def test_stream_file_w_simple_strategy(self):
         from google.cloud.streaming.transfer import SIMPLE_UPLOAD
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload.strategy = SIMPLE_UPLOAD
         with self.assertRaises(ValueError):
             upload.stream_file()
 
     def test_stream_file_w_use_chunks_invalid_chunk_size(self):
         from google.cloud.streaming.transfer import RESUMABLE_UPLOAD
-        upload = self._makeOne(_Stream(), chunksize=1024)
+        upload = self._make_one(_Stream(), chunksize=1024)
         upload.strategy = RESUMABLE_UPLOAD
         upload._server_chunk_granularity = 100
         with self.assertRaises(ValueError):
@@ -1411,7 +1411,7 @@ class Test_Upload(unittest.TestCase):
     def test_stream_file_not_initialized(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
         from google.cloud.streaming.transfer import RESUMABLE_UPLOAD
-        upload = self._makeOne(_Stream(), chunksize=1024)
+        upload = self._make_one(_Stream(), chunksize=1024)
         upload.strategy = RESUMABLE_UPLOAD
         upload._server_chunk_granularity = 128
         with self.assertRaises(TransferInvalidError):
@@ -1422,7 +1422,7 @@ class Test_Upload(unittest.TestCase):
         http = object()
         stream = object()
         response = object()
-        upload = self._makeOne(stream, chunksize=1024)
+        upload = self._make_one(stream, chunksize=1024)
         upload.strategy = RESUMABLE_UPLOAD
         upload._server_chunk_granularity = 128
         upload._initialize(http, _Request.URL)
@@ -1437,7 +1437,7 @@ class Test_Upload(unittest.TestCase):
         http = object()
         stream = _Stream(CONTENT)
         response = object()
-        upload = self._makeOne(stream, chunksize=1024)
+        upload = self._make_one(stream, chunksize=1024)
         upload.strategy = RESUMABLE_UPLOAD
         upload._server_chunk_granularity = 128
         upload._initialize(http, _Request.URL)
@@ -1454,7 +1454,7 @@ class Test_Upload(unittest.TestCase):
         stream = _Stream(CONTENT)
         stream.seek(0, os.SEEK_END)
         response = object()
-        upload = self._makeOne(stream, chunksize=1024)
+        upload = self._make_one(stream, chunksize=1024)
         upload.strategy = RESUMABLE_UPLOAD
         upload._server_chunk_granularity = 128
         upload._initialize(http, _Request.URL)
@@ -1470,7 +1470,7 @@ class Test_Upload(unittest.TestCase):
         stream = _StreamWithSeekableMethod(CONTENT, True)
         stream.seek(0, os.SEEK_END)
         response = object()
-        upload = self._makeOne(stream, chunksize=1024)
+        upload = self._make_one(stream, chunksize=1024)
         upload.strategy = RESUMABLE_UPLOAD
         upload._server_chunk_granularity = 128
         upload._initialize(http, _Request.URL)
@@ -1486,7 +1486,7 @@ class Test_Upload(unittest.TestCase):
         stream = _StreamWithSeekableMethod(CONTENT, False)
         stream.seek(0, os.SEEK_END)
         response = object()
-        upload = self._makeOne(stream, chunksize=1024)
+        upload = self._make_one(stream, chunksize=1024)
         upload.strategy = RESUMABLE_UPLOAD
         upload._server_chunk_granularity = 128
         upload._initialize(http, _Request.URL)
@@ -1503,7 +1503,7 @@ class Test_Upload(unittest.TestCase):
         CONTENT = b'ABCDEFGHIJ'
         http = object()
         stream = _Stream(CONTENT)
-        upload = self._makeOne(stream, chunksize=6)
+        upload = self._make_one(stream, chunksize=6)
         upload.strategy = RESUMABLE_UPLOAD
         upload._server_chunk_granularity = 6
         upload._initialize(http, self.UPLOAD_URL)
@@ -1548,7 +1548,7 @@ class Test_Upload(unittest.TestCase):
         CONTENT = b'ABCDEFGHIJ'
         http = object()
         stream = _Stream(CONTENT)
-        upload = self._makeOne(stream, chunksize=6)
+        upload = self._make_one(stream, chunksize=6)
         upload.strategy = RESUMABLE_UPLOAD
         upload._server_chunk_granularity = 6
         upload._initialize(http, self.UPLOAD_URL)
@@ -1584,7 +1584,7 @@ class Test_Upload(unittest.TestCase):
         CONTENT = b'ABCDEFGHIJ'
         bytes_http = object()
         stream = _Stream(CONTENT)
-        upload = self._makeOne(stream)
+        upload = self._make_one(stream)
         upload.bytes_http = bytes_http
 
         headers = {'Content-Range': 'bytes 0-9/10',
@@ -1615,7 +1615,7 @@ class Test_Upload(unittest.TestCase):
         bytes_http = object()
         http = object()
         stream = _Stream(CONTENT)
-        upload = self._makeOne(stream)
+        upload = self._make_one(stream)
         upload.strategy = RESUMABLE_UPLOAD
         upload._initialize(http, self.UPLOAD_URL)
         upload.bytes_http = bytes_http
@@ -1647,14 +1647,14 @@ class Test_Upload(unittest.TestCase):
 
     def test__send_media_body_not_initialized(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         with self.assertRaises(TransferInvalidError):
             upload._send_media_body(0)
 
     def test__send_media_body_wo_total_size(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
         http = object()
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         upload._initialize(http, _Request.URL)
         with self.assertRaises(TransferInvalidError):
             upload._send_media_body(0)
@@ -1664,7 +1664,7 @@ class Test_Upload(unittest.TestCase):
         SIZE = 1234
         http = object()
         stream = _Stream()
-        upload = self._makeOne(stream, total_size=SIZE)
+        upload = self._make_one(stream, total_size=SIZE)
         upload._initialize(http, self.UPLOAD_URL)
         response = object()
         streamer = _MediaStreamer(response)
@@ -1691,7 +1691,7 @@ class Test_Upload(unittest.TestCase):
         SIZE = 1234
         http = object()
         stream = _Stream()
-        upload = self._makeOne(stream, total_size=SIZE)
+        upload = self._make_one(stream, total_size=SIZE)
         upload._initialize(http, self.UPLOAD_URL)
         response = object()
         streamer = _MediaStreamer(response)
@@ -1715,7 +1715,7 @@ class Test_Upload(unittest.TestCase):
 
     def test__send_chunk_not_initialized(self):
         from google.cloud.streaming.exceptions import TransferInvalidError
-        upload = self._makeOne(_Stream())
+        upload = self._make_one(_Stream())
         with self.assertRaises(TransferInvalidError):
             upload._send_chunk(0)
 
@@ -1723,7 +1723,7 @@ class Test_Upload(unittest.TestCase):
         CONTENT = b'ABCDEFGHIJ'
         SIZE = len(CONTENT)
         http = object()
-        upload = self._makeOne(_Stream(CONTENT), chunksize=1000)
+        upload = self._make_one(_Stream(CONTENT), chunksize=1000)
         upload._initialize(http, self.UPLOAD_URL)
         response = object()
         streamer = _MediaStreamer(response)
@@ -1749,7 +1749,7 @@ class Test_Upload(unittest.TestCase):
         SIZE = len(CONTENT)
         CHUNK_SIZE = SIZE - 5
         http = object()
-        upload = self._makeOne(_Stream(CONTENT), chunksize=CHUNK_SIZE)
+        upload = self._make_one(_Stream(CONTENT), chunksize=CHUNK_SIZE)
         upload._initialize(http, self.UPLOAD_URL)
         response = object()
         streamer = _MediaStreamer(response)
@@ -1779,7 +1779,7 @@ class Test_Upload(unittest.TestCase):
         CHUNK_SIZE = SIZE - 5
         http = object()
         stream = _Stream(CONTENT)
-        upload = self._makeOne(stream, total_size=SIZE, chunksize=CHUNK_SIZE)
+        upload = self._make_one(stream, total_size=SIZE, chunksize=CHUNK_SIZE)
         upload._initialize(http, self.UPLOAD_URL)
         response = object()
         streamer = _MediaStreamer(response)
@@ -1810,7 +1810,7 @@ class Test_Upload(unittest.TestCase):
         CHUNK_SIZE = 1000
         http = object()
         stream = _Stream(CONTENT)
-        upload = self._makeOne(stream, total_size=SIZE, chunksize=CHUNK_SIZE)
+        upload = self._make_one(stream, total_size=SIZE, chunksize=CHUNK_SIZE)
         upload._initialize(http, self.UPLOAD_URL)
         response = object()
         streamer = _MediaStreamer(response)

--- a/core/unit_tests/streaming/test_util.py
+++ b/core/unit_tests/streaming/test_util.py
@@ -17,7 +17,7 @@ import unittest
 
 class Test_calculate_wait_for_retry(unittest.TestCase):
 
-    def _callFUT(self, *args, **kw):
+    def _call_fut(self, *args, **kw):
         from google.cloud.streaming.util import calculate_wait_for_retry
         return calculate_wait_for_retry(*args, **kw)
 
@@ -25,38 +25,38 @@ class Test_calculate_wait_for_retry(unittest.TestCase):
         import random
         from google.cloud._testing import _Monkey
         with _Monkey(random, uniform=lambda lower, upper: lower):
-            self.assertEqual(self._callFUT(1), 1.5)
+            self.assertEqual(self._call_fut(1), 1.5)
 
     def test_w_positive_jitter_gt_max_wait(self):
         import random
         from google.cloud._testing import _Monkey
         with _Monkey(random, uniform=lambda lower, upper: upper):
-            self.assertEqual(self._callFUT(4), 20)
+            self.assertEqual(self._call_fut(4), 20)
 
 
 class Test_acceptable_mime_type(unittest.TestCase):
 
-    def _callFUT(self, *args, **kw):
+    def _call_fut(self, *args, **kw):
         from google.cloud.streaming.util import acceptable_mime_type
         return acceptable_mime_type(*args, **kw)
 
     def test_pattern_wo_slash(self):
         with self.assertRaises(ValueError) as err:
-            self._callFUT(['text/*'], 'BOGUS')
+            self._call_fut(['text/*'], 'BOGUS')
         self.assertEqual(
             err.exception.args,
             ('Invalid MIME type: "BOGUS"',))
 
     def test_accept_pattern_w_semicolon(self):
         with self.assertRaises(ValueError) as err:
-            self._callFUT(['text/*;charset=utf-8'], 'text/plain')
+            self._call_fut(['text/*;charset=utf-8'], 'text/plain')
         self.assertEqual(
             err.exception.args,
             ('MIME patterns with parameter unsupported: '
              '"text/*;charset=utf-8"',))
 
     def test_miss(self):
-        self.assertFalse(self._callFUT(['image/*'], 'text/plain'))
+        self.assertFalse(self._call_fut(['image/*'], 'text/plain'))
 
     def test_hit(self):
-        self.assertTrue(self._callFUT(['text/*'], 'text/plain'))
+        self.assertTrue(self._call_fut(['text/*'], 'text/plain'))

--- a/core/unit_tests/test__helpers.py
+++ b/core/unit_tests/test__helpers.py
@@ -1038,7 +1038,7 @@ class Test_make_secure_stub(unittest.TestCase):
         host = 'localhost'
         with _Monkey(MUT, make_secure_channel=mock_channel):
             stub = self._call_fut(credentials, user_agent,
-                                 stub_class, host)
+                                  stub_class, host)
 
         self.assertIs(stub, result)
         self.assertEqual(channels, [channel_obj])

--- a/core/unit_tests/test__helpers.py
+++ b/core/unit_tests/test__helpers.py
@@ -101,34 +101,34 @@ class Test__UTC(unittest.TestCase):
 
 class Test__ensure_tuple_or_list(unittest.TestCase):
 
-    def _callFUT(self, arg_name, tuple_or_list):
+    def _call_fut(self, arg_name, tuple_or_list):
         from google.cloud._helpers import _ensure_tuple_or_list
         return _ensure_tuple_or_list(arg_name, tuple_or_list)
 
     def test_valid_tuple(self):
         valid_tuple_or_list = ('a', 'b', 'c', 'd')
-        result = self._callFUT('ARGNAME', valid_tuple_or_list)
+        result = self._call_fut('ARGNAME', valid_tuple_or_list)
         self.assertEqual(result, ['a', 'b', 'c', 'd'])
 
     def test_valid_list(self):
         valid_tuple_or_list = ['a', 'b', 'c', 'd']
-        result = self._callFUT('ARGNAME', valid_tuple_or_list)
+        result = self._call_fut('ARGNAME', valid_tuple_or_list)
         self.assertEqual(result, valid_tuple_or_list)
 
     def test_invalid(self):
         invalid_tuple_or_list = object()
         with self.assertRaises(TypeError):
-            self._callFUT('ARGNAME', invalid_tuple_or_list)
+            self._call_fut('ARGNAME', invalid_tuple_or_list)
 
     def test_invalid_iterable(self):
         invalid_tuple_or_list = 'FOO'
         with self.assertRaises(TypeError):
-            self._callFUT('ARGNAME', invalid_tuple_or_list)
+            self._call_fut('ARGNAME', invalid_tuple_or_list)
 
 
 class Test__app_engine_id(unittest.TestCase):
 
-    def _callFUT(self):
+    def _call_fut(self):
         from google.cloud._helpers import _app_engine_id
         return _app_engine_id()
 
@@ -137,7 +137,7 @@ class Test__app_engine_id(unittest.TestCase):
         from google.cloud import _helpers
 
         with _Monkey(_helpers, app_identity=None):
-            dataset_id = self._callFUT()
+            dataset_id = self._call_fut()
             self.assertIsNone(dataset_id)
 
     def test_value_set(self):
@@ -147,13 +147,13 @@ class Test__app_engine_id(unittest.TestCase):
         APP_ENGINE_ID = object()
         APP_IDENTITY = _AppIdentity(APP_ENGINE_ID)
         with _Monkey(_helpers, app_identity=APP_IDENTITY):
-            dataset_id = self._callFUT()
+            dataset_id = self._call_fut()
             self.assertEqual(dataset_id, APP_ENGINE_ID)
 
 
 class Test__file_project_id(unittest.TestCase):
 
-    def _callFUT(self):
+    def _call_fut(self):
         from google.cloud._helpers import _file_project_id
         return _file_project_id()
 
@@ -170,7 +170,7 @@ class Test__file_project_id(unittest.TestCase):
 
             environ = {CREDENTIALS: temp.name}
             with _Monkey(os, getenv=environ.get):
-                result = self._callFUT()
+                result = self._call_fut()
 
             self.assertEqual(result, project_id)
 
@@ -179,14 +179,14 @@ class Test__file_project_id(unittest.TestCase):
 
         environ = {}
         with _Monkey(os, getenv=environ.get):
-            result = self._callFUT()
+            result = self._call_fut()
 
         self.assertIsNone(result)
 
 
 class Test__get_nix_config_path(unittest.TestCase):
 
-    def _callFUT(self):
+    def _call_fut(self):
         from google.cloud._helpers import _get_nix_config_path
         return _get_nix_config_path()
 
@@ -198,7 +198,7 @@ class Test__get_nix_config_path(unittest.TestCase):
         config_file = 'b'
         with _Monkey(MUT, _USER_ROOT=user_root,
                      _GCLOUD_CONFIG_FILE=config_file):
-            result = self._callFUT()
+            result = self._call_fut()
 
         expected = os.path.join(user_root, '.config', config_file)
         self.assertEqual(result, expected)
@@ -206,7 +206,7 @@ class Test__get_nix_config_path(unittest.TestCase):
 
 class Test__get_windows_config_path(unittest.TestCase):
 
-    def _callFUT(self):
+    def _call_fut(self):
         from google.cloud._helpers import _get_windows_config_path
         return _get_windows_config_path()
 
@@ -219,7 +219,7 @@ class Test__get_windows_config_path(unittest.TestCase):
         config_file = 'b'
         with _Monkey(os, getenv=environ.get):
             with _Monkey(MUT, _GCLOUD_CONFIG_FILE=config_file):
-                result = self._callFUT()
+                result = self._call_fut()
 
         expected = os.path.join(appdata_dir, config_file)
         self.assertEqual(result, expected)
@@ -229,7 +229,7 @@ class Test__default_service_project_id(unittest.TestCase):
 
     CONFIG_TEMPLATE = '[%s]\n%s = %s\n'
 
-    def _callFUT(self):
+    def _call_fut(self):
         from google.cloud._helpers import _default_service_project_id
         return _default_service_project_id()
 
@@ -252,7 +252,7 @@ class Test__default_service_project_id(unittest.TestCase):
             with _Monkey(os, name='not-nt'):
                 with _Monkey(MUT, _get_nix_config_path=mock_get_path,
                              _USER_ROOT='not-None'):
-                    result = self._callFUT()
+                    result = self._call_fut()
 
             self.assertEqual(result, project_id)
 
@@ -272,7 +272,7 @@ class Test__default_service_project_id(unittest.TestCase):
             with _Monkey(os, name='not-nt'):
                 with _Monkey(MUT, _get_nix_config_path=mock_get_path,
                              _USER_ROOT='not-None'):
-                    result = self._callFUT()
+                    result = self._call_fut()
 
             self.assertEqual(result, None)
 
@@ -295,7 +295,7 @@ class Test__default_service_project_id(unittest.TestCase):
             with _Monkey(os, name='nt'):
                 with _Monkey(MUT, _get_windows_config_path=mock_get_path,
                              _USER_ROOT=None):
-                    result = self._callFUT()
+                    result = self._call_fut()
 
             self.assertEqual(result, project_id)
 
@@ -305,14 +305,14 @@ class Test__default_service_project_id(unittest.TestCase):
 
         with _Monkey(os, name='not-nt'):
             with _Monkey(MUT, _USER_ROOT=None):
-                result = self._callFUT()
+                result = self._call_fut()
 
         self.assertIsNone(result)
 
 
 class Test__compute_engine_id(unittest.TestCase):
 
-    def _callFUT(self):
+    def _call_fut(self):
         from google.cloud._helpers import _compute_engine_id
         return _compute_engine_id()
 
@@ -330,26 +330,26 @@ class Test__compute_engine_id(unittest.TestCase):
     def test_bad_status(self):
         connection = _HTTPConnection(404, None)
         with self._monkeyConnection(connection):
-            dataset_id = self._callFUT()
+            dataset_id = self._call_fut()
             self.assertIsNone(dataset_id)
 
     def test_success(self):
         COMPUTE_ENGINE_ID = object()
         connection = _HTTPConnection(200, COMPUTE_ENGINE_ID)
         with self._monkeyConnection(connection):
-            dataset_id = self._callFUT()
+            dataset_id = self._call_fut()
             self.assertEqual(dataset_id, COMPUTE_ENGINE_ID)
 
     def test_socket_raises(self):
         connection = _TimeoutHTTPConnection()
         with self._monkeyConnection(connection):
-            dataset_id = self._callFUT()
+            dataset_id = self._call_fut()
             self.assertIsNone(dataset_id)
 
 
 class Test__get_production_project(unittest.TestCase):
 
-    def _callFUT(self):
+    def _call_fut(self):
         from google.cloud._helpers import _get_production_project
         return _get_production_project()
 
@@ -358,7 +358,7 @@ class Test__get_production_project(unittest.TestCase):
 
         environ = {}
         with _Monkey(os, getenv=environ.get):
-            project = self._callFUT()
+            project = self._call_fut()
             self.assertIsNone(project)
 
     def test_value_set(self):
@@ -368,13 +368,13 @@ class Test__get_production_project(unittest.TestCase):
         MOCK_PROJECT = object()
         environ = {PROJECT: MOCK_PROJECT}
         with _Monkey(os, getenv=environ.get):
-            project = self._callFUT()
+            project = self._call_fut()
             self.assertEqual(project, MOCK_PROJECT)
 
 
 class Test__determine_default_project(unittest.TestCase):
 
-    def _callFUT(self, project=None):
+    def _call_fut(self, project=None):
         from google.cloud._helpers import _determine_default_project
         return _determine_default_project(project=project)
 
@@ -414,7 +414,7 @@ class Test__determine_default_project(unittest.TestCase):
         }
 
         with _Monkey(_helpers, **patched_methods):
-            returned_project = self._callFUT(project)
+            returned_project = self._call_fut(project)
 
         return returned_project, _callers
 
@@ -453,7 +453,7 @@ class Test__determine_default_project(unittest.TestCase):
 
 class Test__millis(unittest.TestCase):
 
-    def _callFUT(self, value):
+    def _call_fut(self, value):
         from google.cloud._helpers import _millis
         return _millis(value)
 
@@ -462,12 +462,12 @@ class Test__millis(unittest.TestCase):
         from google.cloud._helpers import UTC
 
         WHEN = datetime.datetime(1970, 1, 1, 0, 0, 1, tzinfo=UTC)
-        self.assertEqual(self._callFUT(WHEN), 1000)
+        self.assertEqual(self._call_fut(WHEN), 1000)
 
 
 class Test__microseconds_from_datetime(unittest.TestCase):
 
-    def _callFUT(self, value):
+    def _call_fut(self, value):
         from google.cloud._helpers import _microseconds_from_datetime
         return _microseconds_from_datetime(value)
 
@@ -478,18 +478,18 @@ class Test__microseconds_from_datetime(unittest.TestCase):
         timestamp = datetime.datetime(1970, 1, 1, hour=0,
                                       minute=0, second=0,
                                       microsecond=microseconds)
-        result = self._callFUT(timestamp)
+        result = self._call_fut(timestamp)
         self.assertEqual(result, microseconds)
 
 
 class Test__millis_from_datetime(unittest.TestCase):
 
-    def _callFUT(self, value):
+    def _call_fut(self, value):
         from google.cloud._helpers import _millis_from_datetime
         return _millis_from_datetime(value)
 
     def test_w_none(self):
-        self.assertIsNone(self._callFUT(None))
+        self.assertIsNone(self._call_fut(None))
 
     def test_w_utc_datetime(self):
         import datetime
@@ -500,7 +500,7 @@ class Test__millis_from_datetime(unittest.TestCase):
         NOW = datetime.datetime.utcnow().replace(tzinfo=UTC)
         NOW_MICROS = _microseconds_from_datetime(NOW)
         MILLIS = NOW_MICROS // 1000
-        result = self._callFUT(NOW)
+        result = self._call_fut(NOW)
         self.assertIsInstance(result, six.integer_types)
         self.assertEqual(result, MILLIS)
 
@@ -518,7 +518,7 @@ class Test__millis_from_datetime(unittest.TestCase):
         NOW = datetime.datetime(2015, 7, 28, 16, 34, 47, tzinfo=zone)
         NOW_MICROS = _microseconds_from_datetime(NOW)
         MILLIS = NOW_MICROS // 1000
-        result = self._callFUT(NOW)
+        result = self._call_fut(NOW)
         self.assertIsInstance(result, six.integer_types)
         self.assertEqual(result, MILLIS)
 
@@ -532,14 +532,14 @@ class Test__millis_from_datetime(unittest.TestCase):
         UTC_NOW = NOW.replace(tzinfo=UTC)
         UTC_NOW_MICROS = _microseconds_from_datetime(UTC_NOW)
         MILLIS = UTC_NOW_MICROS // 1000
-        result = self._callFUT(NOW)
+        result = self._call_fut(NOW)
         self.assertIsInstance(result, six.integer_types)
         self.assertEqual(result, MILLIS)
 
 
 class Test__datetime_from_microseconds(unittest.TestCase):
 
-    def _callFUT(self, value):
+    def _call_fut(self, value):
         from google.cloud._helpers import _datetime_from_microseconds
         return _datetime_from_microseconds(value)
 
@@ -551,24 +551,24 @@ class Test__datetime_from_microseconds(unittest.TestCase):
         NOW = datetime.datetime(2015, 7, 29, 17, 45, 21, 123456,
                                 tzinfo=UTC)
         NOW_MICROS = _microseconds_from_datetime(NOW)
-        self.assertEqual(self._callFUT(NOW_MICROS), NOW)
+        self.assertEqual(self._call_fut(NOW_MICROS), NOW)
 
 
 class Test___date_from_iso8601_date(unittest.TestCase):
 
-    def _callFUT(self, value):
+    def _call_fut(self, value):
         from google.cloud._helpers import _date_from_iso8601_date
         return _date_from_iso8601_date(value)
 
     def test_todays_date(self):
         import datetime
         TODAY = datetime.date.today()
-        self.assertEqual(self._callFUT(TODAY.strftime("%Y-%m-%d")), TODAY)
+        self.assertEqual(self._call_fut(TODAY.strftime("%Y-%m-%d")), TODAY)
 
 
 class Test__rfc3339_to_datetime(unittest.TestCase):
 
-    def _callFUT(self, dt_str):
+    def _call_fut(self, dt_str):
         from google.cloud._helpers import _rfc3339_to_datetime
         return _rfc3339_to_datetime(dt_str)
 
@@ -584,7 +584,7 @@ class Test__rfc3339_to_datetime(unittest.TestCase):
         dt_str = '%d-%02d-%02dT%02d:%02d:%02d.%06dBOGUS' % (
             year, month, day, hour, minute, seconds, micros)
         with self.assertRaises(ValueError):
-            self._callFUT(dt_str)
+            self._call_fut(dt_str)
 
     def test_w_microseconds(self):
         import datetime
@@ -600,7 +600,7 @@ class Test__rfc3339_to_datetime(unittest.TestCase):
 
         dt_str = '%d-%02d-%02dT%02d:%02d:%02d.%06dZ' % (
             year, month, day, hour, minute, seconds, micros)
-        result = self._callFUT(dt_str)
+        result = self._call_fut(dt_str)
         expected_result = datetime.datetime(
             year, month, day, hour, minute, seconds, micros, UTC)
         self.assertEqual(result, expected_result)
@@ -617,12 +617,12 @@ class Test__rfc3339_to_datetime(unittest.TestCase):
         dt_str = '%d-%02d-%02dT%02d:%02d:%02d.%09dZ' % (
             year, month, day, hour, minute, seconds, nanos)
         with self.assertRaises(ValueError):
-            self._callFUT(dt_str)
+            self._call_fut(dt_str)
 
 
 class Test__rfc3339_nanos_to_datetime(unittest.TestCase):
 
-    def _callFUT(self, dt_str):
+    def _call_fut(self, dt_str):
         from google.cloud._helpers import _rfc3339_nanos_to_datetime
         return _rfc3339_nanos_to_datetime(dt_str)
 
@@ -638,7 +638,7 @@ class Test__rfc3339_nanos_to_datetime(unittest.TestCase):
         dt_str = '%d-%02d-%02dT%02d:%02d:%02d.%06dBOGUS' % (
             year, month, day, hour, minute, seconds, micros)
         with self.assertRaises(ValueError):
-            self._callFUT(dt_str)
+            self._call_fut(dt_str)
 
     def test_w_truncated_nanos(self):
         import datetime
@@ -664,7 +664,7 @@ class Test__rfc3339_nanos_to_datetime(unittest.TestCase):
         for truncated, micros in truncateds_and_micros:
             dt_str = '%d-%02d-%02dT%02d:%02d:%02d.%sZ' % (
                 year, month, day, hour, minute, seconds, truncated)
-            result = self._callFUT(dt_str)
+            result = self._call_fut(dt_str)
             expected_result = datetime.datetime(
                 year, month, day, hour, minute, seconds, micros, UTC)
             self.assertEqual(result, expected_result)
@@ -682,7 +682,7 @@ class Test__rfc3339_nanos_to_datetime(unittest.TestCase):
 
         dt_str = '%d-%02d-%02dT%02d:%02d:%02dZ' % (
             year, month, day, hour, minute, seconds)
-        result = self._callFUT(dt_str)
+        result = self._call_fut(dt_str)
         expected_result = datetime.datetime(
             year, month, day, hour, minute, seconds, 0, UTC)
         self.assertEqual(result, expected_result)
@@ -702,7 +702,7 @@ class Test__rfc3339_nanos_to_datetime(unittest.TestCase):
 
         dt_str = '%d-%02d-%02dT%02d:%02d:%02d.%09dZ' % (
             year, month, day, hour, minute, seconds, nanos)
-        result = self._callFUT(dt_str)
+        result = self._call_fut(dt_str)
         expected_result = datetime.datetime(
             year, month, day, hour, minute, seconds, micros, UTC)
         self.assertEqual(result, expected_result)
@@ -710,7 +710,7 @@ class Test__rfc3339_nanos_to_datetime(unittest.TestCase):
 
 class Test__datetime_to_rfc3339(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud._helpers import _datetime_to_rfc3339
         return _datetime_to_rfc3339(*args, **kwargs)
 
@@ -729,7 +729,7 @@ class Test__datetime_to_rfc3339(unittest.TestCase):
         from google.cloud._helpers import UTC
 
         TIMESTAMP = datetime.datetime(2016, 4, 5, 13, 30, 0, tzinfo=UTC)
-        result = self._callFUT(TIMESTAMP, ignore_zone=False)
+        result = self._call_fut(TIMESTAMP, ignore_zone=False)
         self.assertEqual(result, '2016-04-05T13:30:00.000000Z')
 
     def test_w_non_utc_datetime(self):
@@ -737,7 +737,7 @@ class Test__datetime_to_rfc3339(unittest.TestCase):
 
         zone = self._make_timezone(offset=datetime.timedelta(hours=-1))
         TIMESTAMP = datetime.datetime(2016, 4, 5, 13, 30, 0, tzinfo=zone)
-        result = self._callFUT(TIMESTAMP, ignore_zone=False)
+        result = self._call_fut(TIMESTAMP, ignore_zone=False)
         self.assertEqual(result, '2016-04-05T14:30:00.000000Z')
 
     def test_w_non_utc_datetime_and_ignore_zone(self):
@@ -745,68 +745,68 @@ class Test__datetime_to_rfc3339(unittest.TestCase):
 
         zone = self._make_timezone(offset=datetime.timedelta(hours=-1))
         TIMESTAMP = datetime.datetime(2016, 4, 5, 13, 30, 0, tzinfo=zone)
-        result = self._callFUT(TIMESTAMP)
+        result = self._call_fut(TIMESTAMP)
         self.assertEqual(result, '2016-04-05T13:30:00.000000Z')
 
     def test_w_naive_datetime(self):
         import datetime
 
         TIMESTAMP = datetime.datetime(2016, 4, 5, 13, 30, 0)
-        result = self._callFUT(TIMESTAMP)
+        result = self._call_fut(TIMESTAMP)
         self.assertEqual(result, '2016-04-05T13:30:00.000000Z')
 
 
 class Test__to_bytes(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud._helpers import _to_bytes
         return _to_bytes(*args, **kwargs)
 
     def test_with_bytes(self):
         value = b'bytes-val'
-        self.assertEqual(self._callFUT(value), value)
+        self.assertEqual(self._call_fut(value), value)
 
     def test_with_unicode(self):
         value = u'string-val'
         encoded_value = b'string-val'
-        self.assertEqual(self._callFUT(value), encoded_value)
+        self.assertEqual(self._call_fut(value), encoded_value)
 
     def test_unicode_non_ascii(self):
         value = u'\u2013'  # Long hyphen
         encoded_value = b'\xe2\x80\x93'
-        self.assertRaises(UnicodeEncodeError, self._callFUT, value)
-        self.assertEqual(self._callFUT(value, encoding='utf-8'),
+        self.assertRaises(UnicodeEncodeError, self._call_fut, value)
+        self.assertEqual(self._call_fut(value, encoding='utf-8'),
                          encoded_value)
 
     def test_with_nonstring_type(self):
         value = object()
-        self.assertRaises(TypeError, self._callFUT, value)
+        self.assertRaises(TypeError, self._call_fut, value)
 
 
 class Test__bytes_to_unicode(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud._helpers import _bytes_to_unicode
         return _bytes_to_unicode(*args, **kwargs)
 
     def test_with_bytes(self):
         value = b'bytes-val'
         encoded_value = 'bytes-val'
-        self.assertEqual(self._callFUT(value), encoded_value)
+        self.assertEqual(self._call_fut(value), encoded_value)
 
     def test_with_unicode(self):
         value = u'string-val'
         encoded_value = 'string-val'
-        self.assertEqual(self._callFUT(value), encoded_value)
+        self.assertEqual(self._call_fut(value), encoded_value)
 
     def test_with_nonstring_type(self):
         value = object()
-        self.assertRaises(ValueError, self._callFUT, value)
+        self.assertRaises(ValueError, self._call_fut, value)
 
 
 class Test__pb_timestamp_to_datetime(unittest.TestCase):
 
-    def _callFUT(self, timestamp):
+    def _call_fut(self, timestamp):
         from google.cloud._helpers import _pb_timestamp_to_datetime
         return _pb_timestamp_to_datetime(timestamp)
 
@@ -822,12 +822,12 @@ class Test__pb_timestamp_to_datetime(unittest.TestCase):
         # ... so 1 minute and 1 second after is 61 seconds and 1234
         # microseconds is 1234000 nanoseconds.
         timestamp = Timestamp(seconds=61, nanos=1234000)
-        self.assertEqual(self._callFUT(timestamp), dt_stamp)
+        self.assertEqual(self._call_fut(timestamp), dt_stamp)
 
 
 class Test__pb_timestamp_to_rfc3339(unittest.TestCase):
 
-    def _callFUT(self, timestamp):
+    def _call_fut(self, timestamp):
         from google.cloud._helpers import _pb_timestamp_to_rfc3339
         return _pb_timestamp_to_rfc3339(timestamp)
 
@@ -838,13 +838,13 @@ class Test__pb_timestamp_to_rfc3339(unittest.TestCase):
         # ... so 1 minute and 1 second after is 61 seconds and 1234
         # microseconds is 1234000 nanoseconds.
         timestamp = Timestamp(seconds=61, nanos=1234000)
-        self.assertEqual(self._callFUT(timestamp),
+        self.assertEqual(self._call_fut(timestamp),
                          '1970-01-01T00:01:01.001234Z')
 
 
 class Test__datetime_to_pb_timestamp(unittest.TestCase):
 
-    def _callFUT(self, when):
+    def _call_fut(self, when):
         from google.cloud._helpers import _datetime_to_pb_timestamp
         return _datetime_to_pb_timestamp(when)
 
@@ -860,7 +860,7 @@ class Test__datetime_to_pb_timestamp(unittest.TestCase):
         # ... so 1 minute and 1 second after is 61 seconds and 1234
         # microseconds is 1234000 nanoseconds.
         timestamp = Timestamp(seconds=61, nanos=1234000)
-        self.assertEqual(self._callFUT(dt_stamp), timestamp)
+        self.assertEqual(self._call_fut(dt_stamp), timestamp)
 
 
 class Test__name_from_project_path(unittest.TestCase):
@@ -869,39 +869,39 @@ class Test__name_from_project_path(unittest.TestCase):
     THING_NAME = 'THING_NAME'
     TEMPLATE = r'projects/(?P<project>\w+)/things/(?P<name>\w+)'
 
-    def _callFUT(self, path, project, template):
+    def _call_fut(self, path, project, template):
         from google.cloud._helpers import _name_from_project_path
         return _name_from_project_path(path, project, template)
 
     def test_w_invalid_path_length(self):
         PATH = 'projects/foo'
         with self.assertRaises(ValueError):
-            self._callFUT(PATH, None, self.TEMPLATE)
+            self._call_fut(PATH, None, self.TEMPLATE)
 
     def test_w_invalid_path_segments(self):
         PATH = 'foo/%s/bar/%s' % (self.PROJECT, self.THING_NAME)
         with self.assertRaises(ValueError):
-            self._callFUT(PATH, self.PROJECT, self.TEMPLATE)
+            self._call_fut(PATH, self.PROJECT, self.TEMPLATE)
 
     def test_w_mismatched_project(self):
         PROJECT1 = 'PROJECT1'
         PROJECT2 = 'PROJECT2'
         PATH = 'projects/%s/things/%s' % (PROJECT1, self.THING_NAME)
         with self.assertRaises(ValueError):
-            self._callFUT(PATH, PROJECT2, self.TEMPLATE)
+            self._call_fut(PATH, PROJECT2, self.TEMPLATE)
 
     def test_w_valid_data_w_compiled_regex(self):
         import re
         template = re.compile(self.TEMPLATE)
         PATH = 'projects/%s/things/%s' % (self.PROJECT, self.THING_NAME)
-        name = self._callFUT(PATH, self.PROJECT, template)
+        name = self._call_fut(PATH, self.PROJECT, template)
         self.assertEqual(name, self.THING_NAME)
 
     def test_w_project_passed_as_none(self):
         PROJECT1 = 'PROJECT1'
         PATH = 'projects/%s/things/%s' % (PROJECT1, self.THING_NAME)
-        self._callFUT(PATH, None, self.TEMPLATE)
-        name = self._callFUT(PATH, None, self.TEMPLATE)
+        self._call_fut(PATH, None, self.TEMPLATE)
+        name = self._call_fut(PATH, None, self.TEMPLATE)
         self.assertEqual(name, self.THING_NAME)
 
 
@@ -940,7 +940,7 @@ class TestMetadataPlugin(unittest.TestCase):
 
 class Test_make_secure_channel(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud._helpers import make_secure_channel
         return make_secure_channel(*args, **kwargs)
 
@@ -991,7 +991,7 @@ class Test_make_secure_channel(unittest.TestCase):
         user_agent = 'USER_AGENT'
         with _Monkey(MUT, grpc=grpc_mod,
                      MetadataPlugin=mock_plugin):
-            result = self._callFUT(credentials, user_agent, host)
+            result = self._call_fut(credentials, user_agent, host)
 
         self.assertIs(result, CHANNEL)
         self.assertEqual(plugin_args, [(credentials,)])
@@ -1012,7 +1012,7 @@ class Test_make_secure_channel(unittest.TestCase):
 
 class Test_make_secure_stub(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud._helpers import make_secure_stub
         return make_secure_stub(*args, **kwargs)
 
@@ -1037,7 +1037,7 @@ class Test_make_secure_stub(unittest.TestCase):
         user_agent = 'you-sir-age-int'
         host = 'localhost'
         with _Monkey(MUT, make_secure_channel=mock_channel):
-            stub = self._callFUT(credentials, user_agent,
+            stub = self._call_fut(credentials, user_agent,
                                  stub_class, host)
 
         self.assertIs(stub, result)
@@ -1048,7 +1048,7 @@ class Test_make_secure_stub(unittest.TestCase):
 
 class Test_make_insecure_stub(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud._helpers import make_insecure_stub
         return make_insecure_stub(*args, **kwargs)
 
@@ -1073,7 +1073,7 @@ class Test_make_insecure_stub(unittest.TestCase):
             return mock_result
 
         with _Monkey(MUT, grpc=grpc_mod):
-            result = self._callFUT(mock_stub_class, host, port=port)
+            result = self._call_fut(mock_stub_class, host, port=port)
 
         self.assertIs(result, mock_result)
         self.assertEqual(stub_inputs, [CHANNEL])

--- a/core/unit_tests/test__helpers.py
+++ b/core/unit_tests/test__helpers.py
@@ -25,7 +25,7 @@ class Test__LocalStack(unittest.TestCase):
         return _LocalStack
 
     def _makeOne(self):
-        return self._getTargetClass()()
+        return self._get_target_class()()
 
     def test_it(self):
         batch1, batch2 = object(), object()
@@ -53,11 +53,11 @@ class Test__UTC(unittest.TestCase):
         return _UTC
 
     def _makeOne(self):
-        return self._getTargetClass()()
+        return self._get_target_class()()
 
     def test_module_property(self):
         from google.cloud import _helpers as MUT
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         try:
             import pytz
         except ImportError:
@@ -913,7 +913,7 @@ class TestMetadataPlugin(unittest.TestCase):
         return MetadataPlugin
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         credentials = object()

--- a/core/unit_tests/test__helpers.py
+++ b/core/unit_tests/test__helpers.py
@@ -24,12 +24,12 @@ class Test__LocalStack(unittest.TestCase):
 
         return _LocalStack
 
-    def _makeOne(self):
+    def _make_one(self):
         return self._get_target_class()()
 
     def test_it(self):
         batch1, batch2 = object(), object()
-        batches = self._makeOne()
+        batches = self._make_one()
         self.assertEqual(list(batches), [])
         self.assertIsNone(batches.top)
         batches.push(batch1)
@@ -52,7 +52,7 @@ class Test__UTC(unittest.TestCase):
         from google.cloud._helpers import _UTC
         return _UTC
 
-    def _makeOne(self):
+    def _make_one(self):
         return self._get_target_class()()
 
     def test_module_property(self):
@@ -68,7 +68,7 @@ class Test__UTC(unittest.TestCase):
     def test_dst(self):
         import datetime
 
-        tz = self._makeOne()
+        tz = self._make_one()
         self.assertEqual(tz.dst(None), datetime.timedelta(0))
 
     def test_fromutc(self):
@@ -76,26 +76,26 @@ class Test__UTC(unittest.TestCase):
 
         naive_epoch = datetime.datetime.utcfromtimestamp(0)
         self.assertIsNone(naive_epoch.tzinfo)
-        tz = self._makeOne()
+        tz = self._make_one()
         epoch = tz.fromutc(naive_epoch)
         self.assertEqual(epoch.tzinfo, tz)
 
     def test_tzname(self):
-        tz = self._makeOne()
+        tz = self._make_one()
         self.assertEqual(tz.tzname(None), 'UTC')
 
     def test_utcoffset(self):
         import datetime
 
-        tz = self._makeOne()
+        tz = self._make_one()
         self.assertEqual(tz.utcoffset(None), datetime.timedelta(0))
 
     def test___repr__(self):
-        tz = self._makeOne()
+        tz = self._make_one()
         self.assertEqual(repr(tz), '<UTC>')
 
     def test___str__(self):
-        tz = self._makeOne()
+        tz = self._make_one()
         self.assertEqual(str(tz), 'UTC')
 
 
@@ -912,12 +912,12 @@ class TestMetadataPlugin(unittest.TestCase):
         from google.cloud._helpers import MetadataPlugin
         return MetadataPlugin
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         credentials = object()
-        plugin = self._makeOne(credentials)
+        plugin = self._make_one(credentials)
         self.assertIs(plugin._credentials, credentials)
 
     def test___call__(self):
@@ -928,7 +928,7 @@ class TestMetadataPlugin(unittest.TestCase):
         def callback(*args):
             callback_args.append(args)
 
-        transformer = self._makeOne(credentials)
+        transformer = self._make_one(credentials)
         result = transformer(None, callback)
         cb_headers = [
             ('authorization', 'Bearer ' + access_token_expected),

--- a/core/unit_tests/test__helpers.py
+++ b/core/unit_tests/test__helpers.py
@@ -18,7 +18,8 @@ import unittest
 
 class Test__LocalStack(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud._helpers import _LocalStack
 
         return _LocalStack
@@ -46,7 +47,8 @@ class Test__LocalStack(unittest.TestCase):
 
 class Test__UTC(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud._helpers import _UTC
         return _UTC
 
@@ -905,7 +907,8 @@ class Test__name_from_project_path(unittest.TestCase):
 
 class TestMetadataPlugin(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud._helpers import MetadataPlugin
         return MetadataPlugin
 

--- a/core/unit_tests/test_client.py
+++ b/core/unit_tests/test_client.py
@@ -180,7 +180,8 @@ class TestJSONClient(unittest.TestCase):
         CREDENTIALS = object()
         HTTP = object()
         with self.assertRaises(ValueError):
-            self._make_one(project=object(), credentials=CREDENTIALS, http=HTTP)
+            self._make_one(project=object(), credentials=CREDENTIALS,
+                           http=HTTP)
 
     def _explicit_ctor_helper(self, project):
         import six
@@ -189,7 +190,7 @@ class TestJSONClient(unittest.TestCase):
         HTTP = object()
 
         client_obj = self._make_one(project=project, credentials=CREDENTIALS,
-                                   http=HTTP)
+                                    http=HTTP)
 
         if isinstance(project, six.binary_type):
             self.assertEqual(client_obj.project, project.decode('utf-8'))

--- a/core/unit_tests/test_client.py
+++ b/core/unit_tests/test_client.py
@@ -43,7 +43,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
@@ -58,7 +58,7 @@ class TestClient(unittest.TestCase):
             return CREDENTIALS
 
         with _Monkey(client, get_credentials=mock_get_credentials):
-            client_obj = self._makeOne()
+            client_obj = self._make_one()
 
         self.assertIsInstance(client_obj.connection, _MockConnection)
         self.assertIs(client_obj.connection.credentials, CREDENTIALS)
@@ -67,7 +67,7 @@ class TestClient(unittest.TestCase):
     def test_ctor_explicit(self):
         CREDENTIALS = object()
         HTTP = object()
-        client_obj = self._makeOne(credentials=CREDENTIALS, http=HTTP)
+        client_obj = self._make_one(credentials=CREDENTIALS, http=HTTP)
 
         self.assertIsInstance(client_obj.connection, _MockConnection)
         self.assertIs(client_obj.connection.credentials, CREDENTIALS)
@@ -131,7 +131,7 @@ class TestJSONClient(unittest.TestCase):
         from google.cloud.client import JSONClient
         return JSONClient
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
@@ -152,7 +152,7 @@ class TestJSONClient(unittest.TestCase):
 
         with _Monkey(client, get_credentials=mock_get_credentials,
                      _determine_default_project=mock_determine_proj):
-            client_obj = self._makeOne()
+            client_obj = self._make_one()
 
         self.assertEqual(client_obj.project, PROJECT)
         self.assertIsInstance(client_obj.connection, _MockConnection)
@@ -172,7 +172,7 @@ class TestJSONClient(unittest.TestCase):
             return None
 
         with _Monkey(client, _determine_default_project=mock_determine_proj):
-            self.assertRaises(EnvironmentError, self._makeOne)
+            self.assertRaises(EnvironmentError, self._make_one)
 
         self.assertEqual(FUNC_CALLS, [(None, '_determine_default_project')])
 
@@ -180,7 +180,7 @@ class TestJSONClient(unittest.TestCase):
         CREDENTIALS = object()
         HTTP = object()
         with self.assertRaises(ValueError):
-            self._makeOne(project=object(), credentials=CREDENTIALS, http=HTTP)
+            self._make_one(project=object(), credentials=CREDENTIALS, http=HTTP)
 
     def _explicit_ctor_helper(self, project):
         import six
@@ -188,7 +188,7 @@ class TestJSONClient(unittest.TestCase):
         CREDENTIALS = object()
         HTTP = object()
 
-        client_obj = self._makeOne(project=project, credentials=CREDENTIALS,
+        client_obj = self._make_one(project=project, credentials=CREDENTIALS,
                                    http=HTTP)
 
         if isinstance(project, six.binary_type):

--- a/core/unit_tests/test_client.py
+++ b/core/unit_tests/test_client.py
@@ -17,7 +17,8 @@ import unittest
 
 class Test_ClientFactoryMixin(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.client import _ClientFactoryMixin
         return _ClientFactoryMixin
 
@@ -37,7 +38,8 @@ class TestClient(unittest.TestCase):
         KLASS = self._getTargetClass()
         KLASS._connection_class = self.original_cnxn_class
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.client import Client
         return Client
 
@@ -124,7 +126,8 @@ class TestJSONClient(unittest.TestCase):
         KLASS = self._getTargetClass()
         KLASS._connection_class = self.original_cnxn_class
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.client import JSONClient
         return JSONClient
 

--- a/core/unit_tests/test_client.py
+++ b/core/unit_tests/test_client.py
@@ -23,19 +23,19 @@ class Test_ClientFactoryMixin(unittest.TestCase):
         return _ClientFactoryMixin
 
     def test_virtual(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         self.assertFalse('__init__' in klass.__dict__)
 
 
 class TestClient(unittest.TestCase):
 
     def setUp(self):
-        KLASS = self._getTargetClass()
+        KLASS = self._get_target_class()
         self.original_cnxn_class = KLASS._connection_class
         KLASS._connection_class = _MockConnection
 
     def tearDown(self):
-        KLASS = self._getTargetClass()
+        KLASS = self._get_target_class()
         KLASS._connection_class = self.original_cnxn_class
 
     @staticmethod
@@ -44,7 +44,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         from google.cloud._testing import _Monkey
@@ -77,7 +77,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud import client
 
-        KLASS = self._getTargetClass()
+        KLASS = self._get_target_class()
         MOCK_FILENAME = 'foo.path'
         mock_creds = _MockServiceAccountCredentials()
         with _Monkey(client, ServiceAccountCredentials=mock_creds):
@@ -87,7 +87,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(mock_creds.json_called, [MOCK_FILENAME])
 
     def test_from_service_account_json_fail(self):
-        KLASS = self._getTargetClass()
+        KLASS = self._get_target_class()
         CREDENTIALS = object()
         self.assertRaises(TypeError, KLASS.from_service_account_json, None,
                           credentials=CREDENTIALS)
@@ -96,7 +96,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud import client
 
-        KLASS = self._getTargetClass()
+        KLASS = self._get_target_class()
         CLIENT_EMAIL = 'phred@example.com'
         MOCK_FILENAME = 'foo.path'
         mock_creds = _MockServiceAccountCredentials()
@@ -109,7 +109,7 @@ class TestClient(unittest.TestCase):
                          [(CLIENT_EMAIL, MOCK_FILENAME)])
 
     def test_from_service_account_p12_fail(self):
-        KLASS = self._getTargetClass()
+        KLASS = self._get_target_class()
         CREDENTIALS = object()
         self.assertRaises(TypeError, KLASS.from_service_account_p12, None,
                           None, credentials=CREDENTIALS)
@@ -118,12 +118,12 @@ class TestClient(unittest.TestCase):
 class TestJSONClient(unittest.TestCase):
 
     def setUp(self):
-        KLASS = self._getTargetClass()
+        KLASS = self._get_target_class()
         self.original_cnxn_class = KLASS._connection_class
         KLASS._connection_class = _MockConnection
 
     def tearDown(self):
-        KLASS = self._getTargetClass()
+        KLASS = self._get_target_class()
         KLASS._connection_class = self.original_cnxn_class
 
     @staticmethod
@@ -132,7 +132,7 @@ class TestJSONClient(unittest.TestCase):
         return JSONClient
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         from google.cloud._testing import _Monkey

--- a/core/unit_tests/test_connection.py
+++ b/core/unit_tests/test_connection.py
@@ -22,41 +22,41 @@ class TestConnection(unittest.TestCase):
         from google.cloud.connection import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         self.assertIsNone(conn.credentials)
 
     def test_ctor_explicit(self):
         credentials = _Credentials()
         self.assertEqual(credentials._create_scoped_calls, 0)
-        conn = self._makeOne(credentials)
+        conn = self._make_one(credentials)
         self.assertEqual(credentials._create_scoped_calls, 1)
         self.assertIs(conn.credentials, credentials)
         self.assertIsNone(conn._http)
 
     def test_ctor_explicit_http(self):
         http = object()
-        conn = self._makeOne(http=http)
+        conn = self._make_one(http=http)
         self.assertIsNone(conn.credentials)
         self.assertIs(conn.http, http)
 
     def test_ctor_credentials_wo_create_scoped(self):
         credentials = object()
-        conn = self._makeOne(credentials)
+        conn = self._make_one(credentials)
         self.assertIs(conn.credentials, credentials)
         self.assertIsNone(conn._http)
 
     def test_http_w_existing(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         conn._http = http = object()
         self.assertIs(conn.http, http)
 
     def test_http_wo_creds(self):
         import httplib2
-        conn = self._makeOne()
+        conn = self._make_one()
         self.assertIsInstance(conn.http, httplib2.Http)
 
     def test_http_w_creds(self):
@@ -64,7 +64,7 @@ class TestConnection(unittest.TestCase):
 
         authorized = object()
         credentials = _Credentials(authorized)
-        conn = self._makeOne(credentials)
+        conn = self._make_one(credentials)
         self.assertIs(conn.http, authorized)
         self.assertIsInstance(credentials._called_with, httplib2.Http)
 
@@ -72,7 +72,7 @@ class TestConnection(unittest.TestCase):
         from pkg_resources import get_distribution
         expected_ua = 'gcloud-python/{0}'.format(
             get_distribution('google-cloud-core').version)
-        conn = self._makeOne()
+        conn = self._make_one()
         self.assertEqual(conn.USER_AGENT, expected_ua)
 
     def test__create_scoped_credentials_with_scoped_credentials(self):
@@ -114,7 +114,7 @@ class TestJSONConnection(unittest.TestCase):
         from google.cloud.connection import JSONConnection
         return JSONConnection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _makeMockOne(self, *args, **kw):
@@ -131,22 +131,22 @@ class TestJSONConnection(unittest.TestCase):
         self.assertIsNone(klass.API_VERSION)
 
     def test_ctor_defaults(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         self.assertIsNone(conn.credentials)
 
     def test_ctor_explicit(self):
         credentials = _Credentials()
-        conn = self._makeOne(credentials)
+        conn = self._make_one(credentials)
         self.assertIs(conn.credentials, credentials)
 
     def test_http_w_existing(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         conn._http = http = object()
         self.assertIs(conn.http, http)
 
     def test_http_wo_creds(self):
         import httplib2
-        conn = self._makeOne()
+        conn = self._make_one()
         self.assertIsInstance(conn.http, httplib2.Http)
 
     def test_http_w_creds(self):
@@ -154,7 +154,7 @@ class TestJSONConnection(unittest.TestCase):
 
         authorized = object()
         credentials = _Credentials(authorized)
-        conn = self._makeOne(credentials)
+        conn = self._make_one(credentials)
         self.assertIs(conn.http, authorized)
         self.assertIsInstance(credentials._called_with, httplib2.Http)
 
@@ -189,7 +189,7 @@ class TestJSONConnection(unittest.TestCase):
         self.assertEqual(parms['bar'], 'baz')
 
     def test__make_request_no_data_no_content_type_no_headers(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = 'http://example.com/test'
         http = conn._http = _Http(
             {'status': '200', 'content-type': 'text/plain'},
@@ -210,7 +210,7 @@ class TestJSONConnection(unittest.TestCase):
         self.assertEqual(http._called_with['headers'], expected_headers)
 
     def test__make_request_w_data_no_extra_headers(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = 'http://example.com/test'
         http = conn._http = _Http(
             {'status': '200', 'content-type': 'text/plain'},
@@ -229,7 +229,7 @@ class TestJSONConnection(unittest.TestCase):
         self.assertEqual(http._called_with['headers'], expected_headers)
 
     def test__make_request_w_extra_headers(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = 'http://example.com/test'
         http = conn._http = _Http(
             {'status': '200', 'content-type': 'text/plain'},

--- a/core/unit_tests/test_connection.py
+++ b/core/unit_tests/test_connection.py
@@ -23,7 +23,7 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         conn = self._makeOne()
@@ -76,7 +76,7 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(conn.USER_AGENT, expected_ua)
 
     def test__create_scoped_credentials_with_scoped_credentials(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         scoped_creds = object()
         scope = 'google-specific-scope'
         credentials = _Credentials(scoped=scoped_creds)
@@ -87,7 +87,7 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(credentials._scopes, [scope])
 
     def test__create_scoped_credentials_without_scope_required(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         credentials = _Credentials()
 
         result = klass._create_scoped_credentials(credentials, None)
@@ -96,13 +96,13 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(credentials._scopes, [])
 
     def test__create_scoped_credentials_non_scoped_credentials(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         credentials = object()
         result = klass._create_scoped_credentials(credentials, None)
         self.assertIs(result, credentials)
 
     def test__create_scoped_credentials_no_credentials(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         result = klass._create_scoped_credentials(None, None)
         self.assertIsNone(result)
 
@@ -115,17 +115,17 @@ class TestJSONConnection(unittest.TestCase):
         return JSONConnection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _makeMockOne(self, *args, **kw):
-        class MockConnection(self._getTargetClass()):
+        class MockConnection(self._get_target_class()):
             API_URL_TEMPLATE = '{api_base_url}/mock/{api_version}{path}'
             API_BASE_URL = 'http://mock'
             API_VERSION = 'vMOCK'
         return MockConnection(*args, **kw)
 
     def test_class_defaults(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         self.assertIsNone(klass.API_URL_TEMPLATE)
         self.assertIsNone(klass.API_BASE_URL)
         self.assertIsNone(klass.API_VERSION)

--- a/core/unit_tests/test_connection.py
+++ b/core/unit_tests/test_connection.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.connection import Connection
         return Connection
 
@@ -108,7 +109,8 @@ class TestConnection(unittest.TestCase):
 
 class TestJSONConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.connection import JSONConnection
         return JSONConnection
 

--- a/core/unit_tests/test_credentials.py
+++ b/core/unit_tests/test_credentials.py
@@ -62,10 +62,10 @@ class Test_generate_signed_url(unittest.TestCase):
 
         with _Monkey(MUT, _get_signed_query_params=_get_signed_query_params):
             url = self._call_fut(CREDENTIALS, RESOURCE, 1000,
-                                api_access_endpoint=ENDPOINT,
-                                response_type=response_type,
-                                response_disposition=response_disposition,
-                                generation=generation)
+                                 api_access_endpoint=ENDPOINT,
+                                 response_type=response_type,
+                                 response_disposition=response_disposition,
+                                 generation=generation)
 
         scheme, netloc, path, qs, frag = urlsplit(url)
         self.assertEqual(scheme, 'http')
@@ -130,7 +130,7 @@ class Test__get_signed_query_params(unittest.TestCase):
         EXPIRATION = 100
         STRING_TO_SIGN = 'dummy_signature'
         result = self._call_fut(CREDENTIALS, EXPIRATION,
-                               STRING_TO_SIGN)
+                                STRING_TO_SIGN)
 
         self.assertEqual(result, {
             'GoogleAccessId': ACCOUNT_NAME,

--- a/core/unit_tests/test_credentials.py
+++ b/core/unit_tests/test_credentials.py
@@ -17,7 +17,7 @@ import unittest
 
 class Test_get_credentials(unittest.TestCase):
 
-    def _callFUT(self):
+    def _call_fut(self):
         from google.cloud import credentials
         return credentials.get_credentials()
 
@@ -27,7 +27,7 @@ class Test_get_credentials(unittest.TestCase):
 
         client = _Client()
         with _Monkey(MUT, client=client):
-            found = self._callFUT()
+            found = self._call_fut()
         self.assertIsInstance(found, _Credentials)
         self.assertIs(found, client._signed)
         self.assertTrue(client._get_app_default_called)
@@ -35,7 +35,7 @@ class Test_get_credentials(unittest.TestCase):
 
 class Test_generate_signed_url(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud.credentials import generate_signed_url
         return generate_signed_url(*args, **kwargs)
 
@@ -61,7 +61,7 @@ class Test_generate_signed_url(unittest.TestCase):
             }
 
         with _Monkey(MUT, _get_signed_query_params=_get_signed_query_params):
-            url = self._callFUT(CREDENTIALS, RESOURCE, 1000,
+            url = self._call_fut(CREDENTIALS, RESOURCE, 1000,
                                 api_access_endpoint=ENDPOINT,
                                 response_type=response_type,
                                 response_disposition=response_disposition,
@@ -115,7 +115,7 @@ class Test_generate_signed_url_exception(unittest.TestCase):
 
 class Test__get_signed_query_params(unittest.TestCase):
 
-    def _callFUT(self, credentials, expiration, string_to_sign):
+    def _call_fut(self, credentials, expiration, string_to_sign):
         from google.cloud.credentials import _get_signed_query_params
         return _get_signed_query_params(credentials, expiration,
                                         string_to_sign)
@@ -129,7 +129,7 @@ class Test__get_signed_query_params(unittest.TestCase):
                                    service_account_email=ACCOUNT_NAME)
         EXPIRATION = 100
         STRING_TO_SIGN = 'dummy_signature'
-        result = self._callFUT(CREDENTIALS, EXPIRATION,
+        result = self._call_fut(CREDENTIALS, EXPIRATION,
                                STRING_TO_SIGN)
 
         self.assertEqual(result, {
@@ -142,7 +142,7 @@ class Test__get_signed_query_params(unittest.TestCase):
 
 class Test__get_expiration_seconds(unittest.TestCase):
 
-    def _callFUT(self, expiration):
+    def _call_fut(self, expiration):
         from google.cloud.credentials import _get_expiration_seconds
         return _get_expiration_seconds(expiration)
 
@@ -151,11 +151,11 @@ class Test__get_expiration_seconds(unittest.TestCase):
         return int(calendar.timegm(when.timetuple()))
 
     def test_w_invalid(self):
-        self.assertRaises(TypeError, self._callFUT, object())
-        self.assertRaises(TypeError, self._callFUT, None)
+        self.assertRaises(TypeError, self._call_fut, object())
+        self.assertRaises(TypeError, self._call_fut, None)
 
     def test_w_int(self):
-        self.assertEqual(self._callFUT(123), 123)
+        self.assertEqual(self._call_fut(123), 123)
 
     def test_w_long(self):
         try:
@@ -163,14 +163,14 @@ class Test__get_expiration_seconds(unittest.TestCase):
         except NameError:  # pragma: NO COVER Py3K
             pass
         else:
-            self.assertEqual(self._callFUT(long(123)), 123)
+            self.assertEqual(self._call_fut(long(123)), 123)
 
     def test_w_naive_datetime(self):
         import datetime
 
         expiration_no_tz = datetime.datetime(2004, 8, 19, 0, 0, 0, 0)
         utc_seconds = self._utc_seconds(expiration_no_tz)
-        self.assertEqual(self._callFUT(expiration_no_tz), utc_seconds)
+        self.assertEqual(self._call_fut(expiration_no_tz), utc_seconds)
 
     def test_w_utc_datetime(self):
         import datetime
@@ -178,7 +178,7 @@ class Test__get_expiration_seconds(unittest.TestCase):
 
         expiration_utc = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, UTC)
         utc_seconds = self._utc_seconds(expiration_utc)
-        self.assertEqual(self._callFUT(expiration_utc), utc_seconds)
+        self.assertEqual(self._call_fut(expiration_utc), utc_seconds)
 
     def test_w_other_zone_datetime(self):
         import datetime
@@ -192,7 +192,7 @@ class Test__get_expiration_seconds(unittest.TestCase):
         expiration_other = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, zone)
         utc_seconds = self._utc_seconds(expiration_other)
         cet_seconds = utc_seconds - (60 * 60)  # CET one hour earlier than UTC
-        self.assertEqual(self._callFUT(expiration_other), cet_seconds)
+        self.assertEqual(self._call_fut(expiration_other), cet_seconds)
 
     def test_w_timedelta_seconds(self):
         import datetime
@@ -204,7 +204,7 @@ class Test__get_expiration_seconds(unittest.TestCase):
         expiration_as_delta = datetime.timedelta(seconds=10)
 
         with _Monkey(MUT, _NOW=lambda: dummy_utcnow):
-            result = self._callFUT(expiration_as_delta)
+            result = self._call_fut(expiration_as_delta)
 
         self.assertEqual(result, utc_seconds + 10)
 
@@ -218,7 +218,7 @@ class Test__get_expiration_seconds(unittest.TestCase):
         expiration_as_delta = datetime.timedelta(days=1)
 
         with _Monkey(MUT, _NOW=lambda: dummy_utcnow):
-            result = self._callFUT(expiration_as_delta)
+            result = self._call_fut(expiration_as_delta)
 
         self.assertEqual(result, utc_seconds + 86400)
 

--- a/core/unit_tests/test_exceptions.py
+++ b/core/unit_tests/test_exceptions.py
@@ -22,11 +22,11 @@ class Test_GoogleCloudError(unittest.TestCase):
         from google.cloud.exceptions import GoogleCloudError
         return GoogleCloudError
 
-    def _makeOne(self, message, errors=()):
+    def _make_one(self, message, errors=()):
         return self._get_target_class()(message, errors=errors)
 
     def test_ctor_defaults(self):
-        e = self._makeOne('Testing')
+        e = self._make_one('Testing')
         e.code = 600
         self.assertEqual(str(e), '600 Testing')
         self.assertEqual(e.message, 'Testing')
@@ -40,7 +40,7 @@ class Test_GoogleCloudError(unittest.TestCase):
             'message': 'Testing',
             'reason': 'test',
             }
-        e = self._makeOne('Testing', [ERROR])
+        e = self._make_one('Testing', [ERROR])
         e.code = 600
         self.assertEqual(str(e), '600 Testing')
         self.assertEqual(e.message, 'Testing')

--- a/core/unit_tests/test_exceptions.py
+++ b/core/unit_tests/test_exceptions.py
@@ -49,7 +49,7 @@ class Test_GoogleCloudError(unittest.TestCase):
 
 class Test_make_exception(unittest.TestCase):
 
-    def _callFUT(self, response, content, error_info=None, use_json=True):
+    def _call_fut(self, response, content, error_info=None, use_json=True):
         from google.cloud.exceptions import make_exception
         return make_exception(response, content, error_info=error_info,
                               use_json=use_json)
@@ -58,7 +58,7 @@ class Test_make_exception(unittest.TestCase):
         from google.cloud.exceptions import NotFound
         response = _Response(404)
         content = b'{"error": {"message": "Not Found"}}'
-        exception = self._callFUT(response, content)
+        exception = self._call_fut(response, content)
         self.assertIsInstance(exception, NotFound)
         self.assertEqual(exception.message, 'Not Found')
         self.assertEqual(list(exception.errors), [])
@@ -73,7 +73,7 @@ class Test_make_exception(unittest.TestCase):
         response = _Response(404)
         content = u'{"error": {"message": "%s" }}' % (error_message,)
 
-        exception = self._callFUT(response, content)
+        exception = self._call_fut(response, content)
         if six.PY2:
             self.assertEqual(str(exception),
                              _to_bytes(expected, encoding='utf-8'))
@@ -94,7 +94,7 @@ class Test_make_exception(unittest.TestCase):
         with _Monkey(six, PY2=False):
             response = _Response(404)
             content = u'{"error": {"message": "%s" }}' % (error_message,)
-            exception = self._callFUT(response, content)
+            exception = self._call_fut(response, content)
 
             self.assertIsInstance(exception, NotFound)
             self.assertEqual(exception.message, error_message)
@@ -112,7 +112,7 @@ class Test_make_exception(unittest.TestCase):
             }
         response = _Response(600)
         content = {"error": {"message": "Unknown Error", "errors": [ERROR]}}
-        exception = self._callFUT(response, content)
+        exception = self._call_fut(response, content)
         self.assertIsInstance(exception, GoogleCloudError)
         self.assertEqual(exception.message, 'Unknown Error')
         self.assertEqual(list(exception.errors), [ERROR])
@@ -121,7 +121,7 @@ class Test_make_exception(unittest.TestCase):
         from google.cloud.exceptions import NotFound
         response = _Response(NotFound.code)
         content = '<html><body>404 Not Found</body></html>'
-        exception = self._callFUT(response, content, use_json=True)
+        exception = self._call_fut(response, content, use_json=True)
         self.assertIsInstance(exception, NotFound)
         self.assertEqual(exception.message, content)
         self.assertEqual(list(exception.errors), [])
@@ -131,7 +131,7 @@ class Test_make_exception(unittest.TestCase):
 
         content = u'error-content'
         response = _Response(TooManyRequests.code)
-        exception = self._callFUT(response, content, use_json=False)
+        exception = self._call_fut(response, content, use_json=False)
 
         self.assertIsInstance(exception, TooManyRequests)
         self.assertEqual(exception.message, content)

--- a/core/unit_tests/test_exceptions.py
+++ b/core/unit_tests/test_exceptions.py
@@ -23,7 +23,7 @@ class Test_GoogleCloudError(unittest.TestCase):
         return GoogleCloudError
 
     def _makeOne(self, message, errors=()):
-        return self._getTargetClass()(message, errors=errors)
+        return self._get_target_class()(message, errors=errors)
 
     def test_ctor_defaults(self):
         e = self._makeOne('Testing')

--- a/core/unit_tests/test_exceptions.py
+++ b/core/unit_tests/test_exceptions.py
@@ -17,7 +17,8 @@ import unittest
 
 class Test_GoogleCloudError(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.exceptions import GoogleCloudError
         return GoogleCloudError
 

--- a/core/unit_tests/test_iterator.py
+++ b/core/unit_tests/test_iterator.py
@@ -34,7 +34,7 @@ class TestPage(unittest.TestCase):
         return Page
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         parent = object()
@@ -98,7 +98,7 @@ class TestIterator(unittest.TestCase):
         return Iterator
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         connection = _Connection()
@@ -241,7 +241,7 @@ class TestHTTPIterator(unittest.TestCase):
         return HTTPIterator
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         from google.cloud.iterator import _do_nothing_page_start
@@ -474,7 +474,7 @@ class TestGAXIterator(unittest.TestCase):
         return GAXIterator
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         client = _Client(None)

--- a/core/unit_tests/test_iterator.py
+++ b/core/unit_tests/test_iterator.py
@@ -33,32 +33,32 @@ class TestPage(unittest.TestCase):
         from google.cloud.iterator import Page
         return Page
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         parent = object()
         item_to_value = object()
-        page = self._makeOne(parent, (1, 2, 3), item_to_value)
+        page = self._make_one(parent, (1, 2, 3), item_to_value)
         self.assertIs(page._parent, parent)
         self.assertEqual(page._num_items, 3)
         self.assertEqual(page._remaining, 3)
         self.assertIs(page._item_to_value, item_to_value)
 
     def test_num_items_property(self):
-        page = self._makeOne(None, (), None)
+        page = self._make_one(None, (), None)
         num_items = 42
         page._num_items = num_items
         self.assertEqual(page.num_items, num_items)
 
     def test_remaining_property(self):
-        page = self._makeOne(None, (), None)
+        page = self._make_one(None, (), None)
         remaining = 1337
         page._remaining = remaining
         self.assertEqual(page.remaining, remaining)
 
     def test___iter__(self):
-        page = self._makeOne(None, (), None)
+        page = self._make_one(None, (), None)
         self.assertIs(iter(page), page)
 
     def test_iterator_calls__item_to_value(self):
@@ -73,7 +73,7 @@ class TestPage(unittest.TestCase):
                 return item
 
         parent = Parent()
-        page = self._makeOne(parent, (10, 11, 12),
+        page = self._make_one(parent, (10, 11, 12),
                              Parent.item_to_value)
         page._remaining = 100
 
@@ -97,7 +97,7 @@ class TestIterator(unittest.TestCase):
         from google.cloud.iterator import Iterator
         return Iterator
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
@@ -106,7 +106,7 @@ class TestIterator(unittest.TestCase):
         item_to_value = object()
         token = 'ab13nceor03'
         max_results = 1337
-        iterator = self._makeOne(client, item_to_value, page_token=token,
+        iterator = self._make_one(client, item_to_value, page_token=token,
                                  max_results=max_results)
 
         self.assertFalse(iterator._started)
@@ -119,7 +119,7 @@ class TestIterator(unittest.TestCase):
         self.assertEqual(iterator.num_results, 0)
 
     def test_pages_property(self):
-        iterator = self._makeOne(None, None)
+        iterator = self._make_one(None, None)
         self.assertFalse(iterator._started)
         mock_iter = object()
         incremented = []
@@ -137,7 +137,7 @@ class TestIterator(unittest.TestCase):
     def test_pages_property_started(self):
         import types
 
-        iterator = self._makeOne(None, None)
+        iterator = self._make_one(None, None)
         self.assertIsInstance(iterator.pages, types.GeneratorType)
         # Make sure we cannot restart.
         with self.assertRaises(ValueError):
@@ -146,7 +146,7 @@ class TestIterator(unittest.TestCase):
     def test_pages_property_items_started(self):
         import types
 
-        iterator = self._makeOne(None, None)
+        iterator = self._make_one(None, None)
         self.assertIsInstance(iter(iterator), types.GeneratorType)
         with self.assertRaises(ValueError):
             getattr(iterator, 'pages')
@@ -170,7 +170,7 @@ class TestIterator(unittest.TestCase):
         page1 = Page(parent, (item1, item2), self._do_nothing)
         page2 = Page(parent, (item3,), self._do_nothing)
 
-        iterator = self._makeOne(None, None)
+        iterator = self._make_one(None, None)
         # Fake the page iterator on the object.
         incremented = []
 
@@ -198,7 +198,7 @@ class TestIterator(unittest.TestCase):
         self.assertEqual(incremented, [False])
 
     def test___iter__(self):
-        iterator = self._makeOne(None, None)
+        iterator = self._make_one(None, None)
         self.assertFalse(iterator._started)
         incremented = []
 
@@ -214,7 +214,7 @@ class TestIterator(unittest.TestCase):
     def test___iter___started(self):
         import types
 
-        iterator = self._makeOne(None, None)
+        iterator = self._make_one(None, None)
         self.assertIsInstance(iter(iterator), types.GeneratorType)
         with self.assertRaises(ValueError):
             iter(iterator)
@@ -222,13 +222,13 @@ class TestIterator(unittest.TestCase):
     def test___iter___pages_started(self):
         import types
 
-        iterator = self._makeOne(None, None)
+        iterator = self._make_one(None, None)
         self.assertIsInstance(iterator.pages, types.GeneratorType)
         with self.assertRaises(ValueError):
             iter(iterator)
 
     def test__next_page_virtual(self):
-        iterator = self._makeOne(None, None)
+        iterator = self._make_one(None, None)
         with self.assertRaises(NotImplementedError):
             iterator._next_page()
 
@@ -240,7 +240,7 @@ class TestHTTPIterator(unittest.TestCase):
         from google.cloud.iterator import HTTPIterator
         return HTTPIterator
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
@@ -249,7 +249,7 @@ class TestHTTPIterator(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         path = '/foo'
-        iterator = self._makeOne(client, path, None)
+        iterator = self._make_one(client, path, None)
         self.assertFalse(iterator._started)
         self.assertIs(iterator.client, client)
         self.assertEqual(iterator.path, path)
@@ -269,7 +269,7 @@ class TestHTTPIterator(unittest.TestCase):
         path = '/foo'
         extra_params = {'pageToken': 'val'}
         with self.assertRaises(ValueError):
-            self._makeOne(client, path, None, extra_params=extra_params)
+            self._make_one(client, path, None, extra_params=extra_params)
 
     def test_pages_iter_empty_then_another(self):
         import six
@@ -277,7 +277,7 @@ class TestHTTPIterator(unittest.TestCase):
         from google.cloud import iterator as MUT
 
         items_key = 'its-key'
-        iterator = self._makeOne(None, None, None, items_key=items_key)
+        iterator = self._make_one(None, None, None, items_key=items_key)
         # Fake the next page class.
         fake_page = MUT.Page(None, (), None)
         page_args = []
@@ -312,7 +312,7 @@ class TestHTTPIterator(unittest.TestCase):
         connection = _Connection(
             {'items': [{'name': key1}, {'name': key2}]})
         client = _Client(connection)
-        iterator = self._makeOne(client, path=path,
+        iterator = self._make_one(client, path=path,
                                  item_to_value=item_to_value)
         self.assertEqual(iterator.num_results, 0)
 
@@ -337,14 +337,14 @@ class TestHTTPIterator(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         path = '/foo'
-        iterator = self._makeOne(client, path, None)
+        iterator = self._make_one(client, path, None)
         self.assertTrue(iterator._has_next_page())
 
     def test__has_next_page_w_number_no_token(self):
         connection = _Connection()
         client = _Client(connection)
         path = '/foo'
-        iterator = self._makeOne(client, path, None)
+        iterator = self._make_one(client, path, None)
         iterator.page_number = 1
         self.assertFalse(iterator._has_next_page())
 
@@ -353,20 +353,20 @@ class TestHTTPIterator(unittest.TestCase):
         client = _Client(connection)
         path = '/foo'
         token = 'token'
-        iterator = self._makeOne(client, path, None)
+        iterator = self._make_one(client, path, None)
         iterator.page_number = 1
         iterator.next_page_token = token
         self.assertTrue(iterator._has_next_page())
 
     def test__has_next_page_w_max_results_not_done(self):
-        iterator = self._makeOne(None, None, None, max_results=3,
+        iterator = self._make_one(None, None, None, max_results=3,
                                  page_token='definitely-not-none')
         iterator.page_number = 1
         self.assertLess(iterator.num_results, iterator.max_results)
         self.assertTrue(iterator._has_next_page())
 
     def test__has_next_page_w_max_results_done(self):
-        iterator = self._makeOne(None, None, None, max_results=3)
+        iterator = self._make_one(None, None, None, max_results=3)
         iterator.page_number = 1
         iterator.num_results = iterator.max_results
         self.assertFalse(iterator._has_next_page())
@@ -375,7 +375,7 @@ class TestHTTPIterator(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         path = '/foo'
-        iterator = self._makeOne(client, path, None)
+        iterator = self._make_one(client, path, None)
         self.assertEqual(iterator._get_query_params(), {})
 
     def test__get_query_params_w_token(self):
@@ -383,7 +383,7 @@ class TestHTTPIterator(unittest.TestCase):
         client = _Client(connection)
         path = '/foo'
         token = 'token'
-        iterator = self._makeOne(client, path, None)
+        iterator = self._make_one(client, path, None)
         iterator.next_page_token = token
         self.assertEqual(iterator._get_query_params(),
                          {'pageToken': token})
@@ -393,7 +393,7 @@ class TestHTTPIterator(unittest.TestCase):
         client = _Client(connection)
         path = '/foo'
         max_results = 3
-        iterator = self._makeOne(client, path, None,
+        iterator = self._make_one(client, path, None,
                                  max_results=max_results)
         iterator.num_results = 1
         local_max = max_results - iterator.num_results
@@ -405,7 +405,7 @@ class TestHTTPIterator(unittest.TestCase):
         client = _Client(connection)
         path = '/foo'
         extra_params = {'key': 'val'}
-        iterator = self._makeOne(client, path, None,
+        iterator = self._make_one(client, path, None,
                                  extra_params=extra_params)
         self.assertEqual(iterator._get_query_params(), extra_params)
 
@@ -415,7 +415,7 @@ class TestHTTPIterator(unittest.TestCase):
         path = '/foo'
         token = 'token'
         extra_params = {'key': 'val'}
-        iterator = self._makeOne(client, path, None,
+        iterator = self._make_one(client, path, None,
                                  extra_params=extra_params)
         iterator.next_page_token = token
 
@@ -431,7 +431,7 @@ class TestHTTPIterator(unittest.TestCase):
         connection = _Connection({'items': [{'name': key1}, {'name': key2}],
                                   'nextPageToken': token})
         client = _Client(connection)
-        iterator = self._makeOne(client, path, None)
+        iterator = self._make_one(client, path, None)
         response = iterator._get_next_page_response()
         self.assertEqual(response['items'], [{'name': key1}, {'name': key2}])
         kw, = connection._requested
@@ -444,7 +444,7 @@ class TestHTTPIterator(unittest.TestCase):
         returned = {'green': 'eggs', 'ham': 55}
         connection = _Connection(returned)
         client = _Client(connection)
-        iterator = self._makeOne(client, path, None)
+        iterator = self._make_one(client, path, None)
         iterator._HTTP_METHOD = 'POST'
         response = iterator._get_next_page_response()
         self.assertEqual(response, returned)
@@ -460,7 +460,7 @@ class TestHTTPIterator(unittest.TestCase):
     def test__get_next_page_bad_http_method(self):
         path = '/foo'
         client = _Client(None)
-        iterator = self._makeOne(client, path, None)
+        iterator = self._make_one(client, path, None)
         iterator._HTTP_METHOD = 'NOT-A-VERB'
         with self.assertRaises(ValueError):
             iterator._get_next_page_response()
@@ -473,7 +473,7 @@ class TestGAXIterator(unittest.TestCase):
         from google.cloud.iterator import GAXIterator
         return GAXIterator
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
@@ -482,7 +482,7 @@ class TestGAXIterator(unittest.TestCase):
         page_iter = SimpleIter(token)
         item_to_value = object()
         max_results = 1337
-        iterator = self._makeOne(client, page_iter, item_to_value,
+        iterator = self._make_one(client, page_iter, item_to_value,
                                  max_results=max_results)
 
         self.assertFalse(iterator._started)
@@ -508,7 +508,7 @@ class TestGAXIterator(unittest.TestCase):
         page_token = '2sde98ds2s0hh'
         page_iter = _GAXPageIterator(page_items, page_token=page_token)
         # Wrap the GAX iterator.
-        iterator = self._makeOne(None, page_iter, self._do_nothing)
+        iterator = self._make_one(None, page_iter, self._do_nothing)
 
         page = iterator._next_page()
         # First check the page token.
@@ -525,7 +525,7 @@ class TestGAXIterator(unittest.TestCase):
         # Make a mock ``google.gax.PageIterator``
         page_iter = _GAXPageIterator()
         # Wrap the GAX iterator.
-        iterator = self._makeOne(None, page_iter, self._do_nothing)
+        iterator = self._make_one(None, page_iter, self._do_nothing)
 
         page = iterator._next_page()
         self.assertIsNone(page)
@@ -545,7 +545,7 @@ class TestGAXIterator(unittest.TestCase):
         page1 = (item1,)
         page2 = (item2, item3)
         page_iter = _GAXPageIterator(page1, page2, page_token=token1)
-        iterator = self._makeOne(None, page_iter, self._do_nothing)
+        iterator = self._make_one(None, page_iter, self._do_nothing)
 
         self.assertEqual(iterator.num_results, 0)
 

--- a/core/unit_tests/test_iterator.py
+++ b/core/unit_tests/test_iterator.py
@@ -17,12 +17,12 @@ import unittest
 
 class Test__do_nothing_page_start(unittest.TestCase):
 
-    def _callFUT(self, iterator, page, response):
+    def _call_fut(self, iterator, page, response):
         from google.cloud.iterator import _do_nothing_page_start
         return _do_nothing_page_start(iterator, page, response)
 
     def test_do_nothing(self):
-        result = self._callFUT(None, None, None)
+        result = self._call_fut(None, None, None)
         self.assertIsNone(result)
 
 

--- a/core/unit_tests/test_iterator.py
+++ b/core/unit_tests/test_iterator.py
@@ -28,7 +28,8 @@ class Test__do_nothing_page_start(unittest.TestCase):
 
 class TestPage(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.iterator import Page
         return Page
 
@@ -91,7 +92,8 @@ class TestPage(unittest.TestCase):
 
 class TestIterator(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.iterator import Iterator
         return Iterator
 
@@ -233,7 +235,8 @@ class TestIterator(unittest.TestCase):
 
 class TestHTTPIterator(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.iterator import HTTPIterator
         return HTTPIterator
 
@@ -465,7 +468,8 @@ class TestHTTPIterator(unittest.TestCase):
 
 class TestGAXIterator(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.iterator import GAXIterator
         return GAXIterator
 

--- a/core/unit_tests/test_iterator.py
+++ b/core/unit_tests/test_iterator.py
@@ -74,7 +74,7 @@ class TestPage(unittest.TestCase):
 
         parent = Parent()
         page = self._make_one(parent, (10, 11, 12),
-                             Parent.item_to_value)
+                              Parent.item_to_value)
         page._remaining = 100
 
         self.assertEqual(parent.calls, 0)
@@ -107,7 +107,7 @@ class TestIterator(unittest.TestCase):
         token = 'ab13nceor03'
         max_results = 1337
         iterator = self._make_one(client, item_to_value, page_token=token,
-                                 max_results=max_results)
+                                  max_results=max_results)
 
         self.assertFalse(iterator._started)
         self.assertIs(iterator.client, client)
@@ -313,7 +313,7 @@ class TestHTTPIterator(unittest.TestCase):
             {'items': [{'name': key1}, {'name': key2}]})
         client = _Client(connection)
         iterator = self._make_one(client, path=path,
-                                 item_to_value=item_to_value)
+                                  item_to_value=item_to_value)
         self.assertEqual(iterator.num_results, 0)
 
         items_iter = iter(iterator)
@@ -360,7 +360,7 @@ class TestHTTPIterator(unittest.TestCase):
 
     def test__has_next_page_w_max_results_not_done(self):
         iterator = self._make_one(None, None, None, max_results=3,
-                                 page_token='definitely-not-none')
+                                  page_token='definitely-not-none')
         iterator.page_number = 1
         self.assertLess(iterator.num_results, iterator.max_results)
         self.assertTrue(iterator._has_next_page())
@@ -394,7 +394,7 @@ class TestHTTPIterator(unittest.TestCase):
         path = '/foo'
         max_results = 3
         iterator = self._make_one(client, path, None,
-                                 max_results=max_results)
+                                  max_results=max_results)
         iterator.num_results = 1
         local_max = max_results - iterator.num_results
         self.assertEqual(iterator._get_query_params(),
@@ -406,7 +406,7 @@ class TestHTTPIterator(unittest.TestCase):
         path = '/foo'
         extra_params = {'key': 'val'}
         iterator = self._make_one(client, path, None,
-                                 extra_params=extra_params)
+                                  extra_params=extra_params)
         self.assertEqual(iterator._get_query_params(), extra_params)
 
     def test__get_query_params_w_token_and_extra_params(self):
@@ -416,7 +416,7 @@ class TestHTTPIterator(unittest.TestCase):
         token = 'token'
         extra_params = {'key': 'val'}
         iterator = self._make_one(client, path, None,
-                                 extra_params=extra_params)
+                                  extra_params=extra_params)
         iterator.next_page_token = token
 
         expected_query = extra_params.copy()
@@ -483,7 +483,7 @@ class TestGAXIterator(unittest.TestCase):
         item_to_value = object()
         max_results = 1337
         iterator = self._make_one(client, page_iter, item_to_value,
-                                 max_results=max_results)
+                                  max_results=max_results)
 
         self.assertFalse(iterator._started)
         self.assertIs(iterator.client, client)

--- a/core/unit_tests/test_operation.py
+++ b/core/unit_tests/test_operation.py
@@ -107,7 +107,8 @@ class TestOperation(unittest.TestCase):
 
     OPERATION_NAME = 'operations/projects/foo/instances/bar/operations/123'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.operation import Operation
         return Operation
 

--- a/core/unit_tests/test_operation.py
+++ b/core/unit_tests/test_operation.py
@@ -17,7 +17,7 @@ import unittest
 
 class Test__compute_type_url(unittest.TestCase):
 
-    def _callFUT(self, klass, prefix=None):
+    def _call_fut(self, klass, prefix=None):
         from google.cloud.operation import _compute_type_url
         if prefix is None:
             return _compute_type_url(klass)
@@ -27,7 +27,7 @@ class Test__compute_type_url(unittest.TestCase):
         from google.protobuf.struct_pb2 import Struct
         from google.cloud.operation import _GOOGLE_APIS_PREFIX
 
-        type_url = self._callFUT(Struct)
+        type_url = self._call_fut(Struct)
 
         self.assertEqual(
             type_url,
@@ -37,7 +37,7 @@ class Test__compute_type_url(unittest.TestCase):
         from google.protobuf.struct_pb2 import Struct
         PREFIX = 'test.google-cloud-python.com'
 
-        type_url = self._callFUT(Struct, PREFIX)
+        type_url = self._call_fut(Struct, PREFIX)
 
         self.assertEqual(
             type_url,
@@ -46,7 +46,7 @@ class Test__compute_type_url(unittest.TestCase):
 
 class Test_register_type(unittest.TestCase):
 
-    def _callFUT(self, klass, type_url=None):
+    def _call_fut(self, klass, type_url=None):
         from google.cloud.operation import register_type
         register_type(klass, type_url=type_url)
 
@@ -59,7 +59,7 @@ class Test_register_type(unittest.TestCase):
         type_url_map = {}
 
         with _Monkey(MUT, _TYPE_URL_MAP=type_url_map):
-            self._callFUT(klass, type_url)
+            self._call_fut(klass, type_url)
 
         self.assertEqual(type_url_map, {type_url: klass})
 
@@ -70,7 +70,7 @@ class Test_register_type(unittest.TestCase):
 
         type_url_map = {}
         with _Monkey(MUT, _TYPE_URL_MAP=type_url_map):
-            self._callFUT(Struct)
+            self._call_fut(Struct)
 
         type_url = MUT._compute_type_url(Struct)
         self.assertEqual(type_url_map, {type_url: Struct})
@@ -84,7 +84,7 @@ class Test_register_type(unittest.TestCase):
         type_url_map = {type_url: klass}
 
         with _Monkey(MUT, _TYPE_URL_MAP=type_url_map):
-            self._callFUT(klass, type_url)
+            self._call_fut(klass, type_url)
 
         self.assertEqual(type_url_map, {type_url: klass})
 
@@ -98,7 +98,7 @@ class Test_register_type(unittest.TestCase):
 
         with _Monkey(MUT, _TYPE_URL_MAP=type_url_map):
             with self.assertRaises(ValueError):
-                self._callFUT(klass, type_url)
+                self._call_fut(klass, type_url)
 
         self.assertEqual(type_url_map, {type_url: other})
 

--- a/core/unit_tests/test_operation.py
+++ b/core/unit_tests/test_operation.py
@@ -113,7 +113,7 @@ class TestOperation(unittest.TestCase):
         return Operation
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         client = _Client()
@@ -146,7 +146,7 @@ class TestOperation(unittest.TestCase):
         from google.longrunning import operations_pb2
         client = _Client()
         operation_pb = operations_pb2.Operation(name=self.OPERATION_NAME)
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         operation = klass.from_pb(operation_pb, client)
 
@@ -169,7 +169,7 @@ class TestOperation(unittest.TestCase):
         metadata_pb = Any(type_url=type_url, value=meta.SerializeToString())
         operation_pb = operations_pb2.Operation(
             name=self.OPERATION_NAME, metadata=metadata_pb)
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         with _Monkey(MUT, _TYPE_URL_MAP={type_url: Struct}):
             operation = klass.from_pb(operation_pb, client)
@@ -195,7 +195,7 @@ class TestOperation(unittest.TestCase):
         metadata_pb = Any(type_url=type_url, value=meta.SerializeToString())
         operation_pb = operations_pb2.Operation(
             name=self.OPERATION_NAME, metadata=metadata_pb)
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         with _Monkey(MUT, _TYPE_URL_MAP=type_url_map):
             operation = klass.from_pb(operation_pb, client, baz='qux')
@@ -220,7 +220,7 @@ class TestOperation(unittest.TestCase):
         }
 
         client = _Client()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         with _Monkey(MUT, _TYPE_URL_MAP={type_url: Struct}):
             operation = klass.from_dict(api_response, client)

--- a/core/unit_tests/test_operation.py
+++ b/core/unit_tests/test_operation.py
@@ -112,12 +112,12 @@ class TestOperation(unittest.TestCase):
         from google.cloud.operation import Operation
         return Operation
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         client = _Client()
-        operation = self._makeOne(
+        operation = self._make_one(
             self.OPERATION_NAME, client)
         self.assertEqual(operation.name, self.OPERATION_NAME)
         self.assertIs(operation.client, client)
@@ -130,7 +130,7 @@ class TestOperation(unittest.TestCase):
 
     def test_ctor_explicit(self):
         client = _Client()
-        operation = self._makeOne(
+        operation = self._make_one(
             self.OPERATION_NAME, client, foo='bar')
 
         self.assertEqual(operation.name, self.OPERATION_NAME)
@@ -239,7 +239,7 @@ class TestOperation(unittest.TestCase):
 
     def test_complete_property(self):
         client = _Client()
-        operation = self._makeOne(self.OPERATION_NAME, client)
+        operation = self._make_one(self.OPERATION_NAME, client)
         self.assertFalse(operation.complete)
         operation._complete = True
         self.assertTrue(operation.complete)
@@ -248,7 +248,7 @@ class TestOperation(unittest.TestCase):
 
     def test_poll_already_complete(self):
         client = _Client()
-        operation = self._makeOne(self.OPERATION_NAME, client)
+        operation = self._make_one(self.OPERATION_NAME, client)
         operation._complete = True
 
         with self.assertRaises(ValueError):
@@ -261,7 +261,7 @@ class TestOperation(unittest.TestCase):
         client = _Client()
         stub = client._operations_stub
         stub._get_operation_response = response_pb
-        operation = self._makeOne(self.OPERATION_NAME, client)
+        operation = self._make_one(self.OPERATION_NAME, client)
 
         self.assertFalse(operation.poll())
 
@@ -276,7 +276,7 @@ class TestOperation(unittest.TestCase):
         client = _Client()
         stub = client._operations_stub
         stub._get_operation_response = response_pb
-        operation = self._makeOne(self.OPERATION_NAME, client)
+        operation = self._make_one(self.OPERATION_NAME, client)
 
         self.assertTrue(operation.poll())
 
@@ -301,7 +301,7 @@ class TestOperation(unittest.TestCase):
         }
         connection = _Connection(api_response)
         client = _Client(connection)
-        operation = self._makeOne(name, client)
+        operation = self._make_one(name, client)
         operation._from_grpc = False
 
         with _Monkey(MUT, _TYPE_URL_MAP={type_url: Struct}):
@@ -316,7 +316,7 @@ class TestOperation(unittest.TestCase):
     def test__update_state_done(self):
         from google.longrunning import operations_pb2
 
-        operation = self._makeOne(None, None)
+        operation = self._make_one(None, None)
         self.assertFalse(operation.complete)
         operation_pb = operations_pb2.Operation(done=True)
         operation._update_state(operation_pb)
@@ -329,7 +329,7 @@ class TestOperation(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud import operation as MUT
 
-        operation = self._makeOne(None, None)
+        operation = self._make_one(None, None)
         self.assertIsNone(operation.metadata)
 
         val_pb = Value(number_value=1337)
@@ -347,7 +347,7 @@ class TestOperation(unittest.TestCase):
         from google.rpc.status_pb2 import Status
         from google.cloud._testing import _Monkey
 
-        operation = self._makeOne(None, None)
+        operation = self._make_one(None, None)
         self.assertIsNone(operation.error)
         self.assertIsNone(operation.response)
 
@@ -365,7 +365,7 @@ class TestOperation(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud import operation as MUT
 
-        operation = self._makeOne(None, None)
+        operation = self._make_one(None, None)
         self.assertIsNone(operation.error)
         self.assertIsNone(operation.response)
 
@@ -384,7 +384,7 @@ class TestOperation(unittest.TestCase):
     def test__update_state_no_result(self):
         from google.longrunning import operations_pb2
 
-        operation = self._makeOne(None, None)
+        operation = self._make_one(None, None)
         self.assertIsNone(operation.error)
         self.assertIsNone(operation.response)
 

--- a/datastore/unit_tests/test__http.py
+++ b/datastore/unit_tests/test__http.py
@@ -25,7 +25,7 @@ class Test_DatastoreAPIOverHttp(unittest.TestCase):
         return _DatastoreAPIOverHttp
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test__rpc(self):
         class ReqPB(object):
@@ -201,7 +201,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
         else:
             to_monkey = {'make_insecure_stub': mock_make_stub}
         with _Monkey(MUT, **to_monkey):
-            return self._getTargetClass()(connection, secure)
+            return self._get_target_class()(connection, secure)
 
     def test_constructor(self):
         from google.cloud.datastore import _http as MUT
@@ -375,7 +375,7 @@ class TestConnection(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud.datastore import _http as MUT
         with _Monkey(MUT, _USE_GRPC=use_grpc):
-            return self._getTargetClass()(credentials=credentials, http=http)
+            return self._get_target_class()(credentials=credentials, http=http)
 
     def _verifyProtobufCall(self, called_with, URI, conn):
         self.assertEqual(called_with['uri'], URI)
@@ -386,7 +386,7 @@ class TestConnection(unittest.TestCase):
                          conn.USER_AGENT)
 
     def test_default_url(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         conn = self._makeOne()
         self.assertEqual(conn.api_base_url, klass.API_BASE_URL)
 

--- a/datastore/unit_tests/test__http.py
+++ b/datastore/unit_tests/test__http.py
@@ -213,7 +213,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
         stub = _GRPCStub()
         mock_args = []
         datastore_api = self._make_one(stub, connection=conn,
-                                      mock_args=mock_args)
+                                       mock_args=mock_args)
         self.assertIs(datastore_api._stub, stub)
 
         self.assertEqual(mock_args, [(
@@ -233,8 +233,8 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
         stub = _GRPCStub()
         mock_args = []
         datastore_api = self._make_one(stub, connection=conn,
-                                      secure=False,
-                                      mock_args=mock_args)
+                                       secure=False,
+                                       mock_args=mock_args)
         self.assertIs(datastore_api._stub, stub)
 
         self.assertEqual(mock_args, [(

--- a/datastore/unit_tests/test__http.py
+++ b/datastore/unit_tests/test__http.py
@@ -19,7 +19,8 @@ from google.cloud.datastore._http import _HAVE_GRPC
 
 class Test_DatastoreAPIOverHttp(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore._http import _DatastoreAPIOverHttp
         return _DatastoreAPIOverHttp
 
@@ -174,7 +175,8 @@ class Test__grpc_catch_rendezvous(unittest.TestCase):
 
 class Test_DatastoreAPIOverGRPC(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore._http import _DatastoreAPIOverGRPC
         return _DatastoreAPIOverGRPC
 
@@ -350,7 +352,8 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore._http import Connection
 
         return Connection

--- a/datastore/unit_tests/test__http.py
+++ b/datastore/unit_tests/test__http.py
@@ -24,7 +24,7 @@ class Test_DatastoreAPIOverHttp(unittest.TestCase):
         from google.cloud.datastore._http import _DatastoreAPIOverHttp
         return _DatastoreAPIOverHttp
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test__rpc(self):
@@ -47,7 +47,7 @@ class Test_DatastoreAPIOverHttp(unittest.TestCase):
         METHOD = 'METHOD'
         URI = 'http://api-url'
         conn = _Connection(URI)
-        datastore_api = self._makeOne(conn)
+        datastore_api = self._make_one(conn)
         http = conn.http = Http({'status': '200'}, 'CONTENT')
         response = datastore_api._rpc(PROJECT, METHOD, ReqPB(), RspPB)
         self.assertIsInstance(response, RspPB)
@@ -69,7 +69,7 @@ class Test_DatastoreAPIOverHttp(unittest.TestCase):
         DATA = b'DATA'
         URI = 'http://api-url'
         conn = _Connection(URI)
-        datastore_api = self._makeOne(conn)
+        datastore_api = self._make_one(conn)
         http = conn.http = Http({'status': '200'}, 'CONTENT')
         self.assertEqual(datastore_api._request(PROJECT, METHOD, DATA),
                          'CONTENT')
@@ -97,7 +97,7 @@ class Test_DatastoreAPIOverHttp(unittest.TestCase):
         DATA = 'DATA'
         URI = 'http://api-url'
         conn = _Connection(URI)
-        datastore_api = self._makeOne(conn)
+        datastore_api = self._make_one(conn)
         conn.http = Http({'status': '400'}, error.SerializeToString())
         with self.assertRaises(BadRequest) as exc:
             datastore_api._request(PROJECT, METHOD, DATA)
@@ -180,7 +180,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
         from google.cloud.datastore._http import _DatastoreAPIOverGRPC
         return _DatastoreAPIOverGRPC
 
-    def _makeOne(self, stub, connection=None, secure=True, mock_args=None):
+    def _make_one(self, stub, connection=None, secure=True, mock_args=None):
         from google.cloud._testing import _Monkey
         from google.cloud.datastore import _http as MUT
 
@@ -212,7 +212,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
 
         stub = _GRPCStub()
         mock_args = []
-        datastore_api = self._makeOne(stub, connection=conn,
+        datastore_api = self._make_one(stub, connection=conn,
                                       mock_args=mock_args)
         self.assertIs(datastore_api._stub, stub)
 
@@ -232,7 +232,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
 
         stub = _GRPCStub()
         mock_args = []
-        datastore_api = self._makeOne(stub, connection=conn,
+        datastore_api = self._make_one(stub, connection=conn,
                                       secure=False,
                                       mock_args=mock_args)
         self.assertIs(datastore_api._stub, stub)
@@ -245,7 +245,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
     def test_lookup(self):
         return_val = object()
         stub = _GRPCStub(return_val)
-        datastore_api = self._makeOne(stub=stub)
+        datastore_api = self._make_one(stub=stub)
 
         request_pb = _RequestPB()
         project = 'PROJECT'
@@ -258,7 +258,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
     def test_run_query(self):
         return_val = object()
         stub = _GRPCStub(return_val)
-        datastore_api = self._makeOne(stub=stub)
+        datastore_api = self._make_one(stub=stub)
 
         request_pb = _RequestPB()
         project = 'PROJECT'
@@ -270,7 +270,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
 
     def _run_query_failure_helper(self, exc, err_class):
         stub = _GRPCStub(side_effect=exc)
-        datastore_api = self._makeOne(stub=stub)
+        datastore_api = self._make_one(stub=stub)
 
         request_pb = _RequestPB()
         project = 'PROJECT'
@@ -298,7 +298,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
     def test_begin_transaction(self):
         return_val = object()
         stub = _GRPCStub(return_val)
-        datastore_api = self._makeOne(stub=stub)
+        datastore_api = self._make_one(stub=stub)
 
         request_pb = _RequestPB()
         project = 'PROJECT'
@@ -312,7 +312,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
     def test_commit_success(self):
         return_val = object()
         stub = _GRPCStub(return_val)
-        datastore_api = self._makeOne(stub=stub)
+        datastore_api = self._make_one(stub=stub)
 
         request_pb = _RequestPB()
         project = 'PROJECT'
@@ -325,7 +325,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
     def test_rollback(self):
         return_val = object()
         stub = _GRPCStub(return_val)
-        datastore_api = self._makeOne(stub=stub)
+        datastore_api = self._make_one(stub=stub)
 
         request_pb = _RequestPB()
         project = 'PROJECT'
@@ -338,7 +338,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
     def test_allocate_ids(self):
         return_val = object()
         stub = _GRPCStub(return_val)
-        datastore_api = self._makeOne(stub=stub)
+        datastore_api = self._make_one(stub=stub)
 
         request_pb = _RequestPB()
         project = 'PROJECT'
@@ -371,7 +371,7 @@ class TestConnection(unittest.TestCase):
         pb.kind.add().name = kind
         return pb
 
-    def _makeOne(self, credentials=None, http=None, use_grpc=False):
+    def _make_one(self, credentials=None, http=None, use_grpc=False):
         from google.cloud._testing import _Monkey
         from google.cloud.datastore import _http as MUT
         with _Monkey(MUT, _USE_GRPC=use_grpc):
@@ -387,7 +387,7 @@ class TestConnection(unittest.TestCase):
 
     def test_default_url(self):
         klass = self._get_target_class()
-        conn = self._makeOne()
+        conn = self._make_one()
         self.assertEqual(conn.api_base_url, klass.API_BASE_URL)
 
     def test_custom_url_from_env(self):
@@ -400,13 +400,13 @@ class TestConnection(unittest.TestCase):
         fake_environ = {GCD_HOST: HOST}
 
         with _Monkey(os, environ=fake_environ):
-            conn = self._makeOne()
+            conn = self._make_one()
 
         self.assertNotEqual(conn.api_base_url, API_BASE_URL)
         self.assertEqual(conn.api_base_url, 'http://' + HOST)
 
     def test_ctor_defaults(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         self.assertIsNone(conn.credentials)
 
     def test_ctor_without_grpc(self):
@@ -421,7 +421,7 @@ class TestConnection(unittest.TestCase):
             return return_val
 
         with _Monkey(MUT, _DatastoreAPIOverHttp=mock_api):
-            conn = self._makeOne(use_grpc=False)
+            conn = self._make_one(use_grpc=False)
 
         self.assertIsNone(conn.credentials)
         self.assertIs(conn._datastore_api, return_val)
@@ -439,7 +439,7 @@ class TestConnection(unittest.TestCase):
             return return_val
 
         with _Monkey(MUT, _DatastoreAPIOverGRPC=mock_api):
-            conn = self._makeOne(use_grpc=True)
+            conn = self._make_one(use_grpc=True)
 
         self.assertIsNone(conn.credentials)
         self.assertIs(conn._datastore_api, return_val)
@@ -452,18 +452,18 @@ class TestConnection(unittest.TestCase):
                 return False
 
         creds = Creds()
-        conn = self._makeOne(creds)
+        conn = self._make_one(creds)
         self.assertIs(conn.credentials, creds)
 
     def test_http_w_existing(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         conn._http = http = object()
         self.assertIs(conn.http, http)
 
     def test_http_wo_creds(self):
         import httplib2
 
-        conn = self._makeOne()
+        conn = self._make_one()
         self.assertIsInstance(conn.http, httplib2.Http)
 
     def test_http_w_creds(self):
@@ -481,14 +481,14 @@ class TestConnection(unittest.TestCase):
                 return False
 
         creds = Creds()
-        conn = self._makeOne(creds)
+        conn = self._make_one(creds)
         self.assertIs(conn.http, authorized)
         self.assertIsInstance(creds._called_with, httplib2.Http)
 
     def test_build_api_url_w_default_base_version(self):
         PROJECT = 'PROJECT'
         METHOD = 'METHOD'
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -502,7 +502,7 @@ class TestConnection(unittest.TestCase):
         VER = '3.1415926'
         PROJECT = 'PROJECT'
         METHOD = 'METHOD'
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             BASE,
             VER,
@@ -518,7 +518,7 @@ class TestConnection(unittest.TestCase):
         PROJECT = 'PROJECT'
         key_pb = self._make_key_pb(PROJECT)
         rsp_pb = datastore_pb2.LookupResponse()
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -545,7 +545,7 @@ class TestConnection(unittest.TestCase):
         PROJECT = 'PROJECT'
         key_pb = self._make_key_pb(PROJECT)
         rsp_pb = datastore_pb2.LookupResponse()
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -574,7 +574,7 @@ class TestConnection(unittest.TestCase):
         PROJECT = 'PROJECT'
         TRANSACTION = b'TRANSACTION'
         key_pb = self._make_key_pb(PROJECT)
-        conn = self._makeOne()
+        conn = self._make_one()
         self.assertRaises(ValueError, conn.lookup, PROJECT, key_pb,
                           eventual=True, transaction_id=TRANSACTION)
 
@@ -585,7 +585,7 @@ class TestConnection(unittest.TestCase):
         TRANSACTION = b'TRANSACTION'
         key_pb = self._make_key_pb(PROJECT)
         rsp_pb = datastore_pb2.LookupResponse()
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -618,7 +618,7 @@ class TestConnection(unittest.TestCase):
         entity = entity_pb2.Entity()
         entity.key.CopyFrom(key_pb)
         rsp_pb.found.add(entity=entity)
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -647,7 +647,7 @@ class TestConnection(unittest.TestCase):
         key_pb1 = self._make_key_pb(PROJECT)
         key_pb2 = self._make_key_pb(PROJECT, id_=2345)
         rsp_pb = datastore_pb2.LookupResponse()
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -680,7 +680,7 @@ class TestConnection(unittest.TestCase):
         er_1.entity.key.CopyFrom(key_pb1)
         er_2 = rsp_pb.missing.add()
         er_2.entity.key.CopyFrom(key_pb2)
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -712,7 +712,7 @@ class TestConnection(unittest.TestCase):
         rsp_pb = datastore_pb2.LookupResponse()
         rsp_pb.deferred.add().CopyFrom(key_pb1)
         rsp_pb.deferred.add().CopyFrom(key_pb2)
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -752,7 +752,7 @@ class TestConnection(unittest.TestCase):
         no_more = query_pb2.QueryResultBatch.NO_MORE_RESULTS
         rsp_pb.batch.more_results = no_more
         rsp_pb.batch.entity_result_type = query_pb2.EntityResult.FULL
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -791,7 +791,7 @@ class TestConnection(unittest.TestCase):
         no_more = query_pb2.QueryResultBatch.NO_MORE_RESULTS
         rsp_pb.batch.more_results = no_more
         rsp_pb.batch.entity_result_type = query_pb2.EntityResult.FULL
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -831,7 +831,7 @@ class TestConnection(unittest.TestCase):
         no_more = query_pb2.QueryResultBatch.NO_MORE_RESULTS
         rsp_pb.batch.more_results = no_more
         rsp_pb.batch.entity_result_type = query_pb2.EntityResult.FULL
-        conn = self._makeOne()
+        conn = self._make_one()
         self.assertRaises(ValueError, conn.run_query, PROJECT, q_pb,
                           eventual=True, transaction_id=TRANSACTION)
 
@@ -848,7 +848,7 @@ class TestConnection(unittest.TestCase):
         no_more = query_pb2.QueryResultBatch.NO_MORE_RESULTS
         rsp_pb.batch.more_results = no_more
         rsp_pb.batch.entity_result_type = query_pb2.EntityResult.FULL
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -881,7 +881,7 @@ class TestConnection(unittest.TestCase):
         rsp_pb.batch.entity_results.add(entity=entity)
         rsp_pb.batch.entity_result_type = 1  # FULL
         rsp_pb.batch.more_results = 3  # NO_MORE_RESULTS
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -906,7 +906,7 @@ class TestConnection(unittest.TestCase):
         TRANSACTION = b'TRANSACTION'
         rsp_pb = datastore_pb2.BeginTransactionResponse()
         rsp_pb.transaction = TRANSACTION
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -936,7 +936,7 @@ class TestConnection(unittest.TestCase):
         insert.key.CopyFrom(key_pb)
         value_pb = _new_value_pb(insert, 'foo')
         value_pb.string_value = u'Foo'
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -982,7 +982,7 @@ class TestConnection(unittest.TestCase):
         insert.key.CopyFrom(key_pb)
         value_pb = _new_value_pb(insert, 'foo')
         value_pb.string_value = u'Foo'
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -1019,7 +1019,7 @@ class TestConnection(unittest.TestCase):
         TRANSACTION = b'xact'
 
         rsp_pb = datastore_pb2.RollbackResponse()
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -1040,7 +1040,7 @@ class TestConnection(unittest.TestCase):
 
         PROJECT = 'PROJECT'
         rsp_pb = datastore_pb2.AllocateIdsResponse()
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
@@ -1071,7 +1071,7 @@ class TestConnection(unittest.TestCase):
         rsp_pb = datastore_pb2.AllocateIdsResponse()
         rsp_pb.keys.add().CopyFrom(after_key_pbs[0])
         rsp_pb.keys.add().CopyFrom(after_key_pbs[1])
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,

--- a/datastore/unit_tests/test__http.py
+++ b/datastore/unit_tests/test__http.py
@@ -110,7 +110,7 @@ class Test_DatastoreAPIOverHttp(unittest.TestCase):
 @unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
 class Test__grpc_catch_rendezvous(unittest.TestCase):
 
-    def _callFUT(self):
+    def _call_fut(self):
         from google.cloud.datastore._http import _grpc_catch_rendezvous
         return _grpc_catch_rendezvous()
 
@@ -123,7 +123,7 @@ class Test__grpc_catch_rendezvous(unittest.TestCase):
 
     def test_success(self):
         expected = object()
-        with self._callFUT():
+        with self._call_fut():
             result = self._fake_method(None, expected)
         self.assertIs(result, expected)
 
@@ -137,7 +137,7 @@ class Test__grpc_catch_rendezvous(unittest.TestCase):
         exc_state = _RPCState((), None, None, StatusCode.ABORTED, details)
         exc = GrpcRendezvous(exc_state, None, None, None)
         with self.assertRaises(Conflict):
-            with self._callFUT():
+            with self._call_fut():
                 self._fake_method(exc)
 
     def test_failure_invalid_argument(self):
@@ -152,7 +152,7 @@ class Test__grpc_catch_rendezvous(unittest.TestCase):
                               StatusCode.INVALID_ARGUMENT, details)
         exc = GrpcRendezvous(exc_state, None, None, None)
         with self.assertRaises(BadRequest):
-            with self._callFUT():
+            with self._call_fut():
                 self._fake_method(exc)
 
     def test_failure_cancelled(self):
@@ -163,13 +163,13 @@ class Test__grpc_catch_rendezvous(unittest.TestCase):
         exc_state = _RPCState((), None, None, StatusCode.CANCELLED, None)
         exc = GrpcRendezvous(exc_state, None, None, None)
         with self.assertRaises(GrpcRendezvous):
-            with self._callFUT():
+            with self._call_fut():
                 self._fake_method(exc)
 
     def test_commit_failure_non_grpc_err(self):
         exc = RuntimeError('Not a gRPC error')
         with self.assertRaises(RuntimeError):
-            with self._callFUT():
+            with self._call_fut():
                 self._fake_method(exc)
 
 
@@ -1093,7 +1093,7 @@ class TestConnection(unittest.TestCase):
 
 class Test__parse_commit_response(unittest.TestCase):
 
-    def _callFUT(self, commit_response_pb):
+    def _call_fut(self, commit_response_pb):
         from google.cloud.datastore._http import _parse_commit_response
         return _parse_commit_response(commit_response_pb)
 
@@ -1126,7 +1126,7 @@ class Test__parse_commit_response(unittest.TestCase):
             ],
             index_updates=index_updates,
         )
-        result = self._callFUT(response)
+        result = self._call_fut(response)
         self.assertEqual(result, (index_updates, keys))
 
 

--- a/datastore/unit_tests/test_batch.py
+++ b/datastore/unit_tests/test_batch.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestBatch(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore.batch import Batch
 
         return Batch

--- a/datastore/unit_tests/test_batch.py
+++ b/datastore/unit_tests/test_batch.py
@@ -23,7 +23,7 @@ class TestBatch(unittest.TestCase):
 
         return Batch
 
-    def _makeOne(self, client):
+    def _make_one(self, client):
         return self._get_target_class()(client)
 
     def test_ctor(self):
@@ -32,7 +32,7 @@ class TestBatch(unittest.TestCase):
         _NAMESPACE = 'NAMESPACE'
         connection = _Connection()
         client = _Client(_PROJECT, connection, _NAMESPACE)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
 
         self.assertEqual(batch.project, _PROJECT)
         self.assertEqual(batch.connection, connection)
@@ -48,8 +48,8 @@ class TestBatch(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch1 = self._makeOne(client)
-        batch2 = self._makeOne(client)
+        batch1 = self._make_one(client)
+        batch2 = self._make_one(client)
         self.assertIsNone(batch1.current())
         self.assertIsNone(batch2.current())
         with batch1:
@@ -67,7 +67,7 @@ class TestBatch(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
 
         batch.begin()
         self.assertRaises(ValueError, batch.put, _Entity())
@@ -76,7 +76,7 @@ class TestBatch(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         entity = _Entity()
         entity.key = _Key('OTHER')
 
@@ -87,7 +87,7 @@ class TestBatch(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         entity = _Entity()
         entity.key = _Key('OTHER')
 
@@ -99,7 +99,7 @@ class TestBatch(unittest.TestCase):
         _PROPERTIES = {'foo': 'bar'}
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         entity = _Entity(_PROPERTIES)
         key = entity.key = _Key(_PROJECT)
         key._id = None
@@ -123,7 +123,7 @@ class TestBatch(unittest.TestCase):
             }
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         entity = _Entity(_PROPERTIES)
         entity.exclude_from_indexes = ('baz', 'spam')
         key = entity.key = _Key(_PROJECT)
@@ -149,7 +149,7 @@ class TestBatch(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         key = _Key(_PROJECT)
         key._id = None
 
@@ -160,7 +160,7 @@ class TestBatch(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         key = _Key(_PROJECT)
         key._id = None
 
@@ -171,7 +171,7 @@ class TestBatch(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         key = _Key('OTHER')
 
         batch.begin()
@@ -181,7 +181,7 @@ class TestBatch(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         key = _Key(_PROJECT)
 
         batch.begin()
@@ -193,7 +193,7 @@ class TestBatch(unittest.TestCase):
     def test_begin(self):
         _PROJECT = 'PROJECT'
         client = _Client(_PROJECT, None)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         self.assertEqual(batch._status, batch._INITIAL)
         batch.begin()
         self.assertEqual(batch._status, batch._IN_PROGRESS)
@@ -201,7 +201,7 @@ class TestBatch(unittest.TestCase):
     def test_begin_fail(self):
         _PROJECT = 'PROJECT'
         client = _Client(_PROJECT, None)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         batch._status = batch._IN_PROGRESS
         with self.assertRaises(ValueError):
             batch.begin()
@@ -209,7 +209,7 @@ class TestBatch(unittest.TestCase):
     def test_rollback(self):
         _PROJECT = 'PROJECT'
         client = _Client(_PROJECT, None)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         batch.begin()
         self.assertEqual(batch._status, batch._IN_PROGRESS)
         batch.rollback()
@@ -218,7 +218,7 @@ class TestBatch(unittest.TestCase):
     def test_rollback_wrong_status(self):
         _PROJECT = 'PROJECT'
         client = _Client(_PROJECT, None)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
 
         self.assertEqual(batch._status, batch._INITIAL)
         self.assertRaises(ValueError, batch.rollback)
@@ -227,7 +227,7 @@ class TestBatch(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
 
         self.assertEqual(batch._status, batch._INITIAL)
         batch.begin()
@@ -242,7 +242,7 @@ class TestBatch(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
 
         self.assertEqual(batch._status, batch._INITIAL)
         self.assertRaises(ValueError, batch.commit)
@@ -252,7 +252,7 @@ class TestBatch(unittest.TestCase):
         _NEW_ID = 1234
         connection = _Connection(_NEW_ID)
         client = _Client(_PROJECT, connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         entity = _Entity({})
         key = entity.key = _Key(_PROJECT)
         key._id = None
@@ -279,7 +279,7 @@ class TestBatch(unittest.TestCase):
         client = _Client(_PROJECT, connection)
         self.assertEqual(list(client._batches), [])
 
-        with self._makeOne(client) as batch:
+        with self._make_one(client) as batch:
             self.assertEqual(list(client._batches), [batch])
             batch.put(entity)
 
@@ -302,10 +302,10 @@ class TestBatch(unittest.TestCase):
         client = _Client(_PROJECT, connection)
         self.assertEqual(list(client._batches), [])
 
-        with self._makeOne(client) as batch1:
+        with self._make_one(client) as batch1:
             self.assertEqual(list(client._batches), [batch1])
             batch1.put(entity1)
-            with self._makeOne(client) as batch2:
+            with self._make_one(client) as batch2:
                 self.assertEqual(list(client._batches), [batch2, batch1])
                 batch2.put(entity2)
 
@@ -334,7 +334,7 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(list(client._batches), [])
 
         try:
-            with self._makeOne(client) as batch:
+            with self._make_one(client) as batch:
                 self.assertEqual(list(client._batches), [batch])
                 batch.put(entity)
                 raise ValueError("testing")

--- a/datastore/unit_tests/test_batch.py
+++ b/datastore/unit_tests/test_batch.py
@@ -24,7 +24,7 @@ class TestBatch(unittest.TestCase):
         return Batch
 
     def _makeOne(self, client):
-        return self._getTargetClass()(client)
+        return self._get_target_class()(client)
 
     def test_ctor(self):
         from google.cloud.datastore._generated import datastore_pb2
@@ -348,7 +348,7 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(connection._committed, [])
 
     def test_as_context_mgr_enter_fails(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         class FailedBegin(klass):
 

--- a/datastore/unit_tests/test_client.py
+++ b/datastore/unit_tests/test_client.py
@@ -120,12 +120,12 @@ class TestClient(unittest.TestCase):
     PROJECT = 'PROJECT'
 
     def setUp(self):
-        KLASS = self._getTargetClass()
+        KLASS = self._get_target_class()
         self.original_cnxn_class = KLASS._connection_class
         KLASS._connection_class = _MockConnection
 
     def tearDown(self):
-        KLASS = self._getTargetClass()
+        KLASS = self._get_target_class()
         KLASS._connection_class = self.original_cnxn_class
 
     @staticmethod
@@ -135,7 +135,7 @@ class TestClient(unittest.TestCase):
 
     def _makeOne(self, project=PROJECT, namespace=None,
                  credentials=None, http=None):
-        return self._getTargetClass()(project=project,
+        return self._get_target_class()(project=project,
                                       namespace=namespace,
                                       credentials=credentials,
                                       http=http)
@@ -162,7 +162,7 @@ class TestClient(unittest.TestCase):
             default_called.append(project)
             return project or OTHER
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with _Monkey(_MUT,
                      _determine_default_project=fallback_mock):
             with _Monkey(_base_client,

--- a/datastore/unit_tests/test_client.py
+++ b/datastore/unit_tests/test_client.py
@@ -33,7 +33,7 @@ def _make_entity_pb(project, kind, integer_id, name=None, str_val=None):
 
 class Test__get_gcd_project(unittest.TestCase):
 
-    def _callFUT(self):
+    def _call_fut(self):
         from google.cloud.datastore.client import _get_gcd_project
         return _get_gcd_project()
 
@@ -43,7 +43,7 @@ class Test__get_gcd_project(unittest.TestCase):
 
         environ = {}
         with _Monkey(os, getenv=environ.get):
-            project = self._callFUT()
+            project = self._call_fut()
             self.assertIsNone(project)
 
     def test_value_set(self):
@@ -54,13 +54,13 @@ class Test__get_gcd_project(unittest.TestCase):
         MOCK_PROJECT = object()
         environ = {GCD_DATASET: MOCK_PROJECT}
         with _Monkey(os, getenv=environ.get):
-            project = self._callFUT()
+            project = self._call_fut()
             self.assertEqual(project, MOCK_PROJECT)
 
 
 class Test__determine_default_project(unittest.TestCase):
 
-    def _callFUT(self, project=None):
+    def _call_fut(self, project=None):
         from google.cloud.datastore.client import (
             _determine_default_project)
         return _determine_default_project(project=project)
@@ -86,7 +86,7 @@ class Test__determine_default_project(unittest.TestCase):
         }
 
         with _Monkey(client, **patched_methods):
-            returned_project = self._callFUT(project_called)
+            returned_project = self._call_fut(project_called)
 
         return returned_project, _callers
 

--- a/datastore/unit_tests/test_client.py
+++ b/datastore/unit_tests/test_client.py
@@ -134,11 +134,11 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _make_one(self, project=PROJECT, namespace=None,
-                 credentials=None, http=None):
+                  credentials=None, http=None):
         return self._get_target_class()(project=project,
-                                      namespace=namespace,
-                                      credentials=credentials,
-                                      http=http)
+                                        namespace=namespace,
+                                        credentials=credentials,
+                                        http=http)
 
     def test_ctor_w_project_no_environ(self):
         from google.cloud._testing import _Monkey
@@ -183,9 +183,9 @@ class TestClient(unittest.TestCase):
         creds = object()
         http = object()
         client = self._make_one(project=OTHER,
-                               namespace=NAMESPACE,
-                               credentials=creds,
-                               http=http)
+                                namespace=NAMESPACE,
+                                credentials=creds,
+                                http=http)
         self.assertEqual(client.project, OTHER)
         self.assertEqual(client.namespace, NAMESPACE)
         self.assertIsInstance(client.connection, _MockConnection)

--- a/datastore/unit_tests/test_client.py
+++ b/datastore/unit_tests/test_client.py
@@ -128,7 +128,8 @@ class TestClient(unittest.TestCase):
         KLASS = self._getTargetClass()
         KLASS._connection_class = self.original_cnxn_class
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore.client import Client
         return Client
 

--- a/datastore/unit_tests/test_client.py
+++ b/datastore/unit_tests/test_client.py
@@ -133,7 +133,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.datastore.client import Client
         return Client
 
-    def _makeOne(self, project=PROJECT, namespace=None,
+    def _make_one(self, project=PROJECT, namespace=None,
                  credentials=None, http=None):
         return self._get_target_class()(project=project,
                                       namespace=namespace,
@@ -147,7 +147,7 @@ class TestClient(unittest.TestCase):
         # Some environments (e.g. AppVeyor CI) run in GCE, so
         # this test would fail artificially.
         with _Monkey(_MUT, _base_default_project=lambda project: None):
-            self.assertRaises(EnvironmentError, self._makeOne, None)
+            self.assertRaises(EnvironmentError, self._make_one, None)
 
     def test_ctor_w_implicit_inputs(self):
         from google.cloud._testing import _Monkey
@@ -182,7 +182,7 @@ class TestClient(unittest.TestCase):
         NAMESPACE = 'namespace'
         creds = object()
         http = object()
-        client = self._makeOne(project=OTHER,
+        client = self._make_one(project=OTHER,
                                namespace=NAMESPACE,
                                credentials=creds,
                                http=http)
@@ -196,7 +196,7 @@ class TestClient(unittest.TestCase):
 
     def test__push_batch_and__pop_batch(self):
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         batch = client.batch()
         xact = client.transaction()
         client._push_batch(batch)
@@ -221,7 +221,7 @@ class TestClient(unittest.TestCase):
             return []
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.get_multi = _get_multi
 
         key = object()
@@ -244,7 +244,7 @@ class TestClient(unittest.TestCase):
             return [_entity]
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.get_multi = _get_multi
 
         key, missing, deferred = object(), [], []
@@ -259,7 +259,7 @@ class TestClient(unittest.TestCase):
 
     def test_get_multi_no_keys(self):
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         results = client.get_multi([])
         self.assertEqual(results, [])
 
@@ -267,7 +267,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.datastore.key import Key
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.connection._add_lookup_result()
         key = Key('Kind', 1234, project=self.PROJECT)
         results = client.get_multi([key])
@@ -288,7 +288,7 @@ class TestClient(unittest.TestCase):
         path_element.id = ID
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         # Set missing entity on mock connection.
         client.connection._add_lookup_result(missing=[missed])
 
@@ -303,7 +303,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.datastore.key import Key
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         key = Key('Kind', 1234, project=self.PROJECT)
 
         missing = ['this', 'list', 'is', 'not', 'empty']
@@ -314,7 +314,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.datastore.key import Key
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         key = Key('Kind', 1234, project=self.PROJECT)
 
         deferred = ['this', 'list', 'is', 'not', 'empty']
@@ -328,7 +328,7 @@ class TestClient(unittest.TestCase):
 
         # Set deferred entity on mock connection.
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.connection._add_lookup_result(deferred=[key.to_protobuf()])
 
         deferred = []
@@ -353,7 +353,7 @@ class TestClient(unittest.TestCase):
         entity2_pb.key.CopyFrom(key2_pb)
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         # mock up two separate requests
         client.connection._add_lookup_result([entity1_pb], deferred=[key2_pb])
         client.connection._add_lookup_result([entity2_pb])
@@ -402,7 +402,7 @@ class TestClient(unittest.TestCase):
 
         # Make a connection to return the entity pb.
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.connection._add_lookup_result([entity_pb])
 
         key = Key(KIND, ID, project=self.PROJECT)
@@ -429,7 +429,7 @@ class TestClient(unittest.TestCase):
 
         # Make a connection to return the entity pb.
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.connection._add_lookup_result([entity_pb])
 
         key = Key(KIND, ID, project=self.PROJECT)
@@ -463,7 +463,7 @@ class TestClient(unittest.TestCase):
 
         # Make a connection to return the entity pbs.
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.connection._add_lookup_result([entity_pb1, entity_pb2])
 
         key1 = Key(KIND, ID1, project=self.PROJECT)
@@ -489,7 +489,7 @@ class TestClient(unittest.TestCase):
         key2 = Key('KIND', 1234, project=PROJECT2)
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
 
         with self.assertRaises(ValueError):
             client.get_multi([key1, key2])
@@ -507,7 +507,7 @@ class TestClient(unittest.TestCase):
 
         # Make a connection to return the entity pb.
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.connection._add_lookup_result([entity_pb])
 
         key = Key(KIND, ID, project=self.PROJECT)
@@ -530,7 +530,7 @@ class TestClient(unittest.TestCase):
             _called_with.append((args, kw))
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.put_multi = _put_multi
         entity = object()
 
@@ -541,7 +541,7 @@ class TestClient(unittest.TestCase):
 
     def test_put_multi_no_entities(self):
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         self.assertIsNone(client.put_multi([]))
 
     def test_put_multi_w_single_empty_entity(self):
@@ -549,7 +549,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.datastore.entity import Entity
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         self.assertRaises(ValueError, client.put_multi, Entity())
 
     def test_put_multi_no_batch_w_partial_key(self):
@@ -560,7 +560,7 @@ class TestClient(unittest.TestCase):
         key._id = None
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.connection._commit.append([_KeyPB(key)])
 
         result = client.put_multi([entity])
@@ -586,7 +586,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.datastore.helpers import _property_tuples
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         entity = _Entity(foo=u'bar')
         key = entity.key = _Key(self.PROJECT)
 
@@ -610,7 +610,7 @@ class TestClient(unittest.TestCase):
             _called_with.append((args, kw))
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.delete_multi = _delete_multi
         key = object()
 
@@ -621,7 +621,7 @@ class TestClient(unittest.TestCase):
 
     def test_delete_multi_no_keys(self):
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         result = client.delete_multi([])
         self.assertIsNone(result)
         self.assertEqual(len(client.connection._commit_cw), 0)
@@ -630,7 +630,7 @@ class TestClient(unittest.TestCase):
         key = _Key(self.PROJECT)
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         client.connection._commit.append([])
 
         result = client.delete_multi([key])
@@ -646,7 +646,7 @@ class TestClient(unittest.TestCase):
 
     def test_delete_multi_w_existing_batch(self):
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         key = _Key(self.PROJECT)
 
         with _NoCommitBatch(client) as CURR_BATCH:
@@ -659,7 +659,7 @@ class TestClient(unittest.TestCase):
 
     def test_delete_multi_w_existing_transaction(self):
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         key = _Key(self.PROJECT)
 
         with _NoCommitTransaction(client) as CURR_XACT:
@@ -677,7 +677,7 @@ class TestClient(unittest.TestCase):
         INCOMPLETE_KEY._id = None
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
 
         result = client.allocate_ids(INCOMPLETE_KEY, NUM_IDS)
 
@@ -686,7 +686,7 @@ class TestClient(unittest.TestCase):
 
     def test_allocate_ids_with_completed_key(self):
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
 
         COMPLETE_KEY = _Key(self.PROJECT)
         self.assertRaises(ValueError, client.allocate_ids, COMPLETE_KEY, 2)
@@ -696,7 +696,7 @@ class TestClient(unittest.TestCase):
         ID = 1234
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
 
         self.assertRaises(TypeError,
                           client.key, KIND, ID, project=self.PROJECT)
@@ -709,7 +709,7 @@ class TestClient(unittest.TestCase):
         ID = 1234
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
 
         with _Monkey(MUT, Key=_Dummy):
             key = client.key(KIND, ID)
@@ -731,7 +731,7 @@ class TestClient(unittest.TestCase):
         NAMESPACE = object()
 
         creds = object()
-        client = self._makeOne(namespace=NAMESPACE, credentials=creds)
+        client = self._make_one(namespace=NAMESPACE, credentials=creds)
 
         with _Monkey(MUT, Key=_Dummy):
             key = client.key(KIND, ID)
@@ -753,7 +753,7 @@ class TestClient(unittest.TestCase):
         NAMESPACE2 = object()
 
         creds = object()
-        client = self._makeOne(namespace=NAMESPACE1, credentials=creds)
+        client = self._make_one(namespace=NAMESPACE1, credentials=creds)
 
         with _Monkey(MUT, Key=_Dummy):
             key = client.key(KIND, ID, namespace=NAMESPACE2)
@@ -770,7 +770,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
 
         with _Monkey(MUT, Batch=_Dummy):
             batch = client.batch()
@@ -784,7 +784,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
 
         with _Monkey(MUT, Transaction=_Dummy):
             xact = client.transaction()
@@ -797,8 +797,8 @@ class TestClient(unittest.TestCase):
         KIND = 'KIND'
 
         creds = object()
-        client = self._makeOne(credentials=creds)
-        other = self._makeOne(credentials=object())
+        client = self._make_one(credentials=creds)
+        other = self._make_one(credentials=object())
 
         self.assertRaises(TypeError, client.query, kind=KIND, client=other)
 
@@ -806,7 +806,7 @@ class TestClient(unittest.TestCase):
         KIND = 'KIND'
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
 
         self.assertRaises(TypeError,
                           client.query, kind=KIND, project=self.PROJECT)
@@ -816,7 +816,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
 
         with _Monkey(MUT, Query=_Dummy):
             query = client.query()
@@ -842,7 +842,7 @@ class TestClient(unittest.TestCase):
         DISTINCT_ON = ['DISTINCT_ON']
 
         creds = object()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
 
         with _Monkey(MUT, Query=_Dummy):
             query = client.query(
@@ -877,7 +877,7 @@ class TestClient(unittest.TestCase):
         NAMESPACE = object()
 
         creds = object()
-        client = self._makeOne(namespace=NAMESPACE, credentials=creds)
+        client = self._make_one(namespace=NAMESPACE, credentials=creds)
 
         with _Monkey(MUT, Query=_Dummy):
             query = client.query(kind=KIND)
@@ -900,7 +900,7 @@ class TestClient(unittest.TestCase):
         NAMESPACE2 = object()
 
         creds = object()
-        client = self._makeOne(namespace=NAMESPACE1, credentials=creds)
+        client = self._make_one(namespace=NAMESPACE1, credentials=creds)
 
         with _Monkey(MUT, Query=_Dummy):
             query = client.query(kind=KIND, namespace=NAMESPACE2)

--- a/datastore/unit_tests/test_entity.py
+++ b/datastore/unit_tests/test_entity.py
@@ -21,7 +21,8 @@ _ID = 1234
 
 class TestEntity(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore.entity import Entity
         return Entity
 

--- a/datastore/unit_tests/test_entity.py
+++ b/datastore/unit_tests/test_entity.py
@@ -27,11 +27,11 @@ class TestEntity(unittest.TestCase):
         return Entity
 
     def _makeOne(self, key=None, exclude_from_indexes=()):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         return klass(key=key, exclude_from_indexes=exclude_from_indexes)
 
     def test_ctor_defaults(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         entity = klass()
         self.assertIsNone(entity.key)
         self.assertIsNone(entity.kind)

--- a/datastore/unit_tests/test_entity.py
+++ b/datastore/unit_tests/test_entity.py
@@ -26,7 +26,7 @@ class TestEntity(unittest.TestCase):
         from google.cloud.datastore.entity import Entity
         return Entity
 
-    def _makeOne(self, key=None, exclude_from_indexes=()):
+    def _make_one(self, key=None, exclude_from_indexes=()):
         klass = self._get_target_class()
         return klass(key=key, exclude_from_indexes=exclude_from_indexes)
 
@@ -40,7 +40,7 @@ class TestEntity(unittest.TestCase):
     def test_ctor_explicit(self):
         _EXCLUDE_FROM_INDEXES = ['foo', 'bar']
         key = _Key()
-        entity = self._makeOne(
+        entity = self._make_one(
             key=key, exclude_from_indexes=_EXCLUDE_FROM_INDEXES)
         self.assertEqual(sorted(entity.exclude_from_indexes),
                          sorted(_EXCLUDE_FROM_INDEXES))
@@ -48,13 +48,13 @@ class TestEntity(unittest.TestCase):
     def test_ctor_bad_exclude_from_indexes(self):
         BAD_EXCLUDE_FROM_INDEXES = object()
         key = _Key()
-        self.assertRaises(TypeError, self._makeOne, key=key,
+        self.assertRaises(TypeError, self._make_one, key=key,
                           exclude_from_indexes=BAD_EXCLUDE_FROM_INDEXES)
 
     def test___eq_____ne___w_non_entity(self):
         from google.cloud.datastore.key import Key
         key = Key(_KIND, _ID, project=_PROJECT)
-        entity = self._makeOne(key=key)
+        entity = self._make_one(key=key)
         self.assertFalse(entity == object())
         self.assertTrue(entity != object())
 
@@ -63,9 +63,9 @@ class TestEntity(unittest.TestCase):
         _ID1 = 1234
         _ID2 = 2345
         key1 = Key(_KIND, _ID1, project=_PROJECT)
-        entity1 = self._makeOne(key=key1)
+        entity1 = self._make_one(key=key1)
         key2 = Key(_KIND, _ID2, project=_PROJECT)
-        entity2 = self._makeOne(key=key2)
+        entity2 = self._make_one(key=key2)
         self.assertFalse(entity1 == entity2)
         self.assertTrue(entity1 != entity2)
 
@@ -77,12 +77,12 @@ class TestEntity(unittest.TestCase):
         meaning = 9
 
         key1 = Key(_KIND, _ID, project=_PROJECT)
-        entity1 = self._makeOne(key=key1, exclude_from_indexes=(name,))
+        entity1 = self._make_one(key=key1, exclude_from_indexes=(name,))
         entity1[name] = value
         entity1._meanings[name] = (meaning, value)
 
         key2 = Key(_KIND, _ID, project=_PROJECT)
-        entity2 = self._makeOne(key=key2, exclude_from_indexes=(name,))
+        entity2 = self._make_one(key=key2, exclude_from_indexes=(name,))
         entity2[name] = value
         entity2._meanings[name] = (meaning, value)
 
@@ -92,10 +92,10 @@ class TestEntity(unittest.TestCase):
     def test___eq_____ne___w_same_keys_different_props(self):
         from google.cloud.datastore.key import Key
         key1 = Key(_KIND, _ID, project=_PROJECT)
-        entity1 = self._makeOne(key=key1)
+        entity1 = self._make_one(key=key1)
         entity1['foo'] = 'Foo'
         key2 = Key(_KIND, _ID, project=_PROJECT)
-        entity2 = self._makeOne(key=key2)
+        entity2 = self._make_one(key=key2)
         entity1['bar'] = 'Bar'
         self.assertFalse(entity1 == entity2)
         self.assertTrue(entity1 != entity2)
@@ -104,9 +104,9 @@ class TestEntity(unittest.TestCase):
         from google.cloud.datastore.key import Key
         key1 = Key(_KIND, _ID, project=_PROJECT)
         key2 = Key(_KIND, _ID, project=_PROJECT)
-        entity1 = self._makeOne(key=key1)
+        entity1 = self._make_one(key=key1)
         entity1['some_key'] = key1
-        entity2 = self._makeOne(key=key1)
+        entity2 = self._make_one(key=key1)
         entity2['some_key'] = key2
         self.assertTrue(entity1 == entity2)
         self.assertFalse(entity1 != entity2)
@@ -117,9 +117,9 @@ class TestEntity(unittest.TestCase):
         _ID2 = 2345
         key1 = Key(_KIND, _ID1, project=_PROJECT)
         key2 = Key(_KIND, _ID2, project=_PROJECT)
-        entity1 = self._makeOne(key=key1)
+        entity1 = self._make_one(key=key1)
         entity1['some_key'] = key1
-        entity2 = self._makeOne(key=key1)
+        entity2 = self._make_one(key=key1)
         entity2['some_key'] = key2
         self.assertFalse(entity1 == entity2)
         self.assertTrue(entity1 != entity2)
@@ -127,12 +127,12 @@ class TestEntity(unittest.TestCase):
     def test___eq_____ne___w_same_keys_props_w_equiv_entities_as_value(self):
         from google.cloud.datastore.key import Key
         key = Key(_KIND, _ID, project=_PROJECT)
-        entity1 = self._makeOne(key=key)
-        sub1 = self._makeOne()
+        entity1 = self._make_one(key=key)
+        sub1 = self._make_one()
         sub1.update({'foo': 'Foo'})
         entity1['some_entity'] = sub1
-        entity2 = self._makeOne(key=key)
-        sub2 = self._makeOne()
+        entity2 = self._make_one(key=key)
+        sub2 = self._make_one()
         sub2.update({'foo': 'Foo'})
         entity2['some_entity'] = sub2
         self.assertTrue(entity1 == entity2)
@@ -141,12 +141,12 @@ class TestEntity(unittest.TestCase):
     def test___eq_____ne___w_same_keys_props_w_diff_entities_as_value(self):
         from google.cloud.datastore.key import Key
         key = Key(_KIND, _ID, project=_PROJECT)
-        entity1 = self._makeOne(key=key)
-        sub1 = self._makeOne()
+        entity1 = self._make_one(key=key)
+        sub1 = self._make_one()
         sub1.update({'foo': 'Foo'})
         entity1['some_entity'] = sub1
-        entity2 = self._makeOne(key=key)
-        sub2 = self._makeOne()
+        entity2 = self._make_one(key=key)
+        sub2 = self._make_one()
         sub2.update({'foo': 'Bar'})
         entity2['some_entity'] = sub2
         self.assertFalse(entity1 == entity2)
@@ -159,10 +159,10 @@ class TestEntity(unittest.TestCase):
         value = 42
         key = Key(_KIND, _ID, project=_PROJECT)
 
-        entity1 = self._makeOne(key=key, exclude_from_indexes=(name,))
+        entity1 = self._make_one(key=key, exclude_from_indexes=(name,))
         entity1[name] = value
 
-        entity2 = self._makeOne(key=key, exclude_from_indexes=())
+        entity2 = self._make_one(key=key, exclude_from_indexes=())
         entity2[name] = value
 
         self.assertFalse(entity1 == entity2)
@@ -175,23 +175,23 @@ class TestEntity(unittest.TestCase):
         meaning = 9
         key = Key(_KIND, _ID, project=_PROJECT)
 
-        entity1 = self._makeOne(key=key, exclude_from_indexes=(name,))
+        entity1 = self._make_one(key=key, exclude_from_indexes=(name,))
         entity1[name] = value
 
-        entity2 = self._makeOne(key=key, exclude_from_indexes=(name,))
+        entity2 = self._make_one(key=key, exclude_from_indexes=(name,))
         entity2[name] = value
         entity2._meanings[name] = (meaning, value)
 
         self.assertFalse(entity1 == entity2)
 
     def test___repr___no_key_empty(self):
-        entity = self._makeOne()
+        entity = self._make_one()
         self.assertEqual(repr(entity), '<Entity {}>')
 
     def test___repr___w_key_non_empty(self):
         key = _Key()
         key._path = '/bar/baz'
-        entity = self._makeOne(key=key)
+        entity = self._make_one(key=key)
         entity['foo'] = 'Foo'
         self.assertEqual(repr(entity), "<Entity/bar/baz {'foo': 'Foo'}>")
 

--- a/datastore/unit_tests/test_helpers.py
+++ b/datastore/unit_tests/test_helpers.py
@@ -880,7 +880,7 @@ class TestGeoPoint(unittest.TestCase):
         return GeoPoint
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         lat = 81.2

--- a/datastore/unit_tests/test_helpers.py
+++ b/datastore/unit_tests/test_helpers.py
@@ -17,7 +17,7 @@ import unittest
 
 class Test__new_value_pb(unittest.TestCase):
 
-    def _callFUT(self, entity_pb, name):
+    def _call_fut(self, entity_pb, name):
         from google.cloud.datastore.helpers import _new_value_pb
         return _new_value_pb(entity_pb, name)
 
@@ -26,7 +26,7 @@ class Test__new_value_pb(unittest.TestCase):
 
         entity_pb = entity_pb2.Entity()
         name = 'foo'
-        result = self._callFUT(entity_pb, name)
+        result = self._call_fut(entity_pb, name)
 
         self.assertIsInstance(result, entity_pb2.Value)
         self.assertEqual(len(entity_pb.properties), 1)
@@ -35,7 +35,7 @@ class Test__new_value_pb(unittest.TestCase):
 
 class Test__property_tuples(unittest.TestCase):
 
-    def _callFUT(self, entity_pb):
+    def _call_fut(self, entity_pb):
         from google.cloud.datastore.helpers import _property_tuples
         return _property_tuples(entity_pb)
 
@@ -50,7 +50,7 @@ class Test__property_tuples(unittest.TestCase):
         val_pb1 = _new_value_pb(entity_pb, name1)
         val_pb2 = _new_value_pb(entity_pb, name2)
 
-        result = self._callFUT(entity_pb)
+        result = self._call_fut(entity_pb)
         self.assertIsInstance(result, types.GeneratorType)
         self.assertEqual(sorted(result),
                          sorted([(name1, val_pb1), (name2, val_pb2)]))
@@ -58,7 +58,7 @@ class Test__property_tuples(unittest.TestCase):
 
 class Test_entity_from_protobuf(unittest.TestCase):
 
-    def _callFUT(self, val):
+    def _call_fut(self, val):
         from google.cloud.datastore.helpers import entity_from_protobuf
         return entity_from_protobuf(val)
 
@@ -93,7 +93,7 @@ class Test_entity_from_protobuf(unittest.TestCase):
         indexed_array_val_pb = array_pb2.add()
         indexed_array_val_pb.integer_value = 12
 
-        entity = self._callFUT(entity_pb)
+        entity = self._call_fut(entity_pb)
         self.assertEqual(entity.kind, _KIND)
         self.assertEqual(entity.exclude_from_indexes,
                          frozenset(['bar', 'baz']))
@@ -130,13 +130,13 @@ class Test_entity_from_protobuf(unittest.TestCase):
         unindexed_value_pb2.integer_value = 11
 
         with self.assertRaises(ValueError):
-            self._callFUT(entity_pb)
+            self._call_fut(entity_pb)
 
     def test_entity_no_key(self):
         from google.cloud.datastore._generated import entity_pb2
 
         entity_pb = entity_pb2.Entity()
-        entity = self._callFUT(entity_pb)
+        entity = self._call_fut(entity_pb)
 
         self.assertIsNone(entity.key)
         self.assertEqual(dict(entity), {})
@@ -151,7 +151,7 @@ class Test_entity_from_protobuf(unittest.TestCase):
         value_pb.meaning = meaning = 9
         value_pb.string_value = val = u'something'
 
-        entity = self._callFUT(entity_pb)
+        entity = self._call_fut(entity_pb)
         self.assertIsNone(entity.key)
         self.assertEqual(dict(entity), {name: val})
         self.assertEqual(entity._meanings, {name: (meaning, val)})
@@ -178,7 +178,7 @@ class Test_entity_from_protobuf(unittest.TestCase):
         outside_val_pb = _new_value_pb(entity_pb, OUTSIDE_NAME)
         outside_val_pb.entity_value.CopyFrom(entity_inside)
 
-        entity = self._callFUT(entity_pb)
+        entity = self._call_fut(entity_pb)
         self.assertEqual(entity.key.project, PROJECT)
         self.assertEqual(entity.key.flat_path, (KIND,))
         self.assertEqual(len(entity), 1)
@@ -191,7 +191,7 @@ class Test_entity_from_protobuf(unittest.TestCase):
 
 class Test_entity_to_protobuf(unittest.TestCase):
 
-    def _callFUT(self, entity):
+    def _call_fut(self, entity):
         from google.cloud.datastore.helpers import entity_to_protobuf
         return entity_to_protobuf(entity)
 
@@ -218,7 +218,7 @@ class Test_entity_to_protobuf(unittest.TestCase):
         from google.cloud.datastore.entity import Entity
 
         entity = Entity()
-        entity_pb = self._callFUT(entity)
+        entity_pb = self._call_fut(entity)
         self._compareEntityProto(entity_pb, entity_pb2.Entity())
 
     def test_key_only(self):
@@ -230,7 +230,7 @@ class Test_entity_to_protobuf(unittest.TestCase):
         project = 'PROJECT'
         key = Key(kind, name, project=project)
         entity = Entity(key=key)
-        entity_pb = self._callFUT(entity)
+        entity_pb = self._call_fut(entity)
 
         expected_pb = entity_pb2.Entity()
         expected_pb.key.partition_id.project_id = project
@@ -250,7 +250,7 @@ class Test_entity_to_protobuf(unittest.TestCase):
         entity[name1] = value1 = 42
         name2 = 'bar'
         entity[name2] = value2 = u'some-string'
-        entity_pb = self._callFUT(entity)
+        entity_pb = self._call_fut(entity)
 
         expected_pb = entity_pb2.Entity()
         val_pb1 = _new_value_pb(expected_pb, name1)
@@ -266,7 +266,7 @@ class Test_entity_to_protobuf(unittest.TestCase):
 
         entity = Entity()
         entity['foo'] = []
-        entity_pb = self._callFUT(entity)
+        entity_pb = self._call_fut(entity)
 
         self._compareEntityProto(entity_pb, entity_pb2.Entity())
 
@@ -317,7 +317,7 @@ class Test_entity_to_protobuf(unittest.TestCase):
         # Convert to the user-space Entity.
         entity = entity_from_protobuf(original_pb)
         # Convert the user-space Entity back to a protobuf.
-        new_pb = self._callFUT(entity)
+        new_pb = self._call_fut(entity)
 
         # NOTE: entity_to_protobuf() strips the project so we "cheat".
         new_pb.key.partition_id.project_id = project
@@ -332,7 +332,7 @@ class Test_entity_to_protobuf(unittest.TestCase):
         name = 'foo'
         entity[name] = value = 42
         entity._meanings[name] = (9, 1337)
-        entity_pb = self._callFUT(entity)
+        entity_pb = self._call_fut(entity)
 
         expected_pb = entity_pb2.Entity()
         value_pb = _new_value_pb(expected_pb, name)
@@ -351,7 +351,7 @@ class Test_entity_to_protobuf(unittest.TestCase):
         entity[name] = values = [1, 20, 300]
         meaning = 9
         entity._meanings[name] = ([None, meaning, None], values)
-        entity_pb = self._callFUT(entity)
+        entity_pb = self._call_fut(entity)
 
         # Construct the expected protobuf.
         expected_pb = entity_pb2.Entity()
@@ -370,7 +370,7 @@ class Test_entity_to_protobuf(unittest.TestCase):
 
 class Test_key_from_protobuf(unittest.TestCase):
 
-    def _callFUT(self, val):
+    def _call_fut(self, val):
         from google.cloud.datastore.helpers import key_from_protobuf
 
         return key_from_protobuf(val)
@@ -394,7 +394,7 @@ class Test_key_from_protobuf(unittest.TestCase):
     def test_wo_namespace_in_pb(self):
         _PROJECT = 'PROJECT'
         pb = self._makePB(path=[{'kind': 'KIND'}], project=_PROJECT)
-        key = self._callFUT(pb)
+        key = self._call_fut(pb)
         self.assertEqual(key.project, _PROJECT)
         self.assertIsNone(key.namespace)
 
@@ -403,7 +403,7 @@ class Test_key_from_protobuf(unittest.TestCase):
         _NAMESPACE = 'NAMESPACE'
         pb = self._makePB(path=[{'kind': 'KIND'}], namespace=_NAMESPACE,
                           project=_PROJECT)
-        key = self._callFUT(pb)
+        key = self._call_fut(pb)
         self.assertEqual(key.project, _PROJECT)
         self.assertEqual(key.namespace, _NAMESPACE)
 
@@ -414,17 +414,17 @@ class Test_key_from_protobuf(unittest.TestCase):
             {'kind': 'GRANDCHILD', 'id': 5678},
         ]
         pb = self._makePB(path=_PATH, project='PROJECT')
-        key = self._callFUT(pb)
+        key = self._call_fut(pb)
         self.assertEqual(key.path, _PATH)
 
     def test_w_nothing_in_pb(self):
         pb = self._makePB()
-        self.assertRaises(ValueError, self._callFUT, pb)
+        self.assertRaises(ValueError, self._call_fut, pb)
 
 
 class Test__pb_attr_value(unittest.TestCase):
 
-    def _callFUT(self, val):
+    def _call_fut(self, val):
         from google.cloud.datastore.helpers import _pb_attr_value
 
         return _pb_attr_value(val)
@@ -437,7 +437,7 @@ class Test__pb_attr_value(unittest.TestCase):
         micros = 4375
         naive = datetime.datetime(2014, 9, 16, 10, 19, 32, micros)  # No zone.
         utc = datetime.datetime(2014, 9, 16, 10, 19, 32, micros, UTC)
-        name, value = self._callFUT(naive)
+        name, value = self._call_fut(naive)
         self.assertEqual(name, 'timestamp_value')
         self.assertEqual(value.seconds, calendar.timegm(utc.timetuple()))
         self.assertEqual(value.nanos, 1000 * micros)
@@ -449,7 +449,7 @@ class Test__pb_attr_value(unittest.TestCase):
 
         micros = 4375
         utc = datetime.datetime(2014, 9, 16, 10, 19, 32, micros, UTC)
-        name, value = self._callFUT(utc)
+        name, value = self._call_fut(utc)
         self.assertEqual(name, 'timestamp_value')
         self.assertEqual(value.seconds, calendar.timegm(utc.timetuple()))
         self.assertEqual(value.nanos, 1000 * micros)
@@ -458,34 +458,34 @@ class Test__pb_attr_value(unittest.TestCase):
         from google.cloud.datastore.key import Key
 
         key = Key('PATH', 1234, project='PROJECT')
-        name, value = self._callFUT(key)
+        name, value = self._call_fut(key)
         self.assertEqual(name, 'key_value')
         self.assertEqual(value, key.to_protobuf())
 
     def test_bool(self):
-        name, value = self._callFUT(False)
+        name, value = self._call_fut(False)
         self.assertEqual(name, 'boolean_value')
         self.assertEqual(value, False)
 
     def test_float(self):
-        name, value = self._callFUT(3.1415926)
+        name, value = self._call_fut(3.1415926)
         self.assertEqual(name, 'double_value')
         self.assertEqual(value, 3.1415926)
 
     def test_int(self):
-        name, value = self._callFUT(42)
+        name, value = self._call_fut(42)
         self.assertEqual(name, 'integer_value')
         self.assertEqual(value, 42)
 
     def test_long(self):
         must_be_long = (1 << 63) - 1
-        name, value = self._callFUT(must_be_long)
+        name, value = self._call_fut(must_be_long)
         self.assertEqual(name, 'integer_value')
         self.assertEqual(value, must_be_long)
 
     def test_native_str(self):
         import six
-        name, value = self._callFUT('str')
+        name, value = self._call_fut('str')
         if six.PY2:
             self.assertEqual(name, 'blob_value')
         else:  # pragma: NO COVER Python 3
@@ -493,25 +493,25 @@ class Test__pb_attr_value(unittest.TestCase):
         self.assertEqual(value, 'str')
 
     def test_bytes(self):
-        name, value = self._callFUT(b'bytes')
+        name, value = self._call_fut(b'bytes')
         self.assertEqual(name, 'blob_value')
         self.assertEqual(value, b'bytes')
 
     def test_unicode(self):
-        name, value = self._callFUT(u'str')
+        name, value = self._call_fut(u'str')
         self.assertEqual(name, 'string_value')
         self.assertEqual(value, u'str')
 
     def test_entity(self):
         from google.cloud.datastore.entity import Entity
         entity = Entity()
-        name, value = self._callFUT(entity)
+        name, value = self._call_fut(entity)
         self.assertEqual(name, 'entity_value')
         self.assertIs(value, entity)
 
     def test_array(self):
         values = ['a', 0, 3.14]
-        name, value = self._callFUT(values)
+        name, value = self._call_fut(values)
         self.assertEqual(name, 'array_value')
         self.assertIs(value, values)
 
@@ -523,24 +523,24 @@ class Test__pb_attr_value(unittest.TestCase):
         lng = 99.0007
         geo_pt = GeoPoint(latitude=lat, longitude=lng)
         geo_pt_pb = latlng_pb2.LatLng(latitude=lat, longitude=lng)
-        name, value = self._callFUT(geo_pt)
+        name, value = self._call_fut(geo_pt)
         self.assertEqual(name, 'geo_point_value')
         self.assertEqual(value, geo_pt_pb)
 
     def test_null(self):
         from google.protobuf import struct_pb2
 
-        name, value = self._callFUT(None)
+        name, value = self._call_fut(None)
         self.assertEqual(name, 'null_value')
         self.assertEqual(value, struct_pb2.NULL_VALUE)
 
     def test_object(self):
-        self.assertRaises(ValueError, self._callFUT, object())
+        self.assertRaises(ValueError, self._call_fut, object())
 
 
 class Test__get_value_from_value_pb(unittest.TestCase):
 
-    def _callFUT(self, pb):
+    def _call_fut(self, pb):
         from google.cloud.datastore.helpers import _get_value_from_value_pb
 
         return _get_value_from_value_pb(pb)
@@ -563,7 +563,7 @@ class Test__get_value_from_value_pb(unittest.TestCase):
         pb = entity_pb2.Value()
         pb.timestamp_value.seconds = calendar.timegm(utc.timetuple())
         pb.timestamp_value.nanos = 1000 * micros
-        self.assertEqual(self._callFUT(pb), utc)
+        self.assertEqual(self._call_fut(pb), utc)
 
     def test_key(self):
         from google.cloud.datastore._generated import entity_pb2
@@ -572,28 +572,28 @@ class Test__get_value_from_value_pb(unittest.TestCase):
         pb = entity_pb2.Value()
         expected = Key('KIND', 1234, project='PROJECT').to_protobuf()
         pb.key_value.CopyFrom(expected)
-        found = self._callFUT(pb)
+        found = self._call_fut(pb)
         self.assertEqual(found.to_protobuf(), expected)
 
     def test_bool(self):
         pb = self._makePB('boolean_value', False)
-        self.assertEqual(self._callFUT(pb), False)
+        self.assertEqual(self._call_fut(pb), False)
 
     def test_float(self):
         pb = self._makePB('double_value', 3.1415926)
-        self.assertEqual(self._callFUT(pb), 3.1415926)
+        self.assertEqual(self._call_fut(pb), 3.1415926)
 
     def test_int(self):
         pb = self._makePB('integer_value', 42)
-        self.assertEqual(self._callFUT(pb), 42)
+        self.assertEqual(self._call_fut(pb), 42)
 
     def test_bytes(self):
         pb = self._makePB('blob_value', b'str')
-        self.assertEqual(self._callFUT(pb), b'str')
+        self.assertEqual(self._call_fut(pb), b'str')
 
     def test_unicode(self):
         pb = self._makePB('string_value', u'str')
-        self.assertEqual(self._callFUT(pb), u'str')
+        self.assertEqual(self._call_fut(pb), u'str')
 
     def test_entity(self):
         from google.cloud.datastore._generated import entity_pb2
@@ -607,7 +607,7 @@ class Test__get_value_from_value_pb(unittest.TestCase):
 
         value_pb = _new_value_pb(entity_pb, 'foo')
         value_pb.string_value = 'Foo'
-        entity = self._callFUT(pb)
+        entity = self._call_fut(pb)
         self.assertIsInstance(entity, Entity)
         self.assertEqual(entity['foo'], 'Foo')
 
@@ -620,7 +620,7 @@ class Test__get_value_from_value_pb(unittest.TestCase):
         item_pb.string_value = 'Foo'
         item_pb = array_pb.add()
         item_pb.string_value = 'Bar'
-        items = self._callFUT(pb)
+        items = self._call_fut(pb)
         self.assertEqual(items, ['Foo', 'Bar'])
 
     def test_geo_point(self):
@@ -632,7 +632,7 @@ class Test__get_value_from_value_pb(unittest.TestCase):
         lng = 13.37
         geo_pt_pb = latlng_pb2.LatLng(latitude=lat, longitude=lng)
         pb = entity_pb2.Value(geo_point_value=geo_pt_pb)
-        result = self._callFUT(pb)
+        result = self._call_fut(pb)
         self.assertIsInstance(result, GeoPoint)
         self.assertEqual(result.latitude, lat)
         self.assertEqual(result.longitude, lng)
@@ -642,7 +642,7 @@ class Test__get_value_from_value_pb(unittest.TestCase):
         from google.cloud.datastore._generated import entity_pb2
 
         pb = entity_pb2.Value(null_value=struct_pb2.NULL_VALUE)
-        result = self._callFUT(pb)
+        result = self._call_fut(pb)
         self.assertIsNone(result)
 
     def test_unknown(self):
@@ -650,12 +650,12 @@ class Test__get_value_from_value_pb(unittest.TestCase):
 
         pb = entity_pb2.Value()
         with self.assertRaises(ValueError):
-            self._callFUT(pb)
+            self._call_fut(pb)
 
 
 class Test_set_protobuf_value(unittest.TestCase):
 
-    def _callFUT(self, value_pb, val):
+    def _call_fut(self, value_pb, val):
         from google.cloud.datastore.helpers import _set_protobuf_value
 
         return _set_protobuf_value(value_pb, val)
@@ -672,7 +672,7 @@ class Test_set_protobuf_value(unittest.TestCase):
         pb = self._makePB()
         micros = 4375
         utc = datetime.datetime(2014, 9, 16, 10, 19, 32, micros, UTC)
-        self._callFUT(pb, utc)
+        self._call_fut(pb, utc)
         value = pb.timestamp_value
         self.assertEqual(value.seconds, calendar.timegm(utc.timetuple()))
         self.assertEqual(value.nanos, 1000 * micros)
@@ -682,44 +682,44 @@ class Test_set_protobuf_value(unittest.TestCase):
 
         pb = self._makePB()
         key = Key('KIND', 1234, project='PROJECT')
-        self._callFUT(pb, key)
+        self._call_fut(pb, key)
         value = pb.key_value
         self.assertEqual(value, key.to_protobuf())
 
     def test_none(self):
         pb = self._makePB()
-        self._callFUT(pb, None)
+        self._call_fut(pb, None)
         self.assertEqual(pb.WhichOneof('value_type'), 'null_value')
 
     def test_bool(self):
         pb = self._makePB()
-        self._callFUT(pb, False)
+        self._call_fut(pb, False)
         value = pb.boolean_value
         self.assertEqual(value, False)
 
     def test_float(self):
         pb = self._makePB()
-        self._callFUT(pb, 3.1415926)
+        self._call_fut(pb, 3.1415926)
         value = pb.double_value
         self.assertEqual(value, 3.1415926)
 
     def test_int(self):
         pb = self._makePB()
-        self._callFUT(pb, 42)
+        self._call_fut(pb, 42)
         value = pb.integer_value
         self.assertEqual(value, 42)
 
     def test_long(self):
         pb = self._makePB()
         must_be_long = (1 << 63) - 1
-        self._callFUT(pb, must_be_long)
+        self._call_fut(pb, must_be_long)
         value = pb.integer_value
         self.assertEqual(value, must_be_long)
 
     def test_native_str(self):
         import six
         pb = self._makePB()
-        self._callFUT(pb, 'str')
+        self._call_fut(pb, 'str')
         if six.PY2:
             value = pb.blob_value
         else:  # pragma: NO COVER Python 3
@@ -728,13 +728,13 @@ class Test_set_protobuf_value(unittest.TestCase):
 
     def test_bytes(self):
         pb = self._makePB()
-        self._callFUT(pb, b'str')
+        self._call_fut(pb, b'str')
         value = pb.blob_value
         self.assertEqual(value, b'str')
 
     def test_unicode(self):
         pb = self._makePB()
-        self._callFUT(pb, u'str')
+        self._call_fut(pb, u'str')
         value = pb.string_value
         self.assertEqual(value, u'str')
 
@@ -744,7 +744,7 @@ class Test_set_protobuf_value(unittest.TestCase):
 
         pb = self._makePB()
         entity = Entity()
-        self._callFUT(pb, entity)
+        self._call_fut(pb, entity)
         value = pb.entity_value
         self.assertEqual(value.key.SerializeToString(), b'')
         self.assertEqual(len(list(_property_tuples(value))), 0)
@@ -760,7 +760,7 @@ class Test_set_protobuf_value(unittest.TestCase):
         key = Key('KIND', 123, project='PROJECT')
         entity = Entity(key=key)
         entity[name] = value
-        self._callFUT(pb, entity)
+        self._call_fut(pb, entity)
         entity_pb = pb.entity_value
         self.assertEqual(entity_pb.key, key.to_protobuf())
 
@@ -772,7 +772,7 @@ class Test_set_protobuf_value(unittest.TestCase):
     def test_array(self):
         pb = self._makePB()
         values = [u'a', 0, 3.14]
-        self._callFUT(pb, values)
+        self._call_fut(pb, values)
         marshalled = pb.array_value.values
         self.assertEqual(len(marshalled), len(values))
         self.assertEqual(marshalled[0].string_value, values[0])
@@ -788,13 +788,13 @@ class Test_set_protobuf_value(unittest.TestCase):
         lng = 3.337
         geo_pt = GeoPoint(latitude=lat, longitude=lng)
         geo_pt_pb = latlng_pb2.LatLng(latitude=lat, longitude=lng)
-        self._callFUT(pb, geo_pt)
+        self._call_fut(pb, geo_pt)
         self.assertEqual(pb.geo_point_value, geo_pt_pb)
 
 
 class Test__get_meaning(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud.datastore.helpers import _get_meaning
         return _get_meaning(*args, **kwargs)
 
@@ -802,7 +802,7 @@ class Test__get_meaning(unittest.TestCase):
         from google.cloud.datastore._generated import entity_pb2
 
         value_pb = entity_pb2.Value()
-        result = self._callFUT(value_pb)
+        result = self._call_fut(value_pb)
         self.assertIsNone(result)
 
     def test_single(self):
@@ -811,7 +811,7 @@ class Test__get_meaning(unittest.TestCase):
         value_pb = entity_pb2.Value()
         value_pb.meaning = meaning = 22
         value_pb.string_value = u'hi'
-        result = self._callFUT(value_pb)
+        result = self._call_fut(value_pb)
         self.assertEqual(meaning, result)
 
     def test_empty_array_value(self):
@@ -821,7 +821,7 @@ class Test__get_meaning(unittest.TestCase):
         value_pb.array_value.values.add()
         value_pb.array_value.values.pop()
 
-        result = self._callFUT(value_pb, is_list=True)
+        result = self._call_fut(value_pb, is_list=True)
         self.assertEqual(None, result)
 
     def test_array_value(self):
@@ -836,7 +836,7 @@ class Test__get_meaning(unittest.TestCase):
         sub_value_pb1.string_value = u'hi'
         sub_value_pb2.string_value = u'bye'
 
-        result = self._callFUT(value_pb, is_list=True)
+        result = self._call_fut(value_pb, is_list=True)
         self.assertEqual(meaning, result)
 
     def test_array_value_multiple_meanings(self):
@@ -853,7 +853,7 @@ class Test__get_meaning(unittest.TestCase):
         sub_value_pb1.string_value = u'hi'
         sub_value_pb2.string_value = u'bye'
 
-        result = self._callFUT(value_pb, is_list=True)
+        result = self._call_fut(value_pb, is_list=True)
         self.assertEqual(result, [meaning1, meaning2])
 
     def test_array_value_meaning_partially_unset(self):
@@ -868,7 +868,7 @@ class Test__get_meaning(unittest.TestCase):
         sub_value_pb1.string_value = u'hi'
         sub_value_pb2.string_value = u'bye'
 
-        result = self._callFUT(value_pb, is_list=True)
+        result = self._call_fut(value_pb, is_list=True)
         self.assertEqual(result, [meaning1, None])
 
 

--- a/datastore/unit_tests/test_helpers.py
+++ b/datastore/unit_tests/test_helpers.py
@@ -879,13 +879,13 @@ class TestGeoPoint(unittest.TestCase):
         from google.cloud.datastore.helpers import GeoPoint
         return GeoPoint
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         lat = 81.2
         lng = 359.9999
-        geo_pt = self._makeOne(lat, lng)
+        geo_pt = self._make_one(lat, lng)
         self.assertEqual(geo_pt.latitude, lat)
         self.assertEqual(geo_pt.longitude, lng)
 
@@ -894,7 +894,7 @@ class TestGeoPoint(unittest.TestCase):
 
         lat = 0.0001
         lng = 20.03
-        geo_pt = self._makeOne(lat, lng)
+        geo_pt = self._make_one(lat, lng)
         result = geo_pt.to_protobuf()
         geo_pt_pb = latlng_pb2.LatLng(latitude=lat, longitude=lng)
         self.assertEqual(result, geo_pt_pb)
@@ -902,26 +902,26 @@ class TestGeoPoint(unittest.TestCase):
     def test___eq__(self):
         lat = 0.0001
         lng = 20.03
-        geo_pt1 = self._makeOne(lat, lng)
-        geo_pt2 = self._makeOne(lat, lng)
+        geo_pt1 = self._make_one(lat, lng)
+        geo_pt2 = self._make_one(lat, lng)
         self.assertEqual(geo_pt1, geo_pt2)
 
     def test___eq__type_differ(self):
         lat = 0.0001
         lng = 20.03
-        geo_pt1 = self._makeOne(lat, lng)
+        geo_pt1 = self._make_one(lat, lng)
         geo_pt2 = object()
         self.assertNotEqual(geo_pt1, geo_pt2)
 
     def test___ne__same_value(self):
         lat = 0.0001
         lng = 20.03
-        geo_pt1 = self._makeOne(lat, lng)
-        geo_pt2 = self._makeOne(lat, lng)
+        geo_pt1 = self._make_one(lat, lng)
+        geo_pt2 = self._make_one(lat, lng)
         comparison_val = (geo_pt1 != geo_pt2)
         self.assertFalse(comparison_val)
 
     def test___ne__(self):
-        geo_pt1 = self._makeOne(0.0, 1.0)
-        geo_pt2 = self._makeOne(2.0, 3.0)
+        geo_pt1 = self._make_one(0.0, 1.0)
+        geo_pt2 = self._make_one(2.0, 3.0)
         self.assertNotEqual(geo_pt1, geo_pt2)

--- a/datastore/unit_tests/test_helpers.py
+++ b/datastore/unit_tests/test_helpers.py
@@ -874,7 +874,8 @@ class Test__get_meaning(unittest.TestCase):
 
 class TestGeoPoint(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore.helpers import GeoPoint
         return GeoPoint
 

--- a/datastore/unit_tests/test_key.py
+++ b/datastore/unit_tests/test_key.py
@@ -50,8 +50,8 @@ class TestKey(unittest.TestCase):
             {'kind': _CHILD_KIND, 'id': _CHILD_ID},
         ]
         parent_key = self._make_one(_PARENT_KIND, _PARENT_ID,
-                                   project=_PARENT_PROJECT,
-                                   namespace=_PARENT_NAMESPACE)
+                                    project=_PARENT_PROJECT,
+                                    namespace=_PARENT_NAMESPACE)
         key = self._make_one(_CHILD_KIND, _CHILD_ID, parent=parent_key)
         self.assertEqual(key.project, parent_key.project)
         self.assertEqual(key.namespace, parent_key.namespace)
@@ -67,24 +67,24 @@ class TestKey(unittest.TestCase):
     def test_ctor_parent_bad_type(self):
         with self.assertRaises(AttributeError):
             self._make_one('KIND2', 1234, parent=('KIND1', 1234),
-                          project=self._DEFAULT_PROJECT)
+                           project=self._DEFAULT_PROJECT)
 
     def test_ctor_parent_bad_namespace(self):
         parent_key = self._make_one('KIND', 1234, namespace='FOO',
-                                   project=self._DEFAULT_PROJECT)
+                                    project=self._DEFAULT_PROJECT)
         with self.assertRaises(ValueError):
             self._make_one('KIND2', 1234, namespace='BAR', parent=parent_key,
-                          project=self._DEFAULT_PROJECT)
+                           PROJECT=self._DEFAULT_PROJECT)
 
     def test_ctor_parent_bad_project(self):
         parent_key = self._make_one('KIND', 1234, project='FOO')
         with self.assertRaises(ValueError):
             self._make_one('KIND2', 1234, parent=parent_key,
-                          project='BAR')
+                           project='BAR')
 
     def test_ctor_parent_empty_path(self):
         parent_key = self._make_one('KIND', 1234,
-                                   project=self._DEFAULT_PROJECT)
+                                    project=self._DEFAULT_PROJECT)
         with self.assertRaises(ValueError):
             self._make_one(parent=parent_key)
 
@@ -95,7 +95,7 @@ class TestKey(unittest.TestCase):
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         key = self._make_one(_KIND, _ID, namespace=_NAMESPACE,
-                            project=_PROJECT)
+                             project=_PROJECT)
         self.assertEqual(key.project, _PROJECT)
         self.assertEqual(key.namespace, _NAMESPACE)
         self.assertEqual(key.kind, _KIND)
@@ -110,8 +110,8 @@ class TestKey(unittest.TestCase):
                           project=self._DEFAULT_PROJECT)
         self.assertRaises(ValueError, self._make_one, 'KIND', None,
                           project=self._DEFAULT_PROJECT)
-        self.assertRaises(ValueError, self._make_one, 'KIND', 10, 'KIND2', None,
-                          project=self._DEFAULT_PROJECT)
+        self.assertRaises(ValueError, self._make_one, 'KIND', 10, 'KIND2',
+                          None, project=self._DEFAULT_PROJECT)
 
     def test__clone(self):
         _PROJECT = 'PROJECT-ALT'
@@ -120,7 +120,7 @@ class TestKey(unittest.TestCase):
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
         key = self._make_one(_KIND, _ID, namespace=_NAMESPACE,
-                            project=_PROJECT)
+                             project=_PROJECT)
         clone = key._clone()
         self.assertEqual(clone.project, _PROJECT)
         self.assertEqual(clone.namespace, _NAMESPACE)
@@ -137,7 +137,7 @@ class TestKey(unittest.TestCase):
         _PATH = [{'kind': _KIND1, 'id': _ID1}, {'kind': _KIND2, 'id': _ID2}]
 
         parent = self._make_one(_KIND1, _ID1, namespace=_NAMESPACE,
-                               project=_PROJECT)
+                                project=_PROJECT)
         key = self._make_one(_KIND2, _ID2, parent=parent)
         self.assertIs(key.parent, parent)
         clone = key._clone()
@@ -216,9 +216,9 @@ class TestKey(unittest.TestCase):
         _KIND = 'KIND'
         _ID = 1234
         key1 = self._make_one(_KIND, _ID, project=_PROJECT,
-                             namespace=_NAMESPACE1)
+                              namespace=_NAMESPACE1)
         key2 = self._make_one(_KIND, _ID, project=_PROJECT,
-                             namespace=_NAMESPACE2)
+                              namespace=_NAMESPACE2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -258,9 +258,9 @@ class TestKey(unittest.TestCase):
         _KIND = 'KIND'
         _NAME = 'one'
         key1 = self._make_one(_KIND, _NAME, project=_PROJECT,
-                             namespace=_NAMESPACE1)
+                              namespace=_NAMESPACE1)
         key2 = self._make_one(_KIND, _NAME, project=_PROJECT,
-                             namespace=_NAMESPACE2)
+                              namespace=_NAMESPACE2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -343,7 +343,7 @@ class TestKey(unittest.TestCase):
     def test_to_protobuf_w_explicit_namespace(self):
         _NAMESPACE = 'NAMESPACE'
         key = self._make_one('KIND', namespace=_NAMESPACE,
-                            project=self._DEFAULT_PROJECT)
+                             project=self._DEFAULT_PROJECT)
         pb = key.to_protobuf()
         self.assertEqual(pb.partition_id.namespace_id, _NAMESPACE)
 
@@ -353,7 +353,7 @@ class TestKey(unittest.TestCase):
         _ID = 1234
         _NAME = 'NAME'
         key = self._make_one(_PARENT, _NAME, _CHILD, _ID,
-                            project=self._DEFAULT_PROJECT)
+                             project=self._DEFAULT_PROJECT)
         pb = key.to_protobuf()
         elems = list(pb.path)
         self.assertEqual(len(elems), 2)
@@ -391,7 +391,7 @@ class TestKey(unittest.TestCase):
 
     def test_id_or_name_no_name_or_id_child(self):
         key = self._make_one('KIND1', 1234, 'KIND2',
-                            project=self._DEFAULT_PROJECT)
+                             project=self._DEFAULT_PROJECT)
         self.assertIsNone(key.id_or_name)
 
     def test_id_or_name_w_id_only(self):
@@ -417,7 +417,7 @@ class TestKey(unittest.TestCase):
         _PARENT_ID = 1234
         _PARENT_PATH = [{'kind': _PARENT_KIND, 'id': _PARENT_ID}]
         key = self._make_one(_PARENT_KIND, _PARENT_ID, 'KIND2',
-                            project=self._DEFAULT_PROJECT)
+                             project=self._DEFAULT_PROJECT)
         self.assertEqual(key.parent.path, _PARENT_PATH)
 
     def test_parent_multiple_calls(self):
@@ -425,7 +425,7 @@ class TestKey(unittest.TestCase):
         _PARENT_ID = 1234
         _PARENT_PATH = [{'kind': _PARENT_KIND, 'id': _PARENT_ID}]
         key = self._make_one(_PARENT_KIND, _PARENT_ID, 'KIND2',
-                            project=self._DEFAULT_PROJECT)
+                             project=self._DEFAULT_PROJECT)
         parent = key.parent
         self.assertEqual(parent.path, _PARENT_PATH)
         new_parent = key.parent

--- a/datastore/unit_tests/test_key.py
+++ b/datastore/unit_tests/test_key.py
@@ -24,11 +24,11 @@ class TestKey(unittest.TestCase):
         from google.cloud.datastore.key import Key
         return Key
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_ctor_empty(self):
-        self.assertRaises(ValueError, self._makeOne)
+        self.assertRaises(ValueError, self._make_one)
 
     def test_ctor_no_project(self):
         klass = self._get_target_class()
@@ -36,7 +36,7 @@ class TestKey(unittest.TestCase):
 
     def test_ctor_w_explicit_project_empty_path(self):
         _PROJECT = 'PROJECT'
-        self.assertRaises(ValueError, self._makeOne, project=_PROJECT)
+        self.assertRaises(ValueError, self._make_one, project=_PROJECT)
 
     def test_ctor_parent(self):
         _PARENT_KIND = 'KIND1'
@@ -49,10 +49,10 @@ class TestKey(unittest.TestCase):
             {'kind': _PARENT_KIND, 'id': _PARENT_ID},
             {'kind': _CHILD_KIND, 'id': _CHILD_ID},
         ]
-        parent_key = self._makeOne(_PARENT_KIND, _PARENT_ID,
+        parent_key = self._make_one(_PARENT_KIND, _PARENT_ID,
                                    project=_PARENT_PROJECT,
                                    namespace=_PARENT_NAMESPACE)
-        key = self._makeOne(_CHILD_KIND, _CHILD_ID, parent=parent_key)
+        key = self._make_one(_CHILD_KIND, _CHILD_ID, parent=parent_key)
         self.assertEqual(key.project, parent_key.project)
         self.assertEqual(key.namespace, parent_key.namespace)
         self.assertEqual(key.kind, _CHILD_KIND)
@@ -60,33 +60,33 @@ class TestKey(unittest.TestCase):
         self.assertIs(key.parent, parent_key)
 
     def test_ctor_partial_parent(self):
-        parent_key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
+        parent_key = self._make_one('KIND', project=self._DEFAULT_PROJECT)
         with self.assertRaises(ValueError):
-            self._makeOne('KIND2', 1234, parent=parent_key)
+            self._make_one('KIND2', 1234, parent=parent_key)
 
     def test_ctor_parent_bad_type(self):
         with self.assertRaises(AttributeError):
-            self._makeOne('KIND2', 1234, parent=('KIND1', 1234),
+            self._make_one('KIND2', 1234, parent=('KIND1', 1234),
                           project=self._DEFAULT_PROJECT)
 
     def test_ctor_parent_bad_namespace(self):
-        parent_key = self._makeOne('KIND', 1234, namespace='FOO',
+        parent_key = self._make_one('KIND', 1234, namespace='FOO',
                                    project=self._DEFAULT_PROJECT)
         with self.assertRaises(ValueError):
-            self._makeOne('KIND2', 1234, namespace='BAR', parent=parent_key,
+            self._make_one('KIND2', 1234, namespace='BAR', parent=parent_key,
                           project=self._DEFAULT_PROJECT)
 
     def test_ctor_parent_bad_project(self):
-        parent_key = self._makeOne('KIND', 1234, project='FOO')
+        parent_key = self._make_one('KIND', 1234, project='FOO')
         with self.assertRaises(ValueError):
-            self._makeOne('KIND2', 1234, parent=parent_key,
+            self._make_one('KIND2', 1234, parent=parent_key,
                           project='BAR')
 
     def test_ctor_parent_empty_path(self):
-        parent_key = self._makeOne('KIND', 1234,
+        parent_key = self._make_one('KIND', 1234,
                                    project=self._DEFAULT_PROJECT)
         with self.assertRaises(ValueError):
-            self._makeOne(parent=parent_key)
+            self._make_one(parent=parent_key)
 
     def test_ctor_explicit(self):
         _PROJECT = 'PROJECT-ALT'
@@ -94,7 +94,7 @@ class TestKey(unittest.TestCase):
         _KIND = 'KIND'
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
-        key = self._makeOne(_KIND, _ID, namespace=_NAMESPACE,
+        key = self._make_one(_KIND, _ID, namespace=_NAMESPACE,
                             project=_PROJECT)
         self.assertEqual(key.project, _PROJECT)
         self.assertEqual(key.namespace, _NAMESPACE)
@@ -102,15 +102,15 @@ class TestKey(unittest.TestCase):
         self.assertEqual(key.path, _PATH)
 
     def test_ctor_bad_kind(self):
-        self.assertRaises(ValueError, self._makeOne, object(),
+        self.assertRaises(ValueError, self._make_one, object(),
                           project=self._DEFAULT_PROJECT)
 
     def test_ctor_bad_id_or_name(self):
-        self.assertRaises(ValueError, self._makeOne, 'KIND', object(),
+        self.assertRaises(ValueError, self._make_one, 'KIND', object(),
                           project=self._DEFAULT_PROJECT)
-        self.assertRaises(ValueError, self._makeOne, 'KIND', None,
+        self.assertRaises(ValueError, self._make_one, 'KIND', None,
                           project=self._DEFAULT_PROJECT)
-        self.assertRaises(ValueError, self._makeOne, 'KIND', 10, 'KIND2', None,
+        self.assertRaises(ValueError, self._make_one, 'KIND', 10, 'KIND2', None,
                           project=self._DEFAULT_PROJECT)
 
     def test__clone(self):
@@ -119,7 +119,7 @@ class TestKey(unittest.TestCase):
         _KIND = 'KIND'
         _ID = 1234
         _PATH = [{'kind': _KIND, 'id': _ID}]
-        key = self._makeOne(_KIND, _ID, namespace=_NAMESPACE,
+        key = self._make_one(_KIND, _ID, namespace=_NAMESPACE,
                             project=_PROJECT)
         clone = key._clone()
         self.assertEqual(clone.project, _PROJECT)
@@ -136,9 +136,9 @@ class TestKey(unittest.TestCase):
         _ID2 = 2345
         _PATH = [{'kind': _KIND1, 'id': _ID1}, {'kind': _KIND2, 'id': _ID2}]
 
-        parent = self._makeOne(_KIND1, _ID1, namespace=_NAMESPACE,
+        parent = self._make_one(_KIND1, _ID1, namespace=_NAMESPACE,
                                project=_PROJECT)
-        key = self._makeOne(_KIND2, _ID2, parent=parent)
+        key = self._make_one(_KIND2, _ID2, parent=parent)
         self.assertIs(key.parent, parent)
         clone = key._clone()
         self.assertIs(clone.parent, key.parent)
@@ -150,15 +150,15 @@ class TestKey(unittest.TestCase):
         _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _NAME = 'one'
-        key = self._makeOne(_KIND, _NAME, project=_PROJECT)
+        key = self._make_one(_KIND, _NAME, project=_PROJECT)
         self.assertFalse(key == object())
         self.assertTrue(key != object())
 
     def test___eq_____ne___two_incomplete_keys_same_kind(self):
         _PROJECT = 'PROJECT'
         _KIND = 'KIND'
-        key1 = self._makeOne(_KIND, project=_PROJECT)
-        key2 = self._makeOne(_KIND, project=_PROJECT)
+        key1 = self._make_one(_KIND, project=_PROJECT)
+        key2 = self._make_one(_KIND, project=_PROJECT)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -166,8 +166,8 @@ class TestKey(unittest.TestCase):
         _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, project=_PROJECT)
-        key2 = self._makeOne(_KIND, _ID, project=_PROJECT)
+        key1 = self._make_one(_KIND, project=_PROJECT)
+        key2 = self._make_one(_KIND, _ID, project=_PROJECT)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -175,8 +175,8 @@ class TestKey(unittest.TestCase):
         _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, project=_PROJECT)
-        key2 = self._makeOne(_KIND, project=_PROJECT)
+        key1 = self._make_one(_KIND, _ID, project=_PROJECT)
+        key2 = self._make_one(_KIND, project=_PROJECT)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -185,8 +185,8 @@ class TestKey(unittest.TestCase):
         _KIND = 'KIND'
         _ID1 = 1234
         _ID2 = 2345
-        key1 = self._makeOne(_KIND, _ID1, project=_PROJECT)
-        key2 = self._makeOne(_KIND, _ID2, project=_PROJECT)
+        key1 = self._make_one(_KIND, _ID1, project=_PROJECT)
+        key2 = self._make_one(_KIND, _ID2, project=_PROJECT)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -194,8 +194,8 @@ class TestKey(unittest.TestCase):
         _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, project=_PROJECT)
-        key2 = self._makeOne(_KIND, _ID, project=_PROJECT)
+        key1 = self._make_one(_KIND, _ID, project=_PROJECT)
+        key2 = self._make_one(_KIND, _ID, project=_PROJECT)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
@@ -204,8 +204,8 @@ class TestKey(unittest.TestCase):
         _PROJECT2 = 'PROJECT2'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, project=_PROJECT1)
-        key2 = self._makeOne(_KIND, _ID, project=_PROJECT2)
+        key1 = self._make_one(_KIND, _ID, project=_PROJECT1)
+        key2 = self._make_one(_KIND, _ID, project=_PROJECT2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -215,9 +215,9 @@ class TestKey(unittest.TestCase):
         _NAMESPACE2 = 'NAMESPACE2'
         _KIND = 'KIND'
         _ID = 1234
-        key1 = self._makeOne(_KIND, _ID, project=_PROJECT,
+        key1 = self._make_one(_KIND, _ID, project=_PROJECT,
                              namespace=_NAMESPACE1)
-        key2 = self._makeOne(_KIND, _ID, project=_PROJECT,
+        key2 = self._make_one(_KIND, _ID, project=_PROJECT,
                              namespace=_NAMESPACE2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
@@ -227,8 +227,8 @@ class TestKey(unittest.TestCase):
         _KIND = 'KIND'
         _NAME1 = 'one'
         _NAME2 = 'two'
-        key1 = self._makeOne(_KIND, _NAME1, project=_PROJECT)
-        key2 = self._makeOne(_KIND, _NAME2, project=_PROJECT)
+        key1 = self._make_one(_KIND, _NAME1, project=_PROJECT)
+        key2 = self._make_one(_KIND, _NAME2, project=_PROJECT)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -236,8 +236,8 @@ class TestKey(unittest.TestCase):
         _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, project=_PROJECT)
-        key2 = self._makeOne(_KIND, _NAME, project=_PROJECT)
+        key1 = self._make_one(_KIND, _NAME, project=_PROJECT)
+        key2 = self._make_one(_KIND, _NAME, project=_PROJECT)
         self.assertTrue(key1 == key2)
         self.assertFalse(key1 != key2)
 
@@ -246,8 +246,8 @@ class TestKey(unittest.TestCase):
         _PROJECT2 = 'PROJECT2'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, project=_PROJECT1)
-        key2 = self._makeOne(_KIND, _NAME, project=_PROJECT2)
+        key1 = self._make_one(_KIND, _NAME, project=_PROJECT1)
+        key2 = self._make_one(_KIND, _NAME, project=_PROJECT2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
 
@@ -257,9 +257,9 @@ class TestKey(unittest.TestCase):
         _NAMESPACE2 = 'NAMESPACE2'
         _KIND = 'KIND'
         _NAME = 'one'
-        key1 = self._makeOne(_KIND, _NAME, project=_PROJECT,
+        key1 = self._make_one(_KIND, _NAME, project=_PROJECT,
                              namespace=_NAMESPACE1)
-        key2 = self._makeOne(_KIND, _NAME, project=_PROJECT,
+        key2 = self._make_one(_KIND, _NAME, project=_PROJECT,
                              namespace=_NAMESPACE2)
         self.assertFalse(key1 == key2)
         self.assertTrue(key1 != key2)
@@ -267,7 +267,7 @@ class TestKey(unittest.TestCase):
     def test___hash___incomplete(self):
         _PROJECT = 'PROJECT'
         _KIND = 'KIND'
-        key = self._makeOne(_KIND, project=_PROJECT)
+        key = self._make_one(_KIND, project=_PROJECT)
         self.assertNotEqual(hash(key),
                             hash(_KIND) + hash(_PROJECT) + hash(None))
 
@@ -275,7 +275,7 @@ class TestKey(unittest.TestCase):
         _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _ID = 1234
-        key = self._makeOne(_KIND, _ID, project=_PROJECT)
+        key = self._make_one(_KIND, _ID, project=_PROJECT)
         self.assertNotEqual(hash(key),
                             hash(_KIND) + hash(_ID) +
                             hash(_PROJECT) + hash(None))
@@ -284,13 +284,13 @@ class TestKey(unittest.TestCase):
         _PROJECT = 'PROJECT'
         _KIND = 'KIND'
         _NAME = 'NAME'
-        key = self._makeOne(_KIND, _NAME, project=_PROJECT)
+        key = self._make_one(_KIND, _NAME, project=_PROJECT)
         self.assertNotEqual(hash(key),
                             hash(_KIND) + hash(_NAME) +
                             hash(_PROJECT) + hash(None))
 
     def test_completed_key_on_partial_w_id(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', project=self._DEFAULT_PROJECT)
         _ID = 1234
         new_key = key.completed_key(_ID)
         self.assertIsNot(key, new_key)
@@ -298,7 +298,7 @@ class TestKey(unittest.TestCase):
         self.assertIsNone(new_key.name)
 
     def test_completed_key_on_partial_w_name(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', project=self._DEFAULT_PROJECT)
         _NAME = 'NAME'
         new_key = key.completed_key(_NAME)
         self.assertIsNot(key, new_key)
@@ -306,18 +306,18 @@ class TestKey(unittest.TestCase):
         self.assertEqual(new_key.name, _NAME)
 
     def test_completed_key_on_partial_w_invalid(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', project=self._DEFAULT_PROJECT)
         self.assertRaises(ValueError, key.completed_key, object())
 
     def test_completed_key_on_complete(self):
-        key = self._makeOne('KIND', 1234, project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', 1234, project=self._DEFAULT_PROJECT)
         self.assertRaises(ValueError, key.completed_key, 5678)
 
     def test_to_protobuf_defaults(self):
         from google.cloud.datastore._generated import entity_pb2
 
         _KIND = 'KIND'
-        key = self._makeOne(_KIND, project=self._DEFAULT_PROJECT)
+        key = self._make_one(_KIND, project=self._DEFAULT_PROJECT)
         pb = key.to_protobuf()
         self.assertIsInstance(pb, entity_pb2.Key)
 
@@ -336,13 +336,13 @@ class TestKey(unittest.TestCase):
 
     def test_to_protobuf_w_explicit_project(self):
         _PROJECT = 'PROJECT-ALT'
-        key = self._makeOne('KIND', project=_PROJECT)
+        key = self._make_one('KIND', project=_PROJECT)
         pb = key.to_protobuf()
         self.assertEqual(pb.partition_id.project_id, _PROJECT)
 
     def test_to_protobuf_w_explicit_namespace(self):
         _NAMESPACE = 'NAMESPACE'
-        key = self._makeOne('KIND', namespace=_NAMESPACE,
+        key = self._make_one('KIND', namespace=_NAMESPACE,
                             project=self._DEFAULT_PROJECT)
         pb = key.to_protobuf()
         self.assertEqual(pb.partition_id.namespace_id, _NAMESPACE)
@@ -352,7 +352,7 @@ class TestKey(unittest.TestCase):
         _CHILD = 'CHILD'
         _ID = 1234
         _NAME = 'NAME'
-        key = self._makeOne(_PARENT, _NAME, _CHILD, _ID,
+        key = self._make_one(_PARENT, _NAME, _CHILD, _ID,
                             project=self._DEFAULT_PROJECT)
         pb = key.to_protobuf()
         elems = list(pb.path)
@@ -363,7 +363,7 @@ class TestKey(unittest.TestCase):
         self.assertEqual(elems[1].id, _ID)
 
     def test_to_protobuf_w_no_kind(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', project=self._DEFAULT_PROJECT)
         # Force the 'kind' to be unset. Maybe `to_protobuf` should fail
         # on this? The backend certainly will.
         key._path[-1].pop('kind')
@@ -372,51 +372,51 @@ class TestKey(unittest.TestCase):
         self.assertEqual(pb.path[0].kind, '')
 
     def test_is_partial_no_name_or_id(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', project=self._DEFAULT_PROJECT)
         self.assertTrue(key.is_partial)
 
     def test_is_partial_w_id(self):
         _ID = 1234
-        key = self._makeOne('KIND', _ID, project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', _ID, project=self._DEFAULT_PROJECT)
         self.assertFalse(key.is_partial)
 
     def test_is_partial_w_name(self):
         _NAME = 'NAME'
-        key = self._makeOne('KIND', _NAME, project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', _NAME, project=self._DEFAULT_PROJECT)
         self.assertFalse(key.is_partial)
 
     def test_id_or_name_no_name_or_id(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', project=self._DEFAULT_PROJECT)
         self.assertIsNone(key.id_or_name)
 
     def test_id_or_name_no_name_or_id_child(self):
-        key = self._makeOne('KIND1', 1234, 'KIND2',
+        key = self._make_one('KIND1', 1234, 'KIND2',
                             project=self._DEFAULT_PROJECT)
         self.assertIsNone(key.id_or_name)
 
     def test_id_or_name_w_id_only(self):
         _ID = 1234
-        key = self._makeOne('KIND', _ID, project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', _ID, project=self._DEFAULT_PROJECT)
         self.assertEqual(key.id_or_name, _ID)
 
     def test_id_or_name_w_name_only(self):
         _NAME = 'NAME'
-        key = self._makeOne('KIND', _NAME, project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', _NAME, project=self._DEFAULT_PROJECT)
         self.assertEqual(key.id_or_name, _NAME)
 
     def test_parent_default(self):
-        key = self._makeOne('KIND', project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', project=self._DEFAULT_PROJECT)
         self.assertIsNone(key.parent)
 
     def test_parent_explicit_top_level(self):
-        key = self._makeOne('KIND', 1234, project=self._DEFAULT_PROJECT)
+        key = self._make_one('KIND', 1234, project=self._DEFAULT_PROJECT)
         self.assertIsNone(key.parent)
 
     def test_parent_explicit_nested(self):
         _PARENT_KIND = 'KIND1'
         _PARENT_ID = 1234
         _PARENT_PATH = [{'kind': _PARENT_KIND, 'id': _PARENT_ID}]
-        key = self._makeOne(_PARENT_KIND, _PARENT_ID, 'KIND2',
+        key = self._make_one(_PARENT_KIND, _PARENT_ID, 'KIND2',
                             project=self._DEFAULT_PROJECT)
         self.assertEqual(key.parent.path, _PARENT_PATH)
 
@@ -424,7 +424,7 @@ class TestKey(unittest.TestCase):
         _PARENT_KIND = 'KIND1'
         _PARENT_ID = 1234
         _PARENT_PATH = [{'kind': _PARENT_KIND, 'id': _PARENT_ID}]
-        key = self._makeOne(_PARENT_KIND, _PARENT_ID, 'KIND2',
+        key = self._make_one(_PARENT_KIND, _PARENT_ID, 'KIND2',
                             project=self._DEFAULT_PROJECT)
         parent = key.parent
         self.assertEqual(parent.path, _PARENT_PATH)

--- a/datastore/unit_tests/test_key.py
+++ b/datastore/unit_tests/test_key.py
@@ -19,7 +19,8 @@ class TestKey(unittest.TestCase):
 
     _DEFAULT_PROJECT = 'PROJECT'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore.key import Key
         return Key
 

--- a/datastore/unit_tests/test_key.py
+++ b/datastore/unit_tests/test_key.py
@@ -25,13 +25,13 @@ class TestKey(unittest.TestCase):
         return Key
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_ctor_empty(self):
         self.assertRaises(ValueError, self._makeOne)
 
     def test_ctor_no_project(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         self.assertRaises(ValueError, klass, 'KIND')
 
     def test_ctor_w_explicit_project_empty_path(self):

--- a/datastore/unit_tests/test_query.py
+++ b/datastore/unit_tests/test_query.py
@@ -432,7 +432,7 @@ class TestIterator(unittest.TestCase):
         from google.cloud.datastore._generated import query_pb2
 
         iterator = self._make_one(None, None,
-                                 end_cursor='abcd')
+                                  end_cursor='abcd')
         self.assertIsNotNone(iterator._end_cursor)
 
         entity_pbs = object()
@@ -453,7 +453,7 @@ class TestIterator(unittest.TestCase):
         from google.cloud.datastore._generated import query_pb2
 
         iterator = self._make_one(None, None,
-                                 end_cursor='abcd')
+                                  end_cursor='abcd')
         self.assertIsNotNone(iterator._end_cursor)
 
         entity_pbs = object()

--- a/datastore/unit_tests/test_query.py
+++ b/datastore/unit_tests/test_query.py
@@ -19,7 +19,8 @@ class TestQuery(unittest.TestCase):
 
     _PROJECT = 'PROJECT'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore.query import Query
         return Query
 
@@ -339,7 +340,8 @@ class TestQuery(unittest.TestCase):
 
 class TestIterator(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore.query import Iterator
         return Iterator
 

--- a/datastore/unit_tests/test_query.py
+++ b/datastore/unit_tests/test_query.py
@@ -25,7 +25,7 @@ class TestQuery(unittest.TestCase):
         return Query
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _makeClient(self, connection=None):
         if connection is None:
@@ -346,7 +346,7 @@ class TestIterator(unittest.TestCase):
         return Iterator
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor_defaults(self):
         query = object()

--- a/datastore/unit_tests/test_query.py
+++ b/datastore/unit_tests/test_query.py
@@ -24,7 +24,7 @@ class TestQuery(unittest.TestCase):
         from google.cloud.datastore.query import Query
         return Query
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _makeClient(self, connection=None):
@@ -34,7 +34,7 @@ class TestQuery(unittest.TestCase):
 
     def test_ctor_defaults(self):
         client = self._makeClient()
-        query = self._makeOne(client)
+        query = self._make_one(client)
         self.assertIs(query._client, client)
         self.assertEqual(query.project, client.project)
         self.assertIsNone(query.kind)
@@ -56,7 +56,7 @@ class TestQuery(unittest.TestCase):
         PROJECTION = ['foo', 'bar', 'baz']
         ORDER = ['foo', 'bar']
         DISTINCT_ON = ['foo']
-        query = self._makeOne(
+        query = self._make_one(
             client,
             kind=_KIND,
             project=_PROJECT,
@@ -79,26 +79,26 @@ class TestQuery(unittest.TestCase):
 
     def test_ctor_bad_projection(self):
         BAD_PROJECTION = object()
-        self.assertRaises(TypeError, self._makeOne, self._makeClient(),
+        self.assertRaises(TypeError, self._make_one, self._makeClient(),
                           projection=BAD_PROJECTION)
 
     def test_ctor_bad_order(self):
         BAD_ORDER = object()
-        self.assertRaises(TypeError, self._makeOne, self._makeClient(),
+        self.assertRaises(TypeError, self._make_one, self._makeClient(),
                           order=BAD_ORDER)
 
     def test_ctor_bad_distinct_on(self):
         BAD_DISTINCT_ON = object()
-        self.assertRaises(TypeError, self._makeOne, self._makeClient(),
+        self.assertRaises(TypeError, self._make_one, self._makeClient(),
                           distinct_on=BAD_DISTINCT_ON)
 
     def test_ctor_bad_filters(self):
         FILTERS_CANT_UNPACK = [('one', 'two')]
-        self.assertRaises(ValueError, self._makeOne, self._makeClient(),
+        self.assertRaises(ValueError, self._make_one, self._makeClient(),
                           filters=FILTERS_CANT_UNPACK)
 
     def test_namespace_setter_w_non_string(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
 
         def _assign(val):
             query.namespace = val
@@ -107,12 +107,12 @@ class TestQuery(unittest.TestCase):
 
     def test_namespace_setter(self):
         _NAMESPACE = 'OTHER_NAMESPACE'
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.namespace = _NAMESPACE
         self.assertEqual(query.namespace, _NAMESPACE)
 
     def test_kind_setter_w_non_string(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
 
         def _assign(val):
             query.kind = val
@@ -121,21 +121,21 @@ class TestQuery(unittest.TestCase):
 
     def test_kind_setter_wo_existing(self):
         _KIND = 'KIND'
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.kind = _KIND
         self.assertEqual(query.kind, _KIND)
 
     def test_kind_setter_w_existing(self):
         _KIND_BEFORE = 'KIND_BEFORE'
         _KIND_AFTER = 'KIND_AFTER'
-        query = self._makeOne(self._makeClient(), kind=_KIND_BEFORE)
+        query = self._make_one(self._makeClient(), kind=_KIND_BEFORE)
         self.assertEqual(query.kind, _KIND_BEFORE)
         query.kind = _KIND_AFTER
         self.assertEqual(query.project, self._PROJECT)
         self.assertEqual(query.kind, _KIND_AFTER)
 
     def test_ancestor_setter_w_non_key(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
 
         def _assign(val):
             query.ancestor = val
@@ -147,7 +147,7 @@ class TestQuery(unittest.TestCase):
         from google.cloud.datastore.key import Key
         _NAME = u'NAME'
         key = Key('KIND', 123, project=self._PROJECT)
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.add_filter('name', '=', _NAME)
         query.ancestor = key
         self.assertEqual(query.ancestor.path, key.path)
@@ -155,22 +155,22 @@ class TestQuery(unittest.TestCase):
     def test_ancestor_deleter_w_key(self):
         from google.cloud.datastore.key import Key
         key = Key('KIND', 123, project=self._PROJECT)
-        query = self._makeOne(client=self._makeClient(), ancestor=key)
+        query = self._make_one(client=self._makeClient(), ancestor=key)
         del query.ancestor
         self.assertIsNone(query.ancestor)
 
     def test_add_filter_setter_w_unknown_operator(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         self.assertRaises(ValueError, query.add_filter,
                           'firstname', '~~', 'John')
 
     def test_add_filter_w_known_operator(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.add_filter('firstname', '=', u'John')
         self.assertEqual(query.filters, [('firstname', '=', u'John')])
 
     def test_add_filter_w_all_operators(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.add_filter('leq_prop', '<=', u'val1')
         query.add_filter('geq_prop', '>=', u'val2')
         query.add_filter('lt_prop', '<', u'val3')
@@ -185,7 +185,7 @@ class TestQuery(unittest.TestCase):
 
     def test_add_filter_w_known_operator_and_entity(self):
         from google.cloud.datastore.entity import Entity
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         other = Entity()
         other['firstname'] = u'John'
         other['lastname'] = u'Smith'
@@ -193,14 +193,14 @@ class TestQuery(unittest.TestCase):
         self.assertEqual(query.filters, [('other', '=', other)])
 
     def test_add_filter_w_whitespace_property_name(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         PROPERTY_NAME = '  property with lots of space '
         query.add_filter(PROPERTY_NAME, '=', u'John')
         self.assertEqual(query.filters, [(PROPERTY_NAME, '=', u'John')])
 
     def test_add_filter___key__valid_key(self):
         from google.cloud.datastore.key import Key
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         key = Key('Foo', project=self._PROJECT)
         query.add_filter('__key__', '=', key)
         self.assertEqual(query.filters, [('__key__', '=', key)])
@@ -208,40 +208,40 @@ class TestQuery(unittest.TestCase):
     def test_filter___key__not_equal_operator(self):
         from google.cloud.datastore.key import Key
         key = Key('Foo', project=self._PROJECT)
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.add_filter('__key__', '<', key)
         self.assertEqual(query.filters, [('__key__', '<', key)])
 
     def test_filter___key__invalid_value(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         self.assertRaises(ValueError, query.add_filter, '__key__', '=', None)
 
     def test_projection_setter_empty(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.projection = []
         self.assertEqual(query.projection, [])
 
     def test_projection_setter_string(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.projection = 'field1'
         self.assertEqual(query.projection, ['field1'])
 
     def test_projection_setter_non_empty(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.projection = ['field1', 'field2']
         self.assertEqual(query.projection, ['field1', 'field2'])
 
     def test_projection_setter_multiple_calls(self):
         _PROJECTION1 = ['field1', 'field2']
         _PROJECTION2 = ['field3']
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.projection = _PROJECTION1
         self.assertEqual(query.projection, _PROJECTION1)
         query.projection = _PROJECTION2
         self.assertEqual(query.projection, _PROJECTION2)
 
     def test_keys_only(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.keys_only()
         self.assertEqual(query.projection, ['__key__'])
 
@@ -249,7 +249,7 @@ class TestQuery(unittest.TestCase):
         from google.cloud.datastore.key import Key
 
         client = self._makeClient()
-        query = self._makeOne(client)
+        query = self._make_one(client)
         self.assertEqual(query.filters, [])
         key = Key('Kind', 1234, project='project')
         query.key_filter(key)
@@ -259,51 +259,51 @@ class TestQuery(unittest.TestCase):
         from google.cloud.datastore.key import Key
 
         client = self._makeClient()
-        query = self._makeOne(client)
+        query = self._make_one(client)
         self.assertEqual(query.filters, [])
         key = Key('Kind', 1234, project='project')
         query.key_filter(key, operator='>')
         self.assertEqual(query.filters, [('__key__', '>', key)])
 
     def test_order_setter_empty(self):
-        query = self._makeOne(self._makeClient(), order=['foo', '-bar'])
+        query = self._make_one(self._makeClient(), order=['foo', '-bar'])
         query.order = []
         self.assertEqual(query.order, [])
 
     def test_order_setter_string(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.order = 'field'
         self.assertEqual(query.order, ['field'])
 
     def test_order_setter_single_item_list_desc(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.order = ['-field']
         self.assertEqual(query.order, ['-field'])
 
     def test_order_setter_multiple(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.order = ['foo', '-bar']
         self.assertEqual(query.order, ['foo', '-bar'])
 
     def test_distinct_on_setter_empty(self):
-        query = self._makeOne(self._makeClient(), distinct_on=['foo', 'bar'])
+        query = self._make_one(self._makeClient(), distinct_on=['foo', 'bar'])
         query.distinct_on = []
         self.assertEqual(query.distinct_on, [])
 
     def test_distinct_on_setter_string(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.distinct_on = 'field1'
         self.assertEqual(query.distinct_on, ['field1'])
 
     def test_distinct_on_setter_non_empty(self):
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.distinct_on = ['field1', 'field2']
         self.assertEqual(query.distinct_on, ['field1', 'field2'])
 
     def test_distinct_on_multiple_calls(self):
         _DISTINCT_ON1 = ['field1', 'field2']
         _DISTINCT_ON2 = ['field3']
-        query = self._makeOne(self._makeClient())
+        query = self._make_one(self._makeClient())
         query.distinct_on = _DISTINCT_ON1
         self.assertEqual(query.distinct_on, _DISTINCT_ON1)
         query.distinct_on = _DISTINCT_ON2
@@ -314,7 +314,7 @@ class TestQuery(unittest.TestCase):
 
         connection = _Connection()
         client = self._makeClient(connection)
-        query = self._makeOne(client)
+        query = self._make_one(client)
         iterator = query.fetch()
 
         self.assertIsInstance(iterator, Iterator)
@@ -329,7 +329,7 @@ class TestQuery(unittest.TestCase):
         connection = _Connection()
         client = self._makeClient(connection)
         other_client = self._makeClient(connection)
-        query = self._makeOne(client)
+        query = self._make_one(client)
         iterator = query.fetch(limit=7, offset=8, client=other_client)
         self.assertIsInstance(iterator, Iterator)
         self.assertIs(iterator._query, query)
@@ -345,13 +345,13 @@ class TestIterator(unittest.TestCase):
         from google.cloud.datastore.query import Iterator
         return Iterator
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor_defaults(self):
         query = object()
         client = object()
-        iterator = self._makeOne(query, client)
+        iterator = self._make_one(query, client)
 
         self.assertFalse(iterator._started)
         self.assertIs(iterator.client, client)
@@ -372,7 +372,7 @@ class TestIterator(unittest.TestCase):
         offset = 9
         start_cursor = b'8290\xff'
         end_cursor = b'so20rc\ta'
-        iterator = self._makeOne(
+        iterator = self._make_one(
             query, client, limit=limit, offset=offset,
             start_cursor=start_cursor, end_cursor=end_cursor)
 
@@ -394,7 +394,7 @@ class TestIterator(unittest.TestCase):
 
         client = _Client(None, None)
         query = Query(client)
-        iterator = self._makeOne(query, client)
+        iterator = self._make_one(query, client)
 
         pb = iterator._build_protobuf()
         expected_pb = query_pb2.Query()
@@ -412,7 +412,7 @@ class TestIterator(unittest.TestCase):
         start_cursor = 'abcd'
         end_bytes = b'\xc3\x1c\xb3'
         end_cursor = 'wxyz'
-        iterator = self._makeOne(
+        iterator = self._make_one(
             query, client, limit=limit, offset=offset,
             start_cursor=start_cursor, end_cursor=end_cursor)
         self.assertEqual(iterator.max_results, limit)
@@ -431,7 +431,7 @@ class TestIterator(unittest.TestCase):
     def test__process_query_results(self):
         from google.cloud.datastore._generated import query_pb2
 
-        iterator = self._makeOne(None, None,
+        iterator = self._make_one(None, None,
                                  end_cursor='abcd')
         self.assertIsNotNone(iterator._end_cursor)
 
@@ -452,7 +452,7 @@ class TestIterator(unittest.TestCase):
     def test__process_query_results_done(self):
         from google.cloud.datastore._generated import query_pb2
 
-        iterator = self._makeOne(None, None,
+        iterator = self._make_one(None, None,
                                  end_cursor='abcd')
         self.assertIsNotNone(iterator._end_cursor)
 
@@ -470,7 +470,7 @@ class TestIterator(unittest.TestCase):
         self.assertFalse(iterator._more_results)
 
     def test__process_query_results_bad_enum(self):
-        iterator = self._makeOne(None, None)
+        iterator = self._make_one(None, None)
         more_results_enum = 999
         with self.assertRaises(ValueError):
             iterator._process_query_results(
@@ -488,7 +488,7 @@ class TestIterator(unittest.TestCase):
         project = 'prujekt'
         client = _Client(project, connection)
         query = Query(client)
-        iterator = self._makeOne(query, client)
+        iterator = self._make_one(query, client)
 
         page = iterator._next_page()
         self.assertIsInstance(page, Page)
@@ -507,7 +507,7 @@ class TestIterator(unittest.TestCase):
         connection = _Connection()
         client = _Client(None, connection)
         query = Query(client)
-        iterator = self._makeOne(query, client)
+        iterator = self._make_one(query, client)
         iterator._more_results = False
 
         page = iterator._next_page()

--- a/datastore/unit_tests/test_query.py
+++ b/datastore/unit_tests/test_query.py
@@ -517,7 +517,7 @@ class TestIterator(unittest.TestCase):
 
 class Test__item_to_entity(unittest.TestCase):
 
-    def _callFUT(self, iterator, entity_pb):
+    def _call_fut(self, iterator, entity_pb):
         from google.cloud.datastore.query import _item_to_entity
         return _item_to_entity(iterator, entity_pb)
 
@@ -534,21 +534,21 @@ class Test__item_to_entity(unittest.TestCase):
 
         entity_pb = object()
         with _Monkey(helpers, entity_from_protobuf=mocked):
-            self.assertIs(result, self._callFUT(None, entity_pb))
+            self.assertIs(result, self._call_fut(None, entity_pb))
 
         self.assertEqual(entities, [entity_pb])
 
 
 class Test__pb_from_query(unittest.TestCase):
 
-    def _callFUT(self, query):
+    def _call_fut(self, query):
         from google.cloud.datastore.query import _pb_from_query
         return _pb_from_query(query)
 
     def test_empty(self):
         from google.cloud.datastore._generated import query_pb2
 
-        pb = self._callFUT(_Query())
+        pb = self._call_fut(_Query())
         self.assertEqual(list(pb.projection), [])
         self.assertEqual(list(pb.kind), [])
         self.assertEqual(list(pb.order), [])
@@ -564,12 +564,12 @@ class Test__pb_from_query(unittest.TestCase):
         self.assertEqual(pb.offset, 0)
 
     def test_projection(self):
-        pb = self._callFUT(_Query(projection=['a', 'b', 'c']))
+        pb = self._call_fut(_Query(projection=['a', 'b', 'c']))
         self.assertEqual([item.property.name for item in pb.projection],
                          ['a', 'b', 'c'])
 
     def test_kind(self):
-        pb = self._callFUT(_Query(kind='KIND'))
+        pb = self._call_fut(_Query(kind='KIND'))
         self.assertEqual([item.name for item in pb.kind], ['KIND'])
 
     def test_ancestor(self):
@@ -577,7 +577,7 @@ class Test__pb_from_query(unittest.TestCase):
         from google.cloud.datastore._generated import query_pb2
 
         ancestor = Key('Ancestor', 123, project='PROJECT')
-        pb = self._callFUT(_Query(ancestor=ancestor))
+        pb = self._call_fut(_Query(ancestor=ancestor))
         cfilter = pb.filter.composite_filter
         self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
         self.assertEqual(len(cfilter.filters), 1)
@@ -593,7 +593,7 @@ class Test__pb_from_query(unittest.TestCase):
         query.OPERATORS = {
             '=': query_pb2.PropertyFilter.EQUAL,
         }
-        pb = self._callFUT(query)
+        pb = self._call_fut(query)
         cfilter = pb.filter.composite_filter
         self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
         self.assertEqual(len(cfilter.filters), 1)
@@ -610,7 +610,7 @@ class Test__pb_from_query(unittest.TestCase):
         query.OPERATORS = {
             '=': query_pb2.PropertyFilter.EQUAL,
         }
-        pb = self._callFUT(query)
+        pb = self._call_fut(query)
         cfilter = pb.filter.composite_filter
         self.assertEqual(cfilter.op, query_pb2.CompositeFilter.AND)
         self.assertEqual(len(cfilter.filters), 1)
@@ -622,7 +622,7 @@ class Test__pb_from_query(unittest.TestCase):
     def test_order(self):
         from google.cloud.datastore._generated import query_pb2
 
-        pb = self._callFUT(_Query(order=['a', '-b', 'c']))
+        pb = self._call_fut(_Query(order=['a', '-b', 'c']))
         self.assertEqual([item.property.name for item in pb.order],
                          ['a', 'b', 'c'])
         self.assertEqual([item.direction for item in pb.order],
@@ -631,7 +631,7 @@ class Test__pb_from_query(unittest.TestCase):
                           query_pb2.PropertyOrder.ASCENDING])
 
     def test_distinct_on(self):
-        pb = self._callFUT(_Query(distinct_on=['a', 'b', 'c']))
+        pb = self._call_fut(_Query(distinct_on=['a', 'b', 'c']))
         self.assertEqual([item.name for item in pb.distinct_on],
                          ['a', 'b', 'c'])
 

--- a/datastore/unit_tests/test_transaction.py
+++ b/datastore/unit_tests/test_transaction.py
@@ -23,7 +23,7 @@ class TestTransaction(unittest.TestCase):
         return Transaction
 
     def _makeOne(self, client, **kw):
-        return self._getTargetClass()(client, **kw)
+        return self._get_target_class()(client, **kw)
 
     def test_ctor_defaults(self):
         from google.cloud.datastore._generated import datastore_pb2
@@ -35,7 +35,7 @@ class TestTransaction(unittest.TestCase):
         self.assertEqual(xact.project, _PROJECT)
         self.assertEqual(xact.connection, connection)
         self.assertIsNone(xact.id)
-        self.assertEqual(xact._status, self._getTargetClass()._INITIAL)
+        self.assertEqual(xact._status, self._get_target_class()._INITIAL)
         self.assertIsInstance(xact._commit_request,
                               datastore_pb2.CommitRequest)
         self.assertIs(xact.mutations, xact._commit_request.mutations)

--- a/datastore/unit_tests/test_transaction.py
+++ b/datastore/unit_tests/test_transaction.py
@@ -22,7 +22,7 @@ class TestTransaction(unittest.TestCase):
         from google.cloud.datastore.transaction import Transaction
         return Transaction
 
-    def _makeOne(self, client, **kw):
+    def _make_one(self, client, **kw):
         return self._get_target_class()(client, **kw)
 
     def test_ctor_defaults(self):
@@ -31,7 +31,7 @@ class TestTransaction(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        xact = self._makeOne(client)
+        xact = self._make_one(client)
         self.assertEqual(xact.project, _PROJECT)
         self.assertEqual(xact.connection, connection)
         self.assertIsNone(xact.id)
@@ -45,8 +45,8 @@ class TestTransaction(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection()
         client = _Client(_PROJECT, connection)
-        xact1 = self._makeOne(client)
-        xact2 = self._makeOne(client)
+        xact1 = self._make_one(client)
+        xact2 = self._make_one(client)
         self.assertIsNone(xact1.current())
         self.assertIsNone(xact2.current())
         with xact1:
@@ -70,7 +70,7 @@ class TestTransaction(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection(234)
         client = _Client(_PROJECT, connection)
-        xact = self._makeOne(client)
+        xact = self._make_one(client)
         xact.begin()
         self.assertEqual(xact.id, 234)
         self.assertEqual(connection._begun, _PROJECT)
@@ -79,7 +79,7 @@ class TestTransaction(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection(234)
         client = _Client(_PROJECT, connection)
-        xact = self._makeOne(client)
+        xact = self._make_one(client)
         xact.begin()
         self.assertEqual(xact.id, 234)
         self.assertEqual(connection._begun, _PROJECT)
@@ -93,7 +93,7 @@ class TestTransaction(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection(234)
         client = _Client(_PROJECT, connection)
-        xact = self._makeOne(client)
+        xact = self._make_one(client)
 
         connection._side_effect = RuntimeError
         with self.assertRaises(RuntimeError):
@@ -106,7 +106,7 @@ class TestTransaction(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection(234)
         client = _Client(_PROJECT, connection)
-        xact = self._makeOne(client)
+        xact = self._make_one(client)
         xact.begin()
         xact.rollback()
         self.assertIsNone(xact.id)
@@ -116,7 +116,7 @@ class TestTransaction(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection(234)
         client = _Client(_PROJECT, connection)
-        xact = self._makeOne(client)
+        xact = self._make_one(client)
         xact._commit_request = commit_request = object()
         xact.begin()
         xact.commit()
@@ -131,7 +131,7 @@ class TestTransaction(unittest.TestCase):
         connection = _Connection(234)
         connection._completed_keys = [_make_key(_KIND, _ID, _PROJECT)]
         client = _Client(_PROJECT, connection)
-        xact = self._makeOne(client)
+        xact = self._make_one(client)
         xact.begin()
         entity = _Entity()
         xact.put(entity)
@@ -146,7 +146,7 @@ class TestTransaction(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection(234)
         client = _Client(_PROJECT, connection)
-        xact = self._makeOne(client)
+        xact = self._make_one(client)
         xact._commit_request = commit_request = object()
         with xact:
             self.assertEqual(xact.id, 234)
@@ -163,7 +163,7 @@ class TestTransaction(unittest.TestCase):
         _PROJECT = 'PROJECT'
         connection = _Connection(234)
         client = _Client(_PROJECT, connection)
-        xact = self._makeOne(client)
+        xact = self._make_one(client)
         xact._mutation = object()
         try:
             with xact:

--- a/datastore/unit_tests/test_transaction.py
+++ b/datastore/unit_tests/test_transaction.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestTransaction(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.datastore.transaction import Transaction
         return Transaction
 

--- a/dns/unit_tests/test_changes.py
+++ b/dns/unit_tests/test_changes.py
@@ -20,7 +20,8 @@ class TestChanges(unittest.TestCase):
     ZONE_NAME = 'example.com'
     CHANGES_NAME = 'changeset_id'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.dns.changes import Changes
         return Changes
 

--- a/dns/unit_tests/test_changes.py
+++ b/dns/unit_tests/test_changes.py
@@ -26,7 +26,7 @@ class TestChanges(unittest.TestCase):
         return Changes
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _setUpConstants(self):
         from google.cloud._helpers import UTC
@@ -98,7 +98,7 @@ class TestChanges(unittest.TestCase):
         del RESOURCE['additions']
         del RESOURCE['deletions']
         zone = _Zone()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         changes = klass.from_api_repr(RESOURCE, zone=zone)
 
@@ -108,7 +108,7 @@ class TestChanges(unittest.TestCase):
         self._setUpConstants()
         RESOURCE = self._makeResource()
         zone = _Zone()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         changes = klass.from_api_repr(RESOURCE, zone=zone)
 

--- a/dns/unit_tests/test_changes.py
+++ b/dns/unit_tests/test_changes.py
@@ -25,7 +25,7 @@ class TestChanges(unittest.TestCase):
         from google.cloud.dns.changes import Changes
         return Changes
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _setUpConstants(self):
@@ -83,7 +83,7 @@ class TestChanges(unittest.TestCase):
     def test_ctor(self):
         zone = _Zone()
 
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
 
         self.assertIs(changes.zone, zone)
         self.assertIsNone(changes.name)
@@ -116,19 +116,19 @@ class TestChanges(unittest.TestCase):
 
     def test_name_setter_bad_value(self):
         zone = _Zone()
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
         with self.assertRaises(ValueError):
             changes.name = 12345
 
     def test_name_setter(self):
         zone = _Zone()
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
         changes.name = 'NAME'
         self.assertEqual(changes.name, 'NAME')
 
     def test_add_record_set_invalid_value(self):
         zone = _Zone()
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
 
         with self.assertRaises(ValueError):
             changes.add_record_set(object())
@@ -136,7 +136,7 @@ class TestChanges(unittest.TestCase):
     def test_add_record_set(self):
         from google.cloud.dns.resource_record_set import ResourceRecordSet
         zone = _Zone()
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
         rrs = ResourceRecordSet('test.example.com', 'CNAME', 3600,
                                 ['www.example.com'], zone)
         changes.add_record_set(rrs)
@@ -144,7 +144,7 @@ class TestChanges(unittest.TestCase):
 
     def test_delete_record_set_invalid_value(self):
         zone = _Zone()
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
 
         with self.assertRaises(ValueError):
             changes.delete_record_set(object())
@@ -152,7 +152,7 @@ class TestChanges(unittest.TestCase):
     def test_delete_record_set(self):
         from google.cloud.dns.resource_record_set import ResourceRecordSet
         zone = _Zone()
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
         rrs = ResourceRecordSet('test.example.com', 'CNAME', 3600,
                                 ['www.example.com'], zone)
         changes.delete_record_set(rrs)
@@ -164,7 +164,7 @@ class TestChanges(unittest.TestCase):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         zone = _Zone(client)
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
 
         with self.assertRaises(ValueError):
             changes.create()
@@ -180,7 +180,7 @@ class TestChanges(unittest.TestCase):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         zone = _Zone(client)
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
         changes.add_record_set(ResourceRecordSet(
             'test.example.com', 'CNAME', 3600, ['www.example.com'], zone))
         changes.delete_record_set(ResourceRecordSet(
@@ -210,7 +210,7 @@ class TestChanges(unittest.TestCase):
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         zone = _Zone(client1)
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
         changes.add_record_set(ResourceRecordSet(
             'test.example.com', 'CNAME', 3600, ['www.example.com'], zone))
         changes.delete_record_set(ResourceRecordSet(
@@ -237,7 +237,7 @@ class TestChanges(unittest.TestCase):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
         zone = _Zone(client)
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
         changes.name = self.CHANGES_NAME
 
         self.assertFalse(changes.exists())
@@ -256,7 +256,7 @@ class TestChanges(unittest.TestCase):
         conn2 = _Connection({})
         client2 = _Client(project=self.PROJECT, connection=conn2)
         zone = _Zone(client1)
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
         changes.name = self.CHANGES_NAME
 
         self.assertTrue(changes.exists(client=client2))
@@ -276,7 +276,7 @@ class TestChanges(unittest.TestCase):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         zone = _Zone(client)
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
         changes.name = self.CHANGES_NAME
 
         changes.reload()
@@ -297,7 +297,7 @@ class TestChanges(unittest.TestCase):
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         zone = _Zone(client1)
-        changes = self._makeOne(zone)
+        changes = self._make_one(zone)
         changes.name = self.CHANGES_NAME
 
         changes.reload(client=client2)

--- a/dns/unit_tests/test_client.py
+++ b/dns/unit_tests/test_client.py
@@ -26,7 +26,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         from google.cloud.dns.connection import Connection

--- a/dns/unit_tests/test_client.py
+++ b/dns/unit_tests/test_client.py
@@ -25,14 +25,14 @@ class TestClient(unittest.TestCase):
         from google.cloud.dns.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         from google.cloud.dns.connection import Connection
         creds = _Credentials()
         http = object()
-        client = self._makeOne(project=self.PROJECT, credentials=creds,
+        client = self._make_one(project=self.PROJECT, credentials=creds,
                                http=http)
         self.assertIsInstance(client.connection, Connection)
         self.assertIs(client.connection.credentials, creds)
@@ -59,7 +59,7 @@ class TestClient(unittest.TestCase):
         CONVERTED = {key: int(value)
                      for key, value in DATA['quota'].items()}
         creds = _Credentials()
-        client = self._makeOne(self.PROJECT, creds)
+        client = self._make_one(self.PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
         quotas = client.quotas()
@@ -94,7 +94,7 @@ class TestClient(unittest.TestCase):
         WITH_KIND = {'quota': DATA['quota'].copy()}
         WITH_KIND['quota']['kind'] = 'dns#quota'
         creds = _Credentials()
-        client = self._makeOne(self.PROJECT, creds)
+        client = self._make_one(self.PROJECT, creds)
         conn = client.connection = _Connection(WITH_KIND)
 
         quotas = client.quotas()
@@ -131,7 +131,7 @@ class TestClient(unittest.TestCase):
             ]
         }
         creds = _Credentials()
-        client = self._makeOne(self.PROJECT, creds)
+        client = self._make_one(self.PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_zones()
@@ -176,7 +176,7 @@ class TestClient(unittest.TestCase):
             ]
         }
         creds = _Credentials()
-        client = self._makeOne(self.PROJECT, creds)
+        client = self._make_one(self.PROJECT, creds)
         conn = client.connection = _Connection(DATA)
 
         iterator = client.list_zones(max_results=3, page_token=TOKEN)
@@ -204,7 +204,7 @@ class TestClient(unittest.TestCase):
         DESCRIPTION = 'DESCRIPTION'
         DNS_NAME = 'test.example.com'
         creds = _Credentials()
-        client = self._makeOne(self.PROJECT, creds)
+        client = self._make_one(self.PROJECT, creds)
         zone = client.zone(self.ZONE_NAME, DNS_NAME, DESCRIPTION)
         self.assertIsInstance(zone, ManagedZone)
         self.assertEqual(zone.name, self.ZONE_NAME)
@@ -216,7 +216,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.dns.zone import ManagedZone
         DNS_NAME = 'test.example.com'
         creds = _Credentials()
-        client = self._makeOne(self.PROJECT, creds)
+        client = self._make_one(self.PROJECT, creds)
         zone = client.zone(self.ZONE_NAME, DNS_NAME)
         self.assertIsInstance(zone, ManagedZone)
         self.assertEqual(zone.name, self.ZONE_NAME)
@@ -227,7 +227,7 @@ class TestClient(unittest.TestCase):
     def test_zone_wo_dns_name(self):
         from google.cloud.dns.zone import ManagedZone
         creds = _Credentials()
-        client = self._makeOne(self.PROJECT, creds)
+        client = self._make_one(self.PROJECT, creds)
         zone = client.zone(self.ZONE_NAME)
         self.assertIsInstance(zone, ManagedZone)
         self.assertEqual(zone.name, self.ZONE_NAME)

--- a/dns/unit_tests/test_client.py
+++ b/dns/unit_tests/test_client.py
@@ -20,7 +20,8 @@ class TestClient(unittest.TestCase):
     PROJECT = 'PROJECT'
     ZONE_NAME = 'zone-name'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.dns.client import Client
         return Client
 

--- a/dns/unit_tests/test_client.py
+++ b/dns/unit_tests/test_client.py
@@ -33,7 +33,7 @@ class TestClient(unittest.TestCase):
         creds = _Credentials()
         http = object()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                               http=http)
+                                http=http)
         self.assertIsInstance(client.connection, Connection)
         self.assertIs(client.connection.credentials, creds)
         self.assertIs(client.connection.http, http)

--- a/dns/unit_tests/test_connection.py
+++ b/dns/unit_tests/test_connection.py
@@ -23,7 +23,7 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
         conn = self._makeOne()

--- a/dns/unit_tests/test_connection.py
+++ b/dns/unit_tests/test_connection.py
@@ -22,11 +22,11 @@ class TestConnection(unittest.TestCase):
         from google.cloud.dns.connection import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.API_BASE_URL,
             'dns',
@@ -38,7 +38,7 @@ class TestConnection(unittest.TestCase):
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
-        conn = self._makeOne()
+        conn = self._make_one()
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)

--- a/dns/unit_tests/test_connection.py
+++ b/dns/unit_tests/test_connection.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.dns.connection import Connection
         return Connection
 

--- a/dns/unit_tests/test_resource_record_set.py
+++ b/dns/unit_tests/test_resource_record_set.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestResourceRecordSet(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.dns.resource_record_set import ResourceRecordSet
         return ResourceRecordSet
 

--- a/dns/unit_tests/test_resource_record_set.py
+++ b/dns/unit_tests/test_resource_record_set.py
@@ -29,7 +29,7 @@ class TestResourceRecordSet(unittest.TestCase):
         zone = _Zone()
 
         rrs = self._make_one('test.example.com', 'CNAME', 3600,
-                            ['www.example.com'], zone)
+                             ['www.example.com'], zone)
 
         self.assertEqual(rrs.name, 'test.example.com')
         self.assertEqual(rrs.record_type, 'CNAME')

--- a/dns/unit_tests/test_resource_record_set.py
+++ b/dns/unit_tests/test_resource_record_set.py
@@ -23,7 +23,7 @@ class TestResourceRecordSet(unittest.TestCase):
         return ResourceRecordSet
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         zone = _Zone()
@@ -39,7 +39,7 @@ class TestResourceRecordSet(unittest.TestCase):
 
     def test_from_api_repr_missing_rrdatas(self):
         zone = _Zone()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         with self.assertRaises(KeyError):
             klass.from_api_repr({'name': 'test.example.com',
@@ -48,7 +48,7 @@ class TestResourceRecordSet(unittest.TestCase):
 
     def test_from_api_repr_missing_ttl(self):
         zone = _Zone()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         with self.assertRaises(KeyError):
             klass.from_api_repr({'name': 'test.example.com',
@@ -57,7 +57,7 @@ class TestResourceRecordSet(unittest.TestCase):
 
     def test_from_api_repr_missing_type(self):
         zone = _Zone()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         with self.assertRaises(KeyError):
             klass.from_api_repr({'name': 'test.example.com',
@@ -66,7 +66,7 @@ class TestResourceRecordSet(unittest.TestCase):
 
     def test_from_api_repr_missing_name(self):
         zone = _Zone()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
 
         with self.assertRaises(KeyError):
             klass.from_api_repr({'type': 'CNAME',
@@ -82,7 +82,7 @@ class TestResourceRecordSet(unittest.TestCase):
             'ttl': '3600',
             'rrdatas': ['www.example.com'],
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         rrs = klass.from_api_repr(RESOURCE, zone=zone)
         self.assertEqual(rrs.name, 'test.example.com')
         self.assertEqual(rrs.record_type, 'CNAME')

--- a/dns/unit_tests/test_resource_record_set.py
+++ b/dns/unit_tests/test_resource_record_set.py
@@ -22,13 +22,13 @@ class TestResourceRecordSet(unittest.TestCase):
         from google.cloud.dns.resource_record_set import ResourceRecordSet
         return ResourceRecordSet
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         zone = _Zone()
 
-        rrs = self._makeOne('test.example.com', 'CNAME', 3600,
+        rrs = self._make_one('test.example.com', 'CNAME', 3600,
                             ['www.example.com'], zone)
 
         self.assertEqual(rrs.name, 'test.example.com')

--- a/dns/unit_tests/test_zone.py
+++ b/dns/unit_tests/test_zone.py
@@ -26,7 +26,7 @@ class TestManagedZone(unittest.TestCase):
         from google.cloud.dns.zone import ManagedZone
         return ManagedZone
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _setUpConstants(self):
@@ -86,7 +86,7 @@ class TestManagedZone(unittest.TestCase):
         self.assertEqual(zone.name_server_set, resource.get('nameServerSet'))
 
     def test_ctor_defaults(self):
-        zone = self._makeOne(self.ZONE_NAME)
+        zone = self._make_one(self.ZONE_NAME)
         self.assertEqual(zone.name, self.ZONE_NAME)
         self.assertIsNone(zone.dns_name)
         self.assertIsNone(zone._client)
@@ -103,7 +103,7 @@ class TestManagedZone(unittest.TestCase):
 
     def test_ctor_wo_description(self):
         client = _Client(self.PROJECT)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
         self.assertEqual(zone.name, self.ZONE_NAME)
         self.assertEqual(zone.dns_name, self.DNS_NAME)
         self.assertIs(zone._client, client)
@@ -118,7 +118,7 @@ class TestManagedZone(unittest.TestCase):
     def test_ctor_explicit(self):
         DESCRIPTION = 'DESCRIPTION'
         client = _Client(self.PROJECT)
-        zone = self._makeOne(
+        zone = self._make_one(
             self.ZONE_NAME, self.DNS_NAME, client, DESCRIPTION)
         self.assertEqual(zone.name, self.ZONE_NAME)
         self.assertEqual(zone.dns_name, self.DNS_NAME)
@@ -162,25 +162,25 @@ class TestManagedZone(unittest.TestCase):
 
     def test_description_setter_bad_value(self):
         client = _Client(self.PROJECT)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
         with self.assertRaises(ValueError):
             zone.description = 12345
 
     def test_description_setter(self):
         client = _Client(self.PROJECT)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
         zone.description = 'DESCRIPTION'
         self.assertEqual(zone.description, 'DESCRIPTION')
 
     def test_name_server_set_setter_bad_value(self):
         client = _Client(self.PROJECT)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
         with self.assertRaises(ValueError):
             zone.name_server_set = 12345
 
     def test_name_server_set_setter(self):
         client = _Client(self.PROJECT)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
         zone.name_server_set = 'NAME_SERVER_SET'
         self.assertEqual(zone.name_server_set, 'NAME_SERVER_SET')
 
@@ -191,7 +191,7 @@ class TestManagedZone(unittest.TestCase):
         TTL = 3600
         RRDATAS = ['www.example.com']
         client = _Client(self.PROJECT)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
         rrs = zone.resource_record_set(RRS_NAME, RRS_TYPE, TTL, RRDATAS)
         self.assertIsInstance(rrs, ResourceRecordSet)
         self.assertEqual(rrs.name, RRS_NAME)
@@ -203,7 +203,7 @@ class TestManagedZone(unittest.TestCase):
     def test_changes(self):
         from google.cloud.dns.changes import Changes
         client = _Client(self.PROJECT)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
         changes = zone.changes()
         self.assertIsInstance(changes, Changes)
         self.assertIs(changes.zone, zone)
@@ -213,7 +213,7 @@ class TestManagedZone(unittest.TestCase):
         RESOURCE = self._makeResource()
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
 
         zone.create()
 
@@ -240,7 +240,7 @@ class TestManagedZone(unittest.TestCase):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client1)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client1)
         zone.name_server_set = NAME_SERVER_SET
         zone.description = DESCRIPTION
 
@@ -273,7 +273,7 @@ class TestManagedZone(unittest.TestCase):
         conn = _Connection()
         conn.api_request = _api_request
         client = _Client(project=self.PROJECT, connection=conn)
-        zone = self._makeOne(self.ZONE_NAME, client=client)
+        zone = self._make_one(self.ZONE_NAME, client=client)
 
         with self.assertRaises(BadRequest):
             zone.create()
@@ -298,7 +298,7 @@ class TestManagedZone(unittest.TestCase):
         self.WHEN = None
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
 
         zone.create()
 
@@ -318,7 +318,7 @@ class TestManagedZone(unittest.TestCase):
         PATH = 'projects/%s/managedZones/%s' % (self.PROJECT, self.ZONE_NAME)
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
 
         self.assertFalse(zone.exists())
 
@@ -334,7 +334,7 @@ class TestManagedZone(unittest.TestCase):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection({})
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client1)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client1)
 
         self.assertTrue(zone.exists(client=client2))
 
@@ -350,7 +350,7 @@ class TestManagedZone(unittest.TestCase):
         RESOURCE = self._makeResource()
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        zone = self._makeOne(self.ZONE_NAME, client=client)
+        zone = self._make_one(self.ZONE_NAME, client=client)
 
         zone.reload()
 
@@ -369,7 +369,7 @@ class TestManagedZone(unittest.TestCase):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client1)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client1)
 
         zone.reload(client=client2)
 
@@ -384,7 +384,7 @@ class TestManagedZone(unittest.TestCase):
         PATH = 'projects/%s/managedZones/%s' % (self.PROJECT, self.ZONE_NAME)
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
 
         zone.delete()
 
@@ -399,7 +399,7 @@ class TestManagedZone(unittest.TestCase):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection({})
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client1)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client1)
 
         zone.delete(client=client2)
 
@@ -440,7 +440,7 @@ class TestManagedZone(unittest.TestCase):
         }
         conn = _Connection(DATA)
         client = _Client(project=self.PROJECT, connection=conn)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
 
         iterator = zone.list_resource_record_sets()
         self.assertIs(zone, iterator.zone)
@@ -494,7 +494,7 @@ class TestManagedZone(unittest.TestCase):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(DATA)
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client1)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client1)
 
         iterator = zone.list_resource_record_sets(
             max_results=3, page_token=TOKEN, client=client2)
@@ -569,7 +569,7 @@ class TestManagedZone(unittest.TestCase):
 
         conn = _Connection(data)
         client = _Client(project=self.PROJECT, connection=conn)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
 
         iterator = zone.list_changes()
         self.assertIs(zone, iterator.zone)
@@ -623,7 +623,7 @@ class TestManagedZone(unittest.TestCase):
         client1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(data)
         client2 = _Client(project=self.PROJECT, connection=conn2)
-        zone = self._makeOne(self.ZONE_NAME, self.DNS_NAME, client1)
+        zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client1)
 
         page_token = 'TOKEN'
         iterator = zone.list_changes(

--- a/dns/unit_tests/test_zone.py
+++ b/dns/unit_tests/test_zone.py
@@ -21,7 +21,8 @@ class TestManagedZone(unittest.TestCase):
     DESCRIPTION = 'ZONE DESCRIPTION'
     DNS_NAME = 'test.example.com'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.dns.zone import ManagedZone
         return ManagedZone
 

--- a/dns/unit_tests/test_zone.py
+++ b/dns/unit_tests/test_zone.py
@@ -27,7 +27,7 @@ class TestManagedZone(unittest.TestCase):
         return ManagedZone
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _setUpConstants(self):
         import datetime
@@ -135,7 +135,7 @@ class TestManagedZone(unittest.TestCase):
         self._setUpConstants()
         client = _Client(self.PROJECT)
         RESOURCE = {}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(KeyError):
             klass.from_api_repr(RESOURCE, client=client)
 
@@ -146,7 +146,7 @@ class TestManagedZone(unittest.TestCase):
             'name': self.ZONE_NAME,
             'dnsName': self.DNS_NAME,
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         zone = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(zone._client, client)
         self._verifyResourceProperties(zone, RESOURCE)
@@ -155,7 +155,7 @@ class TestManagedZone(unittest.TestCase):
         self._setUpConstants()
         client = _Client(self.PROJECT)
         RESOURCE = self._makeResource()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         zone = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(zone._client, client)
         self._verifyResourceProperties(zone, RESOURCE)

--- a/error_reporting/unit_tests/test_client.py
+++ b/error_reporting/unit_tests/test_client.py
@@ -40,23 +40,23 @@ class TestClient(unittest.TestCase):
     def test_ctor_default(self):
         CREDENTIALS = _Credentials()
         target = self._make_one(project=self.PROJECT,
-                               credentials=CREDENTIALS)
+                                credentials=CREDENTIALS)
         self.assertEquals(target.service, target.DEFAULT_SERVICE)
         self.assertEquals(target.version, None)
 
     def test_ctor_params(self):
         CREDENTIALS = _Credentials()
         target = self._make_one(project=self.PROJECT,
-                               credentials=CREDENTIALS,
-                               service=self.SERVICE,
-                               version=self.VERSION)
+                                credentials=CREDENTIALS,
+                                service=self.SERVICE,
+                                version=self.VERSION)
         self.assertEquals(target.service, self.SERVICE)
         self.assertEquals(target.version, self.VERSION)
 
     def test_report_exception(self):
         CREDENTIALS = _Credentials()
         target = self._make_one(project=self.PROJECT,
-                               credentials=CREDENTIALS)
+                                credentials=CREDENTIALS)
 
         logger = _Logger()
         target.logging_client.logger = lambda _: logger
@@ -78,9 +78,9 @@ class TestClient(unittest.TestCase):
         SERVICE = "notdefault"
         VERSION = "notdefaultversion"
         target = self._make_one(project=self.PROJECT,
-                               credentials=CREDENTIALS,
-                               service=SERVICE,
-                               version=VERSION)
+                                credentials=CREDENTIALS,
+                                service=SERVICE,
+                                version=VERSION)
 
         logger = _Logger()
         target.logging_client.logger = lambda _: logger
@@ -111,7 +111,7 @@ class TestClient(unittest.TestCase):
     def test_report(self):
         CREDENTIALS = _Credentials()
         target = self._make_one(project=self.PROJECT,
-                               credentials=CREDENTIALS)
+                                credentials=CREDENTIALS)
 
         logger = _Logger()
         target.logging_client.logger = lambda _: logger

--- a/error_reporting/unit_tests/test_client.py
+++ b/error_reporting/unit_tests/test_client.py
@@ -18,7 +18,8 @@ import unittest
 
 class TestClient(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.error_reporting.client import Client
         return Client
 

--- a/error_reporting/unit_tests/test_client.py
+++ b/error_reporting/unit_tests/test_client.py
@@ -28,7 +28,7 @@ class TestClient(unittest.TestCase):
         return HTTPContext
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _makeHTTP(self, *args, **kw):
         return self._getHttpContext()(*args, **kw)

--- a/error_reporting/unit_tests/test_client.py
+++ b/error_reporting/unit_tests/test_client.py
@@ -27,7 +27,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.error_reporting.client import HTTPContext
         return HTTPContext
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _makeHTTP(self, *args, **kw):
@@ -39,14 +39,14 @@ class TestClient(unittest.TestCase):
 
     def test_ctor_default(self):
         CREDENTIALS = _Credentials()
-        target = self._makeOne(project=self.PROJECT,
+        target = self._make_one(project=self.PROJECT,
                                credentials=CREDENTIALS)
         self.assertEquals(target.service, target.DEFAULT_SERVICE)
         self.assertEquals(target.version, None)
 
     def test_ctor_params(self):
         CREDENTIALS = _Credentials()
-        target = self._makeOne(project=self.PROJECT,
+        target = self._make_one(project=self.PROJECT,
                                credentials=CREDENTIALS,
                                service=self.SERVICE,
                                version=self.VERSION)
@@ -55,7 +55,7 @@ class TestClient(unittest.TestCase):
 
     def test_report_exception(self):
         CREDENTIALS = _Credentials()
-        target = self._makeOne(project=self.PROJECT,
+        target = self._make_one(project=self.PROJECT,
                                credentials=CREDENTIALS)
 
         logger = _Logger()
@@ -77,7 +77,7 @@ class TestClient(unittest.TestCase):
         CREDENTIALS = _Credentials()
         SERVICE = "notdefault"
         VERSION = "notdefaultversion"
-        target = self._makeOne(project=self.PROJECT,
+        target = self._make_one(project=self.PROJECT,
                                credentials=CREDENTIALS,
                                service=SERVICE,
                                version=VERSION)
@@ -110,7 +110,7 @@ class TestClient(unittest.TestCase):
 
     def test_report(self):
         CREDENTIALS = _Credentials()
-        target = self._makeOne(project=self.PROJECT,
+        target = self._make_one(project=self.PROJECT,
                                credentials=CREDENTIALS)
 
         logger = _Logger()

--- a/language/unit_tests/test_client.py
+++ b/language/unit_tests/test_client.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestClient(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.language.client import Client
         return Client
 

--- a/language/unit_tests/test_client.py
+++ b/language/unit_tests/test_client.py
@@ -23,7 +23,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         from google.cloud.language.connection import Connection

--- a/language/unit_tests/test_client.py
+++ b/language/unit_tests/test_client.py
@@ -22,7 +22,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.language.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
@@ -30,7 +30,7 @@ class TestClient(unittest.TestCase):
 
         creds = _Credentials()
         http = object()
-        client = self._makeOne(credentials=creds, http=http)
+        client = self._make_one(credentials=creds, http=http)
         self.assertIsInstance(client.connection, Connection)
         self.assertIs(client.connection.credentials, creds)
         self.assertIs(client.connection.http, http)
@@ -39,7 +39,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.language.document import Document
 
         creds = _Credentials()
-        client = self._makeOne(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, http=object())
 
         content = 'abc'
         language = 'es'
@@ -54,7 +54,7 @@ class TestClient(unittest.TestCase):
 
     def test_document_from_text_factory_failure(self):
         creds = _Credentials()
-        client = self._makeOne(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, http=object())
 
         with self.assertRaises(TypeError):
             client.document_from_text('abc', doc_type='foo')
@@ -63,7 +63,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.language.document import Document
 
         creds = _Credentials()
-        client = self._makeOne(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, http=object())
 
         content = '<html>abc</html>'
         language = 'ja'
@@ -78,7 +78,7 @@ class TestClient(unittest.TestCase):
 
     def test_document_from_html_factory_failure(self):
         creds = _Credentials()
-        client = self._makeOne(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, http=object())
 
         with self.assertRaises(TypeError):
             client.document_from_html('abc', doc_type='foo')
@@ -87,7 +87,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.language.document import Document
 
         creds = _Credentials()
-        client = self._makeOne(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, http=object())
 
         gcs_url = 'gs://my-text-bucket/sentiment-me.txt'
         document = client.document_from_url(gcs_url)
@@ -102,7 +102,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.language.document import Encoding
 
         creds = _Credentials()
-        client = self._makeOne(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, http=object())
 
         encoding = Encoding.UTF32
         gcs_url = 'gs://my-text-bucket/sentiment-me.txt'

--- a/language/unit_tests/test_connection.py
+++ b/language/unit_tests/test_connection.py
@@ -23,7 +23,7 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_build_api_url(self):
         conn = self._makeOne()

--- a/language/unit_tests/test_connection.py
+++ b/language/unit_tests/test_connection.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.language.connection import Connection
         return Connection
 

--- a/language/unit_tests/test_connection.py
+++ b/language/unit_tests/test_connection.py
@@ -22,11 +22,11 @@ class TestConnection(unittest.TestCase):
         from google.cloud.language.connection import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         uri = '/'.join([
             conn.API_BASE_URL,
             conn.API_VERSION,

--- a/language/unit_tests/test_document.py
+++ b/language/unit_tests/test_document.py
@@ -103,7 +103,7 @@ class TestDocument(unittest.TestCase):
         return Document
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor_defaults(self):
         import google.cloud.language.document as MUT
@@ -145,7 +145,7 @@ class TestDocument(unittest.TestCase):
                           gcs_url='gs://some-bucket/some-obj.txt')
 
     def test__to_dict_with_content(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         content = 'Hello World'
         document = self._makeOne(None, content=content)
         info = document._to_dict()
@@ -156,7 +156,7 @@ class TestDocument(unittest.TestCase):
         })
 
     def test__to_dict_with_gcs(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         gcs_url = 'gs://some-bucket/some-obj.html'
         document = self._makeOne(None, gcs_url=gcs_url)
         info = document._to_dict()
@@ -167,7 +167,7 @@ class TestDocument(unittest.TestCase):
         })
 
     def test__to_dict_with_no_content(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         document = self._makeOne(None, content='')
         document.content = None  # Manually unset the content.
         info = document._to_dict()

--- a/language/unit_tests/test_document.py
+++ b/language/unit_tests/test_document.py
@@ -125,9 +125,9 @@ class TestDocument(unittest.TestCase):
         gcs_url = 'gs://some-bucket/some-obj.html'
         language = 'ja'
         document = self._make_one(client, gcs_url=gcs_url,
-                                 doc_type=MUT.Document.HTML,
-                                 language=language,
-                                 encoding=MUT.Encoding.UTF32)
+                                  doc_type=MUT.Document.HTML,
+                                  language=language,
+                                  encoding=MUT.Encoding.UTF32)
         self.assertIs(document.client, client)
         self.assertIsNone(document.content)
         self.assertEqual(document.gcs_url, gcs_url)
@@ -142,7 +142,7 @@ class TestDocument(unittest.TestCase):
     def test_constructor_text_and_gcs(self):
         with self.assertRaises(ValueError):
             self._make_one(None, content='abc',
-                          gcs_url='gs://some-bucket/some-obj.txt')
+                           gcs_url='gs://some-bucket/some-obj.txt')
 
     def test__to_dict_with_content(self):
         klass = self._get_target_class()

--- a/language/unit_tests/test_document.py
+++ b/language/unit_tests/test_document.py
@@ -102,7 +102,7 @@ class TestDocument(unittest.TestCase):
         from google.cloud.language.document import Document
         return Document
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor_defaults(self):
@@ -110,7 +110,7 @@ class TestDocument(unittest.TestCase):
 
         client = object()
         content = 'abc'
-        document = self._makeOne(client, content)
+        document = self._make_one(client, content)
         self.assertIs(document.client, client)
         self.assertEqual(document.content, content)
         self.assertIsNone(document.gcs_url)
@@ -124,7 +124,7 @@ class TestDocument(unittest.TestCase):
         client = object()
         gcs_url = 'gs://some-bucket/some-obj.html'
         language = 'ja'
-        document = self._makeOne(client, gcs_url=gcs_url,
+        document = self._make_one(client, gcs_url=gcs_url,
                                  doc_type=MUT.Document.HTML,
                                  language=language,
                                  encoding=MUT.Encoding.UTF32)
@@ -137,17 +137,17 @@ class TestDocument(unittest.TestCase):
 
     def test_constructor_no_text(self):
         with self.assertRaises(ValueError):
-            self._makeOne(None, content=None, gcs_url=None)
+            self._make_one(None, content=None, gcs_url=None)
 
     def test_constructor_text_and_gcs(self):
         with self.assertRaises(ValueError):
-            self._makeOne(None, content='abc',
+            self._make_one(None, content='abc',
                           gcs_url='gs://some-bucket/some-obj.txt')
 
     def test__to_dict_with_content(self):
         klass = self._get_target_class()
         content = 'Hello World'
-        document = self._makeOne(None, content=content)
+        document = self._make_one(None, content=content)
         info = document._to_dict()
         self.assertEqual(info, {
             'content': content,
@@ -158,7 +158,7 @@ class TestDocument(unittest.TestCase):
     def test__to_dict_with_gcs(self):
         klass = self._get_target_class()
         gcs_url = 'gs://some-bucket/some-obj.html'
-        document = self._makeOne(None, gcs_url=gcs_url)
+        document = self._make_one(None, gcs_url=gcs_url)
         info = document._to_dict()
         self.assertEqual(info, {
             'gcsContentUri': gcs_url,
@@ -168,7 +168,7 @@ class TestDocument(unittest.TestCase):
 
     def test__to_dict_with_no_content(self):
         klass = self._get_target_class()
-        document = self._makeOne(None, content='')
+        document = self._make_one(None, content='')
         document.content = None  # Manually unset the content.
         info = document._to_dict()
         self.assertEqual(info, {
@@ -231,7 +231,7 @@ class TestDocument(unittest.TestCase):
         }
         connection = _Connection(response)
         client = _Client(connection=connection)
-        document = self._makeOne(client, content)
+        document = self._make_one(client, content)
 
         entities = document.analyze_entities()
         self.assertEqual(len(entities), 2)
@@ -268,7 +268,7 @@ class TestDocument(unittest.TestCase):
         }
         connection = _Connection(response)
         client = _Client(connection=connection)
-        document = self._makeOne(client, content)
+        document = self._make_one(client, content)
 
         sentiment = document.analyze_sentiment()
         self._verify_sentiment(sentiment, polarity, magnitude)
@@ -326,7 +326,7 @@ class TestDocument(unittest.TestCase):
 
         connection = _Connection(response)
         client = _Client(connection=connection)
-        document = self._makeOne(client, ANNOTATE_CONTENT)
+        document = self._make_one(client, ANNOTATE_CONTENT)
 
         annotations = document.annotate_text(
             include_syntax=include_syntax, include_entities=include_entities,

--- a/language/unit_tests/test_document.py
+++ b/language/unit_tests/test_document.py
@@ -97,7 +97,8 @@ def _get_entities(include_entities):
 
 class TestDocument(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.language.document import Document
         return Document
 

--- a/language/unit_tests/test_entity.py
+++ b/language/unit_tests/test_entity.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestEntity(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.language.entity import Entity
         return Entity
 

--- a/language/unit_tests/test_entity.py
+++ b/language/unit_tests/test_entity.py
@@ -22,7 +22,7 @@ class TestEntity(unittest.TestCase):
         from google.cloud.language.entity import Entity
         return Entity
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor_defaults(self):
@@ -34,7 +34,7 @@ class TestEntity(unittest.TestCase):
         metadata.update(base_metadata)
         salience = 0.19960518
         mentions = ['Italian']
-        entity = self._makeOne(name, entity_type, metadata,
+        entity = self._make_one(name, entity_type, metadata,
                                salience, mentions)
         self.assertEqual(entity.name, name)
         self.assertEqual(entity.entity_type, entity_type)

--- a/language/unit_tests/test_entity.py
+++ b/language/unit_tests/test_entity.py
@@ -35,7 +35,7 @@ class TestEntity(unittest.TestCase):
         salience = 0.19960518
         mentions = ['Italian']
         entity = self._make_one(name, entity_type, metadata,
-                               salience, mentions)
+                                salience, mentions)
         self.assertEqual(entity.name, name)
         self.assertEqual(entity.entity_type, entity_type)
         self.assertEqual(entity.wikipedia_url, wiki_url)

--- a/language/unit_tests/test_entity.py
+++ b/language/unit_tests/test_entity.py
@@ -23,7 +23,7 @@ class TestEntity(unittest.TestCase):
         return Entity
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor_defaults(self):
         name = 'Italian'
@@ -44,7 +44,7 @@ class TestEntity(unittest.TestCase):
         self.assertEqual(entity.mentions, mentions)
 
     def test_from_api_repr(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         name = 'Italy'
         entity_type = 'LOCATION'
         salience = 0.223

--- a/language/unit_tests/test_sentiment.py
+++ b/language/unit_tests/test_sentiment.py
@@ -22,13 +22,13 @@ class TestSentiment(unittest.TestCase):
         from google.cloud.language.sentiment import Sentiment
         return Sentiment
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         polarity = 1
         magnitude = 2.3
-        sentiment = self._makeOne(polarity, magnitude)
+        sentiment = self._make_one(polarity, magnitude)
         self.assertEqual(sentiment.polarity, polarity)
         self.assertEqual(sentiment.magnitude, magnitude)
 

--- a/language/unit_tests/test_sentiment.py
+++ b/language/unit_tests/test_sentiment.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestSentiment(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.language.sentiment import Sentiment
         return Sentiment
 

--- a/language/unit_tests/test_sentiment.py
+++ b/language/unit_tests/test_sentiment.py
@@ -23,7 +23,7 @@ class TestSentiment(unittest.TestCase):
         return Sentiment
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         polarity = 1
@@ -33,7 +33,7 @@ class TestSentiment(unittest.TestCase):
         self.assertEqual(sentiment.magnitude, magnitude)
 
     def test_from_api_repr(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         polarity = -1
         magnitude = 5.55
         payload = {

--- a/language/unit_tests/test_syntax.py
+++ b/language/unit_tests/test_syntax.py
@@ -23,7 +23,7 @@ class TestPartOfSpeech(unittest.TestCase):
         return PartOfSpeech
 
     def test_reverse(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         for attr in dir(klass):
             if attr.startswith('_'):
                 continue
@@ -42,7 +42,7 @@ class TestToken(unittest.TestCase):
         return Token
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         from google.cloud.language.syntax import PartOfSpeech
@@ -65,7 +65,7 @@ class TestToken(unittest.TestCase):
     def test_from_api_repr(self):
         from google.cloud.language.syntax import PartOfSpeech
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         text_content = 'pretty'
         text_begin = -1
         part_of_speech = PartOfSpeech.ADJECTIVE
@@ -103,7 +103,7 @@ class TestSentence(unittest.TestCase):
         return Sentence
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         content = "All the king's horses."
@@ -113,7 +113,7 @@ class TestSentence(unittest.TestCase):
         self.assertEqual(sentence.begin, begin)
 
     def test_from_api_repr(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         content = 'All the pretty horses.'
         begin = -1
         payload = {

--- a/language/unit_tests/test_syntax.py
+++ b/language/unit_tests/test_syntax.py
@@ -41,7 +41,7 @@ class TestToken(unittest.TestCase):
         from google.cloud.language.syntax import Token
         return Token
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
@@ -53,7 +53,7 @@ class TestToken(unittest.TestCase):
         edge_index = 3
         edge_label = 'PREDET'
         lemma = text_content
-        token = self._makeOne(text_content, text_begin, part_of_speech,
+        token = self._make_one(text_content, text_begin, part_of_speech,
                               edge_index, edge_label, lemma)
         self.assertEqual(token.text_content, text_content)
         self.assertEqual(token.text_begin, text_begin)
@@ -102,13 +102,13 @@ class TestSentence(unittest.TestCase):
         from google.cloud.language.syntax import Sentence
         return Sentence
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         content = "All the king's horses."
         begin = 11
-        sentence = self._makeOne(content, begin)
+        sentence = self._make_one(content, begin)
         self.assertEqual(sentence.content, content)
         self.assertEqual(sentence.begin, begin)
 

--- a/language/unit_tests/test_syntax.py
+++ b/language/unit_tests/test_syntax.py
@@ -54,7 +54,7 @@ class TestToken(unittest.TestCase):
         edge_label = 'PREDET'
         lemma = text_content
         token = self._make_one(text_content, text_begin, part_of_speech,
-                              edge_index, edge_label, lemma)
+                               edge_index, edge_label, lemma)
         self.assertEqual(token.text_content, text_content)
         self.assertEqual(token.text_begin, text_begin)
         self.assertEqual(token.part_of_speech, part_of_speech)

--- a/language/unit_tests/test_syntax.py
+++ b/language/unit_tests/test_syntax.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestPartOfSpeech(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.language.syntax import PartOfSpeech
         return PartOfSpeech
 
@@ -35,7 +36,8 @@ class TestPartOfSpeech(unittest.TestCase):
 
 class TestToken(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.language.syntax import Token
         return Token
 
@@ -95,7 +97,8 @@ class TestToken(unittest.TestCase):
 
 class TestSentence(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.language.syntax import Sentence
         return Sentence
 

--- a/logging/unit_tests/handlers/test_handlers.py
+++ b/logging/unit_tests/handlers/test_handlers.py
@@ -25,17 +25,17 @@ class TestCloudLoggingHandler(unittest.TestCase):
         from google.cloud.logging.handlers.handlers import CloudLoggingHandler
         return CloudLoggingHandler
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         client = _Client(self.PROJECT)
-        handler = self._makeOne(client, transport=_Transport)
+        handler = self._make_one(client, transport=_Transport)
         self.assertEqual(handler.client, client)
 
     def test_emit(self):
         client = _Client(self.PROJECT)
-        handler = self._makeOne(client, transport=_Transport)
+        handler = self._make_one(client, transport=_Transport)
         LOGNAME = 'loggername'
         MESSAGE = 'hello world'
         record = _Record(LOGNAME, logging.INFO, MESSAGE)

--- a/logging/unit_tests/handlers/test_handlers.py
+++ b/logging/unit_tests/handlers/test_handlers.py
@@ -20,7 +20,8 @@ class TestCloudLoggingHandler(unittest.TestCase):
 
     PROJECT = 'PROJECT'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.handlers.handlers import CloudLoggingHandler
         return CloudLoggingHandler
 

--- a/logging/unit_tests/handlers/test_handlers.py
+++ b/logging/unit_tests/handlers/test_handlers.py
@@ -26,7 +26,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
         return CloudLoggingHandler
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         client = _Client(self.PROJECT)

--- a/logging/unit_tests/handlers/test_handlers.py
+++ b/logging/unit_tests/handlers/test_handlers.py
@@ -46,7 +46,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
 
 class TestSetupLogging(unittest.TestCase):
 
-    def _callFUT(self, handler, excludes=None):
+    def _call_fut(self, handler, excludes=None):
         from google.cloud.logging.handlers.handlers import setup_logging
         if excludes:
             return setup_logging(handler, excluded_loggers=excludes)
@@ -55,7 +55,7 @@ class TestSetupLogging(unittest.TestCase):
 
     def test_setup_logging(self):
         handler = _Handler(logging.INFO)
-        self._callFUT(handler)
+        self._call_fut(handler)
 
         root_handlers = logging.getLogger().handlers
         self.assertIn(handler, root_handlers)
@@ -65,7 +65,7 @@ class TestSetupLogging(unittest.TestCase):
         EXCLUDED_LOGGER_NAME = 'excludeme'
 
         handler = _Handler(logging.INFO)
-        self._callFUT(handler, (EXCLUDED_LOGGER_NAME,))
+        self._call_fut(handler, (EXCLUDED_LOGGER_NAME,))
 
         included_logger = logging.getLogger(INCLUDED_LOGGER_NAME)
         self.assertTrue(included_logger.propagate)

--- a/logging/unit_tests/handlers/transports/test_background_thread.py
+++ b/logging/unit_tests/handlers/transports/test_background_thread.py
@@ -27,19 +27,19 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             BackgroundThreadTransport)
         return BackgroundThreadTransport
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         client = _Client(self.PROJECT)
         NAME = 'python_logger'
-        transport = self._makeOne(client, NAME)
+        transport = self._make_one(client, NAME)
         self.assertEquals(transport.worker.logger.name, NAME)
 
     def test_send(self):
         client = _Client(self.PROJECT)
         NAME = 'python_logger'
-        transport = self._makeOne(client, NAME)
+        transport = self._make_one(client, NAME)
         transport.worker.batch = client.logger(NAME).batch()
 
         PYTHON_LOGGER_NAME = 'mylogger'
@@ -63,19 +63,19 @@ class TestWorker(unittest.TestCase):
         from google.cloud.logging.handlers.transports import background_thread
         return background_thread._Worker
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         NAME = 'python_logger'
         logger = _Logger(NAME)
-        worker = self._makeOne(logger)
+        worker = self._make_one(logger)
         self.assertEquals(worker.batch, logger._batch)
 
     def test_run(self):
         NAME = 'python_logger'
         logger = _Logger(NAME)
-        worker = self._makeOne(logger)
+        worker = self._make_one(logger)
 
         PYTHON_LOGGER_NAME = 'mylogger'
         MESSAGE = 'hello world'
@@ -101,7 +101,7 @@ class TestWorker(unittest.TestCase):
         # No-op
         NAME = 'python_logger'
         logger = _Logger(NAME)
-        worker = self._makeOne(logger)
+        worker = self._make_one(logger)
 
         PYTHON_LOGGER_NAME = 'mylogger'
         MESSAGE = 'hello world'
@@ -120,7 +120,7 @@ class TestWorker(unittest.TestCase):
         # No-op
         NAME = 'python_logger'
         logger = _Logger(NAME)
-        worker = self._makeOne(logger)
+        worker = self._make_one(logger)
 
         PYTHON_LOGGER_NAME = 'mylogger'
         MESSAGE = 'hello world'

--- a/logging/unit_tests/handlers/transports/test_background_thread.py
+++ b/logging/unit_tests/handlers/transports/test_background_thread.py
@@ -28,7 +28,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
         return BackgroundThreadTransport
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         client = _Client(self.PROJECT)
@@ -64,7 +64,7 @@ class TestWorker(unittest.TestCase):
         return background_thread._Worker
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         NAME = 'python_logger'

--- a/logging/unit_tests/handlers/transports/test_background_thread.py
+++ b/logging/unit_tests/handlers/transports/test_background_thread.py
@@ -21,7 +21,8 @@ class TestBackgroundThreadHandler(unittest.TestCase):
 
     PROJECT = 'PROJECT'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.handlers.transports import (
             BackgroundThreadTransport)
         return BackgroundThreadTransport
@@ -57,7 +58,8 @@ class TestBackgroundThreadHandler(unittest.TestCase):
 
 class TestWorker(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.handlers.transports import background_thread
         return background_thread._Worker
 

--- a/logging/unit_tests/handlers/transports/test_base.py
+++ b/logging/unit_tests/handlers/transports/test_base.py
@@ -19,7 +19,8 @@ class TestBaseHandler(unittest.TestCase):
 
     PROJECT = 'PROJECT'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.handlers.transports import Transport
         return Transport
 

--- a/logging/unit_tests/handlers/transports/test_base.py
+++ b/logging/unit_tests/handlers/transports/test_base.py
@@ -24,10 +24,10 @@ class TestBaseHandler(unittest.TestCase):
         from google.cloud.logging.handlers.transports import Transport
         return Transport
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_send_is_abstract(self):
-        target = self._makeOne()
+        target = self._make_one()
         with self.assertRaises(NotImplementedError):
             target.send(None, None)

--- a/logging/unit_tests/handlers/transports/test_base.py
+++ b/logging/unit_tests/handlers/transports/test_base.py
@@ -25,7 +25,7 @@ class TestBaseHandler(unittest.TestCase):
         return Transport
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_send_is_abstract(self):
         target = self._makeOne()

--- a/logging/unit_tests/handlers/transports/test_sync.py
+++ b/logging/unit_tests/handlers/transports/test_sync.py
@@ -20,7 +20,8 @@ class TestSyncHandler(unittest.TestCase):
 
     PROJECT = 'PROJECT'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.handlers.transports import SyncTransport
         return SyncTransport
 

--- a/logging/unit_tests/handlers/transports/test_sync.py
+++ b/logging/unit_tests/handlers/transports/test_sync.py
@@ -25,20 +25,20 @@ class TestSyncHandler(unittest.TestCase):
         from google.cloud.logging.handlers.transports import SyncTransport
         return SyncTransport
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         client = _Client(self.PROJECT)
         NAME = 'python_logger'
-        transport = self._makeOne(client, NAME)
+        transport = self._make_one(client, NAME)
         self.assertEqual(transport.logger.name, 'python_logger')
 
     def test_send(self):
         client = _Client(self.PROJECT)
         STACKDRIVER_LOGGER_NAME = 'python'
         PYTHON_LOGGER_NAME = 'mylogger'
-        transport = self._makeOne(client, STACKDRIVER_LOGGER_NAME)
+        transport = self._make_one(client, STACKDRIVER_LOGGER_NAME)
         MESSAGE = 'hello world'
         record = _Record(PYTHON_LOGGER_NAME, logging.INFO, MESSAGE)
 

--- a/logging/unit_tests/handlers/transports/test_sync.py
+++ b/logging/unit_tests/handlers/transports/test_sync.py
@@ -26,7 +26,7 @@ class TestSyncHandler(unittest.TestCase):
         return SyncTransport
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         client = _Client(self.PROJECT)

--- a/logging/unit_tests/test__gax.py
+++ b/logging/unit_tests/test__gax.py
@@ -41,7 +41,8 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
     LOG_NAME = 'log_name'
     LOG_PATH = 'projects/%s/logs/%s' % (_Base.PROJECT, LOG_NAME)
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging._gax import _LoggingAPI
         return _LoggingAPI
 
@@ -600,7 +601,8 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     SINK_PATH = 'projects/%s/sinks/%s' % (_Base.PROJECT, SINK_NAME)
     DESTINATION_URI = 'faux.googleapis.com/destination'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging._gax import _SinksAPI
         return _SinksAPI
 
@@ -833,7 +835,8 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     METRIC_PATH = 'projects/%s/metrics/%s' % (_Base.PROJECT, METRIC_NAME)
     DESCRIPTION = 'Description'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging._gax import _MetricsAPI
         return _MetricsAPI
 

--- a/logging/unit_tests/test__gax.py
+++ b/logging/unit_tests/test__gax.py
@@ -33,7 +33,7 @@ class _Base(object):
     FILTER = 'logName:syslog AND severity>=ERROR'
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
 
 @unittest.skipUnless(_HAVE_GAX, 'No gax-python')

--- a/logging/unit_tests/test__gax.py
+++ b/logging/unit_tests/test__gax.py
@@ -32,7 +32,7 @@ class _Base(object):
     PROJECT_PATH = 'projects/%s' % (PROJECT,)
     FILTER = 'logName:syslog AND severity>=ERROR'
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
 
@@ -49,7 +49,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
     def test_ctor(self):
         gax_api = _GAXLoggingAPI()
         client = object()
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
         self.assertIs(api._gax_api, gax_api)
         self.assertIs(api._client, client)
 
@@ -81,7 +81,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         gax_api = _GAXLoggingAPI(_list_log_entries_response=response)
         client = Client(project=self.PROJECT, credentials=object(),
                         use_gax=True)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_entries(
             [self.PROJECT], self.FILTER, DESCENDING)
@@ -137,7 +137,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         gax_api = _GAXLoggingAPI(_list_log_entries_response=response)
         client = Client(project=self.PROJECT, credentials=object(),
                         use_gax=True)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_entries(
             [self.PROJECT], page_size=SIZE, page_token=TOKEN)
@@ -276,7 +276,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         gax_api = _GAXLoggingAPI(_list_log_entries_response=response)
         client = Client(project=self.PROJECT, credentials=object(),
                         use_gax=True)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_entries(
             [self.PROJECT], page_size=SIZE, page_token=TOKEN)
@@ -328,7 +328,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
             'textPayload': TEXT,
         }
         gax_api = _GAXLoggingAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         api.write_entries([ENTRY])
 
@@ -401,7 +401,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
             'operation': OPERATION,
         }
         gax_api = _GAXLoggingAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         api.write_entries([ENTRY])
 
@@ -476,7 +476,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
             'foo': 'bar',
         }
         gax_api = _GAXLoggingAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         api.write_entries(ENTRIES, self.LOG_PATH, RESOURCE, LABELS)
 
@@ -560,7 +560,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
 
     def test_logger_delete(self):
         gax_api = _GAXLoggingAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         api.logger_delete(self.PROJECT, self.LOG_NAME)
 
@@ -572,7 +572,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         from google.cloud.exceptions import NotFound
 
         gax_api = _GAXLoggingAPI(_delete_not_found=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.logger_delete(self.PROJECT, self.LOG_NAME)
@@ -585,7 +585,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         from google.gax.errors import GaxError
 
         gax_api = _GAXLoggingAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.logger_delete(self.PROJECT, self.LOG_NAME)
@@ -609,7 +609,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_ctor(self):
         gax_api = _GAXSinksAPI()
         client = object()
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
         self.assertIs(api._gax_api, gax_api)
         self.assertIs(api._client, client)
 
@@ -627,7 +627,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([sink_pb], page_token=TOKEN)
         gax_api = _GAXSinksAPI(_list_sinks_response=response)
         client = object()
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_sinks(self.PROJECT)
         page = six.next(iterator.pages)
@@ -663,7 +663,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([sink_pb])
         gax_api = _GAXSinksAPI(_list_sinks_response=response)
         client = object()
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_sinks(
             self.PROJECT, page_size=PAGE_SIZE, page_token=TOKEN)
@@ -689,7 +689,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_create_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXSinksAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.sink_create(
@@ -699,7 +699,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_create_conflict(self):
         from google.cloud.exceptions import Conflict
         gax_api = _GAXSinksAPI(_create_sink_conflict=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(Conflict):
             api.sink_create(
@@ -709,7 +709,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_create_ok(self):
         from google.logging.v2.logging_config_pb2 import LogSink
         gax_api = _GAXSinksAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         api.sink_create(
             self.PROJECT, self.SINK_NAME, self.FILTER, self.DESTINATION_URI)
@@ -726,7 +726,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_get_error(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXSinksAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.sink_get(self.PROJECT, self.SINK_NAME)
@@ -734,7 +734,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_get_miss(self):
         from google.gax.errors import GaxError
         gax_api = _GAXSinksAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.sink_get(self.PROJECT, self.SINK_NAME)
@@ -751,7 +751,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
                           destination=self.DESTINATION_URI,
                           filter=self.FILTER)
         gax_api = _GAXSinksAPI(_get_sink_response=sink_pb)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         response = api.sink_get(self.PROJECT, self.SINK_NAME)
 
@@ -764,7 +764,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_update_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXSinksAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.sink_update(
@@ -774,7 +774,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_update_miss(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXSinksAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.sink_update(
@@ -788,7 +788,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
                            destination=self.DESTINATION_URI,
                            filter=self.FILTER)
         gax_api = _GAXSinksAPI(_update_sink_response=response)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         api.sink_update(
             self.PROJECT, self.SINK_NAME, self.FILTER, self.DESTINATION_URI)
@@ -805,7 +805,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_delete_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXSinksAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.sink_delete(self.PROJECT, self.SINK_NAME)
@@ -813,14 +813,14 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_sink_delete_miss(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXSinksAPI(_sink_not_found=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.sink_delete(self.PROJECT, self.SINK_NAME)
 
     def test_sink_delete_hit(self):
         gax_api = _GAXSinksAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         api.sink_delete(self.PROJECT, self.SINK_NAME)
 
@@ -842,7 +842,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
 
     def test_ctor(self):
         gax_api = _GAXMetricsAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
         self.assertIs(api._gax_api, gax_api)
 
     def test_list_metrics_no_paging(self):
@@ -859,7 +859,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([metric_pb], page_token=TOKEN)
         gax_api = _GAXMetricsAPI(_list_log_metrics_response=response)
         client = object()
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_metrics(self.PROJECT)
         page = six.next(iterator.pages)
@@ -895,7 +895,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([metric_pb])
         gax_api = _GAXMetricsAPI(_list_log_metrics_response=response)
         client = object()
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_metrics(
             self.PROJECT, page_size=PAGE_SIZE, page_token=TOKEN)
@@ -921,7 +921,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_create_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXMetricsAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.metric_create(
@@ -931,7 +931,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_create_conflict(self):
         from google.cloud.exceptions import Conflict
         gax_api = _GAXMetricsAPI(_create_log_metric_conflict=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(Conflict):
             api.metric_create(
@@ -941,7 +941,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_create_ok(self):
         from google.logging.v2.logging_metrics_pb2 import LogMetric
         gax_api = _GAXMetricsAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         api.metric_create(
             self.PROJECT, self.METRIC_NAME, self.FILTER, self.DESCRIPTION)
@@ -958,7 +958,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_get_error(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXMetricsAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.metric_get(self.PROJECT, self.METRIC_NAME)
@@ -966,7 +966,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_get_miss(self):
         from google.gax.errors import GaxError
         gax_api = _GAXMetricsAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.metric_get(self.PROJECT, self.METRIC_NAME)
@@ -983,7 +983,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
                               description=self.DESCRIPTION,
                               filter=self.FILTER)
         gax_api = _GAXMetricsAPI(_get_log_metric_response=metric_pb)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         response = api.metric_get(self.PROJECT, self.METRIC_NAME)
 
@@ -996,7 +996,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_update_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXMetricsAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.metric_update(
@@ -1006,7 +1006,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_update_miss(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXMetricsAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.metric_update(
@@ -1020,7 +1020,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
                              description=self.DESCRIPTION,
                              filter=self.FILTER)
         gax_api = _GAXMetricsAPI(_update_log_metric_response=response)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         api.metric_update(
             self.PROJECT, self.METRIC_NAME, self.FILTER, self.DESCRIPTION)
@@ -1037,7 +1037,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_delete_error(self):
         from google.gax.errors import GaxError
         gax_api = _GAXMetricsAPI(_random_gax_error=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(GaxError):
             api.metric_delete(self.PROJECT, self.METRIC_NAME)
@@ -1045,14 +1045,14 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_metric_delete_miss(self):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXMetricsAPI(_log_metric_not_found=True)
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         with self.assertRaises(NotFound):
             api.metric_delete(self.PROJECT, self.METRIC_NAME)
 
     def test_metric_delete_hit(self):
         gax_api = _GAXMetricsAPI()
-        api = self._makeOne(gax_api, None)
+        api = self._make_one(gax_api, None)
 
         api.metric_delete(self.PROJECT, self.METRIC_NAME)
 

--- a/logging/unit_tests/test__http.py
+++ b/logging/unit_tests/test__http.py
@@ -25,12 +25,12 @@ class TestConnection(unittest.TestCase):
         from google.cloud.logging._http import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
         creds = _Credentials()
-        conn = self._makeOne(creds)
+        conn = self._make_one(creds)
         klass = self._get_target_class()
         self.assertEqual(conn.credentials._scopes, klass.SCOPE)
 
@@ -48,13 +48,13 @@ class Test_LoggingAPI(unittest.TestCase):
         from google.cloud.logging._http import _LoggingAPI
         return _LoggingAPI
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         connection = object()
         client = _Client(connection)
-        api = self._makeOne(client)
+        api = self._make_one(client)
         self.assertIs(api._connection, connection)
         self.assertIs(api._client, client)
 
@@ -95,7 +95,7 @@ class Test_LoggingAPI(unittest.TestCase):
         client = Client(project=self.PROJECT, credentials=object(),
                         use_gax=False)
         client.connection = _Connection(RETURNED)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_entries([self.PROJECT])
         page = six.next(iterator.pages)
@@ -173,7 +173,7 @@ class Test_LoggingAPI(unittest.TestCase):
         client = Client(project=self.PROJECT, credentials=object(),
                         use_gax=False)
         client.connection = _Connection(RETURNED)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_entries(
             projects=[PROJECT1, PROJECT2], filter_=self.FILTER,
@@ -230,7 +230,7 @@ class Test_LoggingAPI(unittest.TestCase):
         }
         conn = _Connection({})
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.write_entries([ENTRY])
 
@@ -263,7 +263,7 @@ class Test_LoggingAPI(unittest.TestCase):
         }
         conn = _Connection({})
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.write_entries([ENTRY1, ENTRY2], LOG_NAME, RESOURCE, LABELS)
 
@@ -276,7 +276,7 @@ class Test_LoggingAPI(unittest.TestCase):
         path = '/projects/%s/logs/%s' % (self.PROJECT, self.LOGGER_NAME)
         conn = _Connection({})
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.logger_delete(self.PROJECT, self.LOGGER_NAME)
 
@@ -298,13 +298,13 @@ class Test_SinksAPI(unittest.TestCase):
         from google.cloud.logging._http import _SinksAPI
         return _SinksAPI
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         connection = object()
         client = _Client(connection)
-        api = self._makeOne(client)
+        api = self._make_one(client)
         self.assertIs(api._connection, connection)
         self.assertIs(api._client, client)
 
@@ -323,7 +323,7 @@ class Test_SinksAPI(unittest.TestCase):
         }
         conn = _Connection(RETURNED)
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_sinks(self.PROJECT)
         page = six.next(iterator.pages)
@@ -363,7 +363,7 @@ class Test_SinksAPI(unittest.TestCase):
         }
         conn = _Connection(RETURNED)
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_sinks(
             self.PROJECT, page_size=PAGE_SIZE, page_token=TOKEN)
@@ -402,7 +402,7 @@ class Test_SinksAPI(unittest.TestCase):
         conn = _Connection()
         conn._raise_conflict = True
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(Conflict):
             api.sink_create(
@@ -422,7 +422,7 @@ class Test_SinksAPI(unittest.TestCase):
         }
         conn = _Connection({})
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.sink_create(
             self.PROJECT, self.SINK_NAME, self.FILTER, self.DESTINATION_URI)
@@ -436,7 +436,7 @@ class Test_SinksAPI(unittest.TestCase):
         from google.cloud.exceptions import NotFound
         conn = _Connection()
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(NotFound):
             api.sink_get(self.PROJECT, self.SINK_NAME)
@@ -453,7 +453,7 @@ class Test_SinksAPI(unittest.TestCase):
         }
         conn = _Connection(RESPONSE)
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         response = api.sink_get(self.PROJECT, self.SINK_NAME)
 
@@ -471,7 +471,7 @@ class Test_SinksAPI(unittest.TestCase):
         }
         conn = _Connection()
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(NotFound):
             api.sink_update(
@@ -491,7 +491,7 @@ class Test_SinksAPI(unittest.TestCase):
         }
         conn = _Connection({})
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.sink_update(
             self.PROJECT, self.SINK_NAME, self.FILTER, self.DESTINATION_URI)
@@ -505,7 +505,7 @@ class Test_SinksAPI(unittest.TestCase):
         from google.cloud.exceptions import NotFound
         conn = _Connection()
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(NotFound):
             api.sink_delete(self.PROJECT, self.SINK_NAME)
@@ -517,7 +517,7 @@ class Test_SinksAPI(unittest.TestCase):
     def test_sink_delete_hit(self):
         conn = _Connection({})
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.sink_delete(self.PROJECT, self.SINK_NAME)
 
@@ -540,7 +540,7 @@ class Test_MetricsAPI(unittest.TestCase):
         from google.cloud.logging._http import _MetricsAPI
         return _MetricsAPI
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_list_metrics_no_paging(self):
@@ -557,7 +557,7 @@ class Test_MetricsAPI(unittest.TestCase):
         }
         conn = _Connection(RETURNED)
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_metrics(self.PROJECT)
         page = six.next(iterator.pages)
@@ -596,7 +596,7 @@ class Test_MetricsAPI(unittest.TestCase):
         }
         conn = _Connection(RETURNED)
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_metrics(
             self.PROJECT, page_size=PAGE_SIZE, page_token=TOKEN)
@@ -635,7 +635,7 @@ class Test_MetricsAPI(unittest.TestCase):
         conn = _Connection()
         conn._raise_conflict = True
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(Conflict):
             api.metric_create(
@@ -655,7 +655,7 @@ class Test_MetricsAPI(unittest.TestCase):
         }
         conn = _Connection({})
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.metric_create(
             self.PROJECT, self.METRIC_NAME, self.FILTER, self.DESCRIPTION)
@@ -669,7 +669,7 @@ class Test_MetricsAPI(unittest.TestCase):
         from google.cloud.exceptions import NotFound
         conn = _Connection()
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(NotFound):
             api.metric_get(self.PROJECT, self.METRIC_NAME)
@@ -686,7 +686,7 @@ class Test_MetricsAPI(unittest.TestCase):
         }
         conn = _Connection(RESPONSE)
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         response = api.metric_get(self.PROJECT, self.METRIC_NAME)
 
@@ -704,7 +704,7 @@ class Test_MetricsAPI(unittest.TestCase):
         }
         conn = _Connection()
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(NotFound):
             api.metric_update(
@@ -724,7 +724,7 @@ class Test_MetricsAPI(unittest.TestCase):
         }
         conn = _Connection({})
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.metric_update(
             self.PROJECT, self.METRIC_NAME, self.FILTER, self.DESCRIPTION)
@@ -738,7 +738,7 @@ class Test_MetricsAPI(unittest.TestCase):
         from google.cloud.exceptions import NotFound
         conn = _Connection()
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(NotFound):
             api.metric_delete(self.PROJECT, self.METRIC_NAME)
@@ -750,7 +750,7 @@ class Test_MetricsAPI(unittest.TestCase):
     def test_metric_delete_hit(self):
         conn = _Connection({})
         client = _Client(conn)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.metric_delete(self.PROJECT, self.METRIC_NAME)
 

--- a/logging/unit_tests/test__http.py
+++ b/logging/unit_tests/test__http.py
@@ -20,7 +20,8 @@ class TestConnection(unittest.TestCase):
     PROJECT = 'project'
     FILTER = 'logName:syslog AND severity>=ERROR'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging._http import Connection
         return Connection
 
@@ -42,7 +43,8 @@ class Test_LoggingAPI(unittest.TestCase):
     LOGGER_NAME = 'LOGGER_NAME'
     FILTER = 'logName:syslog AND severity>=ERROR'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging._http import _LoggingAPI
         return _LoggingAPI
 
@@ -291,7 +293,8 @@ class Test_SinksAPI(unittest.TestCase):
     SINK_PATH = 'projects/%s/sinks/%s' % (PROJECT, SINK_NAME)
     DESTINATION_URI = 'faux.googleapis.com/destination'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging._http import _SinksAPI
         return _SinksAPI
 
@@ -532,7 +535,8 @@ class Test_MetricsAPI(unittest.TestCase):
     METRIC_PATH = 'projects/%s/metrics/%s' % (PROJECT, METRIC_NAME)
     DESCRIPTION = 'DESCRIPTION'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging._http import _MetricsAPI
         return _MetricsAPI
 

--- a/logging/unit_tests/test__http.py
+++ b/logging/unit_tests/test__http.py
@@ -26,12 +26,12 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
         creds = _Credentials()
         conn = self._makeOne(creds)
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         self.assertEqual(conn.credentials._scopes, klass.SCOPE)
 
 
@@ -49,7 +49,7 @@ class Test_LoggingAPI(unittest.TestCase):
         return _LoggingAPI
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         connection = object()
@@ -299,7 +299,7 @@ class Test_SinksAPI(unittest.TestCase):
         return _SinksAPI
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         connection = object()
@@ -541,7 +541,7 @@ class Test_MetricsAPI(unittest.TestCase):
         return _MetricsAPI
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_list_metrics_no_paging(self):
         import six

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -31,18 +31,18 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds)
+        client = self._make_one(project=self.PROJECT, credentials=creds)
         self.assertEqual(client.project, self.PROJECT)
 
     def test_logging_api_wo_gax(self):
         from google.cloud.logging._http import _LoggingAPI
 
-        client = self._makeOne(self.PROJECT, credentials=_Credentials(),
+        client = self._make_one(self.PROJECT, credentials=_Credentials(),
                                use_gax=False)
         conn = client.connection = object()
         api = client.logging_api
@@ -65,7 +65,7 @@ class TestClient(unittest.TestCase):
             return api_obj
 
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds,
+        client = self._make_one(project=self.PROJECT, credentials=creds,
                                use_gax=True)
 
         with _Monkey(MUT, make_gax_logging_api=make_api):
@@ -84,7 +84,7 @@ class TestClient(unittest.TestCase):
 
         creds = _Credentials()
         with _Monkey(MUT, _USE_GAX=True):
-            client = self._makeOne(project=self.PROJECT, credentials=creds,
+            client = self._make_one(project=self.PROJECT, credentials=creds,
                                    use_gax=False)
 
         api = client.logging_api
@@ -96,7 +96,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
 
         with _Monkey(MUT, _USE_GAX=False):
-            client = self._makeOne(self.PROJECT, credentials=_Credentials())
+            client = self._make_one(self.PROJECT, credentials=_Credentials())
 
         conn = client.connection = object()
         api = client.sinks_api
@@ -119,7 +119,7 @@ class TestClient(unittest.TestCase):
             return api_obj
 
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds,
+        client = self._make_one(project=self.PROJECT, credentials=creds,
                                use_gax=True)
 
         with _Monkey(MUT, make_gax_sinks_api=make_api):
@@ -137,7 +137,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
 
         with _Monkey(MUT, _USE_GAX=False):
-            client = self._makeOne(self.PROJECT, credentials=_Credentials())
+            client = self._make_one(self.PROJECT, credentials=_Credentials())
 
         conn = client.connection = object()
         api = client.metrics_api
@@ -160,7 +160,7 @@ class TestClient(unittest.TestCase):
             return api_obj
 
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds,
+        client = self._make_one(project=self.PROJECT, credentials=creds,
                                use_gax=True)
 
         with _Monkey(MUT, make_gax_metrics_api=make_api):
@@ -175,7 +175,7 @@ class TestClient(unittest.TestCase):
     def test_logger(self):
         from google.cloud.logging.logger import Logger
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds)
+        client = self._make_one(project=self.PROJECT, credentials=creds)
         logger = client.logger(self.LOGGER_NAME)
         self.assertIsInstance(logger, Logger)
         self.assertEqual(logger.name, self.LOGGER_NAME)
@@ -199,7 +199,7 @@ class TestClient(unittest.TestCase):
                 self.PROJECT, self.LOGGER_NAME),
         }]
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds,
+        client = self._make_one(project=self.PROJECT, credentials=creds,
                                use_gax=False)
         returned = {
             'entries': ENTRIES,
@@ -263,7 +263,7 @@ class TestClient(unittest.TestCase):
             'logName': 'projects/%s/logs/%s' % (
                 self.PROJECT, self.LOGGER_NAME),
         }]
-        client = self._makeOne(self.PROJECT, credentials=_Credentials(),
+        client = self._make_one(self.PROJECT, credentials=_Credentials(),
                                use_gax=False)
         returned = {'entries': ENTRIES}
         client.connection = _Connection(returned)
@@ -315,7 +315,7 @@ class TestClient(unittest.TestCase):
     def test_sink_defaults(self):
         from google.cloud.logging.sink import Sink
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds)
+        client = self._make_one(project=self.PROJECT, credentials=creds)
         sink = client.sink(self.SINK_NAME)
         self.assertIsInstance(sink, Sink)
         self.assertEqual(sink.name, self.SINK_NAME)
@@ -327,7 +327,7 @@ class TestClient(unittest.TestCase):
     def test_sink_explicit(self):
         from google.cloud.logging.sink import Sink
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds)
+        client = self._make_one(project=self.PROJECT, credentials=creds)
         sink = client.sink(self.SINK_NAME, self.FILTER, self.DESTINATION_URI)
         self.assertIsInstance(sink, Sink)
         self.assertEqual(sink.name, self.SINK_NAME)
@@ -349,7 +349,7 @@ class TestClient(unittest.TestCase):
             'filter': FILTER,
             'destination': self.DESTINATION_URI,
         }]
-        client = self._makeOne(project=PROJECT, credentials=_Credentials(),
+        client = self._make_one(project=PROJECT, credentials=_Credentials(),
                                use_gax=False)
         returned = {
             'sinks': SINKS,
@@ -395,7 +395,7 @@ class TestClient(unittest.TestCase):
             'filter': FILTER,
             'destination': self.DESTINATION_URI,
         }]
-        client = self._makeOne(project=PROJECT, credentials=_Credentials(),
+        client = self._make_one(project=PROJECT, credentials=_Credentials(),
                                use_gax=False)
         returned = {
             'sinks': SINKS,
@@ -433,7 +433,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging.metric import Metric
         creds = _Credentials()
 
-        client_obj = self._makeOne(project=self.PROJECT, credentials=creds)
+        client_obj = self._make_one(project=self.PROJECT, credentials=creds)
         metric = client_obj.metric(self.METRIC_NAME)
         self.assertIsInstance(metric, Metric)
         self.assertEqual(metric.name, self.METRIC_NAME)
@@ -446,7 +446,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging.metric import Metric
         creds = _Credentials()
 
-        client_obj = self._makeOne(project=self.PROJECT, credentials=creds)
+        client_obj = self._make_one(project=self.PROJECT, credentials=creds)
         metric = client_obj.metric(self.METRIC_NAME, self.FILTER,
                                    description=self.DESCRIPTION)
         self.assertIsInstance(metric, Metric)
@@ -464,7 +464,7 @@ class TestClient(unittest.TestCase):
             'filter': self.FILTER,
             'description': self.DESCRIPTION,
         }]
-        client = self._makeOne(
+        client = self._make_one(
             project=self.PROJECT, credentials=_Credentials(),
             use_gax=False)
         returned = {
@@ -506,7 +506,7 @@ class TestClient(unittest.TestCase):
             'filter': self.FILTER,
             'description': self.DESCRIPTION,
         }]
-        client = self._makeOne(
+        client = self._make_one(
             project=self.PROJECT, credentials=_Credentials(),
             use_gax=False)
         returned = {

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -26,7 +26,8 @@ class TestClient(unittest.TestCase):
     FILTER = 'logName:syslog AND severity>=ERROR'
     DESCRIPTION = 'DESCRIPTION'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.client import Client
         return Client
 

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -32,7 +32,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         creds = _Credentials()

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -43,7 +43,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging._http import _LoggingAPI
 
         client = self._make_one(self.PROJECT, credentials=_Credentials(),
-                               use_gax=False)
+                                use_gax=False)
         conn = client.connection = object()
         api = client.logging_api
 
@@ -66,7 +66,7 @@ class TestClient(unittest.TestCase):
 
         creds = _Credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                               use_gax=True)
+                                use_gax=True)
 
         with _Monkey(MUT, make_gax_logging_api=make_api):
             api = client.logging_api
@@ -85,7 +85,7 @@ class TestClient(unittest.TestCase):
         creds = _Credentials()
         with _Monkey(MUT, _USE_GAX=True):
             client = self._make_one(project=self.PROJECT, credentials=creds,
-                                   use_gax=False)
+                                    use_gax=False)
 
         api = client.logging_api
         self.assertIsInstance(api, _LoggingAPI)
@@ -120,7 +120,7 @@ class TestClient(unittest.TestCase):
 
         creds = _Credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                               use_gax=True)
+                                use_gax=True)
 
         with _Monkey(MUT, make_gax_sinks_api=make_api):
             api = client.sinks_api
@@ -161,7 +161,7 @@ class TestClient(unittest.TestCase):
 
         creds = _Credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                               use_gax=True)
+                                use_gax=True)
 
         with _Monkey(MUT, make_gax_metrics_api=make_api):
             api = client.metrics_api
@@ -200,7 +200,7 @@ class TestClient(unittest.TestCase):
         }]
         creds = _Credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                               use_gax=False)
+                                use_gax=False)
         returned = {
             'entries': ENTRIES,
             'nextPageToken': TOKEN,
@@ -264,7 +264,7 @@ class TestClient(unittest.TestCase):
                 self.PROJECT, self.LOGGER_NAME),
         }]
         client = self._make_one(self.PROJECT, credentials=_Credentials(),
-                               use_gax=False)
+                                use_gax=False)
         returned = {'entries': ENTRIES}
         client.connection = _Connection(returned)
 
@@ -350,7 +350,7 @@ class TestClient(unittest.TestCase):
             'destination': self.DESTINATION_URI,
         }]
         client = self._make_one(project=PROJECT, credentials=_Credentials(),
-                               use_gax=False)
+                                use_gax=False)
         returned = {
             'sinks': SINKS,
             'nextPageToken': TOKEN,
@@ -396,7 +396,7 @@ class TestClient(unittest.TestCase):
             'destination': self.DESTINATION_URI,
         }]
         client = self._make_one(project=PROJECT, credentials=_Credentials(),
-                               use_gax=False)
+                                use_gax=False)
         returned = {
             'sinks': SINKS,
         }

--- a/logging/unit_tests/test_entries.py
+++ b/logging/unit_tests/test_entries.py
@@ -17,7 +17,7 @@ import unittest
 
 class Test_logger_name_from_path(unittest.TestCase):
 
-    def _callFUT(self, path):
+    def _call_fut(self, path):
         from google.cloud.logging.entries import logger_name_from_path
         return logger_name_from_path(path)
 
@@ -25,14 +25,14 @@ class Test_logger_name_from_path(unittest.TestCase):
         LOGGER_NAME = 'LOGGER_NAME'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/logs/%s' % (PROJECT, LOGGER_NAME)
-        logger_name = self._callFUT(PATH)
+        logger_name = self._call_fut(PATH)
         self.assertEqual(logger_name, LOGGER_NAME)
 
     def test_w_name_w_all_extras(self):
         LOGGER_NAME = 'LOGGER_NAME-part.one~part.two%part-three'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/logs/%s' % (PROJECT, LOGGER_NAME)
-        logger_name = self._callFUT(PATH)
+        logger_name = self._call_fut(PATH)
         self.assertEqual(logger_name, LOGGER_NAME)
 
 

--- a/logging/unit_tests/test_entries.py
+++ b/logging/unit_tests/test_entries.py
@@ -51,7 +51,7 @@ class Test_BaseEntry(unittest.TestCase):
         return _Dummy
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         PAYLOAD = 'PAYLOAD'
@@ -105,7 +105,7 @@ class Test_BaseEntry(unittest.TestCase):
             'dummyPayload': PAYLOAD,
             'logName': LOG_NAME,
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         entry = klass.from_api_repr(API_REPR, client)
         self.assertEqual(entry.payload, PAYLOAD)
         self.assertIsNone(entry.insert_id)
@@ -120,7 +120,7 @@ class Test_BaseEntry(unittest.TestCase):
     def test_from_api_repr_w_loggers_no_logger_match(self):
         from datetime import datetime
         from google.cloud._helpers import UTC
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         client = _Client(self.PROJECT)
         PAYLOAD = 'PAYLOAD'
         SEVERITY = 'CRITICAL'
@@ -180,7 +180,7 @@ class Test_BaseEntry(unittest.TestCase):
         }
         LOGGER = object()
         loggers = {LOG_NAME: LOGGER}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         entry = klass.from_api_repr(API_REPR, client, loggers=loggers)
         self.assertEqual(entry.payload, PAYLOAD)
         self.assertEqual(entry.insert_id, IID)
@@ -200,7 +200,7 @@ class TestProtobufEntry(unittest.TestCase):
         return ProtobufEntry
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_parse_message(self):
         import json

--- a/logging/unit_tests/test_entries.py
+++ b/logging/unit_tests/test_entries.py
@@ -50,13 +50,13 @@ class Test_BaseEntry(unittest.TestCase):
 
         return _Dummy
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         PAYLOAD = 'PAYLOAD'
         logger = _Logger(self.LOGGER_NAME, self.PROJECT)
-        entry = self._makeOne(PAYLOAD, logger)
+        entry = self._make_one(PAYLOAD, logger)
         self.assertEqual(entry.payload, PAYLOAD)
         self.assertIs(entry.logger, logger)
         self.assertIsNone(entry.insert_id)
@@ -81,7 +81,7 @@ class Test_BaseEntry(unittest.TestCase):
             'status': STATUS,
         }
         logger = _Logger(self.LOGGER_NAME, self.PROJECT)
-        entry = self._makeOne(PAYLOAD, logger,
+        entry = self._make_one(PAYLOAD, logger,
                               insert_id=IID,
                               timestamp=TIMESTAMP,
                               labels=LABELS,
@@ -199,7 +199,7 @@ class TestProtobufEntry(unittest.TestCase):
         from google.cloud.logging.entries import ProtobufEntry
         return ProtobufEntry
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_parse_message(self):
@@ -210,7 +210,7 @@ class TestProtobufEntry(unittest.TestCase):
         message = Struct(fields={'foo': Value(bool_value=False)})
         with_true = Struct(fields={'foo': Value(bool_value=True)})
         PAYLOAD = json.loads(MessageToJson(with_true))
-        entry = self._makeOne(PAYLOAD, LOGGER)
+        entry = self._make_one(PAYLOAD, LOGGER)
         entry.parse_message(message)
         self.assertTrue(message.fields['foo'])
 

--- a/logging/unit_tests/test_entries.py
+++ b/logging/unit_tests/test_entries.py
@@ -82,11 +82,11 @@ class Test_BaseEntry(unittest.TestCase):
         }
         logger = _Logger(self.LOGGER_NAME, self.PROJECT)
         entry = self._make_one(PAYLOAD, logger,
-                              insert_id=IID,
-                              timestamp=TIMESTAMP,
-                              labels=LABELS,
-                              severity=SEVERITY,
-                              http_request=REQUEST)
+                               insert_id=IID,
+                               timestamp=TIMESTAMP,
+                               labels=LABELS,
+                               severity=SEVERITY,
+                               http_request=REQUEST)
         self.assertEqual(entry.payload, PAYLOAD)
         self.assertIs(entry.logger, logger)
         self.assertEqual(entry.insert_id, IID)

--- a/logging/unit_tests/test_entries.py
+++ b/logging/unit_tests/test_entries.py
@@ -41,7 +41,8 @@ class Test_BaseEntry(unittest.TestCase):
     PROJECT = 'PROJECT'
     LOGGER_NAME = 'LOGGER_NAME'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.entries import _BaseEntry
 
         class _Dummy(_BaseEntry):
@@ -193,7 +194,8 @@ class TestProtobufEntry(unittest.TestCase):
     PROJECT = 'PROJECT'
     LOGGER_NAME = 'LOGGER_NAME'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.entries import ProtobufEntry
         return ProtobufEntry
 

--- a/logging/unit_tests/test_logger.py
+++ b/logging/unit_tests/test_logger.py
@@ -25,13 +25,13 @@ class TestLogger(unittest.TestCase):
         from google.cloud.logging.logger import Logger
         return Logger
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         conn = object()
         client = _Client(self.PROJECT, conn)
-        logger = self._makeOne(self.LOGGER_NAME, client=client)
+        logger = self._make_one(self.LOGGER_NAME, client=client)
         self.assertEqual(logger.name, self.LOGGER_NAME)
         self.assertIs(logger.client, client)
         self.assertEqual(logger.project, self.PROJECT)
@@ -45,7 +45,7 @@ class TestLogger(unittest.TestCase):
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         conn = object()
         client = _Client(self.PROJECT, conn)
-        logger = self._makeOne(self.LOGGER_NAME, client=client, labels=LABELS)
+        logger = self._make_one(self.LOGGER_NAME, client=client, labels=LABELS)
         self.assertEqual(logger.name, self.LOGGER_NAME)
         self.assertIs(logger.client, client)
         self.assertEqual(logger.project, self.PROJECT)
@@ -59,7 +59,7 @@ class TestLogger(unittest.TestCase):
         from google.cloud.logging.logger import Batch
         conn = object()
         client = _Client(self.PROJECT, conn)
-        logger = self._makeOne(self.LOGGER_NAME, client=client)
+        logger = self._make_one(self.LOGGER_NAME, client=client)
         batch = logger.batch()
         self.assertIsInstance(batch, Batch)
         self.assertIs(batch.logger, logger)
@@ -71,7 +71,7 @@ class TestLogger(unittest.TestCase):
         conn2 = object()
         client1 = _Client(self.PROJECT, conn1)
         client2 = _Client(self.PROJECT, conn2)
-        logger = self._makeOne(self.LOGGER_NAME, client=client1)
+        logger = self._make_one(self.LOGGER_NAME, client=client1)
         batch = logger.batch(client2)
         self.assertIsInstance(batch, Batch)
         self.assertIs(batch.logger, logger)
@@ -89,7 +89,7 @@ class TestLogger(unittest.TestCase):
         }]
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client)
+        logger = self._make_one(self.LOGGER_NAME, client=client)
 
         logger.log_text(TEXT)
 
@@ -110,7 +110,7 @@ class TestLogger(unittest.TestCase):
         }]
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client,
+        logger = self._make_one(self.LOGGER_NAME, client=client,
                                labels=DEFAULT_LABELS)
 
         logger.log_text(TEXT)
@@ -147,7 +147,7 @@ class TestLogger(unittest.TestCase):
         client1 = _Client(self.PROJECT)
         client2 = _Client(self.PROJECT)
         api = client2.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client1,
+        logger = self._make_one(self.LOGGER_NAME, client=client1,
                                labels=DEFAULT_LABELS)
 
         logger.log_text(TEXT, client=client2, labels=LABELS,
@@ -168,7 +168,7 @@ class TestLogger(unittest.TestCase):
         }]
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client)
+        logger = self._make_one(self.LOGGER_NAME, client=client)
 
         logger.log_struct(STRUCT)
 
@@ -189,7 +189,7 @@ class TestLogger(unittest.TestCase):
         }]
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client,
+        logger = self._make_one(self.LOGGER_NAME, client=client,
                                labels=DEFAULT_LABELS)
 
         logger.log_struct(STRUCT)
@@ -226,7 +226,7 @@ class TestLogger(unittest.TestCase):
         client1 = _Client(self.PROJECT)
         client2 = _Client(self.PROJECT)
         api = client2.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client1,
+        logger = self._make_one(self.LOGGER_NAME, client=client1,
                                labels=DEFAULT_LABELS)
 
         logger.log_struct(STRUCT, client=client2, labels=LABELS,
@@ -251,7 +251,7 @@ class TestLogger(unittest.TestCase):
         }]
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client)
+        logger = self._make_one(self.LOGGER_NAME, client=client)
 
         logger.log_proto(message)
 
@@ -275,7 +275,7 @@ class TestLogger(unittest.TestCase):
         }]
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client,
+        logger = self._make_one(self.LOGGER_NAME, client=client,
                                labels=DEFAULT_LABELS)
 
         logger.log_proto(message)
@@ -315,7 +315,7 @@ class TestLogger(unittest.TestCase):
         client1 = _Client(self.PROJECT)
         client2 = _Client(self.PROJECT)
         api = client2.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client1,
+        logger = self._make_one(self.LOGGER_NAME, client=client1,
                                labels=DEFAULT_LABELS)
 
         logger.log_proto(message, client=client2, labels=LABELS,
@@ -328,7 +328,7 @@ class TestLogger(unittest.TestCase):
     def test_delete_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client)
+        logger = self._make_one(self.LOGGER_NAME, client=client)
 
         logger.delete()
 
@@ -339,7 +339,7 @@ class TestLogger(unittest.TestCase):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
         api = client2.logging_api = _DummyLoggingAPI()
-        logger = self._makeOne(self.LOGGER_NAME, client=client1)
+        logger = self._make_one(self.LOGGER_NAME, client=client1)
 
         logger.delete(client=client2)
 
@@ -359,7 +359,7 @@ class TestLogger(unittest.TestCase):
         }
         client.connection = _Connection(returned)
 
-        logger = self._makeOne(self.LOGGER_NAME, client=client)
+        logger = self._make_one(self.LOGGER_NAME, client=client)
 
         iterator = logger.list_entries()
         page = six.next(iterator.pages)
@@ -392,7 +392,7 @@ class TestLogger(unittest.TestCase):
         client = Client(project=self.PROJECT, credentials=object(),
                         use_gax=False)
         client.connection = _Connection({})
-        logger = self._makeOne(self.LOGGER_NAME, client=client)
+        logger = self._make_one(self.LOGGER_NAME, client=client)
         iterator = logger.list_entries(
             projects=[PROJECT1, PROJECT2], filter_=FILTER, order_by=DESCENDING,
             page_size=PAGE_SIZE, page_token=TOKEN)
@@ -427,13 +427,13 @@ class TestBatch(unittest.TestCase):
         from google.cloud.logging.logger import Batch
         return Batch
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_ctor_defaults(self):
         logger = _Logger()
         client = _Client(project=self.PROJECT)
-        batch = self._makeOne(logger, client)
+        batch = self._make_one(logger, client)
         self.assertIs(batch.logger, logger)
         self.assertIs(batch.client, client)
         self.assertEqual(len(batch.entries), 0)
@@ -442,7 +442,7 @@ class TestBatch(unittest.TestCase):
         TEXT = 'This is the entry text'
         client = _Client(project=self.PROJECT, connection=object())
         logger = _Logger()
-        batch = self._makeOne(logger, client=client)
+        batch = self._make_one(logger, client=client)
         batch.log_text(TEXT)
         self.assertEqual(batch.entries,
                          [('text', TEXT, None, None, None, None)])
@@ -462,7 +462,7 @@ class TestBatch(unittest.TestCase):
         }
         client = _Client(project=self.PROJECT, connection=object())
         logger = _Logger()
-        batch = self._makeOne(logger, client=client)
+        batch = self._make_one(logger, client=client)
         batch.log_text(TEXT, labels=LABELS, insert_id=IID, severity=SEVERITY,
                        http_request=REQUEST)
         self.assertEqual(batch.entries,
@@ -472,7 +472,7 @@ class TestBatch(unittest.TestCase):
         STRUCT = {'message': 'Message text', 'weather': 'partly cloudy'}
         client = _Client(project=self.PROJECT, connection=object())
         logger = _Logger()
-        batch = self._makeOne(logger, client=client)
+        batch = self._make_one(logger, client=client)
         batch.log_struct(STRUCT)
         self.assertEqual(batch.entries,
                          [('struct', STRUCT, None, None, None, None)])
@@ -492,7 +492,7 @@ class TestBatch(unittest.TestCase):
         }
         client = _Client(project=self.PROJECT, connection=object())
         logger = _Logger()
-        batch = self._makeOne(logger, client=client)
+        batch = self._make_one(logger, client=client)
         batch.log_struct(STRUCT, labels=LABELS, insert_id=IID,
                          severity=SEVERITY, http_request=REQUEST)
         self.assertEqual(batch.entries,
@@ -503,7 +503,7 @@ class TestBatch(unittest.TestCase):
         message = Struct(fields={'foo': Value(bool_value=True)})
         client = _Client(project=self.PROJECT, connection=object())
         logger = _Logger()
-        batch = self._makeOne(logger, client=client)
+        batch = self._make_one(logger, client=client)
         batch.log_proto(message)
         self.assertEqual(batch.entries,
                          [('proto', message, None, None, None, None)])
@@ -524,7 +524,7 @@ class TestBatch(unittest.TestCase):
         }
         client = _Client(project=self.PROJECT, connection=object())
         logger = _Logger()
-        batch = self._makeOne(logger, client=client)
+        batch = self._make_one(logger, client=client)
         batch.log_proto(message, labels=LABELS, insert_id=IID,
                         severity=SEVERITY, http_request=REQUEST)
         self.assertEqual(batch.entries,
@@ -533,7 +533,7 @@ class TestBatch(unittest.TestCase):
     def test_commit_w_invalid_entry_type(self):
         logger = _Logger()
         client = _Client(project=self.PROJECT, connection=object())
-        batch = self._makeOne(logger, client)
+        batch = self._make_one(logger, client)
         batch.entries.append(('bogus', 'BOGUS', None, None, None, None))
         with self.assertRaises(ValueError):
             batch.commit()
@@ -560,7 +560,7 @@ class TestBatch(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
         logger = _Logger()
-        batch = self._makeOne(logger, client=client)
+        batch = self._make_one(logger, client=client)
 
         batch.log_text(TEXT, insert_id=IID1)
         batch.log_struct(STRUCT, insert_id=IID2)
@@ -604,7 +604,7 @@ class TestBatch(unittest.TestCase):
             {'protoPayload': json.loads(MessageToJson(message)),
              'httpRequest': REQUEST},
         ]
-        batch = self._makeOne(logger, client=client1)
+        batch = self._make_one(logger, client=client1)
 
         batch.log_text(TEXT, labels=LABELS)
         batch.log_struct(STRUCT, severity=SEVERITY)
@@ -646,7 +646,7 @@ class TestBatch(unittest.TestCase):
             {'protoPayload': json.loads(MessageToJson(message)),
              'severity': SEVERITY},
         ]
-        batch = self._makeOne(logger, client=client)
+        batch = self._make_one(logger, client=client)
 
         with batch as other:
             other.log_text(TEXT, http_request=REQUEST)
@@ -681,7 +681,7 @@ class TestBatch(unittest.TestCase):
             ('struct', STRUCT, None, None, SEVERITY, None),
             ('proto', message, LABELS, None, None, REQUEST),
         ]
-        batch = self._makeOne(logger, client=client)
+        batch = self._make_one(logger, client=client)
 
         try:
             with batch as other:

--- a/logging/unit_tests/test_logger.py
+++ b/logging/unit_tests/test_logger.py
@@ -20,7 +20,8 @@ class TestLogger(unittest.TestCase):
     PROJECT = 'test-project'
     LOGGER_NAME = 'logger-name'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.logger import Logger
         return Logger
 
@@ -421,7 +422,8 @@ class TestBatch(unittest.TestCase):
 
     PROJECT = 'test-project'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.logger import Batch
         return Batch
 

--- a/logging/unit_tests/test_logger.py
+++ b/logging/unit_tests/test_logger.py
@@ -111,7 +111,7 @@ class TestLogger(unittest.TestCase):
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client,
-                               labels=DEFAULT_LABELS)
+                                labels=DEFAULT_LABELS)
 
         logger.log_text(TEXT)
 
@@ -148,7 +148,7 @@ class TestLogger(unittest.TestCase):
         client2 = _Client(self.PROJECT)
         api = client2.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client1,
-                               labels=DEFAULT_LABELS)
+                                labels=DEFAULT_LABELS)
 
         logger.log_text(TEXT, client=client2, labels=LABELS,
                         insert_id=IID, severity=SEVERITY, http_request=REQUEST)
@@ -190,7 +190,7 @@ class TestLogger(unittest.TestCase):
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client,
-                               labels=DEFAULT_LABELS)
+                                labels=DEFAULT_LABELS)
 
         logger.log_struct(STRUCT)
 
@@ -227,7 +227,7 @@ class TestLogger(unittest.TestCase):
         client2 = _Client(self.PROJECT)
         api = client2.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client1,
-                               labels=DEFAULT_LABELS)
+                                labels=DEFAULT_LABELS)
 
         logger.log_struct(STRUCT, client=client2, labels=LABELS,
                           insert_id=IID, severity=SEVERITY,
@@ -276,7 +276,7 @@ class TestLogger(unittest.TestCase):
         client = _Client(self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client,
-                               labels=DEFAULT_LABELS)
+                                labels=DEFAULT_LABELS)
 
         logger.log_proto(message)
 
@@ -316,7 +316,7 @@ class TestLogger(unittest.TestCase):
         client2 = _Client(self.PROJECT)
         api = client2.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client1,
-                               labels=DEFAULT_LABELS)
+                                labels=DEFAULT_LABELS)
 
         logger.log_proto(message, client=client2, labels=LABELS,
                          insert_id=IID, severity=SEVERITY,

--- a/logging/unit_tests/test_logger.py
+++ b/logging/unit_tests/test_logger.py
@@ -26,7 +26,7 @@ class TestLogger(unittest.TestCase):
         return Logger
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         conn = object()
@@ -428,7 +428,7 @@ class TestBatch(unittest.TestCase):
         return Batch
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_ctor_defaults(self):
         logger = _Logger()

--- a/logging/unit_tests/test_metric.py
+++ b/logging/unit_tests/test_metric.py
@@ -22,7 +22,8 @@ class TestMetric(unittest.TestCase):
     FILTER = 'logName:syslog AND severity>=ERROR'
     DESCRIPTION = 'DESCRIPTION'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.metric import Metric
         return Metric
 

--- a/logging/unit_tests/test_metric.py
+++ b/logging/unit_tests/test_metric.py
@@ -28,7 +28,7 @@ class TestMetric(unittest.TestCase):
         return Metric
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         FULL = 'projects/%s/metrics/%s' % (self.PROJECT, self.METRIC_NAME)
@@ -62,7 +62,7 @@ class TestMetric(unittest.TestCase):
             'name': self.METRIC_NAME,
             'filter': self.FILTER,
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         metric = klass.from_api_repr(RESOURCE, client=client)
         self.assertEqual(metric.name, self.METRIC_NAME)
         self.assertEqual(metric.filter_, self.FILTER)
@@ -80,7 +80,7 @@ class TestMetric(unittest.TestCase):
             'filter': self.FILTER,
             'description': DESCRIPTION,
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         metric = klass.from_api_repr(RESOURCE, client=client)
         self.assertEqual(metric.name, self.METRIC_NAME)
         self.assertEqual(metric.filter_, self.FILTER)

--- a/logging/unit_tests/test_metric.py
+++ b/logging/unit_tests/test_metric.py
@@ -46,7 +46,7 @@ class TestMetric(unittest.TestCase):
         FULL = 'projects/%s/metrics/%s' % (self.PROJECT, self.METRIC_NAME)
         client = _Client(self.PROJECT)
         metric = self._make_one(self.METRIC_NAME, self.FILTER,
-                               client=client, description=self.DESCRIPTION)
+                                client=client, description=self.DESCRIPTION)
         self.assertEqual(metric.name, self.METRIC_NAME)
         self.assertEqual(metric.filter_, self.FILTER)
         self.assertEqual(metric.description, self.DESCRIPTION)
@@ -105,7 +105,7 @@ class TestMetric(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.metrics_api = _DummyMetricsAPI()
         metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client1,
-                               description=self.DESCRIPTION)
+                                description=self.DESCRIPTION)
 
         metric.create(client=client2)
 
@@ -149,7 +149,7 @@ class TestMetric(unittest.TestCase):
         api = client.metrics_api = _DummyMetricsAPI()
         api._metric_get_response = RESOURCE
         metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client,
-                               description=self.DESCRIPTION)
+                                description=self.DESCRIPTION)
 
         metric.reload()
 
@@ -194,7 +194,7 @@ class TestMetric(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.metrics_api = _DummyMetricsAPI()
         metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client1,
-                               description=self.DESCRIPTION)
+                                description=self.DESCRIPTION)
 
         metric.update(client=client2)
 

--- a/logging/unit_tests/test_metric.py
+++ b/logging/unit_tests/test_metric.py
@@ -27,13 +27,13 @@ class TestMetric(unittest.TestCase):
         from google.cloud.logging.metric import Metric
         return Metric
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         FULL = 'projects/%s/metrics/%s' % (self.PROJECT, self.METRIC_NAME)
         client = _Client(self.PROJECT)
-        metric = self._makeOne(self.METRIC_NAME, client=client)
+        metric = self._make_one(self.METRIC_NAME, client=client)
         self.assertEqual(metric.name, self.METRIC_NAME)
         self.assertIsNone(metric.filter_)
         self.assertEqual(metric.description, '')
@@ -45,7 +45,7 @@ class TestMetric(unittest.TestCase):
     def test_ctor_explicit(self):
         FULL = 'projects/%s/metrics/%s' % (self.PROJECT, self.METRIC_NAME)
         client = _Client(self.PROJECT)
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER,
+        metric = self._make_one(self.METRIC_NAME, self.FILTER,
                                client=client, description=self.DESCRIPTION)
         self.assertEqual(metric.name, self.METRIC_NAME)
         self.assertEqual(metric.filter_, self.FILTER)
@@ -92,7 +92,7 @@ class TestMetric(unittest.TestCase):
     def test_create_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.metrics_api = _DummyMetricsAPI()
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client)
+        metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client)
 
         metric.create()
 
@@ -104,7 +104,7 @@ class TestMetric(unittest.TestCase):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
         api = client2.metrics_api = _DummyMetricsAPI()
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client1,
+        metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client1,
                                description=self.DESCRIPTION)
 
         metric.create(client=client2)
@@ -116,7 +116,7 @@ class TestMetric(unittest.TestCase):
     def test_exists_miss_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.metrics_api = _DummyMetricsAPI()
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client)
+        metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client)
 
         self.assertFalse(metric.exists())
 
@@ -132,7 +132,7 @@ class TestMetric(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.metrics_api = _DummyMetricsAPI()
         api._metric_get_response = RESOURCE
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client1)
+        metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client1)
 
         self.assertTrue(metric.exists(client=client2))
 
@@ -148,7 +148,7 @@ class TestMetric(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.metrics_api = _DummyMetricsAPI()
         api._metric_get_response = RESOURCE
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client,
+        metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client,
                                description=self.DESCRIPTION)
 
         metric.reload()
@@ -169,7 +169,7 @@ class TestMetric(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.metrics_api = _DummyMetricsAPI()
         api._metric_get_response = RESOURCE
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client1)
+        metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client1)
 
         metric.reload(client=client2)
 
@@ -181,7 +181,7 @@ class TestMetric(unittest.TestCase):
     def test_update_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.metrics_api = _DummyMetricsAPI()
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client)
+        metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client)
 
         metric.update()
 
@@ -193,7 +193,7 @@ class TestMetric(unittest.TestCase):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
         api = client2.metrics_api = _DummyMetricsAPI()
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client1,
+        metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client1,
                                description=self.DESCRIPTION)
 
         metric.update(client=client2)
@@ -205,7 +205,7 @@ class TestMetric(unittest.TestCase):
     def test_delete_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.metrics_api = _DummyMetricsAPI()
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client)
+        metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client)
 
         metric.delete()
 
@@ -216,7 +216,7 @@ class TestMetric(unittest.TestCase):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
         api = client2.metrics_api = _DummyMetricsAPI()
-        metric = self._makeOne(self.METRIC_NAME, self.FILTER, client=client1)
+        metric = self._make_one(self.METRIC_NAME, self.FILTER, client=client1)
 
         metric.delete(client=client2)
 

--- a/logging/unit_tests/test_sink.py
+++ b/logging/unit_tests/test_sink.py
@@ -28,7 +28,7 @@ class TestSink(unittest.TestCase):
         return Sink
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         FULL = 'projects/%s/sinks/%s' % (self.PROJECT, self.SINK_NAME)
@@ -63,7 +63,7 @@ class TestSink(unittest.TestCase):
             'filter': self.FILTER,
             'destination': self.DESTINATION_URI,
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         sink = klass.from_api_repr(RESOURCE, client=client)
         self.assertEqual(sink.name, self.SINK_NAME)
         self.assertEqual(sink.filter_, self.FILTER)
@@ -80,7 +80,7 @@ class TestSink(unittest.TestCase):
             'filter': self.FILTER,
             'destination': self.DESTINATION_URI,
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         sink = klass.from_api_repr(RESOURCE, client=client)
         self.assertEqual(sink.name, self.SINK_NAME)
         self.assertEqual(sink.filter_, self.FILTER)

--- a/logging/unit_tests/test_sink.py
+++ b/logging/unit_tests/test_sink.py
@@ -45,8 +45,9 @@ class TestSink(unittest.TestCase):
     def test_ctor_explicit(self):
         FULL = 'projects/%s/sinks/%s' % (self.PROJECT, self.SINK_NAME)
         client = _Client(self.PROJECT)
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client)
         self.assertEqual(sink.name, self.SINK_NAME)
         self.assertEqual(sink.filter_, self.FILTER)
         self.assertEqual(sink.destination, self.DESTINATION_URI)
@@ -92,8 +93,9 @@ class TestSink(unittest.TestCase):
     def test_create_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.sinks_api = _DummySinksAPI()
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client)
 
         sink.create()
 
@@ -104,8 +106,9 @@ class TestSink(unittest.TestCase):
     def test_create_w_alternate_client(self):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client1)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client1)
         api = client2.sinks_api = _DummySinksAPI()
 
         sink.create(client=client2)
@@ -117,8 +120,9 @@ class TestSink(unittest.TestCase):
     def test_exists_miss_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.sinks_api = _DummySinksAPI()
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client)
 
         self.assertFalse(sink.exists())
 
@@ -135,8 +139,9 @@ class TestSink(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.sinks_api = _DummySinksAPI()
         api._sink_get_response = RESOURCE
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client1)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client1)
 
         self.assertTrue(sink.exists(client=client2))
 
@@ -154,8 +159,9 @@ class TestSink(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.sinks_api = _DummySinksAPI()
         api._sink_get_response = RESOURCE
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client)
 
         sink.reload()
 
@@ -176,8 +182,9 @@ class TestSink(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.sinks_api = _DummySinksAPI()
         api._sink_get_response = RESOURCE
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client1)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client1)
 
         sink.reload(client=client2)
 
@@ -189,8 +196,9 @@ class TestSink(unittest.TestCase):
     def test_update_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.sinks_api = _DummySinksAPI()
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client)
 
         sink.update()
 
@@ -202,8 +210,9 @@ class TestSink(unittest.TestCase):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
         api = client2.sinks_api = _DummySinksAPI()
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client1)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client1)
 
         sink.update(client=client2)
 
@@ -214,8 +223,9 @@ class TestSink(unittest.TestCase):
     def test_delete_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.sinks_api = _DummySinksAPI()
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client)
 
         sink.delete()
 
@@ -226,8 +236,9 @@ class TestSink(unittest.TestCase):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
         api = client2.sinks_api = _DummySinksAPI()
-        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
-                             client=client1)
+        sink = self._make_one(self.SINK_NAME, self.FILTER,
+                              self.DESTINATION_URI,
+                              client=client1)
 
         sink.delete(client=client2)
 

--- a/logging/unit_tests/test_sink.py
+++ b/logging/unit_tests/test_sink.py
@@ -22,7 +22,8 @@ class TestSink(unittest.TestCase):
     FILTER = 'logName:syslog AND severity>=INFO'
     DESTINATION_URI = 'faux.googleapis.com/destination'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.logging.sink import Sink
         return Sink
 

--- a/logging/unit_tests/test_sink.py
+++ b/logging/unit_tests/test_sink.py
@@ -27,13 +27,13 @@ class TestSink(unittest.TestCase):
         from google.cloud.logging.sink import Sink
         return Sink
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         FULL = 'projects/%s/sinks/%s' % (self.PROJECT, self.SINK_NAME)
         client = _Client(self.PROJECT)
-        sink = self._makeOne(self.SINK_NAME, client=client)
+        sink = self._make_one(self.SINK_NAME, client=client)
         self.assertEqual(sink.name, self.SINK_NAME)
         self.assertIsNone(sink.filter_)
         self.assertIsNone(sink.destination)
@@ -45,7 +45,7 @@ class TestSink(unittest.TestCase):
     def test_ctor_explicit(self):
         FULL = 'projects/%s/sinks/%s' % (self.PROJECT, self.SINK_NAME)
         client = _Client(self.PROJECT)
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client)
         self.assertEqual(sink.name, self.SINK_NAME)
         self.assertEqual(sink.filter_, self.FILTER)
@@ -92,7 +92,7 @@ class TestSink(unittest.TestCase):
     def test_create_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.sinks_api = _DummySinksAPI()
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client)
 
         sink.create()
@@ -104,7 +104,7 @@ class TestSink(unittest.TestCase):
     def test_create_w_alternate_client(self):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client1)
         api = client2.sinks_api = _DummySinksAPI()
 
@@ -117,7 +117,7 @@ class TestSink(unittest.TestCase):
     def test_exists_miss_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.sinks_api = _DummySinksAPI()
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client)
 
         self.assertFalse(sink.exists())
@@ -135,7 +135,7 @@ class TestSink(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.sinks_api = _DummySinksAPI()
         api._sink_get_response = RESOURCE
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client1)
 
         self.assertTrue(sink.exists(client=client2))
@@ -154,7 +154,7 @@ class TestSink(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.sinks_api = _DummySinksAPI()
         api._sink_get_response = RESOURCE
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client)
 
         sink.reload()
@@ -176,7 +176,7 @@ class TestSink(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.sinks_api = _DummySinksAPI()
         api._sink_get_response = RESOURCE
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client1)
 
         sink.reload(client=client2)
@@ -189,7 +189,7 @@ class TestSink(unittest.TestCase):
     def test_update_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.sinks_api = _DummySinksAPI()
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client)
 
         sink.update()
@@ -202,7 +202,7 @@ class TestSink(unittest.TestCase):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
         api = client2.sinks_api = _DummySinksAPI()
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client1)
 
         sink.update(client=client2)
@@ -214,7 +214,7 @@ class TestSink(unittest.TestCase):
     def test_delete_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.sinks_api = _DummySinksAPI()
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client)
 
         sink.delete()
@@ -226,7 +226,7 @@ class TestSink(unittest.TestCase):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
         api = client2.sinks_api = _DummySinksAPI()
-        sink = self._makeOne(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
+        sink = self._make_one(self.SINK_NAME, self.FILTER, self.DESTINATION_URI,
                              client=client1)
 
         sink.delete(client=client2)

--- a/monitoring/unit_tests/test__dataframe.py
+++ b/monitoring/unit_tests/test__dataframe.py
@@ -86,21 +86,21 @@ def generate_query_results():  # pragma: NO COVER
 @unittest.skipUnless(HAVE_PANDAS, 'No pandas')
 class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud.monitoring._dataframe import _build_dataframe
         return _build_dataframe(*args, **kwargs)
 
     def test_both_label_and_labels_illegal(self):
         with self.assertRaises(ValueError):
-            self._callFUT([], label='instance_name', labels=['zone'])
+            self._call_fut([], label='instance_name', labels=['zone'])
 
     def test_empty_labels_illegal(self):
         with self.assertRaises(ValueError):
-            self._callFUT([], labels=[])
+            self._call_fut([], labels=[])
 
     def test_simple_label(self):
         iterable = generate_query_results()
-        dataframe = self._callFUT(iterable, label='instance_name')
+        dataframe = self._call_fut(iterable, label='instance_name')
 
         self.assertEqual(dataframe.shape, DIMENSIONS)
         self.assertEqual(dataframe.values.tolist(), ARRAY)
@@ -115,7 +115,7 @@ class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
         NAMES = ['resource_type', 'instance_id']
 
         iterable = generate_query_results()
-        dataframe = self._callFUT(iterable, labels=NAMES)
+        dataframe = self._call_fut(iterable, labels=NAMES)
 
         self.assertEqual(dataframe.shape, DIMENSIONS)
         self.assertEqual(dataframe.values.tolist(), ARRAY)
@@ -134,7 +134,7 @@ class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
         NAMES = [NAME]
 
         iterable = generate_query_results()
-        dataframe = self._callFUT(iterable, labels=NAMES)
+        dataframe = self._call_fut(iterable, labels=NAMES)
 
         self.assertEqual(dataframe.shape, DIMENSIONS)
         self.assertEqual(dataframe.values.tolist(), ARRAY)
@@ -152,7 +152,7 @@ class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
                  'instance_name']
 
         iterable = generate_query_results()
-        dataframe = self._callFUT(iterable)
+        dataframe = self._call_fut(iterable)
 
         self.assertEqual(dataframe.shape, DIMENSIONS)
         self.assertEqual(dataframe.values.tolist(), ARRAY)
@@ -169,7 +169,7 @@ class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
         self.assertIsNone(dataframe.index.name)
 
     def test_empty_table_simple_label(self):
-        dataframe = self._callFUT([], label='instance_name')
+        dataframe = self._call_fut([], label='instance_name')
         self.assertEqual(dataframe.shape, (0, 0))
         self.assertIsNone(dataframe.columns.name)
         self.assertIsNone(dataframe.index.name)
@@ -177,7 +177,7 @@ class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
 
     def test_empty_table_multiple_labels(self):
         NAMES = ['resource_type', 'instance_id']
-        dataframe = self._callFUT([], labels=NAMES)
+        dataframe = self._call_fut([], labels=NAMES)
         self.assertEqual(dataframe.shape, (0, 0))
         self.assertEqual(dataframe.columns.names, NAMES)
         self.assertIsNone(dataframe.columns.name)
@@ -187,7 +187,7 @@ class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
     def test_empty_table_multiple_labels_with_just_one(self):
         NAME = 'instance_id'
         NAMES = [NAME]
-        dataframe = self._callFUT([], labels=NAMES)
+        dataframe = self._call_fut([], labels=NAMES)
         self.assertEqual(dataframe.shape, (0, 0))
         self.assertEqual(dataframe.columns.names, NAMES)
         self.assertEqual(dataframe.columns.name, NAME)
@@ -197,7 +197,7 @@ class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
     def test_empty_table_smart_labels(self):
         NAME = 'resource_type'
         NAMES = [NAME]
-        dataframe = self._callFUT([])
+        dataframe = self._call_fut([])
         self.assertEqual(dataframe.shape, (0, 0))
         self.assertEqual(dataframe.columns.names, NAMES)
         self.assertEqual(dataframe.columns.name, NAME)
@@ -207,20 +207,20 @@ class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
 
 class Test__sorted_resource_labels(unittest.TestCase):
 
-    def _callFUT(self, labels):
+    def _call_fut(self, labels):
         from google.cloud.monitoring._dataframe import _sorted_resource_labels
         return _sorted_resource_labels(labels)
 
     def test_empty(self):
-        self.assertEqual(self._callFUT([]), [])
+        self.assertEqual(self._call_fut([]), [])
 
     def test_sorted(self):
         from google.cloud.monitoring._dataframe import TOP_RESOURCE_LABELS
         EXPECTED = TOP_RESOURCE_LABELS + ('other-1', 'other-2')
-        self.assertSequenceEqual(self._callFUT(EXPECTED), EXPECTED)
+        self.assertSequenceEqual(self._call_fut(EXPECTED), EXPECTED)
 
     def test_reversed(self):
         from google.cloud.monitoring._dataframe import TOP_RESOURCE_LABELS
         EXPECTED = TOP_RESOURCE_LABELS + ('other-1', 'other-2')
         INPUT = list(reversed(EXPECTED))
-        self.assertSequenceEqual(self._callFUT(INPUT), EXPECTED)
+        self.assertSequenceEqual(self._call_fut(INPUT), EXPECTED)

--- a/monitoring/unit_tests/test_client.py
+++ b/monitoring/unit_tests/test_client.py
@@ -25,7 +25,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_query(self):
         import datetime

--- a/monitoring/unit_tests/test_client.py
+++ b/monitoring/unit_tests/test_client.py
@@ -19,7 +19,8 @@ PROJECT = 'my-project'
 
 class TestClient(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.client import Client
         return Client
 

--- a/monitoring/unit_tests/test_client.py
+++ b/monitoring/unit_tests/test_client.py
@@ -24,7 +24,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.monitoring.client import Client
         return Client
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_query(self):
@@ -85,7 +85,7 @@ class TestClient(unittest.TestCase):
 
         RESPONSE = {'timeSeries': [SERIES1, SERIES2]}
 
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         connection = client.connection = _Connection(RESPONSE)
 
         # A simple query. In practice, it can be very convenient to let the
@@ -138,7 +138,7 @@ class TestClient(unittest.TestCase):
         VALUE_TYPE = 'DOUBLE'
         DESCRIPTION = 'This is my metric.'
 
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         client.connection = _Connection()   # For safety's sake.
         descriptor = client.metric_descriptor(TYPE,
                                               metric_kind=METRIC_KIND,
@@ -164,7 +164,7 @@ class TestClient(unittest.TestCase):
             'instance_name': 'my-instance'
         }
 
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         client.connection = _Connection()   # For safety's sake.
         metric = client.metric(TYPE, LABELS)
         self.assertEqual(metric.type, TYPE)
@@ -177,7 +177,7 @@ class TestClient(unittest.TestCase):
             'zone': 'us-central1-f'
         }
 
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         client.connection = _Connection()   # For safety's sake.
         resource = client.resource(TYPE, LABELS)
         self.assertEqual(resource.type, TYPE)
@@ -203,7 +203,7 @@ class TestClient(unittest.TestCase):
         TIME1 = datetime.datetime.utcnow()
         TIME1_STR = _datetime_to_rfc3339(TIME1, ignore_zone=False)
 
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         client.connection = _Connection()   # For safety's sake.
         metric = client.metric(METRIC_TYPE, METRIC_LABELS)
         resource = client.resource(RESOURCE_TYPE, RESOURCE_LABELS)
@@ -242,7 +242,7 @@ class TestClient(unittest.TestCase):
             'zone': 'us-central1-f'
         }
 
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         client.connection = _Connection()   # For safety's sake.
         resource = client.resource(RESOURCE_TYPE, RESOURCE_LABELS)
 
@@ -296,7 +296,7 @@ class TestClient(unittest.TestCase):
 
         # This test is identical to TestMetricDescriptor.test_fetch()
         # except for the following three lines.
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         connection = client.connection = _Connection(METRIC_DESCRIPTOR)
         descriptor = client.fetch_metric_descriptor(TYPE)
 
@@ -340,7 +340,7 @@ class TestClient(unittest.TestCase):
 
         # This test is identical to TestMetricDescriptor.test_list()
         # except for the following three lines.
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         connection = client.connection = _Connection(RESPONSE)
         descriptors = client.list_metric_descriptors()
 
@@ -385,7 +385,7 @@ class TestClient(unittest.TestCase):
 
         # This test is identical to TestResourceDescriptor.test_fetch()
         # except for the following three lines.
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         connection = client.connection = _Connection(RESOURCE_DESCRIPTOR)
         descriptor = client.fetch_resource_descriptor(TYPE)
 
@@ -433,7 +433,7 @@ class TestClient(unittest.TestCase):
 
         # This test is identical to TestResourceDescriptor.test_list()
         # except for the following three lines.
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         connection = client.connection = _Connection(RESPONSE)
         descriptors = client.list_resource_descriptors()
 
@@ -460,7 +460,7 @@ class TestClient(unittest.TestCase):
         FILTER = 'resource.type = "gce_instance"'
         IS_CLUSTER = False
 
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         group = client.group(GROUP_ID, display_name=DISPLAY_NAME,
                              parent_id=PARENT_ID, filter_string=FILTER,
                              is_cluster=IS_CLUSTER)
@@ -472,7 +472,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(group.is_cluster, IS_CLUSTER)
 
     def test_group_defaults(self):
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         group = client.group()
 
         self.assertIsNone(group.id)
@@ -499,7 +499,7 @@ class TestClient(unittest.TestCase):
             'isCluster': IS_CLUSTER
         }
 
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         connection = client.connection = _Connection(GROUP)
         group = client.fetch_group(GROUP_ID)
 
@@ -532,7 +532,7 @@ class TestClient(unittest.TestCase):
         RESPONSE = {
             'group': [GROUP],
         }
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
         connection = client.connection = _Connection(RESPONSE)
         groups = client.list_groups()
 
@@ -552,7 +552,7 @@ class TestClient(unittest.TestCase):
 
     def test_write_time_series(self):
         PATH = '/projects/{project}/timeSeries/'.format(project=PROJECT)
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
 
         RESOURCE_TYPE = 'gce_instance'
         RESOURCE_LABELS = {
@@ -594,7 +594,7 @@ class TestClient(unittest.TestCase):
     def test_write_point(self):
         import datetime
         PATH = '/projects/{project}/timeSeries/'.format(project=PROJECT)
-        client = self._makeOne(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=_Credentials())
 
         RESOURCE_TYPE = 'gce_instance'
         RESOURCE_LABELS = {

--- a/monitoring/unit_tests/test_connection.py
+++ b/monitoring/unit_tests/test_connection.py
@@ -22,12 +22,12 @@ class TestConnection(unittest.TestCase):
         from google.cloud.monitoring.connection import Connection
         return Connection
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         credentials = _Credentials()
-        connection = self._makeOne(credentials)
+        connection = self._make_one(credentials)
         self.assertEqual(connection.credentials._scopes,
                          self._get_target_class().SCOPE)
 

--- a/monitoring/unit_tests/test_connection.py
+++ b/monitoring/unit_tests/test_connection.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.connection import Connection
         return Connection
 

--- a/monitoring/unit_tests/test_connection.py
+++ b/monitoring/unit_tests/test_connection.py
@@ -23,13 +23,13 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         credentials = _Credentials()
         connection = self._makeOne(credentials)
         self.assertEqual(connection.credentials._scopes,
-                         self._getTargetClass().SCOPE)
+                         self._get_target_class().SCOPE)
 
 
 class _Credentials(object):

--- a/monitoring/unit_tests/test_group.py
+++ b/monitoring/unit_tests/test_group.py
@@ -113,10 +113,10 @@ class TestGroup(unittest.TestCase):
         return Group
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def _makeOneFromJSON(self, info, client=None):
-        return self._getTargetClass()._from_dict(client=client, info=info)
+        return self._get_target_class()._from_dict(client=client, info=info)
 
     def _validateGroup(self, actual_group, expected_group_json):
         expected_group = self._makeOneFromJSON(expected_group_json)
@@ -179,7 +179,7 @@ class TestGroup(unittest.TestCase):
 
     def test_from_dict(self):
         client = _Client(project=self.PROJECT)
-        group = self._getTargetClass()._from_dict(client, self.JSON_GROUP)
+        group = self._get_target_class()._from_dict(client, self.JSON_GROUP)
 
         self.assertIs(group.client, client)
 
@@ -196,7 +196,7 @@ class TestGroup(unittest.TestCase):
             'displayName': self.DISPLAY_NAME,
             'filter': self.FILTER,
         }
-        group = self._getTargetClass()._from_dict(client, info)
+        group = self._get_target_class()._from_dict(client, info)
 
         self.assertIs(group.client, client)
 
@@ -342,7 +342,7 @@ class TestGroup(unittest.TestCase):
         }
         connection = _Connection(RESPONSE)
         client = _Client(project=self.PROJECT, connection=connection)
-        groups = self._getTargetClass()._list(client)
+        groups = self._get_target_class()._list(client)
         self._validateGroupList(client, groups, LIST_OF_GROUPS)
 
         request, = connection._requested
@@ -365,7 +365,7 @@ class TestGroup(unittest.TestCase):
 
         connection = _Connection(RESPONSE1, RESPONSE2)
         client = _Client(project=self.PROJECT, connection=connection)
-        groups = self._getTargetClass()._list(client)
+        groups = self._get_target_class()._list(client)
         self._validateGroupList(client, groups, LIST_OF_GROUPS)
 
         request1, request2 = connection._requested
@@ -377,7 +377,7 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(request2, expected_request2)
 
         with self.assertRaises(NotFound):
-            self._getTargetClass()._list(client)
+            self._get_target_class()._list(client)
 
     def test_list_children(self):
         CHILDREN = [self.JSON_GROUP, self.JSON_SIBLING]

--- a/monitoring/unit_tests/test_group.py
+++ b/monitoring/unit_tests/test_group.py
@@ -17,7 +17,7 @@ import unittest
 
 class Test_group_id_from_name(unittest.TestCase):
 
-    def _callFUT(self, path, project):
+    def _call_fut(self, path, project):
         from google.cloud.monitoring.group import _group_id_from_name
         return _group_id_from_name(path, project)
 
@@ -25,20 +25,20 @@ class Test_group_id_from_name(unittest.TestCase):
         PROJECT = 'my-project-1234'
         PATH = ''
         with self.assertRaises(ValueError):
-            self._callFUT(PATH, PROJECT)
+            self._call_fut(PATH, PROJECT)
 
     def test_w_simple_name(self):
         GROUP_ID = 'GROUP_ID'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/groups/%s' % (PROJECT, GROUP_ID)
-        group_id = self._callFUT(PATH, PROJECT)
+        group_id = self._call_fut(PATH, PROJECT)
         self.assertEqual(group_id, GROUP_ID)
 
     def test_w_name_w_all_extras(self):
         GROUP_ID = 'GROUP_ID-part.one~part.two%part-three'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/groups/%s' % (PROJECT, GROUP_ID)
-        group_id = self._callFUT(PATH, PROJECT)
+        group_id = self._call_fut(PATH, PROJECT)
         self.assertEqual(group_id, GROUP_ID)
 
 

--- a/monitoring/unit_tests/test_group.py
+++ b/monitoring/unit_tests/test_group.py
@@ -107,7 +107,8 @@ class TestGroup(unittest.TestCase):
         self.RESOURCE2 = Resource._from_dict(info2)
         self.MEMBERS = [info1, info2]
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.group import Group
         return Group
 

--- a/monitoring/unit_tests/test_group.py
+++ b/monitoring/unit_tests/test_group.py
@@ -112,14 +112,14 @@ class TestGroup(unittest.TestCase):
         from google.cloud.monitoring.group import Group
         return Group
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
-    def _makeOneFromJSON(self, info, client=None):
+    def _make_oneFromJSON(self, info, client=None):
         return self._get_target_class()._from_dict(client=client, info=info)
 
     def _validateGroup(self, actual_group, expected_group_json):
-        expected_group = self._makeOneFromJSON(expected_group_json)
+        expected_group = self._make_oneFromJSON(expected_group_json)
         self.assertEqual(actual_group.id, expected_group.id)
         self.assertEqual(actual_group.display_name,
                          expected_group.display_name)
@@ -135,7 +135,7 @@ class TestGroup(unittest.TestCase):
 
     def test_constructor(self):
         client = _Client(project=self.PROJECT)
-        group = self._makeOne(
+        group = self._make_one(
             client=client,
             group_id=self.GROUP_ID,
             display_name=self.DISPLAY_NAME,
@@ -156,7 +156,7 @@ class TestGroup(unittest.TestCase):
 
     def test_constructor_defaults(self):
         client = _Client(project=self.PROJECT)
-        group = self._makeOne(client=client)
+        group = self._make_one(client=client)
 
         self.assertIs(group.client, client)
 
@@ -169,12 +169,12 @@ class TestGroup(unittest.TestCase):
         self.assertFalse(group.is_cluster)
 
     def test_path_no_id(self):
-        group = self._makeOne(client=None)
+        group = self._make_one(client=None)
         self.assertRaises(ValueError, getattr, group, 'path')
 
     def test_path_w_id(self):
         client = _Client(project=self.PROJECT)
-        group = self._makeOne(client=client, group_id=self.GROUP_ID)
+        group = self._make_one(client=client, group_id=self.GROUP_ID)
         self.assertEqual(group.path, '/%s' % self.GROUP_NAME)
 
     def test_from_dict(self):
@@ -208,12 +208,12 @@ class TestGroup(unittest.TestCase):
 
     def test_to_dict(self):
         client = _Client(project=self.PROJECT)
-        group = self._makeOneFromJSON(self.JSON_GROUP, client)
+        group = self._make_oneFromJSON(self.JSON_GROUP, client)
         self.assertEqual(group._to_dict(), self.JSON_GROUP)
 
     def test_to_dict_defaults(self):
         client = _Client(project=self.PROJECT)
-        group = self._makeOne(
+        group = self._make_one(
             client=client, group_id=self.GROUP_ID,
             display_name=self.DISPLAY_NAME,
             filter_string=self.FILTER)
@@ -233,7 +233,7 @@ class TestGroup(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOne(
+        group = self._make_one(
             client=client,
             display_name=self.DISPLAY_NAME,
             parent_id=self.PARENT_ID,
@@ -252,7 +252,7 @@ class TestGroup(unittest.TestCase):
     def test_exists_hit(self):
         connection = _Connection(self.JSON_GROUP)
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOne(client=client, group_id=self.GROUP_ID)
+        group = self._make_one(client=client, group_id=self.GROUP_ID)
 
         self.assertTrue(group.exists())
 
@@ -264,7 +264,7 @@ class TestGroup(unittest.TestCase):
     def test_exists_miss(self):
         connection = _Connection()
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOne(client=client, group_id=self.GROUP_ID)
+        group = self._make_one(client=client, group_id=self.GROUP_ID)
 
         self.assertFalse(group.exists())
 
@@ -276,7 +276,7 @@ class TestGroup(unittest.TestCase):
     def test_reload(self):
         connection = _Connection(self.JSON_GROUP)
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOne(client, group_id=self.GROUP_ID)
+        group = self._make_one(client, group_id=self.GROUP_ID)
         group.reload()
 
         self.assertIs(group.client, client)
@@ -292,7 +292,7 @@ class TestGroup(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOneFromJSON(REQUEST, client)
+        group = self._make_oneFromJSON(REQUEST, client)
         group.update()
 
         self._validateGroup(group, RESPONSE)
@@ -305,7 +305,7 @@ class TestGroup(unittest.TestCase):
     def test_delete(self):
         connection = _Connection(self.JSON_GROUP)
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOneFromJSON(self.JSON_GROUP, client)
+        group = self._make_oneFromJSON(self.JSON_GROUP, client)
         group.delete()
 
         request, = connection._requested
@@ -315,7 +315,7 @@ class TestGroup(unittest.TestCase):
     def test_fetch_parent(self):
         connection = _Connection(self.JSON_PARENT)
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOneFromJSON(self.JSON_GROUP, client)
+        group = self._make_oneFromJSON(self.JSON_GROUP, client)
 
         actual_parent = group.fetch_parent()
 
@@ -329,7 +329,7 @@ class TestGroup(unittest.TestCase):
     def test_fetch_parent_empty(self):
         connection = _Connection()
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOne(client=client)
+        group = self._make_one(client=client)
         actual_parent = group.fetch_parent()
 
         self.assertIsNone(actual_parent)
@@ -386,7 +386,7 @@ class TestGroup(unittest.TestCase):
         }
         connection = _Connection(RESPONSE)
         client = _Client(project=self.PROJECT, connection=connection)
-        parent_group = self._makeOneFromJSON(self.JSON_PARENT, client)
+        parent_group = self._make_oneFromJSON(self.JSON_PARENT, client)
         groups = parent_group.list_children()
         self._validateGroupList(client, groups, CHILDREN)
 
@@ -404,7 +404,7 @@ class TestGroup(unittest.TestCase):
         }
         connection = _Connection(RESPONSE)
         client = _Client(project=self.PROJECT, connection=connection)
-        child_group = self._makeOneFromJSON(self.JSON_CHILD, client)
+        child_group = self._make_oneFromJSON(self.JSON_CHILD, client)
         groups = child_group.list_ancestors()
         self._validateGroupList(client, groups, ANCESTORS)
 
@@ -422,7 +422,7 @@ class TestGroup(unittest.TestCase):
         }
         connection = _Connection(RESPONSE)
         client = _Client(project=self.PROJECT, connection=connection)
-        parent_group = self._makeOneFromJSON(self.JSON_PARENT, client)
+        parent_group = self._make_oneFromJSON(self.JSON_PARENT, client)
         groups = parent_group.list_descendants()
         self._validateGroupList(client, groups, DESCENDANTS)
 
@@ -440,7 +440,7 @@ class TestGroup(unittest.TestCase):
         }
         connection = _Connection(RESPONSE)
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOneFromJSON(self.JSON_GROUP, client)
+        group = self._make_oneFromJSON(self.JSON_GROUP, client)
         members = group.list_members()
 
         self.assertEqual(members, [self.RESOURCE1, self.RESOURCE2])
@@ -465,7 +465,7 @@ class TestGroup(unittest.TestCase):
 
         connection = _Connection(RESPONSE1, RESPONSE2)
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOneFromJSON(self.JSON_GROUP, client)
+        group = self._make_oneFromJSON(self.JSON_GROUP, client)
         members = group.list_members()
 
         self.assertEqual(members, [self.RESOURCE1, self.RESOURCE2])
@@ -497,7 +497,7 @@ class TestGroup(unittest.TestCase):
         }
         connection = _Connection(RESPONSE)
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOneFromJSON(self.JSON_GROUP, client)
+        group = self._make_oneFromJSON(self.JSON_GROUP, client)
         members = group.list_members(
             start_time=T0, end_time=T1, filter_string=MEMBER_FILTER)
 
@@ -521,7 +521,7 @@ class TestGroup(unittest.TestCase):
 
         connection = _Connection()
         client = _Client(project=self.PROJECT, connection=connection)
-        group = self._makeOneFromJSON(self.JSON_GROUP, client)
+        group = self._make_oneFromJSON(self.JSON_GROUP, client)
         with self.assertRaises(ValueError):
             group.list_members(start_time=T0)
 

--- a/monitoring/unit_tests/test_label.py
+++ b/monitoring/unit_tests/test_label.py
@@ -23,12 +23,12 @@ class TestLabelValueType(unittest.TestCase):
         return LabelValueType
 
     def test_one(self):
-        self.assertTrue(hasattr(self._getTargetClass(), 'STRING'))
+        self.assertTrue(hasattr(self._get_target_class(), 'STRING'))
 
     def test_names(self):
-        for name in self._getTargetClass().__dict__:
+        for name in self._get_target_class().__dict__:
             if not name.startswith('_'):
-                self.assertEqual(getattr(self._getTargetClass(), name), name)
+                self.assertEqual(getattr(self._get_target_class(), name), name)
 
 
 class TestLabelDescriptor(unittest.TestCase):
@@ -39,7 +39,7 @@ class TestLabelDescriptor(unittest.TestCase):
         return LabelDescriptor
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         KEY = 'response_code'
@@ -67,7 +67,7 @@ class TestLabelDescriptor(unittest.TestCase):
             'valueType': VALUE_TYPE,
             'description': DESCRIPTION,
         }
-        descriptor = self._getTargetClass()._from_dict(info)
+        descriptor = self._get_target_class()._from_dict(info)
         self.assertEqual(descriptor.key, KEY)
         self.assertEqual(descriptor.value_type, VALUE_TYPE)
         self.assertEqual(descriptor.description, DESCRIPTION)
@@ -75,7 +75,7 @@ class TestLabelDescriptor(unittest.TestCase):
     def test_from_dict_defaults(self):
         KEY = 'response_code'
         info = {'key': KEY}
-        descriptor = self._getTargetClass()._from_dict(info)
+        descriptor = self._get_target_class()._from_dict(info)
         self.assertEqual(descriptor.key, KEY)
         self.assertEqual(descriptor.value_type, 'STRING')
         self.assertEqual(descriptor.description, '')

--- a/monitoring/unit_tests/test_label.py
+++ b/monitoring/unit_tests/test_label.py
@@ -46,7 +46,7 @@ class TestLabelDescriptor(unittest.TestCase):
         VALUE_TYPE = 'INT64'
         DESCRIPTION = 'HTTP status code for the request.'
         descriptor = self._make_one(key=KEY, value_type=VALUE_TYPE,
-                                   description=DESCRIPTION)
+                                    description=DESCRIPTION)
         self.assertEqual(descriptor.key, KEY)
         self.assertEqual(descriptor.value_type, VALUE_TYPE)
         self.assertEqual(descriptor.description, DESCRIPTION)
@@ -85,7 +85,7 @@ class TestLabelDescriptor(unittest.TestCase):
         VALUE_TYPE = 'INT64'
         DESCRIPTION = 'HTTP status code for the request.'
         descriptor = self._make_one(key=KEY, value_type=VALUE_TYPE,
-                                   description=DESCRIPTION)
+                                    description=DESCRIPTION)
         expected = {
             'key': KEY,
             'valueType': VALUE_TYPE,
@@ -107,8 +107,8 @@ class TestLabelDescriptor(unittest.TestCase):
         VALUE_TYPE = 'INT64'
         DESCRIPTION = 'HTTP status code for the request.'
         descriptor1 = self._make_one(key=KEY, value_type=VALUE_TYPE,
-                                    description=DESCRIPTION)
+                                     description=DESCRIPTION)
         descriptor2 = self._make_one(key=KEY, value_type=VALUE_TYPE,
-                                    description=DESCRIPTION)
+                                     description=DESCRIPTION)
         self.assertTrue(descriptor1 == descriptor2)
         self.assertFalse(descriptor1 != descriptor2)

--- a/monitoring/unit_tests/test_label.py
+++ b/monitoring/unit_tests/test_label.py
@@ -38,14 +38,14 @@ class TestLabelDescriptor(unittest.TestCase):
         from google.cloud.monitoring.label import LabelDescriptor
         return LabelDescriptor
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         KEY = 'response_code'
         VALUE_TYPE = 'INT64'
         DESCRIPTION = 'HTTP status code for the request.'
-        descriptor = self._makeOne(key=KEY, value_type=VALUE_TYPE,
+        descriptor = self._make_one(key=KEY, value_type=VALUE_TYPE,
                                    description=DESCRIPTION)
         self.assertEqual(descriptor.key, KEY)
         self.assertEqual(descriptor.value_type, VALUE_TYPE)
@@ -53,7 +53,7 @@ class TestLabelDescriptor(unittest.TestCase):
 
     def test_constructor_defaults(self):
         KEY = 'response_code'
-        descriptor = self._makeOne(key=KEY)
+        descriptor = self._make_one(key=KEY)
         self.assertEqual(descriptor.key, KEY)
         self.assertEqual(descriptor.value_type, 'STRING')
         self.assertEqual(descriptor.description, '')
@@ -84,7 +84,7 @@ class TestLabelDescriptor(unittest.TestCase):
         KEY = 'response_code'
         VALUE_TYPE = 'INT64'
         DESCRIPTION = 'HTTP status code for the request.'
-        descriptor = self._makeOne(key=KEY, value_type=VALUE_TYPE,
+        descriptor = self._make_one(key=KEY, value_type=VALUE_TYPE,
                                    description=DESCRIPTION)
         expected = {
             'key': KEY,
@@ -95,7 +95,7 @@ class TestLabelDescriptor(unittest.TestCase):
 
     def test_to_dict_defaults(self):
         KEY = 'response_code'
-        descriptor = self._makeOne(key=KEY)
+        descriptor = self._make_one(key=KEY)
         expected = {
             'key': KEY,
             'valueType': 'STRING',
@@ -106,9 +106,9 @@ class TestLabelDescriptor(unittest.TestCase):
         KEY = 'response_code'
         VALUE_TYPE = 'INT64'
         DESCRIPTION = 'HTTP status code for the request.'
-        descriptor1 = self._makeOne(key=KEY, value_type=VALUE_TYPE,
+        descriptor1 = self._make_one(key=KEY, value_type=VALUE_TYPE,
                                     description=DESCRIPTION)
-        descriptor2 = self._makeOne(key=KEY, value_type=VALUE_TYPE,
+        descriptor2 = self._make_one(key=KEY, value_type=VALUE_TYPE,
                                     description=DESCRIPTION)
         self.assertTrue(descriptor1 == descriptor2)
         self.assertFalse(descriptor1 != descriptor2)

--- a/monitoring/unit_tests/test_label.py
+++ b/monitoring/unit_tests/test_label.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestLabelValueType(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.label import LabelValueType
         return LabelValueType
 
@@ -32,7 +33,8 @@ class TestLabelValueType(unittest.TestCase):
 
 class TestLabelDescriptor(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.label import LabelDescriptor
         return LabelDescriptor
 

--- a/monitoring/unit_tests/test_metric.py
+++ b/monitoring/unit_tests/test_metric.py
@@ -54,7 +54,7 @@ class TestMetricDescriptor(unittest.TestCase):
         from google.cloud.monitoring.metric import MetricDescriptor
         return MetricDescriptor
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
@@ -77,7 +77,7 @@ class TestMetricDescriptor(unittest.TestCase):
         DISPLAY_NAME = 'Response count'
 
         client = object()
-        descriptor = self._makeOne(
+        descriptor = self._make_one(
             client=client,
             name=NAME,
             type_=TYPE,
@@ -106,7 +106,7 @@ class TestMetricDescriptor(unittest.TestCase):
         TYPE = 'appengine.googleapis.com/http/server/response_count'
 
         client = object()
-        descriptor = self._makeOne(client=client, type_=TYPE)
+        descriptor = self._make_one(client=client, type_=TYPE)
 
         self.assertIs(descriptor.client, client)
 
@@ -262,7 +262,7 @@ class TestMetricDescriptor(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=PROJECT, connection=connection)
-        descriptor = self._makeOne(
+        descriptor = self._make_one(
             client=client,
             type_=TYPE,
             metric_kind=METRIC_KIND,
@@ -295,7 +295,7 @@ class TestMetricDescriptor(unittest.TestCase):
 
         connection = _Connection({})
         client = _Client(project=PROJECT, connection=connection)
-        descriptor = self._makeOne(
+        descriptor = self._make_one(
             client=client,
             type_=TYPE,
             metric_kind='NOTUSED',
@@ -501,7 +501,7 @@ class TestMetric(unittest.TestCase):
         from google.cloud.monitoring.metric import Metric
         return Metric
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
@@ -510,7 +510,7 @@ class TestMetric(unittest.TestCase):
             'response_code': 200,
             'loading': False,
         }
-        metric = self._makeOne(type=TYPE, labels=LABELS)
+        metric = self._make_one(type=TYPE, labels=LABELS)
         self.assertEqual(metric.type, TYPE)
         self.assertEqual(metric.labels, LABELS)
 
@@ -538,7 +538,7 @@ class TestMetric(unittest.TestCase):
     def test_to_dict(self):
         TYPE = 'custom.googleapis.com/my_metric'
         LABELS = {}
-        metric = self._makeOne(TYPE, LABELS)
+        metric = self._make_one(TYPE, LABELS)
         expected_dict = {
             'type': TYPE,
             'labels': LABELS,

--- a/monitoring/unit_tests/test_metric.py
+++ b/monitoring/unit_tests/test_metric.py
@@ -484,7 +484,8 @@ class TestMetricDescriptor(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=PROJECT, connection=connection)
-        descriptors = self._get_target_class()._list(client, type_prefix=PREFIX)
+        descriptors = self._get_target_class()._list(
+            client, type_prefix=PREFIX)
 
         self.assertEqual(len(descriptors), 0)
 

--- a/monitoring/unit_tests/test_metric.py
+++ b/monitoring/unit_tests/test_metric.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestMetricKind(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.metric import MetricKind
         return MetricKind
 
@@ -32,7 +33,8 @@ class TestMetricKind(unittest.TestCase):
 
 class TestValueType(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.metric import ValueType
         return ValueType
 
@@ -47,7 +49,8 @@ class TestValueType(unittest.TestCase):
 
 class TestMetricDescriptor(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.metric import MetricDescriptor
         return MetricDescriptor
 
@@ -493,7 +496,8 @@ class TestMetricDescriptor(unittest.TestCase):
 
 class TestMetric(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.metric import Metric
         return Metric
 

--- a/monitoring/unit_tests/test_metric.py
+++ b/monitoring/unit_tests/test_metric.py
@@ -23,12 +23,12 @@ class TestMetricKind(unittest.TestCase):
         return MetricKind
 
     def test_one(self):
-        self.assertTrue(hasattr(self._getTargetClass(), 'GAUGE'))
+        self.assertTrue(hasattr(self._get_target_class(), 'GAUGE'))
 
     def test_names(self):
-        for name in self._getTargetClass().__dict__:
+        for name in self._get_target_class().__dict__:
             if not name.startswith('_'):
-                self.assertEqual(getattr(self._getTargetClass(), name), name)
+                self.assertEqual(getattr(self._get_target_class(), name), name)
 
 
 class TestValueType(unittest.TestCase):
@@ -39,12 +39,12 @@ class TestValueType(unittest.TestCase):
         return ValueType
 
     def test_one(self):
-        self.assertTrue(hasattr(self._getTargetClass(), 'DISTRIBUTION'))
+        self.assertTrue(hasattr(self._get_target_class(), 'DISTRIBUTION'))
 
     def test_names(self):
-        for name in self._getTargetClass().__dict__:
+        for name in self._get_target_class().__dict__:
             if not name.startswith('_'):
-                self.assertEqual(getattr(self._getTargetClass(), name), name)
+                self.assertEqual(getattr(self._get_target_class(), name), name)
 
 
 class TestMetricDescriptor(unittest.TestCase):
@@ -55,7 +55,7 @@ class TestMetricDescriptor(unittest.TestCase):
         return MetricDescriptor
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         from google.cloud.monitoring.label import LabelDescriptor
@@ -147,7 +147,7 @@ class TestMetricDescriptor(unittest.TestCase):
             'displayName': DISPLAY_NAME,
         }
         client = object()
-        descriptor = self._getTargetClass()._from_dict(client, info)
+        descriptor = self._get_target_class()._from_dict(client, info)
 
         self.assertIs(descriptor.client, client)
 
@@ -179,7 +179,7 @@ class TestMetricDescriptor(unittest.TestCase):
             'valueType': VALUE_TYPE,
         }
         client = object()
-        descriptor = self._getTargetClass()._from_dict(client, info)
+        descriptor = self._get_target_class()._from_dict(client, info)
 
         self.assertIs(descriptor.client, client)
 
@@ -218,7 +218,7 @@ class TestMetricDescriptor(unittest.TestCase):
             'displayName': DISPLAY_NAME,
         }
         client = object()
-        descriptor = self._getTargetClass()._from_dict(client, info)
+        descriptor = self._get_target_class()._from_dict(client, info)
 
         del info['name']
         self.assertEqual(descriptor._to_dict(), info)
@@ -236,7 +236,7 @@ class TestMetricDescriptor(unittest.TestCase):
             'valueType': VALUE_TYPE,
         }
         client = object()
-        descriptor = self._getTargetClass()._from_dict(client, info)
+        descriptor = self._get_target_class()._from_dict(client, info)
 
         del info['name']
         self.assertEqual(descriptor._to_dict(), info)
@@ -324,7 +324,7 @@ class TestMetricDescriptor(unittest.TestCase):
 
         connection = _Connection(METRIC_DESCRIPTOR)
         client = _Client(project=PROJECT, connection=connection)
-        descriptor = self._getTargetClass()._fetch(client, TYPE)
+        descriptor = self._get_target_class()._fetch(client, TYPE)
 
         self.assertIs(descriptor.client, client)
         self.assertEqual(descriptor.name, NAME)
@@ -367,7 +367,7 @@ class TestMetricDescriptor(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=PROJECT, connection=connection)
-        descriptors = self._getTargetClass()._list(client)
+        descriptors = self._get_target_class()._list(client)
 
         self.assertEqual(len(descriptors), 2)
         descriptor1, descriptor2 = descriptors
@@ -426,7 +426,7 @@ class TestMetricDescriptor(unittest.TestCase):
 
         connection = _Connection(RESPONSE1, RESPONSE2)
         client = _Client(project=PROJECT, connection=connection)
-        descriptors = self._getTargetClass()._list(client)
+        descriptors = self._get_target_class()._list(client)
 
         self.assertEqual(len(descriptors), 2)
         descriptor1, descriptor2 = descriptors
@@ -448,7 +448,7 @@ class TestMetricDescriptor(unittest.TestCase):
         self.assertEqual(request2, expected_request2)
 
         with self.assertRaises(NotFound):
-            self._getTargetClass()._list(client)
+            self._get_target_class()._list(client)
 
     def test_list_filtered(self):
         PROJECT = 'my-project'
@@ -462,7 +462,7 @@ class TestMetricDescriptor(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=PROJECT, connection=connection)
-        descriptors = self._getTargetClass()._list(client, FILTER)
+        descriptors = self._get_target_class()._list(client, FILTER)
 
         self.assertEqual(len(descriptors), 0)
 
@@ -484,7 +484,7 @@ class TestMetricDescriptor(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=PROJECT, connection=connection)
-        descriptors = self._getTargetClass()._list(client, type_prefix=PREFIX)
+        descriptors = self._get_target_class()._list(client, type_prefix=PREFIX)
 
         self.assertEqual(len(descriptors), 0)
 
@@ -502,7 +502,7 @@ class TestMetric(unittest.TestCase):
         return Metric
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         TYPE = 'appengine.googleapis.com/http/server/response_count'
@@ -524,14 +524,14 @@ class TestMetric(unittest.TestCase):
             'type': TYPE,
             'labels': LABELS,
         }
-        metric = self._getTargetClass()._from_dict(info)
+        metric = self._get_target_class()._from_dict(info)
         self.assertEqual(metric.type, TYPE)
         self.assertEqual(metric.labels, LABELS)
 
     def test_from_dict_defaults(self):
         TYPE = 'appengine.googleapis.com/http/server/response_count'
         info = {'type': TYPE}
-        metric = self._getTargetClass()._from_dict(info)
+        metric = self._get_target_class()._from_dict(info)
         self.assertEqual(metric.type, TYPE)
         self.assertEqual(metric.labels, {})
 

--- a/monitoring/unit_tests/test_query.py
+++ b/monitoring/unit_tests/test_query.py
@@ -42,7 +42,8 @@ TS2 = '2016-04-06T22:05:02.042Z'
 
 class TestAligner(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.query import Aligner
         return Aligner
 
@@ -57,7 +58,8 @@ class TestAligner(unittest.TestCase):
 
 class TestReducer(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.query import Reducer
         return Reducer
 
@@ -73,7 +75,8 @@ class TestReducer(unittest.TestCase):
 
 class TestQuery(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.query import Query
         return Query
 
@@ -499,7 +502,8 @@ class TestQuery(unittest.TestCase):
 
 class Test_Filter(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.query import _Filter
         return _Filter
 

--- a/monitoring/unit_tests/test_query.py
+++ b/monitoring/unit_tests/test_query.py
@@ -537,18 +537,18 @@ class Test_Filter(unittest.TestCase):
 
 class Test__build_label_filter(unittest.TestCase):
 
-    def _callFUT(self, *args, **kwargs):
+    def _call_fut(self, *args, **kwargs):
         from google.cloud.monitoring.query import _build_label_filter
         return _build_label_filter(*args, **kwargs)
 
     def test_no_labels(self):
-        self.assertEqual(self._callFUT('resource'), '')
+        self.assertEqual(self._call_fut('resource'), '')
 
     def test_label_is_none(self):
-        self.assertEqual(self._callFUT('resource', foo=None), '')
+        self.assertEqual(self._call_fut('resource', foo=None), '')
 
     def test_metric_labels(self):
-        actual = self._callFUT(
+        actual = self._call_fut(
             'metric',
             alpha_prefix='a-',
             beta_gamma_suffix='-b',
@@ -562,7 +562,7 @@ class Test__build_label_filter(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_metric_label_response_code_greater_less(self):
-        actual = self._callFUT(
+        actual = self._call_fut(
             'metric',
             response_code_greater=500,
             response_code_less=600)
@@ -573,7 +573,7 @@ class Test__build_label_filter(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_metric_label_response_code_greater_less_equal(self):
-        actual = self._callFUT(
+        actual = self._call_fut(
             'metric',
             response_code_greaterequal=500,
             response_code_lessequal=600)
@@ -584,7 +584,7 @@ class Test__build_label_filter(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_resource_labels(self):
-        actual = self._callFUT(
+        actual = self._call_fut(
             'resource',
             alpha_prefix='a-',
             beta_gamma_suffix='-b',
@@ -598,7 +598,7 @@ class Test__build_label_filter(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_raw_label_filters(self):
-        actual = self._callFUT(
+        actual = self._call_fut(
             'resource',
             'resource.label.alpha = starts_with("a-")',
             'resource.label.beta_gamma = ends_with("-b")',
@@ -612,17 +612,17 @@ class Test__build_label_filter(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_resource_type(self):
-        actual = self._callFUT('resource', resource_type='foo')
+        actual = self._call_fut('resource', resource_type='foo')
         expected = 'resource.type = "foo"'
         self.assertEqual(actual, expected)
 
     def test_resource_type_prefix(self):
-        actual = self._callFUT('resource', resource_type_prefix='foo-')
+        actual = self._call_fut('resource', resource_type_prefix='foo-')
         expected = 'resource.type = starts_with("foo-")'
         self.assertEqual(actual, expected)
 
     def test_resource_type_suffix(self):
-        actual = self._callFUT('resource', resource_type_suffix='-foo')
+        actual = self._call_fut('resource', resource_type_suffix='-foo')
         expected = 'resource.type = ends_with("-foo")'
         self.assertEqual(actual, expected)
 

--- a/monitoring/unit_tests/test_query.py
+++ b/monitoring/unit_tests/test_query.py
@@ -48,12 +48,12 @@ class TestAligner(unittest.TestCase):
         return Aligner
 
     def test_one(self):
-        self.assertTrue(hasattr(self._getTargetClass(), 'ALIGN_RATE'))
+        self.assertTrue(hasattr(self._get_target_class(), 'ALIGN_RATE'))
 
     def test_names(self):
-        for name in self._getTargetClass().__dict__:
+        for name in self._get_target_class().__dict__:
             if not name.startswith('_'):
-                self.assertEqual(getattr(self._getTargetClass(), name), name)
+                self.assertEqual(getattr(self._get_target_class(), name), name)
 
 
 class TestReducer(unittest.TestCase):
@@ -64,13 +64,13 @@ class TestReducer(unittest.TestCase):
         return Reducer
 
     def test_one(self):
-        self.assertTrue(hasattr(self._getTargetClass(),
+        self.assertTrue(hasattr(self._get_target_class(),
                                 'REDUCE_PERCENTILE_99'))
 
     def test_names(self):
-        for name in self._getTargetClass().__dict__:
+        for name in self._get_target_class().__dict__:
             if not name.startswith('_'):
-                self.assertEqual(getattr(self._getTargetClass(), name), name)
+                self.assertEqual(getattr(self._get_target_class(), name), name)
 
 
 class TestQuery(unittest.TestCase):
@@ -81,7 +81,7 @@ class TestQuery(unittest.TestCase):
         return Query
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     @staticmethod
     def _make_timestamp(value):
@@ -94,7 +94,7 @@ class TestQuery(unittest.TestCase):
 
         self.assertEqual(query._client, client)
         self.assertEqual(query._filter.metric_type,
-                         self._getTargetClass().DEFAULT_METRIC_TYPE)
+                         self._get_target_class().DEFAULT_METRIC_TYPE)
 
         self.assertIsNone(query._start_time)
         self.assertIsNone(query._end_time)
@@ -508,7 +508,7 @@ class Test_Filter(unittest.TestCase):
         return _Filter
 
     def _makeOne(self, metric_type):
-        return self._getTargetClass()(metric_type)
+        return self._get_target_class()(metric_type)
 
     def test_minimal(self):
         obj = self._makeOne(METRIC_TYPE)

--- a/monitoring/unit_tests/test_query.py
+++ b/monitoring/unit_tests/test_query.py
@@ -113,8 +113,8 @@ class TestQuery(unittest.TestCase):
 
         client = _Client(project=PROJECT, connection=_Connection())
         query = self._make_one(client, METRIC_TYPE,
-                              end_time=T1,
-                              days=DAYS, hours=HOURS, minutes=MINUTES)
+                               end_time=T1,
+                               days=DAYS, hours=HOURS, minutes=MINUTES)
 
         self.assertEqual(query._client, client)
         self.assertEqual(query._filter.metric_type, METRIC_TYPE)

--- a/monitoring/unit_tests/test_query.py
+++ b/monitoring/unit_tests/test_query.py
@@ -80,7 +80,7 @@ class TestQuery(unittest.TestCase):
         from google.cloud.monitoring.query import Query
         return Query
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     @staticmethod
@@ -90,7 +90,7 @@ class TestQuery(unittest.TestCase):
 
     def test_constructor_minimal(self):
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client)
+        query = self._make_one(client)
 
         self.assertEqual(query._client, client)
         self.assertEqual(query._filter.metric_type,
@@ -112,7 +112,7 @@ class TestQuery(unittest.TestCase):
         T0 = T1 - datetime.timedelta(days=DAYS, hours=HOURS, minutes=MINUTES)
 
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client, METRIC_TYPE,
+        query = self._make_one(client, METRIC_TYPE,
                               end_time=T1,
                               days=DAYS, hours=HOURS, minutes=MINUTES)
 
@@ -141,7 +141,7 @@ class TestQuery(unittest.TestCase):
 
         client = _Client(project=PROJECT, connection=_Connection())
         with _Monkey(MUT, _UTCNOW=lambda: NOW):
-            query = self._makeOne(client, METRIC_TYPE, minutes=MINUTES)
+            query = self._make_one(client, METRIC_TYPE, minutes=MINUTES)
 
         self.assertEqual(query._start_time, T0)
         self.assertEqual(query._end_time, T1)
@@ -151,29 +151,29 @@ class TestQuery(unittest.TestCase):
         T1 = datetime.datetime(2016, 4, 7, 2, 30, 30)
         client = _Client(project=PROJECT, connection=_Connection())
         with self.assertRaises(ValueError):
-            self._makeOne(client, METRIC_TYPE, end_time=T1)
+            self._make_one(client, METRIC_TYPE, end_time=T1)
 
     def test_execution_without_interval_illegal(self):
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         with self.assertRaises(ValueError):
             list(query)
 
     def test_metric_type(self):
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         self.assertEqual(query.metric_type, METRIC_TYPE)
 
     def test_filter(self):
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         expected = 'metric.type = "{type}"'.format(type=METRIC_TYPE)
         self.assertEqual(query.filter, expected)
 
     def test_filter_by_group(self):
         GROUP = '1234567'
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         query = query.select_group(GROUP)
         expected = (
             'metric.type = "{type}"'
@@ -184,7 +184,7 @@ class TestQuery(unittest.TestCase):
     def test_filter_by_projects(self):
         PROJECT1, PROJECT2 = 'project-1', 'project-2'
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         query = query.select_projects(PROJECT1, PROJECT2)
         expected = (
             'metric.type = "{type}"'
@@ -195,7 +195,7 @@ class TestQuery(unittest.TestCase):
     def test_filter_by_resources(self):
         ZONE_PREFIX = 'europe-'
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         query = query.select_resources(zone_prefix=ZONE_PREFIX)
         expected = (
             'metric.type = "{type}"'
@@ -206,7 +206,7 @@ class TestQuery(unittest.TestCase):
     def test_filter_by_metrics(self):
         INSTANCE = 'my-instance'
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         query = query.select_metrics(instance_name=INSTANCE)
         expected = (
             'metric.type = "{type}"'
@@ -220,7 +220,7 @@ class TestQuery(unittest.TestCase):
         T1 = datetime.datetime(2016, 4, 7, 2, 30, 0)
 
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         query = query.select_interval(end_time=T1)
         actual = list(query._build_query_params())
         expected = [
@@ -245,7 +245,7 @@ class TestQuery(unittest.TestCase):
         PAGE_TOKEN = 'second-page-please'
 
         client = _Client(project=PROJECT, connection=_Connection())
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         query = query.select_interval(start_time=T0, end_time=T1)
         query = query.align(ALIGNER, minutes=MINUTES, seconds=SECONDS)
         query = query.reduce(REDUCER, FIELD1, FIELD2)
@@ -304,7 +304,7 @@ class TestQuery(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=PROJECT, connection=connection)
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         query = query.select_interval(start_time=T0, end_time=T1)
         response = list(query)
 
@@ -384,7 +384,7 @@ class TestQuery(unittest.TestCase):
 
         connection = _Connection(RESPONSE1, RESPONSE2)
         client = _Client(project=PROJECT, connection=connection)
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         query = query.select_interval(start_time=T0, end_time=T1)
         response = list(query)
 
@@ -429,7 +429,7 @@ class TestQuery(unittest.TestCase):
 
         connection = _Connection({})
         client = _Client(project=PROJECT, connection=connection)
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         query = query.select_interval(start_time=T0, end_time=T1)
         response = list(query)
 
@@ -470,7 +470,7 @@ class TestQuery(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=PROJECT, connection=connection)
-        query = self._makeOne(client, METRIC_TYPE)
+        query = self._make_one(client, METRIC_TYPE)
         query = query.select_interval(start_time=T0, end_time=T1)
         response = list(query.iter(headers_only=True))
 
@@ -507,16 +507,16 @@ class Test_Filter(unittest.TestCase):
         from google.cloud.monitoring.query import _Filter
         return _Filter
 
-    def _makeOne(self, metric_type):
+    def _make_one(self, metric_type):
         return self._get_target_class()(metric_type)
 
     def test_minimal(self):
-        obj = self._makeOne(METRIC_TYPE)
+        obj = self._make_one(METRIC_TYPE)
         expected = 'metric.type = "{type}"'.format(type=METRIC_TYPE)
         self.assertEqual(str(obj), expected)
 
     def test_maximal(self):
-        obj = self._makeOne(METRIC_TYPE)
+        obj = self._make_one(METRIC_TYPE)
         obj.group_id = '1234567'
         obj.projects = 'project-1', 'project-2'
         obj.select_resources(resource_type='some-resource',

--- a/monitoring/unit_tests/test_resource.py
+++ b/monitoring/unit_tests/test_resource.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestResourceDescriptor(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.resource import ResourceDescriptor
         return ResourceDescriptor
 
@@ -276,7 +277,8 @@ class TestResourceDescriptor(unittest.TestCase):
 
 class TestResource(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.resource import Resource
         return Resource
 

--- a/monitoring/unit_tests/test_resource.py
+++ b/monitoring/unit_tests/test_resource.py
@@ -22,7 +22,7 @@ class TestResourceDescriptor(unittest.TestCase):
         from google.cloud.monitoring.resource import ResourceDescriptor
         return ResourceDescriptor
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
@@ -41,7 +41,7 @@ class TestResourceDescriptor(unittest.TestCase):
                             description='The GCE zone...'),
         ]
 
-        descriptor = self._makeOne(
+        descriptor = self._make_one(
             name=NAME,
             type_=TYPE,
             display_name=DISPLAY_NAME,
@@ -282,7 +282,7 @@ class TestResource(unittest.TestCase):
         from google.cloud.monitoring.resource import Resource
         return Resource
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
@@ -292,7 +292,7 @@ class TestResource(unittest.TestCase):
             'instance_id': '1234567890123456789',
             'zone': 'us-central1-a',
         }
-        resource = self._makeOne(type=TYPE, labels=LABELS)
+        resource = self._make_one(type=TYPE, labels=LABELS)
         self.assertEqual(resource.type, TYPE)
         self.assertEqual(resource.labels, LABELS)
 
@@ -324,7 +324,7 @@ class TestResource(unittest.TestCase):
             'instance_id': '1234567890123456789',
             'zone': 'us-central1-a',
         }
-        resource = self._makeOne(TYPE, LABELS)
+        resource = self._make_one(TYPE, LABELS)
         expected_dict = {
             'type': TYPE,
             'labels': LABELS,

--- a/monitoring/unit_tests/test_resource.py
+++ b/monitoring/unit_tests/test_resource.py
@@ -23,7 +23,7 @@ class TestResourceDescriptor(unittest.TestCase):
         return ResourceDescriptor
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         from google.cloud.monitoring.label import LabelDescriptor
@@ -74,7 +74,7 @@ class TestResourceDescriptor(unittest.TestCase):
             'description': DESCRIPTION,
             'labels': [LABEL1, LABEL2, LABEL3],
         }
-        descriptor = self._getTargetClass()._from_dict(info)
+        descriptor = self._get_target_class()._from_dict(info)
 
         self.assertEqual(descriptor.name, NAME)
         self.assertEqual(descriptor.type, TYPE)
@@ -95,7 +95,7 @@ class TestResourceDescriptor(unittest.TestCase):
             'name': NAME,
             'type': TYPE,
         }
-        descriptor = self._getTargetClass()._from_dict(info)
+        descriptor = self._get_target_class()._from_dict(info)
 
         self.assertEqual(descriptor.name, NAME)
         self.assertEqual(descriptor.type, TYPE)
@@ -127,7 +127,7 @@ class TestResourceDescriptor(unittest.TestCase):
 
         connection = _Connection(RESOURCE_DESCRIPTOR)
         client = _Client(project=PROJECT, connection=connection)
-        descriptor = self._getTargetClass()._fetch(client, TYPE)
+        descriptor = self._get_target_class()._fetch(client, TYPE)
 
         self.assertEqual(descriptor.name, NAME)
         self.assertEqual(descriptor.type, TYPE)
@@ -174,7 +174,7 @@ class TestResourceDescriptor(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=PROJECT, connection=connection)
-        descriptors = self._getTargetClass()._list(client)
+        descriptors = self._get_target_class()._list(client)
 
         self.assertEqual(len(descriptors), 2)
         descriptor1, descriptor2 = descriptors
@@ -228,7 +228,7 @@ class TestResourceDescriptor(unittest.TestCase):
 
         connection = _Connection(RESPONSE1, RESPONSE2)
         client = _Client(project=PROJECT, connection=connection)
-        descriptors = self._getTargetClass()._list(client)
+        descriptors = self._get_target_class()._list(client)
 
         self.assertEqual(len(descriptors), 2)
         descriptor1, descriptor2 = descriptors
@@ -250,7 +250,7 @@ class TestResourceDescriptor(unittest.TestCase):
         self.assertEqual(request2, expected_request2)
 
         with self.assertRaises(NotFound):
-            self._getTargetClass()._list(client)
+            self._get_target_class()._list(client)
 
     def test_list_filtered(self):
         PROJECT = 'my-project'
@@ -265,7 +265,7 @@ class TestResourceDescriptor(unittest.TestCase):
 
         connection = _Connection(RESPONSE)
         client = _Client(project=PROJECT, connection=connection)
-        descriptors = self._getTargetClass()._list(client, FILTER)
+        descriptors = self._get_target_class()._list(client, FILTER)
 
         self.assertEqual(len(descriptors), 0)
 
@@ -283,7 +283,7 @@ class TestResource(unittest.TestCase):
         return Resource
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         TYPE = 'gce_instance'
@@ -307,14 +307,14 @@ class TestResource(unittest.TestCase):
             'type': TYPE,
             'labels': LABELS,
         }
-        resource = self._getTargetClass()._from_dict(info)
+        resource = self._get_target_class()._from_dict(info)
         self.assertEqual(resource.type, TYPE)
         self.assertEqual(resource.labels, LABELS)
 
     def test_from_dict_defaults(self):
         TYPE = 'gce_instance'
         info = {'type': TYPE}
-        resource = self._getTargetClass()._from_dict(info)
+        resource = self._get_target_class()._from_dict(info)
         self.assertEqual(resource.type, TYPE)
         self.assertEqual(resource.labels, {})
 

--- a/monitoring/unit_tests/test_timeseries.py
+++ b/monitoring/unit_tests/test_timeseries.py
@@ -56,10 +56,10 @@ class TestTimeSeries(unittest.TestCase):
         ]
 
         series = self._make_one(metric=METRIC,
-                               resource=RESOURCE,
-                               metric_kind=METRIC_KIND,
-                               value_type=VALUE_TYPE,
-                               points=POINTS)
+                                resource=RESOURCE,
+                                metric_kind=METRIC_KIND,
+                                value_type=VALUE_TYPE,
+                                points=POINTS)
 
         self.assertEqual(series.metric, METRIC)
         self.assertEqual(series.resource, RESOURCE)
@@ -174,8 +174,8 @@ class TestTimeSeries(unittest.TestCase):
         }
 
         series = self._make_one(metric=METRIC, resource=RESOURCE,
-                               metric_kind=None, value_type=None,
-                               points=[POINT])
+                                metric_kind=None, value_type=None,
+                                points=[POINT])
         series_dict = series._to_dict()
         self.assertEqual(info, series_dict)
 
@@ -236,7 +236,7 @@ class TestPoint(unittest.TestCase):
         end_time = datetime.datetime.now()
         end_time_str = _datetime_to_rfc3339(end_time, ignore_zone=False)
         point = self._make_one(end_time=end_time_str, start_time=None,
-                              value=VALUE)
+                               value=VALUE)
         info = {
             'interval': {'endTime': end_time_str},
             'value': {'int64Value': str(VALUE)},
@@ -254,8 +254,8 @@ class TestPoint(unittest.TestCase):
         end_time = datetime.datetime.now()
         end_time_str = _datetime_to_rfc3339(end_time, ignore_zone=False)
 
-        point = self._make_one(end_time=end_time_str, start_time=start_time_str,
-                              value=VALUE)
+        point = self._make_one(end_time=end_time_str,
+                               start_time=start_time_str, value=VALUE)
         info = {
             'interval': {
                 'startTime': start_time_str,

--- a/monitoring/unit_tests/test_timeseries.py
+++ b/monitoring/unit_tests/test_timeseries.py
@@ -33,7 +33,8 @@ TS2 = '2016-04-06T22:05:02.042Z'
 
 
 class TestTimeSeries(unittest.TestCase):
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.timeseries import TimeSeries
         return TimeSeries
 
@@ -180,7 +181,8 @@ class TestTimeSeries(unittest.TestCase):
 
 
 class TestPoint(unittest.TestCase):
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.monitoring.timeseries import Point
         return Point
 

--- a/monitoring/unit_tests/test_timeseries.py
+++ b/monitoring/unit_tests/test_timeseries.py
@@ -39,7 +39,7 @@ class TestTimeSeries(unittest.TestCase):
         return TimeSeries
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         from google.cloud.monitoring.metric import Metric
@@ -87,7 +87,7 @@ class TestTimeSeries(unittest.TestCase):
             ],
         }
 
-        series = self._getTargetClass()._from_dict(info)
+        series = self._get_target_class()._from_dict(info)
 
         self.assertEqual(series.metric.type, METRIC_TYPE)
         self.assertEqual(series.metric.labels, METRIC_LABELS)
@@ -116,7 +116,7 @@ class TestTimeSeries(unittest.TestCase):
             'valueType': VALUE_TYPE,
         }
 
-        series = self._getTargetClass()._from_dict(info)
+        series = self._get_target_class()._from_dict(info)
 
         self.assertEqual(series.metric.type, METRIC_TYPE)
         self.assertEqual(series.metric.labels, METRIC_LABELS)
@@ -136,7 +136,7 @@ class TestTimeSeries(unittest.TestCase):
             'valueType': VALUE_TYPE,
         }
 
-        series = self._getTargetClass()._from_dict(info)
+        series = self._get_target_class()._from_dict(info)
 
         labels = {'resource_type': RESOURCE_TYPE}
         labels.update(RESOURCE_LABELS)
@@ -187,7 +187,7 @@ class TestPoint(unittest.TestCase):
         return Point
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         VALUE = 3.14
@@ -202,7 +202,7 @@ class TestPoint(unittest.TestCase):
             'interval': {'startTime': TS0, 'endTime': TS1},
             'value': {'doubleValue': VALUE},
         }
-        point = self._getTargetClass()._from_dict(info)
+        point = self._get_target_class()._from_dict(info)
         self.assertEqual(point.start_time, TS0)
         self.assertEqual(point.end_time, TS1)
         self.assertEqual(point.value, VALUE)
@@ -213,7 +213,7 @@ class TestPoint(unittest.TestCase):
             'interval': {'endTime': TS1},
             'value': {'doubleValue': VALUE},
         }
-        point = self._getTargetClass()._from_dict(info)
+        point = self._get_target_class()._from_dict(info)
         self.assertIsNone(point.start_time)
         self.assertEqual(point.end_time, TS1)
         self.assertEqual(point.value, VALUE)
@@ -224,7 +224,7 @@ class TestPoint(unittest.TestCase):
             'interval': {'endTime': TS1},
             'value': {'int64Value': str(VALUE)},
         }
-        point = self._getTargetClass()._from_dict(info)
+        point = self._get_target_class()._from_dict(info)
         self.assertIsNone(point.start_time)
         self.assertEqual(point.end_time, TS1)
         self.assertEqual(point.value, VALUE)

--- a/monitoring/unit_tests/test_timeseries.py
+++ b/monitoring/unit_tests/test_timeseries.py
@@ -38,7 +38,7 @@ class TestTimeSeries(unittest.TestCase):
         from google.cloud.monitoring.timeseries import TimeSeries
         return TimeSeries
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
@@ -55,7 +55,7 @@ class TestTimeSeries(unittest.TestCase):
             Point(start_time=TS1, end_time=TS2, value=VALUE),
         ]
 
-        series = self._makeOne(metric=METRIC,
+        series = self._make_one(metric=METRIC,
                                resource=RESOURCE,
                                metric_kind=METRIC_KIND,
                                value_type=VALUE_TYPE,
@@ -173,7 +173,7 @@ class TestTimeSeries(unittest.TestCase):
             }]
         }
 
-        series = self._makeOne(metric=METRIC, resource=RESOURCE,
+        series = self._make_one(metric=METRIC, resource=RESOURCE,
                                metric_kind=None, value_type=None,
                                points=[POINT])
         series_dict = series._to_dict()
@@ -186,12 +186,12 @@ class TestPoint(unittest.TestCase):
         from google.cloud.monitoring.timeseries import Point
         return Point
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         VALUE = 3.14
-        point = self._makeOne(start_time=TS0, end_time=TS1, value=VALUE)
+        point = self._make_one(start_time=TS0, end_time=TS1, value=VALUE)
         self.assertEqual(point.start_time, TS0)
         self.assertEqual(point.end_time, TS1)
         self.assertEqual(point.value, VALUE)
@@ -235,7 +235,7 @@ class TestPoint(unittest.TestCase):
         VALUE = 42
         end_time = datetime.datetime.now()
         end_time_str = _datetime_to_rfc3339(end_time, ignore_zone=False)
-        point = self._makeOne(end_time=end_time_str, start_time=None,
+        point = self._make_one(end_time=end_time_str, start_time=None,
                               value=VALUE)
         info = {
             'interval': {'endTime': end_time_str},
@@ -254,7 +254,7 @@ class TestPoint(unittest.TestCase):
         end_time = datetime.datetime.now()
         end_time_str = _datetime_to_rfc3339(end_time, ignore_zone=False)
 
-        point = self._makeOne(end_time=end_time_str, start_time=start_time_str,
+        point = self._make_one(end_time=end_time_str, start_time=start_time_str,
                               value=VALUE)
         info = {
             'interval': {

--- a/pubsub/unit_tests/test__gax.py
+++ b/pubsub/unit_tests/test__gax.py
@@ -44,7 +44,8 @@ class _Base(object):
 @unittest.skipUnless(_HAVE_GAX, 'No gax-python')
 class Test_PublisherAPI(_Base, unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub._gax import _PublisherAPI
         return _PublisherAPI
 
@@ -401,7 +402,8 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     PUSH_ENDPOINT = 'https://api.example.com/push'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub._gax import _SubscriberAPI
         return _SubscriberAPI
 

--- a/pubsub/unit_tests/test__gax.py
+++ b/pubsub/unit_tests/test__gax.py
@@ -37,7 +37,7 @@ class _Base(object):
     SUB_NAME = 'sub_name'
     SUB_PATH = '%s/subscriptions/%s' % (TOPIC_PATH, SUB_NAME)
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
 
@@ -52,7 +52,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_ctor(self):
         gax_api = _GAXPublisherAPI()
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
         self.assertIs(api._gax_api, gax_api)
         self.assertIs(api._client, client)
 
@@ -66,7 +66,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
                                     page_token=TOKEN)
         gax_api = _GAXPublisherAPI(_list_topics_response=response)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_topics(self.PROJECT)
         topics = list(iterator)
@@ -95,7 +95,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
             [_TopicPB(self.TOPIC_PATH)], page_token=NEW_TOKEN)
         gax_api = _GAXPublisherAPI(_list_topics_response=response)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_topics(
             self.PROJECT, page_size=SIZE, page_token=TOKEN)
@@ -118,7 +118,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         topic_pb = _TopicPB(self.TOPIC_PATH)
         gax_api = _GAXPublisherAPI(_create_topic_response=topic_pb)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         resource = api.topic_create(self.TOPIC_PATH)
 
@@ -131,7 +131,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         from google.cloud.exceptions import Conflict
         gax_api = _GAXPublisherAPI(_create_topic_conflict=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(Conflict):
             api.topic_create(self.TOPIC_PATH)
@@ -144,7 +144,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         from google.gax.errors import GaxError
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.topic_create(self.TOPIC_PATH)
@@ -157,7 +157,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         topic_pb = _TopicPB(self.TOPIC_PATH)
         gax_api = _GAXPublisherAPI(_get_topic_response=topic_pb)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         resource = api.topic_get(self.TOPIC_PATH)
 
@@ -170,7 +170,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXPublisherAPI()
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.topic_get(self.TOPIC_PATH)
@@ -183,7 +183,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         from google.gax.errors import GaxError
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.topic_get(self.TOPIC_PATH)
@@ -195,7 +195,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_delete_hit(self):
         gax_api = _GAXPublisherAPI(_delete_topic_ok=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         api.topic_delete(self.TOPIC_PATH)
 
@@ -207,7 +207,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXPublisherAPI(_delete_topic_ok=False)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.topic_delete(self.TOPIC_PATH)
@@ -220,7 +220,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         from google.gax.errors import GaxError
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.topic_delete(self.TOPIC_PATH)
@@ -238,7 +238,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         response = _PublishResponsePB([MSGID])
         gax_api = _GAXPublisherAPI(_publish_response=response)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         resource = api.topic_publish(self.TOPIC_PATH, [MESSAGE])
 
@@ -258,7 +258,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         MESSAGE = {'data': B64, 'attributes': {'foo': 'bar'}}
         gax_api = _GAXPublisherAPI()
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.topic_publish(self.TOPIC_PATH, [MESSAGE])
@@ -278,7 +278,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         MESSAGE = {'data': B64, 'attributes': {}}
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.topic_publish(self.TOPIC_PATH, [MESSAGE])
@@ -301,7 +301,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([local_sub_path])
         gax_api = _GAXPublisherAPI(_list_topic_subscriptions_response=response)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         topic = Topic(self.TOPIC_NAME, client)
         iterator = api.topic_list_subscriptions(topic)
@@ -336,7 +336,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
             [local_sub_path], page_token=NEW_TOKEN)
         gax_api = _GAXPublisherAPI(_list_topic_subscriptions_response=response)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         topic = Topic(self.TOPIC_NAME, client)
         iterator = api.topic_list_subscriptions(
@@ -365,7 +365,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
         gax_api = _GAXPublisherAPI()
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(NotFound):
             topic = Topic(self.TOPIC_NAME, client)
@@ -384,7 +384,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             topic = Topic(self.TOPIC_NAME, client)
@@ -410,7 +410,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
     def test_ctor(self):
         gax_api = _GAXSubscriberAPI()
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
         self.assertIs(api._gax_api, gax_api)
         self.assertIs(api._client, client)
 
@@ -432,7 +432,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         gax_api = _GAXSubscriberAPI(_list_subscriptions_response=response)
         creds = _Credentials()
         client = Client(project=self.PROJECT, credentials=creds)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_subscriptions(self.PROJECT)
         subscriptions = list(iterator)
@@ -478,7 +478,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         client = _Client(self.PROJECT)
         creds = _Credentials()
         client = Client(project=self.PROJECT, credentials=creds)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         iterator = api.list_subscriptions(
             self.PROJECT, page_size=SIZE, page_token=TOKEN)
@@ -510,7 +510,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         sub_pb = Subscription(name=self.SUB_PATH, topic=self.TOPIC_PATH)
         gax_api = _GAXSubscriberAPI(_create_subscription_response=sub_pb)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         resource = api.subscription_create(self.SUB_PATH, self.TOPIC_PATH)
 
@@ -532,7 +532,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         DEADLINE = 600
         gax_api = _GAXSubscriberAPI(_create_subscription_conflict=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(Conflict):
             api.subscription_create(
@@ -550,7 +550,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         from google.gax.errors import GaxError
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.subscription_create(self.SUB_PATH, self.TOPIC_PATH)
@@ -572,7 +572,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
                               push_config=push_cfg_pb)
         gax_api = _GAXSubscriberAPI(_get_subscription_response=sub_pb)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         resource = api.subscription_get(self.SUB_PATH)
 
@@ -592,7 +592,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXSubscriberAPI()
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.subscription_get(self.SUB_PATH)
@@ -605,7 +605,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         from google.gax.errors import GaxError
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.subscription_get(self.SUB_PATH)
@@ -617,7 +617,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
     def test_subscription_delete_hit(self):
         gax_api = _GAXSubscriberAPI(_delete_subscription_ok=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         api.subscription_delete(self.TOPIC_PATH)
 
@@ -629,7 +629,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXSubscriberAPI(_delete_subscription_ok=False)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.subscription_delete(self.TOPIC_PATH)
@@ -642,7 +642,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         from google.gax.errors import GaxError
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.subscription_delete(self.TOPIC_PATH)
@@ -654,7 +654,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
     def test_subscription_modify_push_config_hit(self):
         gax_api = _GAXSubscriberAPI(_modify_push_config_ok=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         api.subscription_modify_push_config(self.SUB_PATH, self.PUSH_ENDPOINT)
 
@@ -667,7 +667,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXSubscriberAPI()
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.subscription_modify_push_config(
@@ -682,7 +682,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         from google.gax.errors import GaxError
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.subscription_modify_push_config(
@@ -718,7 +718,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         response_pb = _PullResponsePB([_ReceivedMessagePB(ACK_ID, message_pb)])
         gax_api = _GAXSubscriberAPI(_pull_response=response_pb)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
         MAX_MESSAGES = 10
 
         received = api.subscription_pull(
@@ -736,7 +736,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         from google.cloud.exceptions import NotFound
         gax_api = _GAXSubscriberAPI()
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.subscription_pull(self.SUB_PATH)
@@ -752,7 +752,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         from google.gax.errors import GaxError
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.subscription_pull(self.SUB_PATH)
@@ -769,7 +769,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         ACK_ID2 = 'BEADCAFE'
         gax_api = _GAXSubscriberAPI(_acknowledge_ok=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         api.subscription_acknowledge(self.SUB_PATH, [ACK_ID1, ACK_ID2])
 
@@ -784,7 +784,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         ACK_ID2 = 'BEADCAFE'
         gax_api = _GAXSubscriberAPI()
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.subscription_acknowledge(self.SUB_PATH, [ACK_ID1, ACK_ID2])
@@ -800,7 +800,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         ACK_ID2 = 'BEADCAFE'
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.subscription_acknowledge(self.SUB_PATH, [ACK_ID1, ACK_ID2])
@@ -816,7 +816,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         NEW_DEADLINE = 90
         gax_api = _GAXSubscriberAPI(_modify_ack_deadline_ok=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         api.subscription_modify_ack_deadline(
             self.SUB_PATH, [ACK_ID1, ACK_ID2], NEW_DEADLINE)
@@ -835,7 +835,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         NEW_DEADLINE = 90
         gax_api = _GAXSubscriberAPI()
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(NotFound):
             api.subscription_modify_ack_deadline(
@@ -855,7 +855,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         NEW_DEADLINE = 90
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
-        api = self._makeOne(gax_api, client)
+        api = self._make_one(gax_api, client)
 
         with self.assertRaises(GaxError):
             api.subscription_modify_ack_deadline(

--- a/pubsub/unit_tests/test__gax.py
+++ b/pubsub/unit_tests/test__gax.py
@@ -872,7 +872,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 @unittest.skipUnless(_HAVE_GAX, 'No gax-python')
 class Test_make_gax_publisher_api(_Base, unittest.TestCase):
 
-    def _callFUT(self, connection):
+    def _call_fut(self, connection):
         from google.cloud.pubsub._gax import make_gax_publisher_api
         return make_gax_publisher_api(connection)
 
@@ -901,7 +901,7 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
                                  credentials=creds)
         with _Monkey(MUT, PublisherApi=mock_publisher_api,
                      make_secure_channel=make_channel):
-            result = self._callFUT(connection)
+            result = self._call_fut(connection)
 
         self.assertIs(result, mock_result)
         self.assertEqual(channels, [channel_obj])
@@ -929,7 +929,7 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
         connection = _Connection(in_emulator=True, host=host)
         with _Monkey(MUT, PublisherApi=mock_publisher_api,
                      insecure_channel=mock_insecure_channel):
-            result = self._callFUT(connection)
+            result = self._call_fut(connection)
 
         self.assertIs(result, mock_result)
         self.assertEqual(channels, [mock_channel])
@@ -939,7 +939,7 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
 @unittest.skipUnless(_HAVE_GAX, 'No gax-python')
 class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
 
-    def _callFUT(self, connection):
+    def _call_fut(self, connection):
         from google.cloud.pubsub._gax import make_gax_subscriber_api
         return make_gax_subscriber_api(connection)
 
@@ -968,7 +968,7 @@ class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
                                  credentials=creds)
         with _Monkey(MUT, SubscriberApi=mock_subscriber_api,
                      make_secure_channel=make_channel):
-            result = self._callFUT(connection)
+            result = self._call_fut(connection)
 
         self.assertIs(result, mock_result)
         self.assertEqual(channels, [channel_obj])
@@ -996,7 +996,7 @@ class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
         connection = _Connection(in_emulator=True, host=host)
         with _Monkey(MUT, SubscriberApi=mock_subscriber_api,
                      insecure_channel=mock_insecure_channel):
-            result = self._callFUT(connection)
+            result = self._call_fut(connection)
 
         self.assertIs(result, mock_result)
         self.assertEqual(channels, [mock_channel])

--- a/pubsub/unit_tests/test__gax.py
+++ b/pubsub/unit_tests/test__gax.py
@@ -38,7 +38,7 @@ class _Base(object):
     SUB_PATH = '%s/subscriptions/%s' % (TOPIC_PATH, SUB_NAME)
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
 
 @unittest.skipUnless(_HAVE_GAX, 'No gax-python')

--- a/pubsub/unit_tests/test__helpers.py
+++ b/pubsub/unit_tests/test__helpers.py
@@ -17,7 +17,7 @@ import unittest
 
 class Test_topic_name_from_path(unittest.TestCase):
 
-    def _callFUT(self, path, project):
+    def _call_fut(self, path, project):
         from google.cloud.pubsub._helpers import topic_name_from_path
         return topic_name_from_path(path, project)
 
@@ -25,20 +25,20 @@ class Test_topic_name_from_path(unittest.TestCase):
         TOPIC_NAME = 'TOPIC_NAME'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        topic_name = self._callFUT(PATH, PROJECT)
+        topic_name = self._call_fut(PATH, PROJECT)
         self.assertEqual(topic_name, TOPIC_NAME)
 
     def test_w_name_w_all_extras(self):
         TOPIC_NAME = 'TOPIC_NAME-part.one~part.two%part-three'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
-        topic_name = self._callFUT(PATH, PROJECT)
+        topic_name = self._call_fut(PATH, PROJECT)
         self.assertEqual(topic_name, TOPIC_NAME)
 
 
 class Test_subscription_name_from_path(unittest.TestCase):
 
-    def _callFUT(self, path, project):
+    def _call_fut(self, path, project):
         from google.cloud.pubsub._helpers import subscription_name_from_path
         return subscription_name_from_path(path, project)
 
@@ -46,12 +46,12 @@ class Test_subscription_name_from_path(unittest.TestCase):
         SUBSCRIPTION_NAME = 'SUBSCRIPTION_NAME'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUBSCRIPTION_NAME)
-        subscription_name = self._callFUT(PATH, PROJECT)
+        subscription_name = self._call_fut(PATH, PROJECT)
         self.assertEqual(subscription_name, SUBSCRIPTION_NAME)
 
     def test_w_name_w_all_extras(self):
         SUBSCRIPTION_NAME = 'SUBSCRIPTION_NAME-part.one~part.two%part-three'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUBSCRIPTION_NAME)
-        topic_name = self._callFUT(PATH, PROJECT)
+        topic_name = self._call_fut(PATH, PROJECT)
         self.assertEqual(topic_name, SUBSCRIPTION_NAME)

--- a/pubsub/unit_tests/test__http.py
+++ b/pubsub/unit_tests/test__http.py
@@ -25,7 +25,7 @@ class _Base(unittest.TestCase):
     SUB_NAME = 'subscription_name'
     SUB_PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
 
@@ -37,7 +37,7 @@ class TestConnection(_Base):
         return Connection
 
     def test_default_url(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         klass = self._get_target_class()
         self.assertEqual(conn.api_base_url, klass.API_BASE_URL)
 
@@ -50,14 +50,14 @@ class TestConnection(_Base):
         fake_environ = {PUBSUB_EMULATOR: HOST}
 
         with _Monkey(os, getenv=fake_environ.get):
-            conn = self._makeOne()
+            conn = self._make_one()
 
         klass = self._get_target_class()
         self.assertNotEqual(conn.api_base_url, klass.API_BASE_URL)
         self.assertEqual(conn.api_base_url, 'http://' + HOST)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.API_BASE_URL,
             conn.API_VERSION,
@@ -68,7 +68,7 @@ class TestConnection(_Base):
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
-        conn = self._makeOne()
+        conn = self._make_one()
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)
@@ -80,7 +80,7 @@ class TestConnection(_Base):
     def test_build_api_url_w_base_url_override(self):
         base_url1 = 'api-base-url1'
         base_url2 = 'api-base-url2'
-        conn = self._makeOne()
+        conn = self._make_one()
         conn.api_base_url = base_url1
         URI = '/'.join([
             base_url2,
@@ -98,13 +98,13 @@ class Test_PublisherAPI(_Base):
         from google.cloud.pubsub._http import _PublisherAPI
         return _PublisherAPI
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         connection = _Connection()
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
         self.assertIs(api._client, client)
         self.assertIs(api._connection, connection)
 
@@ -114,7 +114,7 @@ class Test_PublisherAPI(_Base):
         returned = {'topics': [{'name': self.TOPIC_PATH}]}
         connection = _Connection(returned)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_topics(self.PROJECT)
         topics = list(iterator)
@@ -145,7 +145,7 @@ class Test_PublisherAPI(_Base):
         }
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_topics(
             self.PROJECT, page_token=TOKEN1, page_size=SIZE)
@@ -170,7 +170,7 @@ class Test_PublisherAPI(_Base):
         returned = {}
         connection = _Connection(returned)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_topics(self.PROJECT)
         topics = list(iterator)
@@ -188,7 +188,7 @@ class Test_PublisherAPI(_Base):
         RETURNED = {'name': self.TOPIC_PATH}
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         resource = api.topic_create(self.TOPIC_PATH)
 
@@ -202,7 +202,7 @@ class Test_PublisherAPI(_Base):
         connection = _Connection()
         connection._no_response_error = Conflict
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(Conflict):
             api.topic_create(self.TOPIC_PATH)
@@ -215,7 +215,7 @@ class Test_PublisherAPI(_Base):
         RETURNED = {'name': self.TOPIC_PATH}
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         resource = api.topic_get(self.TOPIC_PATH)
 
@@ -228,7 +228,7 @@ class Test_PublisherAPI(_Base):
         from google.cloud.exceptions import NotFound
         connection = _Connection()
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(NotFound):
             api.topic_get(self.TOPIC_PATH)
@@ -241,7 +241,7 @@ class Test_PublisherAPI(_Base):
         RETURNED = {}
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.topic_delete(self.TOPIC_PATH)
 
@@ -253,7 +253,7 @@ class Test_PublisherAPI(_Base):
         from google.cloud.exceptions import NotFound
         connection = _Connection()
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(NotFound):
             api.topic_delete(self.TOPIC_PATH)
@@ -272,7 +272,7 @@ class Test_PublisherAPI(_Base):
         RETURNED = {'messageIds': [MSGID]}
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         resource = api.topic_publish(self.TOPIC_PATH, [MESSAGE])
 
@@ -291,7 +291,7 @@ class Test_PublisherAPI(_Base):
         MESSAGE = {'data': PAYLOAD, 'attributes': {}}
         connection = _Connection()
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(NotFound):
             api.topic_publish(self.TOPIC_PATH, [MESSAGE])
@@ -311,7 +311,7 @@ class Test_PublisherAPI(_Base):
         RETURNED = {'subscriptions': [local_sub_path]}
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         topic = Topic(self.TOPIC_NAME, client)
         iterator = api.topic_list_subscriptions(topic)
@@ -347,7 +347,7 @@ class Test_PublisherAPI(_Base):
         }
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         topic = Topic(self.TOPIC_NAME, client)
         iterator = api.topic_list_subscriptions(
@@ -375,7 +375,7 @@ class Test_PublisherAPI(_Base):
 
         connection = _Connection({})
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         topic = Topic(self.TOPIC_NAME, client)
         iterator = api.topic_list_subscriptions(topic)
@@ -396,7 +396,7 @@ class Test_PublisherAPI(_Base):
 
         connection = _Connection()
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         with self.assertRaises(NotFound):
             topic = Topic(self.TOPIC_NAME, client)
@@ -415,13 +415,13 @@ class Test_SubscriberAPI(_Base):
         from google.cloud.pubsub._http import _SubscriberAPI
         return _SubscriberAPI
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         connection = _Connection()
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
         self.assertIs(api._connection, connection)
         self.assertIs(api._client, client)
 
@@ -436,7 +436,7 @@ class Test_SubscriberAPI(_Base):
         creds = _Credentials()
         client = Client(project=self.PROJECT, credentials=creds)
         client.connection = connection
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_subscriptions(self.PROJECT)
         subscriptions = list(iterator)
@@ -479,7 +479,7 @@ class Test_SubscriberAPI(_Base):
         creds = _Credentials()
         client = Client(project=self.PROJECT, credentials=creds)
         client.connection = connection
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_subscriptions(
             self.PROJECT, page_token=TOKEN1, page_size=SIZE)
@@ -511,7 +511,7 @@ class Test_SubscriberAPI(_Base):
         RETURNED = {}
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         iterator = api.list_subscriptions(self.PROJECT)
         subscriptions = list(iterator)
@@ -531,7 +531,7 @@ class Test_SubscriberAPI(_Base):
         RETURNED['name'] = self.SUB_PATH
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         resource = api.subscription_create(self.SUB_PATH, self.TOPIC_PATH)
 
@@ -555,7 +555,7 @@ class Test_SubscriberAPI(_Base):
         RETURNED['name'] = self.SUB_PATH
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         resource = api.subscription_create(
             self.SUB_PATH, self.TOPIC_PATH,
@@ -578,7 +578,7 @@ class Test_SubscriberAPI(_Base):
         }
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         resource = api.subscription_get(self.SUB_PATH)
 
@@ -591,7 +591,7 @@ class Test_SubscriberAPI(_Base):
         RETURNED = {}
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.subscription_delete(self.SUB_PATH)
 
@@ -607,7 +607,7 @@ class Test_SubscriberAPI(_Base):
         RETURNED = {}
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.subscription_modify_push_config(self.SUB_PATH, PUSH_ENDPOINT)
 
@@ -628,7 +628,7 @@ class Test_SubscriberAPI(_Base):
         }
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
         BODY = {
             'returnImmediately': False,
             'maxMessages': 1,
@@ -655,7 +655,7 @@ class Test_SubscriberAPI(_Base):
         }
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
         MAX_MESSAGES = 10
         BODY = {
             'returnImmediately': True,
@@ -680,7 +680,7 @@ class Test_SubscriberAPI(_Base):
         RETURNED = {}
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.subscription_acknowledge(self.SUB_PATH, [ACK_ID1, ACK_ID2])
 
@@ -700,7 +700,7 @@ class Test_SubscriberAPI(_Base):
         RETURNED = {}
         connection = _Connection(RETURNED)
         client = _Client(connection, self.PROJECT)
-        api = self._makeOne(client)
+        api = self._make_one(client)
 
         api.subscription_modify_ack_deadline(
             self.SUB_PATH, [ACK_ID1, ACK_ID2], NEW_DEADLINE)
@@ -720,7 +720,7 @@ class Test_IAMPolicyAPI(_Base):
 
     def test_ctor(self):
         connection = _Connection()
-        api = self._makeOne(connection)
+        api = self._make_one(connection)
         self.assertIs(api._connection, connection)
 
     def test_get_iam_policy(self):
@@ -744,7 +744,7 @@ class Test_IAMPolicyAPI(_Base):
             ],
         }
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        api = self._make_one(connection)
 
         policy = api.get_iam_policy(self.TOPIC_PATH)
 
@@ -775,7 +775,7 @@ class Test_IAMPolicyAPI(_Base):
         }
         RETURNED = POLICY.copy()
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        api = self._make_one(connection)
 
         policy = api.set_iam_policy(self.TOPIC_PATH, POLICY)
 
@@ -795,7 +795,7 @@ class Test_IAMPolicyAPI(_Base):
         ALLOWED = ALL_ROLES[1:]
         RETURNED = {'permissions': ALLOWED}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        api = self._make_one(connection)
 
         allowed = api.test_iam_permissions(self.TOPIC_PATH, ALL_ROLES)
 
@@ -814,7 +814,7 @@ class Test_IAMPolicyAPI(_Base):
         ALL_ROLES = [OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE]
         RETURNED = {}
         connection = _Connection(RETURNED)
-        api = self._makeOne(connection)
+        api = self._make_one(connection)
 
         allowed = api.test_iam_permissions(self.TOPIC_PATH, ALL_ROLES)
 

--- a/pubsub/unit_tests/test__http.py
+++ b/pubsub/unit_tests/test__http.py
@@ -26,7 +26,7 @@ class _Base(unittest.TestCase):
     SUB_PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
 
 class TestConnection(_Base):
@@ -38,7 +38,7 @@ class TestConnection(_Base):
 
     def test_default_url(self):
         conn = self._makeOne()
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         self.assertEqual(conn.api_base_url, klass.API_BASE_URL)
 
     def test_custom_url_from_env(self):
@@ -52,7 +52,7 @@ class TestConnection(_Base):
         with _Monkey(os, getenv=fake_environ.get):
             conn = self._makeOne()
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         self.assertNotEqual(conn.api_base_url, klass.API_BASE_URL)
         self.assertEqual(conn.api_base_url, 'http://' + HOST)
 
@@ -99,7 +99,7 @@ class Test_PublisherAPI(_Base):
         return _PublisherAPI
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         connection = _Connection()
@@ -416,7 +416,7 @@ class Test_SubscriberAPI(_Base):
         return _SubscriberAPI
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         connection = _Connection()

--- a/pubsub/unit_tests/test__http.py
+++ b/pubsub/unit_tests/test__http.py
@@ -827,33 +827,33 @@ class Test_IAMPolicyAPI(_Base):
 
 
 class Test__transform_messages_base64_empty(unittest.TestCase):
-    def _callFUT(self, messages, transform, key=None):
+    def _call_fut(self, messages, transform, key=None):
         from google.cloud.pubsub._http import _transform_messages_base64
         return _transform_messages_base64(messages, transform, key)
 
     def test__transform_messages_base64_empty_message(self):
         from base64 import b64decode
         DATA = [{'message': {}}]
-        self._callFUT(DATA, b64decode, 'message')
+        self._call_fut(DATA, b64decode, 'message')
         self.assertEqual(DATA, [{'message': {}}])
 
     def test__transform_messages_base64_empty_data(self):
         from base64 import b64decode
         DATA = [{'message': {'data': b''}}]
-        self._callFUT(DATA, b64decode, 'message')
+        self._call_fut(DATA, b64decode, 'message')
         self.assertEqual(DATA, [{'message': {'data': b''}}])
 
     def test__transform_messages_base64_pull(self):
         from base64 import b64encode
         DATA = [{'message': {'data': b'testing 1 2 3'}}]
-        self._callFUT(DATA, b64encode, 'message')
+        self._call_fut(DATA, b64encode, 'message')
         self.assertEqual(DATA[0]['message']['data'],
                          b64encode(b'testing 1 2 3'))
 
     def test__transform_messages_base64_publish(self):
         from base64 import b64encode
         DATA = [{'data': b'testing 1 2 3'}]
-        self._callFUT(DATA, b64encode)
+        self._call_fut(DATA, b64encode)
         self.assertEqual(DATA[0]['data'], b64encode(b'testing 1 2 3'))
 
 

--- a/pubsub/unit_tests/test__http.py
+++ b/pubsub/unit_tests/test__http.py
@@ -31,7 +31,8 @@ class _Base(unittest.TestCase):
 
 class TestConnection(_Base):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub._http import Connection
         return Connection
 
@@ -92,7 +93,8 @@ class TestConnection(_Base):
 
 class Test_PublisherAPI(_Base):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub._http import _PublisherAPI
         return _PublisherAPI
 
@@ -408,7 +410,8 @@ class Test_PublisherAPI(_Base):
 
 class Test_SubscriberAPI(_Base):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub._http import _SubscriberAPI
         return _SubscriberAPI
 
@@ -710,7 +713,8 @@ class Test_SubscriberAPI(_Base):
 
 class Test_IAMPolicyAPI(_Base):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub._http import _IAMPolicyAPI
         return _IAMPolicyAPI
 

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -22,7 +22,8 @@ class TestClient(unittest.TestCase):
     SUB_NAME = 'subscription_name'
     SUB_PATH = 'projects/%s/subscriptions/%s' % (PROJECT, SUB_NAME)
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub.client import Client
         return Client
 

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -27,7 +27,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.pubsub.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_publisher_api_wo_gax(self):
@@ -37,7 +37,7 @@ class TestClient(unittest.TestCase):
         creds = _Credentials()
 
         with _Monkey(MUT, _USE_GAX=False):
-            client = self._makeOne(project=self.PROJECT, credentials=creds)
+            client = self._make_one(project=self.PROJECT, credentials=creds)
 
         conn = client.connection = object()
         api = client.publisher_api
@@ -55,7 +55,7 @@ class TestClient(unittest.TestCase):
 
         creds = _Credentials()
         with _Monkey(MUT, _USE_GAX=True):
-            client = self._makeOne(project=self.PROJECT, credentials=creds,
+            client = self._make_one(project=self.PROJECT, credentials=creds,
                                    use_gax=False)
 
         self.assertFalse(client._use_gax)
@@ -84,7 +84,7 @@ class TestClient(unittest.TestCase):
         with _Monkey(MUT, _USE_GAX=True,
                      make_gax_publisher_api=_generated_api,
                      GAXPublisherAPI=_GaxPublisherAPI):
-            client = self._makeOne(project=self.PROJECT, credentials=creds)
+            client = self._make_one(project=self.PROJECT, credentials=creds)
             api = client.publisher_api
 
         self.assertIsInstance(api, _GaxPublisherAPI)
@@ -103,7 +103,7 @@ class TestClient(unittest.TestCase):
         creds = _Credentials()
 
         with _Monkey(MUT, _USE_GAX=False):
-            client = self._makeOne(project=self.PROJECT, credentials=creds)
+            client = self._make_one(project=self.PROJECT, credentials=creds)
 
         conn = client.connection = object()
         api = client.subscriber_api
@@ -136,7 +136,7 @@ class TestClient(unittest.TestCase):
         with _Monkey(MUT, _USE_GAX=True,
                      make_gax_subscriber_api=_generated_api,
                      GAXSubscriberAPI=_GaxSubscriberAPI):
-            client = self._makeOne(project=self.PROJECT, credentials=creds)
+            client = self._make_one(project=self.PROJECT, credentials=creds)
             api = client.subscriber_api
 
         self.assertIsInstance(api, _GaxSubscriberAPI)
@@ -151,7 +151,7 @@ class TestClient(unittest.TestCase):
     def test_iam_policy_api(self):
         from google.cloud.pubsub._http import _IAMPolicyAPI
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds)
+        client = self._make_one(project=self.PROJECT, credentials=creds)
         conn = client.connection = object()
         api = client.iam_policy_api
         self.assertIsInstance(api, _IAMPolicyAPI)
@@ -164,7 +164,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.pubsub.topic import Topic
 
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds)
+        client = self._make_one(project=self.PROJECT, credentials=creds)
         client.connection = object()
         api = _FauxPublisherAPI(items=[Topic(self.TOPIC_NAME, client)])
         client._publisher_api = api
@@ -187,7 +187,7 @@ class TestClient(unittest.TestCase):
         TOKEN2 = 'TOKEN2'
         SIZE = 1
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds)
+        client = self._make_one(project=self.PROJECT, credentials=creds)
         client.connection = object()
         api = _FauxPublisherAPI([Topic(self.TOPIC_NAME, client)], TOKEN2)
         client._publisher_api = api
@@ -205,7 +205,7 @@ class TestClient(unittest.TestCase):
 
     def test_list_topics_missing_key(self):
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds)
+        client = self._make_one(project=self.PROJECT, credentials=creds)
         client.connection = object()
         api = _FauxPublisherAPI()
         client._publisher_api = api
@@ -225,7 +225,7 @@ class TestClient(unittest.TestCase):
 
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds,
+        client = self._make_one(project=self.PROJECT, credentials=creds,
                                use_gax=False)
         returned = {'subscriptions': [SUB_INFO]}
         client.connection = _Connection(returned)
@@ -263,7 +263,7 @@ class TestClient(unittest.TestCase):
 
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         creds = _Credentials()
-        client = self._makeOne(project=self.PROJECT, credentials=creds,
+        client = self._make_one(project=self.PROJECT, credentials=creds,
                                use_gax=False)
 
         # Set up the mock response.
@@ -317,7 +317,7 @@ class TestClient(unittest.TestCase):
         PROJECT = 'PROJECT'
         creds = _Credentials()
 
-        client = self._makeOne(project=PROJECT, credentials=creds)
+        client = self._make_one(project=PROJECT, credentials=creds)
         client.connection = object()
         api = client._subscriber_api = _FauxSubscriberAPI()
         api._list_subscriptions_response = (), None
@@ -335,7 +335,7 @@ class TestClient(unittest.TestCase):
         TOPIC_NAME = 'TOPIC_NAME'
         creds = _Credentials()
 
-        client_obj = self._makeOne(project=PROJECT, credentials=creds)
+        client_obj = self._make_one(project=PROJECT, credentials=creds)
         new_topic = client_obj.topic(TOPIC_NAME)
         self.assertEqual(new_topic.name, TOPIC_NAME)
         self.assertIs(new_topic._client, client_obj)

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -56,7 +56,7 @@ class TestClient(unittest.TestCase):
         creds = _Credentials()
         with _Monkey(MUT, _USE_GAX=True):
             client = self._make_one(project=self.PROJECT, credentials=creds,
-                                   use_gax=False)
+                                    use_gax=False)
 
         self.assertFalse(client._use_gax)
         api = client.publisher_api
@@ -226,7 +226,7 @@ class TestClient(unittest.TestCase):
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         creds = _Credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                               use_gax=False)
+                                use_gax=False)
         returned = {'subscriptions': [SUB_INFO]}
         client.connection = _Connection(returned)
 
@@ -264,7 +264,7 @@ class TestClient(unittest.TestCase):
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         creds = _Credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                               use_gax=False)
+                                use_gax=False)
 
         # Set up the mock response.
         ACK_DEADLINE = 42

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -28,7 +28,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_publisher_api_wo_gax(self):
         from google.cloud.pubsub._http import _PublisherAPI

--- a/pubsub/unit_tests/test_iam.py
+++ b/pubsub/unit_tests/test_iam.py
@@ -23,7 +23,7 @@ class TestPolicy(unittest.TestCase):
         return Policy
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         policy = self._makeOne()
@@ -83,7 +83,7 @@ class TestPolicy(unittest.TestCase):
         RESOURCE = {
             'etag': 'ACAB',
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         policy = klass.from_api_repr(RESOURCE)
         self.assertEqual(policy.etag, 'ACAB')
         self.assertIsNone(policy.version)
@@ -118,7 +118,7 @@ class TestPolicy(unittest.TestCase):
                 {'role': PUBSUB_SUBSCRIBER_ROLE, 'members': [SUBSCRIBER]},
             ],
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         policy = klass.from_api_repr(RESOURCE)
         self.assertEqual(policy.etag, 'DEADBEEF')
         self.assertEqual(policy.version, 17)
@@ -138,7 +138,7 @@ class TestPolicy(unittest.TestCase):
                 {'role': 'nonesuch', 'members': [BOGUS1, BOGUS2]},
             ],
         }
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         with self.assertRaises(ValueError):
             klass.from_api_repr(RESOURCE)
 

--- a/pubsub/unit_tests/test_iam.py
+++ b/pubsub/unit_tests/test_iam.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestPolicy(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub.iam import Policy
         return Policy
 

--- a/pubsub/unit_tests/test_iam.py
+++ b/pubsub/unit_tests/test_iam.py
@@ -22,11 +22,11 @@ class TestPolicy(unittest.TestCase):
         from google.cloud.pubsub.iam import Policy
         return Policy
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
-        policy = self._makeOne()
+        policy = self._make_one()
         self.assertIsNone(policy.etag)
         self.assertIsNone(policy.version)
         self.assertEqual(list(policy.owners), [])
@@ -38,7 +38,7 @@ class TestPolicy(unittest.TestCase):
     def test_ctor_explicit(self):
         VERSION = 17
         ETAG = 'ETAG'
-        policy = self._makeOne(ETAG, VERSION)
+        policy = self._make_one(ETAG, VERSION)
         self.assertEqual(policy.etag, ETAG)
         self.assertEqual(policy.version, VERSION)
         self.assertEqual(list(policy.owners), [])
@@ -50,33 +50,33 @@ class TestPolicy(unittest.TestCase):
     def test_user(self):
         EMAIL = 'phred@example.com'
         MEMBER = 'user:%s' % (EMAIL,)
-        policy = self._makeOne()
+        policy = self._make_one()
         self.assertEqual(policy.user(EMAIL), MEMBER)
 
     def test_service_account(self):
         EMAIL = 'phred@example.com'
         MEMBER = 'serviceAccount:%s' % (EMAIL,)
-        policy = self._makeOne()
+        policy = self._make_one()
         self.assertEqual(policy.service_account(EMAIL), MEMBER)
 
     def test_group(self):
         EMAIL = 'phred@example.com'
         MEMBER = 'group:%s' % (EMAIL,)
-        policy = self._makeOne()
+        policy = self._make_one()
         self.assertEqual(policy.group(EMAIL), MEMBER)
 
     def test_domain(self):
         DOMAIN = 'example.com'
         MEMBER = 'domain:%s' % (DOMAIN,)
-        policy = self._makeOne()
+        policy = self._make_one()
         self.assertEqual(policy.domain(DOMAIN), MEMBER)
 
     def test_all_users(self):
-        policy = self._makeOne()
+        policy = self._make_one()
         self.assertEqual(policy.all_users(), 'allUsers')
 
     def test_authenticated_users(self):
-        policy = self._makeOne()
+        policy = self._make_one()
         self.assertEqual(policy.authenticated_users(), 'allAuthenticatedUsers')
 
     def test_from_api_repr_only_etag(self):
@@ -143,11 +143,11 @@ class TestPolicy(unittest.TestCase):
             klass.from_api_repr(RESOURCE)
 
     def test_to_api_repr_defaults(self):
-        policy = self._makeOne()
+        policy = self._make_one()
         self.assertEqual(policy.to_api_repr(), {})
 
     def test_to_api_repr_only_etag(self):
-        policy = self._makeOne('DEADBEEF')
+        policy = self._make_one('DEADBEEF')
         self.assertEqual(policy.to_api_repr(), {'etag': 'DEADBEEF'})
 
     def test_to_api_repr_full(self):
@@ -177,7 +177,7 @@ class TestPolicy(unittest.TestCase):
                 {'role': PUBSUB_SUBSCRIBER_ROLE, 'members': [SUBSCRIBER]},
             ],
         }
-        policy = self._makeOne('DEADBEEF', 17)
+        policy = self._make_one('DEADBEEF', 17)
         policy.owners.add(OWNER1)
         policy.owners.add(OWNER2)
         policy.editors.add(EDITOR1)

--- a/pubsub/unit_tests/test_message.py
+++ b/pubsub/unit_tests/test_message.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestMessage(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub.message import Message
         return Message
 

--- a/pubsub/unit_tests/test_message.py
+++ b/pubsub/unit_tests/test_message.py
@@ -23,7 +23,7 @@ class TestMessage(unittest.TestCase):
         return Message
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_no_attributes(self):
         DATA = b'DEADBEEF'
@@ -84,7 +84,7 @@ class TestMessage(unittest.TestCase):
     def test_from_api_repr_missing_data(self):
         MESSAGE_ID = '12345'
         api_repr = {'messageId': MESSAGE_ID}
-        message = self._getTargetClass().from_api_repr(api_repr)
+        message = self._get_target_class().from_api_repr(api_repr)
         self.assertEqual(message.data, b'')
         self.assertEqual(message.message_id, MESSAGE_ID)
         self.assertEqual(message.attributes, {})
@@ -99,7 +99,7 @@ class TestMessage(unittest.TestCase):
             'messageId': MESSAGE_ID,
             'publishTime': TIMESTAMP,
         }
-        message = self._getTargetClass().from_api_repr(api_repr)
+        message = self._get_target_class().from_api_repr(api_repr)
         self.assertEqual(message.data, DATA)
         self.assertEqual(message.message_id, MESSAGE_ID)
         self.assertEqual(message.attributes, {})
@@ -116,7 +116,7 @@ class TestMessage(unittest.TestCase):
             'publishTime': TIMESTAMP,
             'attributes': ATTRS,
         }
-        message = self._getTargetClass().from_api_repr(api_repr)
+        message = self._get_target_class().from_api_repr(api_repr)
         self.assertEqual(message.data, DATA)
         self.assertEqual(message.message_id, MESSAGE_ID)
         self.assertEqual(message.service_timestamp, TIMESTAMP)

--- a/pubsub/unit_tests/test_message.py
+++ b/pubsub/unit_tests/test_message.py
@@ -22,13 +22,13 @@ class TestMessage(unittest.TestCase):
         from google.cloud.pubsub.message import Message
         return Message
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_no_attributes(self):
         DATA = b'DEADBEEF'
         MESSAGE_ID = b'12345'
-        message = self._makeOne(data=DATA, message_id=MESSAGE_ID)
+        message = self._make_one(data=DATA, message_id=MESSAGE_ID)
         self.assertEqual(message.data, DATA)
         self.assertEqual(message.message_id, MESSAGE_ID)
         self.assertEqual(message.attributes, {})
@@ -38,7 +38,7 @@ class TestMessage(unittest.TestCase):
         DATA = b'DEADBEEF'
         MESSAGE_ID = b'12345'
         ATTRS = {'a': 'b'}
-        message = self._makeOne(data=DATA, message_id=MESSAGE_ID,
+        message = self._make_one(data=DATA, message_id=MESSAGE_ID,
                                 attributes=ATTRS)
         self.assertEqual(message.data, DATA)
         self.assertEqual(message.message_id, MESSAGE_ID)
@@ -48,7 +48,7 @@ class TestMessage(unittest.TestCase):
     def test_timestamp_no_attributes(self):
         DATA = b'DEADBEEF'
         MESSAGE_ID = b'12345'
-        message = self._makeOne(data=DATA, message_id=MESSAGE_ID)
+        message = self._make_one(data=DATA, message_id=MESSAGE_ID)
 
         def _to_fail():
             return message.timestamp
@@ -59,7 +59,7 @@ class TestMessage(unittest.TestCase):
         DATA = b'DEADBEEF'
         MESSAGE_ID = b'12345'
         ATTRS = {'a': 'b'}
-        message = self._makeOne(data=DATA, message_id=MESSAGE_ID,
+        message = self._make_one(data=DATA, message_id=MESSAGE_ID,
                                 attributes=ATTRS)
 
         def _to_fail():
@@ -77,7 +77,7 @@ class TestMessage(unittest.TestCase):
         naive = datetime.strptime(TIMESTAMP, _RFC3339_MICROS)
         timestamp = naive.replace(tzinfo=UTC)
         ATTRS = {'timestamp': TIMESTAMP}
-        message = self._makeOne(data=DATA, message_id=MESSAGE_ID,
+        message = self._make_one(data=DATA, message_id=MESSAGE_ID,
                                 attributes=ATTRS)
         self.assertEqual(message.timestamp, timestamp)
 

--- a/pubsub/unit_tests/test_message.py
+++ b/pubsub/unit_tests/test_message.py
@@ -39,7 +39,7 @@ class TestMessage(unittest.TestCase):
         MESSAGE_ID = b'12345'
         ATTRS = {'a': 'b'}
         message = self._make_one(data=DATA, message_id=MESSAGE_ID,
-                                attributes=ATTRS)
+                                 attributes=ATTRS)
         self.assertEqual(message.data, DATA)
         self.assertEqual(message.message_id, MESSAGE_ID)
         self.assertEqual(message.attributes, ATTRS)
@@ -60,7 +60,7 @@ class TestMessage(unittest.TestCase):
         MESSAGE_ID = b'12345'
         ATTRS = {'a': 'b'}
         message = self._make_one(data=DATA, message_id=MESSAGE_ID,
-                                attributes=ATTRS)
+                                 attributes=ATTRS)
 
         def _to_fail():
             return message.timestamp
@@ -78,7 +78,7 @@ class TestMessage(unittest.TestCase):
         timestamp = naive.replace(tzinfo=UTC)
         ATTRS = {'timestamp': TIMESTAMP}
         message = self._make_one(data=DATA, message_id=MESSAGE_ID,
-                                attributes=ATTRS)
+                                 attributes=ATTRS)
         self.assertEqual(message.timestamp, timestamp)
 
     def test_from_api_repr_missing_data(self):

--- a/pubsub/unit_tests/test_subscription.py
+++ b/pubsub/unit_tests/test_subscription.py
@@ -24,7 +24,8 @@ class TestSubscription(unittest.TestCase):
     DEADLINE = 42
     ENDPOINT = 'https://api.example.com/push'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub.subscription import Subscription
         return Subscription
 
@@ -671,7 +672,8 @@ class _FauxSubscribererAPI(object):
 
 class TestAutoAck(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub.subscription import AutoAck
         return AutoAck
 

--- a/pubsub/unit_tests/test_subscription.py
+++ b/pubsub/unit_tests/test_subscription.py
@@ -29,13 +29,13 @@ class TestSubscription(unittest.TestCase):
         from google.cloud.pubsub.subscription import Subscription
         return Subscription
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         client = _Client(project=self.PROJECT)
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
         self.assertEqual(subscription.name, self.SUB_NAME)
         self.assertIs(subscription.topic, topic)
         self.assertIsNone(subscription.ack_deadline)
@@ -44,7 +44,7 @@ class TestSubscription(unittest.TestCase):
     def test_ctor_explicit(self):
         client = _Client(project=self.PROJECT)
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic,
+        subscription = self._make_one(self.SUB_NAME, topic,
                                      self.DEADLINE, self.ENDPOINT)
         self.assertEqual(subscription.name, self.SUB_NAME)
         self.assertIs(subscription.topic, topic)
@@ -53,7 +53,7 @@ class TestSubscription(unittest.TestCase):
 
     def test_ctor_w_client_wo_topic(self):
         client = _Client(project=self.PROJECT)
-        subscription = self._makeOne(self.SUB_NAME, client=client)
+        subscription = self._make_one(self.SUB_NAME, client=client)
         self.assertEqual(subscription.name, self.SUB_NAME)
         self.assertIsNone(subscription.topic)
 
@@ -62,11 +62,11 @@ class TestSubscription(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         topic = _Topic(self.TOPIC_NAME, client=client1)
         with self.assertRaises(TypeError):
-            self._makeOne(self.SUB_NAME, topic, client=client2)
+            self._make_one(self.SUB_NAME, topic, client=client2)
 
     def test_ctor_w_neither_topic_nor_client(self):
         with self.assertRaises(TypeError):
-            self._makeOne(self.SUB_NAME)
+            self._make_one(self.SUB_NAME)
 
     def test_from_api_repr_no_topics(self):
         from google.cloud.pubsub.topic import Topic
@@ -140,7 +140,7 @@ class TestSubscription(unittest.TestCase):
         TOPIC_NAME = 'topic_name'
         CLIENT = _Client(project=PROJECT)
         topic = _Topic(TOPIC_NAME, client=CLIENT)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
         self.assertEqual(subscription.full_name, SUB_FULL)
         self.assertEqual(subscription.path, SUB_PATH)
 
@@ -148,7 +148,7 @@ class TestSubscription(unittest.TestCase):
         from google.cloud.pubsub.subscription import AutoAck
         client = _Client(project=self.PROJECT)
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
         auto_ack = subscription.auto_ack()
         self.assertIsInstance(auto_ack, AutoAck)
         self.assertIs(auto_ack._subscription, subscription)
@@ -161,7 +161,7 @@ class TestSubscription(unittest.TestCase):
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
         auto_ack = subscription.auto_ack(True, 10, client2)
         self.assertIsInstance(auto_ack, AutoAck)
         self.assertIs(auto_ack._subscription, subscription)
@@ -178,7 +178,7 @@ class TestSubscription(unittest.TestCase):
         api = client.subscriber_api = _FauxSubscribererAPI()
         api._subscription_create_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         subscription.create()
 
@@ -197,7 +197,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.subscriber_api = _FauxSubscribererAPI()
         api._subscription_create_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic,
+        subscription = self._make_one(self.SUB_NAME, topic,
                                      self.DEADLINE, self.ENDPOINT)
 
         subscription.create(client=client2)
@@ -210,7 +210,7 @@ class TestSubscription(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.subscriber_api = _FauxSubscribererAPI()
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         self.assertFalse(subscription.exists())
 
@@ -223,7 +223,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.subscriber_api = _FauxSubscribererAPI()
         api._subscription_get_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         self.assertTrue(subscription.exists(client=client2))
 
@@ -240,7 +240,7 @@ class TestSubscription(unittest.TestCase):
         api = client.subscriber_api = _FauxSubscribererAPI()
         api._subscription_get_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         subscription.reload()
 
@@ -258,7 +258,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.subscriber_api = _FauxSubscribererAPI()
         api._subscription_get_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic,
+        subscription = self._make_one(self.SUB_NAME, topic,
                                      self.DEADLINE, self.ENDPOINT)
 
         subscription.reload(client=client2)
@@ -273,7 +273,7 @@ class TestSubscription(unittest.TestCase):
         api = client.subscriber_api = _FauxSubscribererAPI()
         api._subscription_delete_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         subscription.delete()
 
@@ -286,7 +286,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.subscriber_api = _FauxSubscribererAPI()
         api._subscription_delete_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic,
+        subscription = self._make_one(self.SUB_NAME, topic,
                                      self.DEADLINE, self.ENDPOINT)
 
         subscription.delete(client=client2)
@@ -298,7 +298,7 @@ class TestSubscription(unittest.TestCase):
         api = client.subscriber_api = _FauxSubscribererAPI()
         api._subscription_modify_push_config_response = {}
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         subscription.modify_push_configuration(push_endpoint=self.ENDPOINT)
 
@@ -312,7 +312,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.subscriber_api = _FauxSubscribererAPI()
         api._subscription_modify_push_config_response = {}
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic,
+        subscription = self._make_one(self.SUB_NAME, topic,
                                      push_endpoint=self.ENDPOINT)
 
         subscription.modify_push_configuration(push_endpoint=None,
@@ -333,7 +333,7 @@ class TestSubscription(unittest.TestCase):
         api = client.subscriber_api = _FauxSubscribererAPI()
         api._subscription_pull_response = [REC_MESSAGE]
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         pulled = subscription.pull()
 
@@ -360,7 +360,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.subscriber_api = _FauxSubscribererAPI()
         api._subscription_pull_response = [REC_MESSAGE]
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         pulled = subscription.pull(return_immediately=True, max_messages=3,
                                    client=client2)
@@ -380,7 +380,7 @@ class TestSubscription(unittest.TestCase):
         api = client.subscriber_api = _FauxSubscribererAPI()
         api._subscription_pull_response = {}
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         pulled = subscription.pull(return_immediately=False)
 
@@ -395,7 +395,7 @@ class TestSubscription(unittest.TestCase):
         api = client.subscriber_api = _FauxSubscribererAPI()
         api._subscription_acknowlege_response = {}
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         subscription.acknowledge([ACK_ID1, ACK_ID2])
 
@@ -410,7 +410,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.subscriber_api = _FauxSubscribererAPI()
         api._subscription_acknowlege_response = {}
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         subscription.acknowledge([ACK_ID1, ACK_ID2], client=client2)
 
@@ -424,7 +424,7 @@ class TestSubscription(unittest.TestCase):
         api = client.subscriber_api = _FauxSubscribererAPI()
         api._subscription_modify_ack_deadline_response = {}
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         subscription.modify_ack_deadline([ACK_ID1, ACK_ID2], self.DEADLINE)
 
@@ -439,7 +439,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.subscriber_api = _FauxSubscribererAPI()
         api._subscription_modify_ack_deadline_response = {}
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         subscription.modify_ack_deadline(
             [ACK_ID1, ACK_ID2], self.DEADLINE, client=client2)
@@ -478,7 +478,7 @@ class TestSubscription(unittest.TestCase):
         api = client.iam_policy_api = _FauxIAMPolicy()
         api._get_iam_policy_response = POLICY
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         policy = subscription.get_iam_policy()
 
@@ -500,7 +500,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.iam_policy_api = _FauxIAMPolicy()
         api._get_iam_policy_response = POLICY
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         policy = subscription.get_iam_policy(client=client2)
 
@@ -547,7 +547,7 @@ class TestSubscription(unittest.TestCase):
         api = client.iam_policy_api = _FauxIAMPolicy()
         api._set_iam_policy_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
         policy = Policy('DEADBEEF', 17)
         policy.owners.add(OWNER1)
         policy.owners.add(OWNER2)
@@ -577,7 +577,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.iam_policy_api = _FauxIAMPolicy()
         api._set_iam_policy_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         policy = Policy()
         new_policy = subscription.set_iam_policy(policy, client=client2)
@@ -599,7 +599,7 @@ class TestSubscription(unittest.TestCase):
         api = client.iam_policy_api = _FauxIAMPolicy()
         api._test_iam_permissions_response = ROLES[:-1]
         topic = _Topic(self.TOPIC_NAME, client=client)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         allowed = subscription.check_iam_permissions(ROLES)
 
@@ -618,7 +618,7 @@ class TestSubscription(unittest.TestCase):
         api = client2.iam_policy_api = _FauxIAMPolicy()
         api._test_iam_permissions_response = []
         topic = _Topic(self.TOPIC_NAME, client=client1)
-        subscription = self._makeOne(self.SUB_NAME, topic)
+        subscription = self._make_one(self.SUB_NAME, topic)
 
         allowed = subscription.check_iam_permissions(ROLES, client=client2)
 
@@ -677,12 +677,12 @@ class TestAutoAck(unittest.TestCase):
         from google.cloud.pubsub.subscription import AutoAck
         return AutoAck
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         subscription = _FauxSubscription(())
-        auto_ack = self._makeOne(subscription)
+        auto_ack = self._make_one(subscription)
         self.assertEqual(auto_ack._return_immediately, False)
         self.assertEqual(auto_ack._max_messages, 1)
         self.assertIsNone(auto_ack._client)
@@ -690,7 +690,7 @@ class TestAutoAck(unittest.TestCase):
     def test_ctor_explicit(self):
         CLIENT = object()
         subscription = _FauxSubscription(())
-        auto_ack = self._makeOne(
+        auto_ack = self._make_one(
             subscription, return_immediately=True, max_messages=10,
             client=CLIENT)
         self.assertIs(auto_ack._subscription, subscription)
@@ -700,7 +700,7 @@ class TestAutoAck(unittest.TestCase):
 
     def test___enter___w_defaults(self):
         subscription = _FauxSubscription(())
-        auto_ack = self._makeOne(subscription)
+        auto_ack = self._make_one(subscription)
 
         with auto_ack as returned:
             pass
@@ -713,7 +713,7 @@ class TestAutoAck(unittest.TestCase):
     def test___enter___w_explicit(self):
         CLIENT = object()
         subscription = _FauxSubscription(())
-        auto_ack = self._makeOne(
+        auto_ack = self._make_one(
             subscription, return_immediately=True, max_messages=10,
             client=CLIENT)
 
@@ -736,7 +736,7 @@ class TestAutoAck(unittest.TestCase):
             (ACK_ID3, MESSAGE3),
         ]
         subscription = _FauxSubscription(ITEMS)
-        auto_ack = self._makeOne(subscription, client=CLIENT)
+        auto_ack = self._make_one(subscription, client=CLIENT)
         with auto_ack:
             for ack_id, message in list(auto_ack.items()):
                 if message.fail:

--- a/pubsub/unit_tests/test_subscription.py
+++ b/pubsub/unit_tests/test_subscription.py
@@ -45,7 +45,7 @@ class TestSubscription(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         topic = _Topic(self.TOPIC_NAME, client=client)
         subscription = self._make_one(self.SUB_NAME, topic,
-                                     self.DEADLINE, self.ENDPOINT)
+                                      self.DEADLINE, self.ENDPOINT)
         self.assertEqual(subscription.name, self.SUB_NAME)
         self.assertIs(subscription.topic, topic)
         self.assertEqual(subscription.ack_deadline, self.DEADLINE)
@@ -198,7 +198,7 @@ class TestSubscription(unittest.TestCase):
         api._subscription_create_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client1)
         subscription = self._make_one(self.SUB_NAME, topic,
-                                     self.DEADLINE, self.ENDPOINT)
+                                      self.DEADLINE, self.ENDPOINT)
 
         subscription.create(client=client2)
 
@@ -259,7 +259,7 @@ class TestSubscription(unittest.TestCase):
         api._subscription_get_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client1)
         subscription = self._make_one(self.SUB_NAME, topic,
-                                     self.DEADLINE, self.ENDPOINT)
+                                      self.DEADLINE, self.ENDPOINT)
 
         subscription.reload(client=client2)
 
@@ -287,7 +287,7 @@ class TestSubscription(unittest.TestCase):
         api._subscription_delete_response = RESPONSE
         topic = _Topic(self.TOPIC_NAME, client=client1)
         subscription = self._make_one(self.SUB_NAME, topic,
-                                     self.DEADLINE, self.ENDPOINT)
+                                      self.DEADLINE, self.ENDPOINT)
 
         subscription.delete(client=client2)
 
@@ -313,7 +313,7 @@ class TestSubscription(unittest.TestCase):
         api._subscription_modify_push_config_response = {}
         topic = _Topic(self.TOPIC_NAME, client=client1)
         subscription = self._make_one(self.SUB_NAME, topic,
-                                     push_endpoint=self.ENDPOINT)
+                                      push_endpoint=self.ENDPOINT)
 
         subscription.modify_push_configuration(push_endpoint=None,
                                                client=client2)

--- a/pubsub/unit_tests/test_subscription.py
+++ b/pubsub/unit_tests/test_subscription.py
@@ -30,7 +30,7 @@ class TestSubscription(unittest.TestCase):
         return Subscription
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         client = _Client(project=self.PROJECT)
@@ -74,7 +74,7 @@ class TestSubscription(unittest.TestCase):
                     'name': self.SUB_PATH,
                     'ackDeadlineSeconds': self.DEADLINE,
                     'pushConfig': {'pushEndpoint': self.ENDPOINT}}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         client = _Client(project=self.PROJECT)
         subscription = klass.from_api_repr(resource, client)
         self.assertEqual(subscription.name, self.SUB_NAME)
@@ -86,12 +86,12 @@ class TestSubscription(unittest.TestCase):
         self.assertEqual(subscription.push_endpoint, self.ENDPOINT)
 
     def test_from_api_repr_w_deleted_topic(self):
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         resource = {'topic': klass._DELETED_TOPIC_PATH,
                     'name': self.SUB_PATH,
                     'ackDeadlineSeconds': self.DEADLINE,
                     'pushConfig': {'pushEndpoint': self.ENDPOINT}}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         client = _Client(project=self.PROJECT)
         subscription = klass.from_api_repr(resource, client)
         self.assertEqual(subscription.name, self.SUB_NAME)
@@ -106,7 +106,7 @@ class TestSubscription(unittest.TestCase):
                     'ackDeadlineSeconds': self.DEADLINE,
                     'pushConfig': {'pushEndpoint': self.ENDPOINT}}
         topics = {}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         client = _Client(project=self.PROJECT)
         subscription = klass.from_api_repr(resource, client, topics=topics)
         self.assertEqual(subscription.name, self.SUB_NAME)
@@ -126,7 +126,7 @@ class TestSubscription(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         topic = _Topic(self.TOPIC_NAME, client=client)
         topics = {self.TOPIC_PATH: topic}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         subscription = klass.from_api_repr(resource, client, topics=topics)
         self.assertEqual(subscription.name, self.SUB_NAME)
         self.assertIs(subscription.topic, topic)
@@ -678,7 +678,7 @@ class TestAutoAck(unittest.TestCase):
         return AutoAck
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_defaults(self):
         subscription = _FauxSubscription(())

--- a/pubsub/unit_tests/test_topic.py
+++ b/pubsub/unit_tests/test_topic.py
@@ -26,7 +26,7 @@ class TestTopic(unittest.TestCase):
         return Topic
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_w_explicit_timestamp(self):
         client = _Client(project=self.PROJECT)
@@ -41,7 +41,7 @@ class TestTopic(unittest.TestCase):
     def test_from_api_repr(self):
         client = _Client(project=self.PROJECT)
         resource = {'name': self.TOPIC_PATH}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         topic = klass.from_api_repr(resource, client=client)
         self.assertEqual(topic.name, self.TOPIC_NAME)
         self.assertIs(topic._client, client)
@@ -54,7 +54,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=PROJECT1)
         PATH = 'projects/%s/topics/%s' % (PROJECT2, self.TOPIC_NAME)
         resource = {'name': PATH}
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         self.assertRaises(ValueError, klass.from_api_repr,
                           resource, client=client)
 
@@ -626,7 +626,7 @@ class TestBatch(unittest.TestCase):
         return Batch
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_ctor_defaults(self):
         topic = _Topic()

--- a/pubsub/unit_tests/test_topic.py
+++ b/pubsub/unit_tests/test_topic.py
@@ -31,8 +31,8 @@ class TestTopic(unittest.TestCase):
     def test_ctor_w_explicit_timestamp(self):
         client = _Client(project=self.PROJECT)
         topic = self._make_one(self.TOPIC_NAME,
-                              client=client,
-                              timestamp_messages=True)
+                               client=client,
+                               timestamp_messages=True)
         self.assertEqual(topic.name, self.TOPIC_NAME)
         self.assertEqual(topic.project, self.PROJECT)
         self.assertEqual(topic.full_name, self.TOPIC_PATH)
@@ -156,7 +156,7 @@ class TestTopic(unittest.TestCase):
         api._topic_publish_response = [MSGID]
 
         topic = self._make_one(self.TOPIC_NAME, client=client1,
-                              timestamp_messages=True)
+                               timestamp_messages=True)
         with _Monkey(MUT, _NOW=_utcnow):
             msgid = topic.publish(PAYLOAD, client=client2)
 
@@ -173,7 +173,7 @@ class TestTopic(unittest.TestCase):
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID]
         topic = self._make_one(self.TOPIC_NAME, client=client,
-                              timestamp_messages=True)
+                               timestamp_messages=True)
 
         msgid = topic.publish(PAYLOAD, timestamp=OVERRIDE)
 

--- a/pubsub/unit_tests/test_topic.py
+++ b/pubsub/unit_tests/test_topic.py
@@ -25,12 +25,12 @@ class TestTopic(unittest.TestCase):
         from google.cloud.pubsub.topic import Topic
         return Topic
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_w_explicit_timestamp(self):
         client = _Client(project=self.PROJECT)
-        topic = self._makeOne(self.TOPIC_NAME,
+        topic = self._make_one(self.TOPIC_NAME,
                               client=client,
                               timestamp_messages=True)
         self.assertEqual(topic.name, self.TOPIC_NAME)
@@ -62,7 +62,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_create_response = {'name': self.TOPIC_PATH}
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         topic.create()
 
@@ -73,7 +73,7 @@ class TestTopic(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.publisher_api = _FauxPublisherAPI()
         api._topic_create_response = {'name': self.TOPIC_PATH}
-        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        topic = self._make_one(self.TOPIC_NAME, client=client1)
 
         topic.create(client=client2)
 
@@ -82,7 +82,7 @@ class TestTopic(unittest.TestCase):
     def test_exists_miss_w_bound_client(self):
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         self.assertFalse(topic.exists())
 
@@ -93,7 +93,7 @@ class TestTopic(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.publisher_api = _FauxPublisherAPI()
         api._topic_get_response = {'name': self.TOPIC_PATH}
-        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        topic = self._make_one(self.TOPIC_NAME, client=client1)
 
         self.assertTrue(topic.exists(client=client2))
 
@@ -103,7 +103,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_delete_response = {}
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         topic.delete()
 
@@ -114,7 +114,7 @@ class TestTopic(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.publisher_api = _FauxPublisherAPI()
         api._topic_delete_response = {}
-        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        topic = self._make_one(self.TOPIC_NAME, client=client1)
 
         topic.delete(client=client2)
 
@@ -127,7 +127,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID]
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         msgid = topic.publish(PAYLOAD)
 
@@ -155,7 +155,7 @@ class TestTopic(unittest.TestCase):
         api = client2.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID]
 
-        topic = self._makeOne(self.TOPIC_NAME, client=client1,
+        topic = self._make_one(self.TOPIC_NAME, client=client1,
                               timestamp_messages=True)
         with _Monkey(MUT, _NOW=_utcnow):
             msgid = topic.publish(PAYLOAD, client=client2)
@@ -172,7 +172,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID]
-        topic = self._makeOne(self.TOPIC_NAME, client=client,
+        topic = self._make_one(self.TOPIC_NAME, client=client,
                               timestamp_messages=True)
 
         msgid = topic.publish(PAYLOAD, timestamp=OVERRIDE)
@@ -188,7 +188,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID]
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         msgid = topic.publish(PAYLOAD, attr1='value1', attr2='value2')
 
@@ -202,7 +202,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID]
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
         msgid = topic.publish(PAYLOAD)
 
         self.assertEqual(msgid, MSGID)
@@ -215,7 +215,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID]
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
         msgid = topic.publish(PAYLOAD)
 
         self.assertEqual(msgid, MSGID)
@@ -232,7 +232,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID1, MSGID2]
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         with topic.batch() as batch:
             batch.publish(PAYLOAD1)
@@ -247,7 +247,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = []
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         with topic.batch() as batch:
             pass
@@ -269,7 +269,7 @@ class TestTopic(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID1, MSGID2]
-        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        topic = self._make_one(self.TOPIC_NAME, client=client1)
 
         with topic.batch(client=client2) as batch:
             batch.publish(PAYLOAD1)
@@ -285,7 +285,7 @@ class TestTopic(unittest.TestCase):
         PAYLOAD2 = b'This is the second message text'
         client = _Client(project=self.PROJECT)
         api = client.publisher_api = _FauxPublisherAPI()
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         try:
             with topic.batch() as batch:
@@ -301,7 +301,7 @@ class TestTopic(unittest.TestCase):
     def test_subscription(self):
         from google.cloud.pubsub.subscription import Subscription
         client = _Client(project=self.PROJECT)
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         SUBSCRIPTION_NAME = 'subscription_name'
         subscription = topic.subscription(SUBSCRIPTION_NAME)
@@ -332,7 +332,7 @@ class TestTopic(unittest.TestCase):
         }
         client.connection = _Connection(returned)
 
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         iterator = topic.list_subscriptions()
         page = six.next(iterator.pages)
@@ -382,7 +382,7 @@ class TestTopic(unittest.TestCase):
         }
         client.connection = _Connection(returned)
 
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         iterator = topic.list_subscriptions(
             page_size=PAGE_SIZE, page_token=TOKEN)
@@ -417,7 +417,7 @@ class TestTopic(unittest.TestCase):
         client = Client(project=self.PROJECT, credentials=object(),
                         use_gax=False)
         client.connection = _Connection({})
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         iterator = topic.list_subscriptions()
         subscriptions = list(iterator)
@@ -464,7 +464,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.iam_policy_api = _FauxIAMPolicy()
         api._get_iam_policy_response = POLICY
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         policy = topic.get_iam_policy()
 
@@ -486,7 +486,7 @@ class TestTopic(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.iam_policy_api = _FauxIAMPolicy()
         api._get_iam_policy_response = POLICY
-        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        topic = self._make_one(self.TOPIC_NAME, client=client1)
 
         policy = topic.get_iam_policy(client=client2)
 
@@ -538,7 +538,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.iam_policy_api = _FauxIAMPolicy()
         api._set_iam_policy_response = RESPONSE
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
         policy = Policy('DEADBEEF', 17)
         policy.owners.add(OWNER1)
         policy.owners.add(OWNER2)
@@ -568,7 +568,7 @@ class TestTopic(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.iam_policy_api = _FauxIAMPolicy()
         api._set_iam_policy_response = RESPONSE
-        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        topic = self._make_one(self.TOPIC_NAME, client=client1)
 
         policy = Policy()
         new_policy = topic.set_iam_policy(policy, client=client2)
@@ -590,7 +590,7 @@ class TestTopic(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         api = client.iam_policy_api = _FauxIAMPolicy()
         api._test_iam_permissions_response = ROLES[:-1]
-        topic = self._makeOne(self.TOPIC_NAME, client=client)
+        topic = self._make_one(self.TOPIC_NAME, client=client)
 
         allowed = topic.check_iam_permissions(ROLES)
 
@@ -608,7 +608,7 @@ class TestTopic(unittest.TestCase):
         client2 = _Client(project=self.PROJECT)
         api = client2.iam_policy_api = _FauxIAMPolicy()
         api._test_iam_permissions_response = []
-        topic = self._makeOne(self.TOPIC_NAME, client=client1)
+        topic = self._make_one(self.TOPIC_NAME, client=client1)
 
         allowed = topic.check_iam_permissions(ROLES, client=client2)
 
@@ -625,13 +625,13 @@ class TestBatch(unittest.TestCase):
         from google.cloud.pubsub.topic import Batch
         return Batch
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_ctor_defaults(self):
         topic = _Topic()
         client = _Client(project=self.PROJECT)
-        batch = self._makeOne(topic, client)
+        batch = self._make_one(topic, client)
         self.assertIs(batch.topic, topic)
         self.assertIs(batch.client, client)
         self.assertEqual(len(batch.messages), 0)
@@ -640,13 +640,13 @@ class TestBatch(unittest.TestCase):
     def test___iter___empty(self):
         topic = _Topic()
         client = object()
-        batch = self._makeOne(topic, client)
+        batch = self._make_one(topic, client)
         self.assertEqual(list(batch), [])
 
     def test___iter___non_empty(self):
         topic = _Topic()
         client = object()
-        batch = self._makeOne(topic, client)
+        batch = self._make_one(topic, client)
         batch.message_ids[:] = ['ONE', 'TWO', 'THREE']
         self.assertEqual(list(batch), ['ONE', 'TWO', 'THREE'])
 
@@ -656,7 +656,7 @@ class TestBatch(unittest.TestCase):
                    'attributes': {}}
         client = _Client(project=self.PROJECT)
         topic = _Topic()
-        batch = self._makeOne(topic, client=client)
+        batch = self._make_one(topic, client=client)
         batch.publish(PAYLOAD)
         self.assertEqual(batch.messages, [MESSAGE])
 
@@ -666,7 +666,7 @@ class TestBatch(unittest.TestCase):
                    'attributes': {'timestamp': 'TIMESTAMP'}}
         client = _Client(project=self.PROJECT)
         topic = _Topic(timestamp_messages=True)
-        batch = self._makeOne(topic, client=client)
+        batch = self._make_one(topic, client=client)
         batch.publish(PAYLOAD)
         self.assertEqual(batch.messages, [MESSAGE])
 
@@ -683,7 +683,7 @@ class TestBatch(unittest.TestCase):
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID1, MSGID2]
         topic = _Topic()
-        batch = self._makeOne(topic, client=client)
+        batch = self._make_one(topic, client=client)
 
         batch.publish(PAYLOAD1)
         batch.publish(PAYLOAD2, attr1='value1', attr2='value2')
@@ -707,7 +707,7 @@ class TestBatch(unittest.TestCase):
         api = client2.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID1, MSGID2]
         topic = _Topic()
-        batch = self._makeOne(topic, client=client1)
+        batch = self._make_one(topic, client=client1)
 
         batch.publish(PAYLOAD1)
         batch.publish(PAYLOAD2, attr1='value1', attr2='value2')
@@ -730,7 +730,7 @@ class TestBatch(unittest.TestCase):
         api = client.publisher_api = _FauxPublisherAPI()
         api._topic_publish_response = [MSGID1, MSGID2]
         topic = _Topic()
-        batch = self._makeOne(topic, client=client)
+        batch = self._make_one(topic, client=client)
 
         with batch as other:
             batch.publish(PAYLOAD1)
@@ -751,7 +751,7 @@ class TestBatch(unittest.TestCase):
         client = _Client(project='PROJECT')
         api = client.publisher_api = _FauxPublisherAPI()
         topic = _Topic()
-        batch = self._makeOne(topic, client=client)
+        batch = self._make_one(topic, client=client)
 
         try:
             with batch as other:

--- a/pubsub/unit_tests/test_topic.py
+++ b/pubsub/unit_tests/test_topic.py
@@ -20,7 +20,8 @@ class TestTopic(unittest.TestCase):
     TOPIC_NAME = 'topic_name'
     TOPIC_PATH = 'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME)
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub.topic import Topic
         return Topic
 
@@ -619,7 +620,8 @@ class TestTopic(unittest.TestCase):
 class TestBatch(unittest.TestCase):
     PROJECT = 'PROJECT'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.pubsub.topic import Batch
         return Batch
 

--- a/resource_manager/unit_tests/test_client.py
+++ b/resource_manager/unit_tests/test_client.py
@@ -22,7 +22,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.resource_manager.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
@@ -30,7 +30,7 @@ class TestClient(unittest.TestCase):
 
         http = object()
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials, http=http)
+        client = self._make_one(credentials=credentials, http=http)
         self.assertIsInstance(client.connection, Connection)
         self.assertEqual(client.connection._credentials, credentials)
         self.assertEqual(client.connection._http, http)
@@ -39,7 +39,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.resource_manager.project import Project
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
         project_id = 'project_id'
         name = object()
         labels = object()
@@ -67,7 +67,7 @@ class TestClient(unittest.TestCase):
         }
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
         # Patch the connection with one we can easily control.
         client.connection = _Connection(project_resource)
 
@@ -82,7 +82,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.iterator import HTTPIterator
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
         # Patch the connection with one we can easily control.
         client.connection = _Connection({})
 
@@ -91,7 +91,7 @@ class TestClient(unittest.TestCase):
 
     def test_list_projects_no_paging(self):
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
 
         PROJECT_ID = 'project-id'
         PROJECT_NUMBER = 1
@@ -119,7 +119,7 @@ class TestClient(unittest.TestCase):
 
     def test_list_projects_with_paging(self):
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
 
         PROJECT_ID1 = 'project-id'
         PROJECT_NUMBER1 = 1
@@ -182,7 +182,7 @@ class TestClient(unittest.TestCase):
 
     def test_list_projects_with_filter(self):
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
 
         PROJECT_ID = 'project-id'
         PROJECT_NUMBER = 1
@@ -221,7 +221,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.iterator import Page
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
         iterator = client.list_projects()
         page = Page(iterator, (), None)
         iterator._page = page
@@ -247,7 +247,7 @@ class TestClient(unittest.TestCase):
         }
         response = {'projects': [api_resource]}
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
 
         def dummy_response():
             return response

--- a/resource_manager/unit_tests/test_client.py
+++ b/resource_manager/unit_tests/test_client.py
@@ -23,7 +23,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
         from google.cloud.resource_manager.connection import Connection

--- a/resource_manager/unit_tests/test_client.py
+++ b/resource_manager/unit_tests/test_client.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestClient(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.resource_manager.client import Client
         return Client
 

--- a/resource_manager/unit_tests/test_connection.py
+++ b/resource_manager/unit_tests/test_connection.py
@@ -23,7 +23,7 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
         conn = self._makeOne()

--- a/resource_manager/unit_tests/test_connection.py
+++ b/resource_manager/unit_tests/test_connection.py
@@ -22,11 +22,11 @@ class TestConnection(unittest.TestCase):
         from google.cloud.resource_manager.connection import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.API_BASE_URL,
             conn.API_VERSION,
@@ -37,7 +37,7 @@ class TestConnection(unittest.TestCase):
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
-        conn = self._makeOne()
+        conn = self._make_one()
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)

--- a/resource_manager/unit_tests/test_connection.py
+++ b/resource_manager/unit_tests/test_connection.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.resource_manager.connection import Connection
         return Connection
 

--- a/resource_manager/unit_tests/test_project.py
+++ b/resource_manager/unit_tests/test_project.py
@@ -23,7 +23,7 @@ class TestProject(unittest.TestCase):
         return Project
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_constructor_defaults(self):
         client = object()
@@ -62,7 +62,7 @@ class TestProject(unittest.TestCase):
                     'projectNumber': PROJECT_NUMBER,
                     'labels': PROJECT_LABELS,
                     'lifecycleState': PROJECT_LIFECYCLE_STATE}
-        project = self._getTargetClass().from_api_repr(resource, client)
+        project = self._get_target_class().from_api_repr(resource, client)
         self.assertEqual(project.project_id, PROJECT_ID)
         self.assertEqual(project._client, client)
         self.assertEqual(project.name, PROJECT_NAME)

--- a/resource_manager/unit_tests/test_project.py
+++ b/resource_manager/unit_tests/test_project.py
@@ -42,7 +42,7 @@ class TestProject(unittest.TestCase):
         DISPLAY_NAME = 'name'
         LABELS = {'foo': 'bar'}
         project = self._make_one(PROJECT_ID, client,
-                                name=DISPLAY_NAME, labels=LABELS)
+                                 name=DISPLAY_NAME, labels=LABELS)
         self.assertEqual(project.project_id, PROJECT_ID)
         self.assertEqual(project._client, client)
         self.assertEqual(project.name, DISPLAY_NAME)

--- a/resource_manager/unit_tests/test_project.py
+++ b/resource_manager/unit_tests/test_project.py
@@ -22,13 +22,13 @@ class TestProject(unittest.TestCase):
         from google.cloud.resource_manager.project import Project
         return Project
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor_defaults(self):
         client = object()
         PROJECT_ID = 'project-id'
-        project = self._makeOne(PROJECT_ID, client)
+        project = self._make_one(PROJECT_ID, client)
         self.assertEqual(project.project_id, PROJECT_ID)
         self.assertEqual(project._client, client)
         self.assertIsNone(project.name)
@@ -41,7 +41,7 @@ class TestProject(unittest.TestCase):
         PROJECT_ID = 'project-id'
         DISPLAY_NAME = 'name'
         LABELS = {'foo': 'bar'}
-        project = self._makeOne(PROJECT_ID, client,
+        project = self._make_one(PROJECT_ID, client,
                                 name=DISPLAY_NAME, labels=LABELS)
         self.assertEqual(project.project_id, PROJECT_ID)
         self.assertEqual(project._client, client)
@@ -72,17 +72,17 @@ class TestProject(unittest.TestCase):
 
     def test_full_name(self):
         PROJECT_ID = 'project-id'
-        project = self._makeOne(PROJECT_ID, None)
+        project = self._make_one(PROJECT_ID, None)
         self.assertEqual('projects/%s' % PROJECT_ID, project.full_name)
 
     def test_full_name_missing_id(self):
-        project = self._makeOne(None, None)
+        project = self._make_one(None, None)
         with self.assertRaises(ValueError):
             self.assertIsNone(project.full_name)
 
     def test_path(self):
         PROJECT_ID = 'project-id'
-        project = self._makeOne(PROJECT_ID, None)
+        project = self._make_one(PROJECT_ID, None)
         self.assertEqual('/projects/%s' % PROJECT_ID, project.path)
 
     def test_create(self):
@@ -97,7 +97,7 @@ class TestProject(unittest.TestCase):
         }
         connection = _Connection(PROJECT_RESOURCE)
         client = _Client(connection=connection)
-        project = self._makeOne(PROJECT_ID, client)
+        project = self._make_one(PROJECT_ID, client)
         self.assertIsNone(project.number)
         project.create()
         self.assertEqual(project.number, PROJECT_NUMBER)
@@ -126,7 +126,7 @@ class TestProject(unittest.TestCase):
         }
         connection = _Connection(PROJECT_RESOURCE)
         client = _Client(connection=connection)
-        project = self._makeOne(PROJECT_ID, client)
+        project = self._make_one(PROJECT_ID, client)
         self.assertIsNone(project.number)
         self.assertIsNone(project.name)
         self.assertEqual(project.labels, {})
@@ -149,19 +149,19 @@ class TestProject(unittest.TestCase):
         PROJECT_ID = 'project-id'
         connection = _Connection({'projectId': PROJECT_ID})
         client = _Client(connection=connection)
-        project = self._makeOne(PROJECT_ID, client)
+        project = self._make_one(PROJECT_ID, client)
         self.assertTrue(project.exists())
 
     def test_exists_with_explicitly_passed_client(self):
         PROJECT_ID = 'project-id'
         connection = _Connection({'projectId': PROJECT_ID})
         client = _Client(connection=connection)
-        project = self._makeOne(PROJECT_ID, None)
+        project = self._make_one(PROJECT_ID, None)
         self.assertTrue(project.exists(client=client))
 
     def test_exists_with_missing_client(self):
         PROJECT_ID = 'project-id'
-        project = self._makeOne(PROJECT_ID, None)
+        project = self._make_one(PROJECT_ID, None)
         with self.assertRaises(AttributeError):
             project.exists()
 
@@ -169,7 +169,7 @@ class TestProject(unittest.TestCase):
         PROJECT_ID = 'project-id'
         connection = _Connection()
         client = _Client(connection=connection)
-        project = self._makeOne(PROJECT_ID, client)
+        project = self._make_one(PROJECT_ID, client)
         self.assertFalse(project.exists())
 
     def test_update(self):
@@ -186,7 +186,7 @@ class TestProject(unittest.TestCase):
         }
         connection = _Connection(PROJECT_RESOURCE)
         client = _Client(connection=connection)
-        project = self._makeOne(PROJECT_ID, client)
+        project = self._make_one(PROJECT_ID, client)
         project.name = PROJECT_NAME
         project.labels = LABELS
         project.update()
@@ -214,7 +214,7 @@ class TestProject(unittest.TestCase):
         }
         connection = _Connection(PROJECT_RESOURCE)
         client = _Client(connection=connection)
-        project = self._makeOne(PROJECT_ID, client)
+        project = self._make_one(PROJECT_ID, client)
         project.delete(reload_data=False)
 
         request, = connection._requested
@@ -240,7 +240,7 @@ class TestProject(unittest.TestCase):
 
         connection = _Connection(PROJECT_RESOURCE, DELETING_PROJECT)
         client = _Client(connection=connection)
-        project = self._makeOne(PROJECT_ID, client)
+        project = self._make_one(PROJECT_ID, client)
         project.delete(reload_data=True)
         self.assertEqual(project.status, NEW_STATE)
 
@@ -271,7 +271,7 @@ class TestProject(unittest.TestCase):
         }
         connection = _Connection(PROJECT_RESOURCE)
         client = _Client(connection=connection)
-        project = self._makeOne(PROJECT_ID, client)
+        project = self._make_one(PROJECT_ID, client)
         project.undelete(reload_data=False)
 
         request, = connection._requested
@@ -297,7 +297,7 @@ class TestProject(unittest.TestCase):
 
         connection = _Connection(PROJECT_RESOURCE, UNDELETED_PROJECT)
         client = _Client(connection=connection)
-        project = self._makeOne(PROJECT_ID, client)
+        project = self._make_one(PROJECT_ID, client)
         project.undelete(reload_data=True)
         self.assertEqual(project.status, NEW_STATE)
 

--- a/resource_manager/unit_tests/test_project.py
+++ b/resource_manager/unit_tests/test_project.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestProject(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.resource_manager.project import Project
         return Project
 

--- a/runtimeconfig/unit_tests/test__helpers.py
+++ b/runtimeconfig/unit_tests/test__helpers.py
@@ -17,7 +17,7 @@ import unittest
 
 class Test_config_name_from_full_name(unittest.TestCase):
 
-    def _callFUT(self, full_name):
+    def _call_fut(self, full_name):
         from google.cloud.runtimeconfig._helpers import (
             config_name_from_full_name)
         return config_name_from_full_name(full_name)
@@ -26,25 +26,25 @@ class Test_config_name_from_full_name(unittest.TestCase):
         CONFIG_NAME = 'CONFIG_NAME'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/configs/%s' % (PROJECT, CONFIG_NAME)
-        config_name = self._callFUT(PATH)
+        config_name = self._call_fut(PATH)
         self.assertEqual(config_name, CONFIG_NAME)
 
     def test_w_name_w_all_extras(self):
         CONFIG_NAME = 'CONFIG_NAME-part.one~part.two%part-three'
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/configs/%s' % (PROJECT, CONFIG_NAME)
-        config_name = self._callFUT(PATH)
+        config_name = self._call_fut(PATH)
         self.assertEqual(config_name, CONFIG_NAME)
 
     def test_w_bad_format(self):
         PATH = 'definitley/not/a/resource-name'
         with self.assertRaises(ValueError):
-            self._callFUT(PATH)
+            self._call_fut(PATH)
 
 
 class Test_variable_name_from_full_name(unittest.TestCase):
 
-    def _callFUT(self, full_name):
+    def _call_fut(self, full_name):
         from google.cloud.runtimeconfig._helpers import (
             variable_name_from_full_name)
         return variable_name_from_full_name(full_name)
@@ -55,7 +55,7 @@ class Test_variable_name_from_full_name(unittest.TestCase):
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/configs/%s/variables/%s' % (
             PROJECT, CONFIG_NAME, VARIABLE_NAME)
-        variable_name = self._callFUT(PATH)
+        variable_name = self._call_fut(PATH)
         self.assertEqual(variable_name, VARIABLE_NAME)
 
     def test_w_name_w_all_extras(self):
@@ -64,10 +64,10 @@ class Test_variable_name_from_full_name(unittest.TestCase):
         PROJECT = 'my-project-1234'
         PATH = 'projects/%s/configs/%s/variables/%s' % (
             PROJECT, CONFIG_NAME, VARIABLE_NAME)
-        variable_name = self._callFUT(PATH)
+        variable_name = self._call_fut(PATH)
         self.assertEqual(variable_name, VARIABLE_NAME)
 
     def test_w_bad_format(self):
         PATH = 'definitley/not/a/resource/name/for/a/variable'
         with self.assertRaises(ValueError):
-            self._callFUT(PATH)
+            self._call_fut(PATH)

--- a/runtimeconfig/unit_tests/test_client.py
+++ b/runtimeconfig/unit_tests/test_client.py
@@ -22,7 +22,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.runtimeconfig.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_config(self):
@@ -30,7 +30,7 @@ class TestClient(unittest.TestCase):
         CONFIG_NAME = 'config_name'
         creds = _Credentials()
 
-        client_obj = self._makeOne(project=PROJECT, credentials=creds)
+        client_obj = self._make_one(project=PROJECT, credentials=creds)
         new_config = client_obj.config(CONFIG_NAME)
         self.assertEqual(new_config.name, CONFIG_NAME)
         self.assertIs(new_config._client, client_obj)

--- a/runtimeconfig/unit_tests/test_client.py
+++ b/runtimeconfig/unit_tests/test_client.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestClient(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.runtimeconfig.client import Client
         return Client
 

--- a/runtimeconfig/unit_tests/test_client.py
+++ b/runtimeconfig/unit_tests/test_client.py
@@ -23,7 +23,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_config(self):
         PROJECT = 'PROJECT'

--- a/runtimeconfig/unit_tests/test_config.py
+++ b/runtimeconfig/unit_tests/test_config.py
@@ -20,7 +20,8 @@ class TestConfig(unittest.TestCase):
     CONFIG_NAME = 'config_name'
     CONFIG_PATH = 'projects/%s/configs/%s' % (PROJECT, CONFIG_NAME)
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.runtimeconfig.config import Config
         return Config
 

--- a/runtimeconfig/unit_tests/test_config.py
+++ b/runtimeconfig/unit_tests/test_config.py
@@ -25,7 +25,7 @@ class TestConfig(unittest.TestCase):
         from google.cloud.runtimeconfig.config import Config
         return Config
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _verifyResourceProperties(self, config, resource):
@@ -42,7 +42,7 @@ class TestConfig(unittest.TestCase):
 
     def test_ctor(self):
         client = _Client(project=self.PROJECT)
-        config = self._makeOne(name=self.CONFIG_NAME,
+        config = self._make_one(name=self.CONFIG_NAME,
                                client=client)
         self.assertEqual(config.name, self.CONFIG_NAME)
         self.assertEqual(config.project, self.PROJECT)
@@ -50,14 +50,14 @@ class TestConfig(unittest.TestCase):
 
     def test_ctor_w_no_name(self):
         client = _Client(project=self.PROJECT)
-        config = self._makeOne(name=None, client=client)
+        config = self._make_one(name=None, client=client)
         with self.assertRaises(ValueError):
             getattr(config, 'full_name')
 
     def test_exists_miss_w_bound_client(self):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
-        config = self._makeOne(client=client, name=self.CONFIG_NAME)
+        config = self._make_one(client=client, name=self.CONFIG_NAME)
 
         self.assertFalse(config.exists())
 
@@ -72,7 +72,7 @@ class TestConfig(unittest.TestCase):
         CLIENT1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection({})
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        config = self._makeOne(client=CLIENT1, name=self.CONFIG_NAME)
+        config = self._make_one(client=CLIENT1, name=self.CONFIG_NAME)
 
         self.assertTrue(config.exists(client=CLIENT2))
 
@@ -87,7 +87,7 @@ class TestConfig(unittest.TestCase):
         RESOURCE = {}
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        config = self._makeOne(name=self.CONFIG_NAME, client=client)
+        config = self._make_one(name=self.CONFIG_NAME, client=client)
 
         config.reload()
 
@@ -103,7 +103,7 @@ class TestConfig(unittest.TestCase):
         RESOURCE = {'name': self.CONFIG_PATH, 'description': 'hello'}
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        config = self._makeOne(name=self.CONFIG_NAME, client=client)
+        config = self._make_one(name=self.CONFIG_NAME, client=client)
 
         config.reload()
 
@@ -119,7 +119,7 @@ class TestConfig(unittest.TestCase):
         CLIENT1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        config = self._makeOne(name=self.CONFIG_NAME, client=CLIENT1)
+        config = self._make_one(name=self.CONFIG_NAME, client=CLIENT1)
 
         config.reload(client=CLIENT2)
 
@@ -135,7 +135,7 @@ class TestConfig(unittest.TestCase):
         VARIABLE_PATH = '%s/variables/%s' % (self.CONFIG_PATH, VARIABLE_NAME)
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
-        config = self._makeOne(name=self.CONFIG_NAME, client=client)
+        config = self._make_one(name=self.CONFIG_NAME, client=client)
 
         variable = config.variable(VARIABLE_NAME)
 
@@ -156,7 +156,7 @@ class TestConfig(unittest.TestCase):
         }
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
-        config = self._makeOne(name=self.CONFIG_NAME, client=client)
+        config = self._make_one(name=self.CONFIG_NAME, client=client)
 
         variable = config.get_variable(VARIABLE_NAME)
 
@@ -176,7 +176,7 @@ class TestConfig(unittest.TestCase):
         VARIABLE_NAME = 'my-variable/abcd'
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
-        config = self._makeOne(name=self.CONFIG_NAME, client=client)
+        config = self._make_one(name=self.CONFIG_NAME, client=client)
         variable = config.get_variable(VARIABLE_NAME)
         self.assertIsNone(variable)
 
@@ -195,7 +195,7 @@ class TestConfig(unittest.TestCase):
         CLIENT1 = _Client(project=self.PROJECT, connection=conn1)
         conn2 = _Connection(RESOURCE)
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        config = self._makeOne(client=CLIENT1, name=self.CONFIG_NAME)
+        config = self._make_one(client=CLIENT1, name=self.CONFIG_NAME)
 
         variable = config.get_variable(VARIABLE_NAME, client=CLIENT2)
 
@@ -217,7 +217,7 @@ class TestConfig(unittest.TestCase):
 
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
-        config = self._makeOne(name=self.CONFIG_NAME, client=client)
+        config = self._make_one(name=self.CONFIG_NAME, client=client)
 
         iterator = config.list_variables()
         page = six.next(iterator.pages)
@@ -255,7 +255,7 @@ class TestConfig(unittest.TestCase):
 
         conn = _Connection(DATA)
         client = _Client(project=self.PROJECT, connection=conn)
-        config = self._makeOne(name=self.CONFIG_NAME, client=client)
+        config = self._make_one(name=self.CONFIG_NAME, client=client)
 
         iterator = config.list_variables()
         page = six.next(iterator.pages)
@@ -298,7 +298,7 @@ class TestConfig(unittest.TestCase):
 
         conn = _Connection(DATA)
         client = _Client(project=self.PROJECT, connection=conn)
-        config = self._makeOne(name=self.CONFIG_NAME, client=client)
+        config = self._make_one(name=self.CONFIG_NAME, client=client)
 
         iterator = config.list_variables(
             page_size=3,

--- a/runtimeconfig/unit_tests/test_config.py
+++ b/runtimeconfig/unit_tests/test_config.py
@@ -43,7 +43,7 @@ class TestConfig(unittest.TestCase):
     def test_ctor(self):
         client = _Client(project=self.PROJECT)
         config = self._make_one(name=self.CONFIG_NAME,
-                               client=client)
+                                client=client)
         self.assertEqual(config.name, self.CONFIG_NAME)
         self.assertEqual(config.project, self.PROJECT)
         self.assertEqual(config.full_name, self.CONFIG_PATH)

--- a/runtimeconfig/unit_tests/test_config.py
+++ b/runtimeconfig/unit_tests/test_config.py
@@ -26,7 +26,7 @@ class TestConfig(unittest.TestCase):
         return Config
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _verifyResourceProperties(self, config, resource):
         from google.cloud.runtimeconfig._helpers import (

--- a/runtimeconfig/unit_tests/test_connection.py
+++ b/runtimeconfig/unit_tests/test_connection.py
@@ -23,12 +23,12 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
         creds = _Credentials()
         conn = self._makeOne(creds)
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         self.assertEqual(conn.credentials._scopes, klass.SCOPE)
 
 

--- a/runtimeconfig/unit_tests/test_connection.py
+++ b/runtimeconfig/unit_tests/test_connection.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.runtimeconfig.connection import Connection
         return Connection
 

--- a/runtimeconfig/unit_tests/test_connection.py
+++ b/runtimeconfig/unit_tests/test_connection.py
@@ -22,12 +22,12 @@ class TestConnection(unittest.TestCase):
         from google.cloud.runtimeconfig.connection import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
         creds = _Credentials()
-        conn = self._makeOne(creds)
+        conn = self._make_one(creds)
         klass = self._get_target_class()
         self.assertEqual(conn.credentials._scopes, klass.SCOPE)
 

--- a/runtimeconfig/unit_tests/test_variable.py
+++ b/runtimeconfig/unit_tests/test_variable.py
@@ -28,7 +28,7 @@ class TestVariable(unittest.TestCase):
         return Variable
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _verifyResourceProperties(self, variable, resource):
         import base64

--- a/runtimeconfig/unit_tests/test_variable.py
+++ b/runtimeconfig/unit_tests/test_variable.py
@@ -22,7 +22,8 @@ class TestVariable(unittest.TestCase):
     PATH = 'projects/%s/configs/%s/variables/%s' % (
         PROJECT, CONFIG_NAME, VARIABLE_NAME)
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.runtimeconfig.variable import Variable
         return Variable
 

--- a/runtimeconfig/unit_tests/test_variable.py
+++ b/runtimeconfig/unit_tests/test_variable.py
@@ -27,7 +27,7 @@ class TestVariable(unittest.TestCase):
         from google.cloud.runtimeconfig.variable import Variable
         return Variable
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _verifyResourceProperties(self, variable, resource):
@@ -58,7 +58,7 @@ class TestVariable(unittest.TestCase):
 
         client = _Client(project=self.PROJECT)
         config = Config(name=self.CONFIG_NAME, client=client)
-        variable = self._makeOne(name=self.VARIABLE_NAME, config=config)
+        variable = self._make_one(name=self.VARIABLE_NAME, config=config)
         self.assertEqual(variable.name, self.VARIABLE_NAME)
         self.assertEqual(variable.full_name, self.PATH)
         self.assertEqual(variable.path, '/%s' % (self.PATH,))
@@ -69,7 +69,7 @@ class TestVariable(unittest.TestCase):
 
         client = _Client(project=self.PROJECT)
         config = Config(name=self.CONFIG_NAME, client=client)
-        variable = self._makeOne(name=None, config=config)
+        variable = self._make_one(name=None, config=config)
         with self.assertRaises(ValueError):
             getattr(variable, 'full_name')
 
@@ -79,7 +79,7 @@ class TestVariable(unittest.TestCase):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
         config = Config(name=self.CONFIG_NAME, client=client)
-        variable = self._makeOne(name=self.VARIABLE_NAME, config=config)
+        variable = self._make_one(name=self.VARIABLE_NAME, config=config)
 
         self.assertFalse(variable.exists())
 
@@ -97,7 +97,7 @@ class TestVariable(unittest.TestCase):
         CONFIG1 = Config(name=self.CONFIG_NAME, client=CLIENT1)
         conn2 = _Connection({})
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        variable = self._makeOne(name=self.VARIABLE_NAME, config=CONFIG1)
+        variable = self._make_one(name=self.VARIABLE_NAME, config=CONFIG1)
 
         self.assertTrue(variable.exists(client=CLIENT2))
 
@@ -120,7 +120,7 @@ class TestVariable(unittest.TestCase):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         config = Config(name=self.CONFIG_NAME, client=client)
-        variable = self._makeOne(name=self.VARIABLE_NAME, config=config)
+        variable = self._make_one(name=self.VARIABLE_NAME, config=config)
 
         variable.reload()
 
@@ -137,7 +137,7 @@ class TestVariable(unittest.TestCase):
         conn = _Connection(RESOURCE)
         client = _Client(project=self.PROJECT, connection=conn)
         config = Config(name=self.CONFIG_NAME, client=client)
-        variable = self._makeOne(name=self.VARIABLE_NAME, config=config)
+        variable = self._make_one(name=self.VARIABLE_NAME, config=config)
 
         variable.reload()
 
@@ -164,7 +164,7 @@ class TestVariable(unittest.TestCase):
         CONFIG1 = Config(name=self.CONFIG_NAME, client=CLIENT1)
         conn2 = _Connection(RESOURCE)
         CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        variable = self._makeOne(name=self.VARIABLE_NAME, config=CONFIG1)
+        variable = self._make_one(name=self.VARIABLE_NAME, config=CONFIG1)
 
         variable.reload(client=CLIENT2)
 

--- a/speech/unit_tests/test__gax.py
+++ b/speech/unit_tests/test__gax.py
@@ -25,7 +25,7 @@ class TestGAPICSpeechAPI(unittest.TestCase):
         return GAPICSpeechAPI
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_use_bytes_instead_of_file_like_object(self):
         from google.cloud import speech

--- a/speech/unit_tests/test__gax.py
+++ b/speech/unit_tests/test__gax.py
@@ -51,8 +51,8 @@ class TestSpeechGAXMakeRequests(unittest.TestCase):
     AUDIO_CONTENT = b'/9j/4QNURXhpZgAASUkq'
 
     def _call_fut(self, sample, language_code, max_alternatives,
-                 profanity_filter, speech_context, single_utterance,
-                 interim_results):
+                  profanity_filter, speech_context, single_utterance,
+                  interim_results):
         from google.cloud.speech._gax import _make_streaming_request
         return _make_streaming_request(sample=sample,
                                        language_code=language_code,
@@ -85,9 +85,9 @@ class TestSpeechGAXMakeRequests(unittest.TestCase):
         interim_results = False
 
         streaming_request = self._call_fut(sample, language_code,
-                                          max_alternatives, profanity_filter,
-                                          speech_context, single_utterance,
-                                          interim_results)
+                                           max_alternatives, profanity_filter,
+                                           speech_context, single_utterance,
+                                           interim_results)
         self.assertIsInstance(streaming_request, StreamingRecognizeRequest)
 
         # This isn't set by _make_streaming_request().
@@ -116,8 +116,8 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
     AUDIO_CONTENT = b'/9j/4QNURXhpZgAASUkq'
 
     def _call_fut(self, sample, language_code, max_alternatives,
-                 profanity_filter, speech_context, single_utterance,
-                 interim_results):
+                  profanity_filter, speech_context, single_utterance,
+                  interim_results):
         from google.cloud.speech._gax import _stream_requests
         return _stream_requests(sample=sample,
                                 language_code=language_code,
@@ -148,9 +148,9 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
         single_utterance = True
         interim_results = False
         streaming_requests = self._call_fut(sample, language_code,
-                                           max_alternatives, profanity_filter,
-                                           speech_context, single_utterance,
-                                           interim_results)
+                                            max_alternatives, profanity_filter,
+                                            speech_context, single_utterance,
+                                            interim_results)
         all_requests = []
         for streaming_request in streaming_requests:
             self.assertIsInstance(streaming_request, StreamingRecognizeRequest)

--- a/speech/unit_tests/test__gax.py
+++ b/speech/unit_tests/test__gax.py
@@ -18,7 +18,8 @@ import unittest
 class TestGAPICSpeechAPI(unittest.TestCase):
     SAMPLE_RATE = 16000
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.speech._gax import GAPICSpeechAPI
 
         return GAPICSpeechAPI

--- a/speech/unit_tests/test__gax.py
+++ b/speech/unit_tests/test__gax.py
@@ -50,7 +50,7 @@ class TestSpeechGAXMakeRequests(unittest.TestCase):
     HINTS = ['hi']
     AUDIO_CONTENT = b'/9j/4QNURXhpZgAASUkq'
 
-    def _callFUT(self, sample, language_code, max_alternatives,
+    def _call_fut(self, sample, language_code, max_alternatives,
                  profanity_filter, speech_context, single_utterance,
                  interim_results):
         from google.cloud.speech._gax import _make_streaming_request
@@ -84,7 +84,7 @@ class TestSpeechGAXMakeRequests(unittest.TestCase):
         single_utterance = True
         interim_results = False
 
-        streaming_request = self._callFUT(sample, language_code,
+        streaming_request = self._call_fut(sample, language_code,
                                           max_alternatives, profanity_filter,
                                           speech_context, single_utterance,
                                           interim_results)
@@ -115,7 +115,7 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
     HINTS = ['hi']
     AUDIO_CONTENT = b'/9j/4QNURXhpZgAASUkq'
 
-    def _callFUT(self, sample, language_code, max_alternatives,
+    def _call_fut(self, sample, language_code, max_alternatives,
                  profanity_filter, speech_context, single_utterance,
                  interim_results):
         from google.cloud.speech._gax import _stream_requests
@@ -147,7 +147,7 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
         speech_context = SpeechContext(phrases=self.HINTS)
         single_utterance = True
         interim_results = False
-        streaming_requests = self._callFUT(sample, language_code,
+        streaming_requests = self._call_fut(sample, language_code,
                                            max_alternatives, profanity_filter,
                                            speech_context, single_utterance,
                                            interim_results)

--- a/speech/unit_tests/test__gax.py
+++ b/speech/unit_tests/test__gax.py
@@ -24,7 +24,7 @@ class TestGAPICSpeechAPI(unittest.TestCase):
 
         return GAPICSpeechAPI
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_use_bytes_instead_of_file_like_object(self):
@@ -39,7 +39,7 @@ class TestGAPICSpeechAPI(unittest.TestCase):
         sample = Sample(content=b'', encoding=speech.Encoding.FLAC,
                         sample_rate=self.SAMPLE_RATE)
 
-        api = self._makeOne(client)
+        api = self._make_one(client)
         with self.assertRaises(ValueError):
             api.streaming_recognize(sample)
         self.assertEqual(client.connection._requested, [])

--- a/speech/unit_tests/test_alternative.py
+++ b/speech/unit_tests/test_alternative.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestAlternative(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.speech.alternative import Alternative
         return Alternative
 

--- a/speech/unit_tests/test_alternative.py
+++ b/speech/unit_tests/test_alternative.py
@@ -23,7 +23,7 @@ class TestAlternative(unittest.TestCase):
         return Alternative
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         text = 'hello goodbye upstairs'
@@ -47,7 +47,7 @@ class TestAlternative(unittest.TestCase):
             'transcript': 'testing 1 2 3',
         }
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         alternative = klass.from_api_repr(data)
         self.assertEqual(alternative.transcript, data['transcript'])
         self.assertIsNone(alternative.confidence)
@@ -60,7 +60,7 @@ class TestAlternative(unittest.TestCase):
             transcript=text)
         self.assertEqual(pb_value.confidence, 0.0)
 
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         alternative = klass.from_pb(pb_value)
         self.assertEqual(alternative.transcript, text)
         self.assertIsNone(alternative.confidence)

--- a/speech/unit_tests/test_alternative.py
+++ b/speech/unit_tests/test_alternative.py
@@ -22,24 +22,24 @@ class TestAlternative(unittest.TestCase):
         from google.cloud.speech.alternative import Alternative
         return Alternative
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         text = 'hello goodbye upstairs'
         confidence = 0.5546875
-        alternative = self._makeOne(text, confidence)
+        alternative = self._make_one(text, confidence)
         self.assertEqual(alternative._transcript, text)
         self.assertEqual(alternative._confidence, confidence)
 
     def test_transcript_property(self):
         text = 'is this thing on?'
-        alternative = self._makeOne(text, None)
+        alternative = self._make_one(text, None)
         self.assertEqual(alternative.transcript, text)
 
     def test_confidence_property(self):
         confidence = 0.412109375
-        alternative = self._makeOne(None, confidence)
+        alternative = self._make_one(None, confidence)
         self.assertEqual(alternative.confidence, confidence)
 
     def test_from_api_repr_with_no_confidence(self):

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -66,7 +66,8 @@ class TestClient(unittest.TestCase):
     AUDIO_SOURCE_URI = 'gs://sample-bucket/sample-recording.flac'
     AUDIO_CONTENT = '/9j/4QNURXhpZgAASUkq'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.speech.client import Client
 
         return Client

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -383,7 +383,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _Credentials()
         client = self._make_one(credentials=credentials,
-                               use_gax=True)
+                                use_gax=True)
         client.connection = _Connection()
         client.connection.credentials = credentials
 

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -72,7 +72,7 @@ class TestClient(unittest.TestCase):
 
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
@@ -80,7 +80,7 @@ class TestClient(unittest.TestCase):
 
         creds = _Credentials()
         http = object()
-        client = self._makeOne(credentials=creds, http=http)
+        client = self._make_one(credentials=creds, http=http)
         self.assertIsInstance(client.connection, Connection)
         self.assertTrue(client.connection.credentials is creds)
         self.assertTrue(client.connection.http is http)
@@ -88,7 +88,7 @@ class TestClient(unittest.TestCase):
     def test_ctor_use_gax_preset(self):
         creds = _Credentials()
         http = object()
-        client = self._makeOne(credentials=creds, http=http, use_gax=True)
+        client = self._make_one(credentials=creds, http=http, use_gax=True)
         self.assertTrue(client._use_gax)
 
     def test_create_sample_from_client(self):
@@ -96,7 +96,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.sample import Sample
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
 
         sample = client.sample(source_uri=self.AUDIO_SOURCE_URI,
                                encoding=speech.Encoding.FLAC,
@@ -145,7 +145,7 @@ class TestClient(unittest.TestCase):
             }
         }
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials, use_gax=False)
+        client = self._make_one(credentials=credentials, use_gax=False)
         client.connection = _Connection(RETURNED)
 
         encoding = speech.Encoding.FLAC
@@ -190,7 +190,7 @@ class TestClient(unittest.TestCase):
             }
         }
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials, use_gax=False)
+        client = self._make_one(credentials=credentials, use_gax=False)
         client.connection = _Connection(RETURNED)
 
         encoding = speech.Encoding.FLAC
@@ -220,7 +220,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import SYNC_RECOGNIZE_EMPTY_RESPONSE
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials, use_gax=False)
+        client = self._make_one(credentials=credentials, use_gax=False)
         client.connection = _Connection(SYNC_RECOGNIZE_EMPTY_RESPONSE)
 
         sample = Sample(source_uri=self.AUDIO_SOURCE_URI,
@@ -238,7 +238,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.sample import Sample
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials, use_gax=True)
+        client = self._make_one(credentials=credentials, use_gax=True)
         client.connection = _Connection()
         client.connection.credentials = credentials
 
@@ -281,7 +281,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech import _gax
 
         creds = _Credentials()
-        client = self._makeOne(credentials=creds, use_gax=True)
+        client = self._make_one(credentials=creds, use_gax=True)
         client.connection = _Connection()
         client.connection.credentials = creds
         client._speech_api = None
@@ -342,7 +342,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.sample import Sample
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
         client.connection = _Connection({})
 
         sample = Sample(source_uri=self.AUDIO_SOURCE_URI,
@@ -360,7 +360,7 @@ class TestClient(unittest.TestCase):
         RETURNED = ASYNC_RECOGNIZE_RESPONSE
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials, use_gax=False)
+        client = self._make_one(credentials=credentials, use_gax=False)
         client.connection = _Connection(RETURNED)
 
         sample = Sample(source_uri=self.AUDIO_SOURCE_URI,
@@ -382,7 +382,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.operation import Operation
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials,
+        client = self._make_one(credentials=credentials,
                                use_gax=True)
         client.connection = _Connection()
         client.connection.credentials = credentials
@@ -424,7 +424,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
 
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials, use_gax=False)
+        client = self._make_one(credentials=credentials, use_gax=False)
         client.connection = _Connection()
 
         with self.assertRaises(EnvironmentError):
@@ -440,7 +440,7 @@ class TestClient(unittest.TestCase):
 
         stream = BytesIO(b'Some audio data...')
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
         client.connection = _Connection()
         client.connection.credentials = credentials
 
@@ -480,7 +480,7 @@ class TestClient(unittest.TestCase):
 
         stream = BytesIO(b'Some audio data...')
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
         client.connection = _Connection()
         client.connection.credentials = credentials
 
@@ -542,7 +542,7 @@ class TestClient(unittest.TestCase):
 
         stream = BytesIO(b'Some audio data...')
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
         client.connection = _Connection()
         client.connection.credentials = credentials
 
@@ -598,7 +598,7 @@ class TestClient(unittest.TestCase):
 
         stream = BytesIO(b'Some audio data...')
         credentials = _Credentials()
-        client = self._makeOne(credentials=credentials)
+        client = self._make_one(credentials=credentials)
         client.connection = _Connection()
         client.connection.credentials = credentials
 
@@ -634,7 +634,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech import _gax
 
         creds = _Credentials()
-        client = self._makeOne(credentials=creds, use_gax=True)
+        client = self._make_one(credentials=creds, use_gax=True)
         client.connection = _Connection()
         client.connection.credentials = creds
 
@@ -667,14 +667,14 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.client import _JSONSpeechAPI
 
         creds = _Credentials()
-        client = self._makeOne(credentials=creds, use_gax=False)
+        client = self._make_one(credentials=creds, use_gax=False)
         self.assertIsNone(client._speech_api)
         self.assertIsInstance(client.speech_api, _JSONSpeechAPI)
         self.assertIsInstance(client.speech_api.connection, Connection)
 
     def test_speech_api_preset(self):
         creds = _Credentials()
-        client = self._makeOne(credentials=creds)
+        client = self._make_one(credentials=creds)
         fake_api = object()
         client._speech_api = fake_api
 

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -73,7 +73,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         from google.cloud.speech.connection import Connection

--- a/speech/unit_tests/test_connection.py
+++ b/speech/unit_tests/test_connection.py
@@ -23,7 +23,7 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_build_api_url(self):
         conn = self._makeOne()

--- a/speech/unit_tests/test_connection.py
+++ b/speech/unit_tests/test_connection.py
@@ -22,11 +22,11 @@ class TestConnection(unittest.TestCase):
         from google.cloud.speech.connection import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         method = 'speech:syncrecognize'
         uri = '/'.join([
             conn.API_BASE_URL,

--- a/speech/unit_tests/test_connection.py
+++ b/speech/unit_tests/test_connection.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.speech.connection import Connection
         return Connection
 

--- a/speech/unit_tests/test_operation.py
+++ b/speech/unit_tests/test_operation.py
@@ -24,12 +24,12 @@ class TestOperation(unittest.TestCase):
         from google.cloud.speech.operation import Operation
         return Operation
 
-    def _makeOne(self, *args, **kwargs):
+    def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         client = object()
-        operation = self._makeOne(
+        operation = self._make_one(
             self.OPERATION_NAME, client)
         self.assertEqual(operation.name, self.OPERATION_NAME)
         self.assertIs(operation.client, client)
@@ -75,7 +75,7 @@ class TestOperation(unittest.TestCase):
 
     def test__update_state_no_response(self):
         client = object()
-        operation = self._makeOne(
+        operation = self._make_one(
             self.OPERATION_NAME, client)
 
         operation_pb = self._make_operation_pb()
@@ -87,7 +87,7 @@ class TestOperation(unittest.TestCase):
         from google.cloud.speech.alternative import Alternative
 
         client = object()
-        operation = self._makeOne(
+        operation = self._make_one(
             self.OPERATION_NAME, client)
 
         text = 'hi mom'
@@ -105,7 +105,7 @@ class TestOperation(unittest.TestCase):
 
     def test__update_state_bad_response(self):
         client = object()
-        operation = self._makeOne(
+        operation = self._make_one(
             self.OPERATION_NAME, client)
 
         result1 = self._make_result('is this ok?', 0.625)

--- a/speech/unit_tests/test_operation.py
+++ b/speech/unit_tests/test_operation.py
@@ -19,7 +19,8 @@ class TestOperation(unittest.TestCase):
 
     OPERATION_NAME = '123456789'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.speech.operation import Operation
         return Operation
 

--- a/speech/unit_tests/test_operation.py
+++ b/speech/unit_tests/test_operation.py
@@ -25,7 +25,7 @@ class TestOperation(unittest.TestCase):
         return Operation
 
     def _makeOne(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+        return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
         client = object()

--- a/speech/unit_tests/test_sample.py
+++ b/speech/unit_tests/test_sample.py
@@ -19,7 +19,8 @@ class TestSample(unittest.TestCase):
     SAMPLE_RATE = 16000
     AUDIO_SOURCE_URI = 'gs://sample-bucket/sample-recording.flac'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.speech.sample import Sample
         return Sample
 

--- a/speech/unit_tests/test_sample.py
+++ b/speech/unit_tests/test_sample.py
@@ -24,13 +24,13 @@ class TestSample(unittest.TestCase):
         from google.cloud.speech.sample import Sample
         return Sample
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_initialize_sample(self):
         from google.cloud.speech.encoding import Encoding
 
-        sample = self._makeOne(source_uri=self.AUDIO_SOURCE_URI,
+        sample = self._make_one(source_uri=self.AUDIO_SOURCE_URI,
                                encoding=Encoding.FLAC,
                                sample_rate=self.SAMPLE_RATE)
         self.assertEqual(sample.source_uri, self.AUDIO_SOURCE_URI)
@@ -39,26 +39,26 @@ class TestSample(unittest.TestCase):
 
     def test_content_and_source_uri(self):
         with self.assertRaises(ValueError):
-            self._makeOne(content='awefawagaeragere',
+            self._make_one(content='awefawagaeragere',
                           source_uri=self.AUDIO_SOURCE_URI)
 
     def test_sample_rates(self):
         from google.cloud.speech.encoding import Encoding
 
         with self.assertRaises(ValueError):
-            self._makeOne(source_uri=self.AUDIO_SOURCE_URI,
+            self._make_one(source_uri=self.AUDIO_SOURCE_URI,
                           sample_rate=7999)
         with self.assertRaises(ValueError):
-            self._makeOne(source_uri=self.AUDIO_SOURCE_URI,
+            self._make_one(source_uri=self.AUDIO_SOURCE_URI,
                           sample_rate=48001)
 
-        sample = self._makeOne(source_uri=self.AUDIO_SOURCE_URI,
+        sample = self._make_one(source_uri=self.AUDIO_SOURCE_URI,
                                sample_rate=self.SAMPLE_RATE,
                                encoding=Encoding.FLAC)
         self.assertEqual(sample.sample_rate, self.SAMPLE_RATE)
         self.assertEqual(sample.encoding, Encoding.FLAC)
 
-        sample = self._makeOne(source_uri=self.AUDIO_SOURCE_URI,
+        sample = self._make_one(source_uri=self.AUDIO_SOURCE_URI,
                                encoding=Encoding.FLAC)
         self.assertEqual(sample.sample_rate, self.SAMPLE_RATE)
 
@@ -66,13 +66,13 @@ class TestSample(unittest.TestCase):
         from google.cloud.speech.encoding import Encoding
 
         with self.assertRaises(ValueError):
-            self._makeOne(source_uri=self.AUDIO_SOURCE_URI,
+            self._make_one(source_uri=self.AUDIO_SOURCE_URI,
                           sample_rate=self.SAMPLE_RATE,
                           encoding='OGG')
         with self.assertRaises(ValueError):
-            self._makeOne(source_uri=self.AUDIO_SOURCE_URI,
+            self._make_one(source_uri=self.AUDIO_SOURCE_URI,
                           sample_rate=self.SAMPLE_RATE)
-        sample = self._makeOne(source_uri=self.AUDIO_SOURCE_URI,
+        sample = self._make_one(source_uri=self.AUDIO_SOURCE_URI,
                                sample_rate=self.SAMPLE_RATE,
                                encoding=Encoding.FLAC)
         self.assertEqual(sample.encoding, Encoding.FLAC)

--- a/speech/unit_tests/test_sample.py
+++ b/speech/unit_tests/test_sample.py
@@ -25,7 +25,7 @@ class TestSample(unittest.TestCase):
         return Sample
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_initialize_sample(self):
         from google.cloud.speech.encoding import Encoding

--- a/speech/unit_tests/test_sample.py
+++ b/speech/unit_tests/test_sample.py
@@ -31,8 +31,8 @@ class TestSample(unittest.TestCase):
         from google.cloud.speech.encoding import Encoding
 
         sample = self._make_one(source_uri=self.AUDIO_SOURCE_URI,
-                               encoding=Encoding.FLAC,
-                               sample_rate=self.SAMPLE_RATE)
+                                encoding=Encoding.FLAC,
+                                sample_rate=self.SAMPLE_RATE)
         self.assertEqual(sample.source_uri, self.AUDIO_SOURCE_URI)
         self.assertEqual(sample.encoding, Encoding.FLAC)
         self.assertEqual(sample.sample_rate, self.SAMPLE_RATE)
@@ -40,26 +40,26 @@ class TestSample(unittest.TestCase):
     def test_content_and_source_uri(self):
         with self.assertRaises(ValueError):
             self._make_one(content='awefawagaeragere',
-                          source_uri=self.AUDIO_SOURCE_URI)
+                           source_uri=self.AUDIO_SOURCE_URI)
 
     def test_sample_rates(self):
         from google.cloud.speech.encoding import Encoding
 
         with self.assertRaises(ValueError):
             self._make_one(source_uri=self.AUDIO_SOURCE_URI,
-                          sample_rate=7999)
+                           sample_rate=7999)
         with self.assertRaises(ValueError):
             self._make_one(source_uri=self.AUDIO_SOURCE_URI,
-                          sample_rate=48001)
+                           sample_rate=48001)
 
         sample = self._make_one(source_uri=self.AUDIO_SOURCE_URI,
-                               sample_rate=self.SAMPLE_RATE,
-                               encoding=Encoding.FLAC)
+                                sample_rate=self.SAMPLE_RATE,
+                                encoding=Encoding.FLAC)
         self.assertEqual(sample.sample_rate, self.SAMPLE_RATE)
         self.assertEqual(sample.encoding, Encoding.FLAC)
 
         sample = self._make_one(source_uri=self.AUDIO_SOURCE_URI,
-                               encoding=Encoding.FLAC)
+                                encoding=Encoding.FLAC)
         self.assertEqual(sample.sample_rate, self.SAMPLE_RATE)
 
     def test_encoding(self):
@@ -67,12 +67,12 @@ class TestSample(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self._make_one(source_uri=self.AUDIO_SOURCE_URI,
-                          sample_rate=self.SAMPLE_RATE,
-                          encoding='OGG')
+                           sample_rate=self.SAMPLE_RATE,
+                           encoding='OGG')
         with self.assertRaises(ValueError):
             self._make_one(source_uri=self.AUDIO_SOURCE_URI,
-                          sample_rate=self.SAMPLE_RATE)
+                           sample_rate=self.SAMPLE_RATE)
         sample = self._make_one(source_uri=self.AUDIO_SOURCE_URI,
-                               sample_rate=self.SAMPLE_RATE,
-                               encoding=Encoding.FLAC)
+                                sample_rate=self.SAMPLE_RATE,
+                                encoding=Encoding.FLAC)
         self.assertEqual(sample.encoding, Encoding.FLAC)

--- a/storage/unit_tests/test__helpers.py
+++ b/storage/unit_tests/test__helpers.py
@@ -23,11 +23,11 @@ class Test_PropertyMixin(unittest.TestCase):
         return _PropertyMixin
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def _derivedClass(self, path=None):
 
-        class Derived(self._getTargetClass()):
+        class Derived(self._get_target_class()):
 
             client = None
 

--- a/storage/unit_tests/test__helpers.py
+++ b/storage/unit_tests/test__helpers.py
@@ -17,7 +17,8 @@ import unittest
 
 class Test_PropertyMixin(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.storage._helpers import _PropertyMixin
         return _PropertyMixin
 

--- a/storage/unit_tests/test__helpers.py
+++ b/storage/unit_tests/test__helpers.py
@@ -22,7 +22,7 @@ class Test_PropertyMixin(unittest.TestCase):
         from google.cloud.storage._helpers import _PropertyMixin
         return _PropertyMixin
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def _derivedClass(self, path=None):
@@ -38,11 +38,11 @@ class Test_PropertyMixin(unittest.TestCase):
         return Derived
 
     def test_path_is_abstract(self):
-        mixin = self._makeOne()
+        mixin = self._make_one()
         self.assertRaises(NotImplementedError, lambda: mixin.path)
 
     def test_client_is_abstract(self):
-        mixin = self._makeOne()
+        mixin = self._make_one()
         self.assertRaises(NotImplementedError, lambda: mixin.client)
 
     def test_reload(self):
@@ -62,7 +62,7 @@ class Test_PropertyMixin(unittest.TestCase):
         self.assertEqual(derived._changes, set())
 
     def test__set_properties(self):
-        mixin = self._makeOne()
+        mixin = self._make_one()
         self.assertEqual(mixin._properties, {})
         VALUE = object()
         mixin._set_properties(VALUE)

--- a/storage/unit_tests/test__helpers.py
+++ b/storage/unit_tests/test__helpers.py
@@ -97,7 +97,7 @@ class Test_PropertyMixin(unittest.TestCase):
 
 class Test__scalar_property(unittest.TestCase):
 
-    def _callFUT(self, fieldName):
+    def _call_fut(self, fieldName):
         from google.cloud.storage._helpers import _scalar_property
         return _scalar_property(fieldName)
 
@@ -106,7 +106,7 @@ class Test__scalar_property(unittest.TestCase):
         class Test(object):
             def __init__(self, **kw):
                 self._properties = kw.copy()
-            do_re_mi = self._callFUT('solfege')
+            do_re_mi = self._call_fut('solfege')
 
         test = Test(solfege='Latido')
         self.assertEqual(test.do_re_mi, 'Latido')
@@ -116,7 +116,7 @@ class Test__scalar_property(unittest.TestCase):
         class Test(object):
             def _patch_property(self, name, value):
                 self._patched = (name, value)
-            do_re_mi = self._callFUT('solfege')
+            do_re_mi = self._call_fut('solfege')
 
         test = Test()
         test.do_re_mi = 'Latido'
@@ -125,7 +125,7 @@ class Test__scalar_property(unittest.TestCase):
 
 class Test__base64_md5hash(unittest.TestCase):
 
-    def _callFUT(self, bytes_to_sign):
+    def _call_fut(self, bytes_to_sign):
         from google.cloud.storage._helpers import _base64_md5hash
         return _base64_md5hash(bytes_to_sign)
 
@@ -136,7 +136,7 @@ class Test__base64_md5hash(unittest.TestCase):
         BUFFER.write(BYTES_TO_SIGN)
         BUFFER.seek(0)
 
-        SIGNED_CONTENT = self._callFUT(BUFFER)
+        SIGNED_CONTENT = self._call_fut(BUFFER)
         self.assertEqual(SIGNED_CONTENT, b'kBiQqOnIz21aGlQrIp/r/w==')
 
     def test_it_with_stubs(self):
@@ -160,7 +160,7 @@ class Test__base64_md5hash(unittest.TestCase):
         MD5 = _MD5(DIGEST_VAL)
 
         with _Monkey(MUT, base64=BASE64, md5=MD5):
-            SIGNED_CONTENT = self._callFUT(BUFFER)
+            SIGNED_CONTENT = self._call_fut(BUFFER)
 
         self.assertEqual(BUFFER._block_sizes, [8192, 8192])
         self.assertIs(SIGNED_CONTENT, DIGEST_VAL)

--- a/storage/unit_tests/test__http.py
+++ b/storage/unit_tests/test__http.py
@@ -23,7 +23,7 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
         conn = self._makeOne()

--- a/storage/unit_tests/test__http.py
+++ b/storage/unit_tests/test__http.py
@@ -22,11 +22,11 @@ class TestConnection(unittest.TestCase):
         from google.cloud.storage._http import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.API_BASE_URL,
             'storage',
@@ -38,7 +38,7 @@ class TestConnection(unittest.TestCase):
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
-        conn = self._makeOne()
+        conn = self._make_one()
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)

--- a/storage/unit_tests/test__http.py
+++ b/storage/unit_tests/test__http.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.storage._http import Connection
         return Connection
 

--- a/storage/unit_tests/test_acl.py
+++ b/storage/unit_tests/test_acl.py
@@ -23,7 +23,7 @@ class Test_ACLEntity(unittest.TestCase):
         return _ACLEntity
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_default_identifier(self):
         TYPE = 'type'
@@ -133,7 +133,7 @@ class Test_ACL(unittest.TestCase):
         return ACL
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         acl = self._makeOne()
@@ -718,7 +718,7 @@ class Test_BucketACL(unittest.TestCase):
         return BucketACL
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         NAME = 'name'
@@ -739,7 +739,7 @@ class Test_DefaultObjectACL(unittest.TestCase):
         return DefaultObjectACL
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         NAME = 'name'
@@ -760,7 +760,7 @@ class Test_ObjectACL(unittest.TestCase):
         return ObjectACL
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         NAME = 'name'

--- a/storage/unit_tests/test_acl.py
+++ b/storage/unit_tests/test_acl.py
@@ -22,12 +22,12 @@ class Test_ACLEntity(unittest.TestCase):
         from google.cloud.storage.acl import _ACLEntity
         return _ACLEntity
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_default_identifier(self):
         TYPE = 'type'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         self.assertEqual(entity.type, TYPE)
         self.assertIsNone(entity.identifier)
         self.assertEqual(entity.get_roles(), set())
@@ -35,26 +35,26 @@ class Test_ACLEntity(unittest.TestCase):
     def test_ctor_w_identifier(self):
         TYPE = 'type'
         ID = 'id'
-        entity = self._makeOne(TYPE, ID)
+        entity = self._make_one(TYPE, ID)
         self.assertEqual(entity.type, TYPE)
         self.assertEqual(entity.identifier, ID)
         self.assertEqual(entity.get_roles(), set())
 
     def test___str__no_identifier(self):
         TYPE = 'type'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         self.assertEqual(str(entity), TYPE)
 
     def test___str__w_identifier(self):
         TYPE = 'type'
         ID = 'id'
-        entity = self._makeOne(TYPE, ID)
+        entity = self._make_one(TYPE, ID)
         self.assertEqual(str(entity), '%s-%s' % (TYPE, ID))
 
     def test_grant_simple(self):
         TYPE = 'type'
         ROLE = 'role'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         entity.grant(ROLE)
         self.assertEqual(entity.get_roles(), set([ROLE]))
 
@@ -62,7 +62,7 @@ class Test_ACLEntity(unittest.TestCase):
         TYPE = 'type'
         ROLE1 = 'role1'
         ROLE2 = 'role2'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         entity.grant(ROLE1)
         entity.grant(ROLE2)
         entity.grant(ROLE1)
@@ -71,7 +71,7 @@ class Test_ACLEntity(unittest.TestCase):
     def test_revoke_miss(self):
         TYPE = 'type'
         ROLE = 'nonesuch'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         entity.revoke(ROLE)
         self.assertEqual(entity.get_roles(), set())
 
@@ -79,7 +79,7 @@ class Test_ACLEntity(unittest.TestCase):
         TYPE = 'type'
         ROLE1 = 'role1'
         ROLE2 = 'role2'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         entity.grant(ROLE1)
         entity.grant(ROLE2)
         entity.revoke(ROLE1)
@@ -87,39 +87,39 @@ class Test_ACLEntity(unittest.TestCase):
 
     def test_grant_read(self):
         TYPE = 'type'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         entity.grant_read()
         self.assertEqual(entity.get_roles(), set([entity.READER_ROLE]))
 
     def test_grant_write(self):
         TYPE = 'type'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         entity.grant_write()
         self.assertEqual(entity.get_roles(), set([entity.WRITER_ROLE]))
 
     def test_grant_owner(self):
         TYPE = 'type'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         entity.grant_owner()
         self.assertEqual(entity.get_roles(), set([entity.OWNER_ROLE]))
 
     def test_revoke_read(self):
         TYPE = 'type'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         entity.grant(entity.READER_ROLE)
         entity.revoke_read()
         self.assertEqual(entity.get_roles(), set())
 
     def test_revoke_write(self):
         TYPE = 'type'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         entity.grant(entity.WRITER_ROLE)
         entity.revoke_write()
         self.assertEqual(entity.get_roles(), set())
 
     def test_revoke_owner(self):
         TYPE = 'type'
-        entity = self._makeOne(TYPE)
+        entity = self._make_one(TYPE)
         entity.grant(entity.OWNER_ROLE)
         entity.revoke_owner()
         self.assertEqual(entity.get_roles(), set())
@@ -132,16 +132,16 @@ class Test_ACL(unittest.TestCase):
         from google.cloud.storage.acl import ACL
         return ACL
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
-        acl = self._makeOne()
+        acl = self._make_one()
         self.assertEqual(acl.entities, {})
         self.assertFalse(acl.loaded)
 
     def test__ensure_loaded(self):
-        acl = self._makeOne()
+        acl = self._make_one()
 
         def _reload():
             acl._really_loaded = True
@@ -151,13 +151,13 @@ class Test_ACL(unittest.TestCase):
         self.assertTrue(acl._really_loaded)
 
     def test_client_is_abstract(self):
-        acl = self._makeOne()
+        acl = self._make_one()
         self.assertRaises(NotImplementedError, lambda: acl.client)
 
     def test_reset(self):
         TYPE = 'type'
         ID = 'id'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         acl.entity(TYPE, ID)
         acl.reset()
@@ -165,12 +165,12 @@ class Test_ACL(unittest.TestCase):
         self.assertFalse(acl.loaded)
 
     def test___iter___empty_eager(self):
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         self.assertEqual(list(acl), [])
 
     def test___iter___empty_lazy(self):
-        acl = self._makeOne()
+        acl = self._make_one()
 
         def _reload():
             acl.loaded = True
@@ -182,7 +182,7 @@ class Test_ACL(unittest.TestCase):
     def test___iter___non_empty_no_roles(self):
         TYPE = 'type'
         ID = 'id'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         acl.entity(TYPE, ID)
         self.assertEqual(list(acl), [])
@@ -191,7 +191,7 @@ class Test_ACL(unittest.TestCase):
         TYPE = 'type'
         ID = 'id'
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.entity(TYPE, ID)
         entity.grant(ROLE)
@@ -201,7 +201,7 @@ class Test_ACL(unittest.TestCase):
     def test___iter___non_empty_w_empty_role(self):
         TYPE = 'type'
         ID = 'id'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.entity(TYPE, ID)
         entity.grant('')
@@ -209,7 +209,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_entity_from_dict_allUsers_eager(self):
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.entity_from_dict({'entity': 'allUsers', 'role': ROLE})
         self.assertEqual(entity.type, 'allUsers')
@@ -221,7 +221,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_entity_from_dict_allAuthenticatedUsers(self):
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.entity_from_dict({'entity': 'allAuthenticatedUsers',
                                        'role': ROLE})
@@ -234,7 +234,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_entity_from_dict_string_w_hyphen(self):
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.entity_from_dict({'entity': 'type-id', 'role': ROLE})
         self.assertEqual(entity.type, 'type')
@@ -246,7 +246,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_entity_from_dict_string_wo_hyphen(self):
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         self.assertRaises(ValueError,
                           acl.entity_from_dict,
@@ -254,12 +254,12 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(list(acl.get_entities()), [])
 
     def test_has_entity_miss_str_eager(self):
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         self.assertFalse(acl.has_entity('nonesuch'))
 
     def test_has_entity_miss_str_lazy(self):
-        acl = self._makeOne()
+        acl = self._make_one()
 
         def _reload():
             acl.loaded = True
@@ -273,14 +273,14 @@ class Test_ACL(unittest.TestCase):
         TYPE = 'type'
         ID = 'id'
         entity = _ACLEntity(TYPE, ID)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         self.assertFalse(acl.has_entity(entity))
 
     def test_has_entity_hit_str(self):
         TYPE = 'type'
         ID = 'id'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         acl.entity(TYPE, ID)
         self.assertTrue(acl.has_entity('%s-%s' % (TYPE, ID)))
@@ -288,18 +288,18 @@ class Test_ACL(unittest.TestCase):
     def test_has_entity_hit_entity(self):
         TYPE = 'type'
         ID = 'id'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.entity(TYPE, ID)
         self.assertTrue(acl.has_entity(entity))
 
     def test_get_entity_miss_str_no_default_eager(self):
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         self.assertIsNone(acl.get_entity('nonesuch'))
 
     def test_get_entity_miss_str_no_default_lazy(self):
-        acl = self._makeOne()
+        acl = self._make_one()
 
         def _reload():
             acl.loaded = True
@@ -313,13 +313,13 @@ class Test_ACL(unittest.TestCase):
         TYPE = 'type'
         ID = 'id'
         entity = _ACLEntity(TYPE, ID)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         self.assertIsNone(acl.get_entity(entity))
 
     def test_get_entity_miss_str_w_default(self):
         DEFAULT = object()
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         self.assertIs(acl.get_entity('nonesuch', DEFAULT), DEFAULT)
 
@@ -329,14 +329,14 @@ class Test_ACL(unittest.TestCase):
         TYPE = 'type'
         ID = 'id'
         entity = _ACLEntity(TYPE, ID)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         self.assertIs(acl.get_entity(entity, DEFAULT), DEFAULT)
 
     def test_get_entity_hit_str(self):
         TYPE = 'type'
         ID = 'id'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         acl.entity(TYPE, ID)
         self.assertTrue(acl.has_entity('%s-%s' % (TYPE, ID)))
@@ -344,7 +344,7 @@ class Test_ACL(unittest.TestCase):
     def test_get_entity_hit_entity(self):
         TYPE = 'type'
         ID = 'id'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.entity(TYPE, ID)
         self.assertTrue(acl.has_entity(entity))
@@ -356,7 +356,7 @@ class Test_ACL(unittest.TestCase):
         ROLE = 'role'
         entity = _ACLEntity(TYPE, ID)
         entity.grant(ROLE)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         acl.add_entity(entity)
         self.assertTrue(acl.loaded)
@@ -371,7 +371,7 @@ class Test_ACL(unittest.TestCase):
         ROLE = 'role'
         entity = _ACLEntity(TYPE, ID)
         entity.grant(ROLE)
-        acl = self._makeOne()
+        acl = self._make_one()
 
         def _reload():
             acl.loaded = True
@@ -392,7 +392,7 @@ class Test_ACL(unittest.TestCase):
         ROLE = 'role'
         entity = _ACLEntity(TYPE, ID)
         entity.grant(ROLE)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         before = acl.entity(TYPE, ID)
         acl.add_entity(entity)
@@ -407,7 +407,7 @@ class Test_ACL(unittest.TestCase):
         TYPE = 'type'
         ID = 'id'
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.entity(TYPE, ID)
         self.assertTrue(acl.loaded)
@@ -420,7 +420,7 @@ class Test_ACL(unittest.TestCase):
         TYPE = 'type'
         ID = 'id'
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         before = acl.entity(TYPE, ID)
         before.grant(ROLE)
@@ -433,7 +433,7 @@ class Test_ACL(unittest.TestCase):
     def test_user(self):
         ID = 'id'
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.user(ID)
         entity.grant(ROLE)
@@ -445,7 +445,7 @@ class Test_ACL(unittest.TestCase):
     def test_group(self):
         ID = 'id'
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.group(ID)
         entity.grant(ROLE)
@@ -457,7 +457,7 @@ class Test_ACL(unittest.TestCase):
     def test_domain(self):
         ID = 'id'
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.domain(ID)
         entity.grant(ROLE)
@@ -468,7 +468,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_all(self):
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.all()
         entity.grant(ROLE)
@@ -479,7 +479,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_all_authenticated(self):
         ROLE = 'role'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.all_authenticated()
         entity.grant(ROLE)
@@ -489,12 +489,12 @@ class Test_ACL(unittest.TestCase):
                          [{'entity': 'allAuthenticatedUsers', 'role': ROLE}])
 
     def test_get_entities_empty_eager(self):
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         self.assertEqual(acl.get_entities(), [])
 
     def test_get_entities_empty_lazy(self):
-        acl = self._makeOne()
+        acl = self._make_one()
 
         def _reload():
             acl.loaded = True
@@ -506,7 +506,7 @@ class Test_ACL(unittest.TestCase):
     def test_get_entities_nonempty(self):
         TYPE = 'type'
         ID = 'id'
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.loaded = True
         entity = acl.entity(TYPE, ID)
         self.assertEqual(acl.get_entities(), [entity])
@@ -516,7 +516,7 @@ class Test_ACL(unittest.TestCase):
         ROLE = 'role'
         connection = _Connection({})
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.entity('allUsers', ROLE)
@@ -531,7 +531,7 @@ class Test_ACL(unittest.TestCase):
         ROLE = 'role'
         connection = _Connection({'items': []})
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.entity('allUsers', ROLE)
@@ -548,7 +548,7 @@ class Test_ACL(unittest.TestCase):
         connection = _Connection(
             {'items': [{'entity': 'allUsers', 'role': ROLE}]})
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.reload(client=client)
@@ -562,7 +562,7 @@ class Test_ACL(unittest.TestCase):
     def test_save_none_set_none_passed(self):
         connection = _Connection()
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.save_path = '/testing'
         acl.save(client=client)
         kw = connection._requested
@@ -571,7 +571,7 @@ class Test_ACL(unittest.TestCase):
     def test_save_existing_missing_none_passed(self):
         connection = _Connection({})
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.save_path = '/testing'
         acl.loaded = True
         acl.save(client=client)
@@ -588,7 +588,7 @@ class Test_ACL(unittest.TestCase):
         AFTER = [{'entity': 'allUsers', 'role': ROLE}]
         connection = _Connection({'acl': AFTER})
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.save_path = '/testing'
         acl.loaded = True
         acl.entity('allUsers').grant(ROLE)
@@ -608,7 +608,7 @@ class Test_ACL(unittest.TestCase):
         new_acl = [{'entity': 'allUsers', 'role': ROLE1}]
         connection = _Connection({'acl': [STICKY] + new_acl})
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.save_path = '/testing'
         acl.loaded = True
         acl.save(new_acl, client=client)
@@ -626,7 +626,7 @@ class Test_ACL(unittest.TestCase):
     def test_save_prefefined_invalid(self):
         connection = _Connection()
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.save_path = '/testing'
         acl.loaded = True
         with self.assertRaises(ValueError):
@@ -636,7 +636,7 @@ class Test_ACL(unittest.TestCase):
         PREDEFINED = 'private'
         connection = _Connection({'acl': []})
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.save_path = '/testing'
         acl.loaded = True
         acl.save_predefined(PREDEFINED, client=client)
@@ -655,7 +655,7 @@ class Test_ACL(unittest.TestCase):
         PREDEFINED_JSON = 'projectPrivate'
         connection = _Connection({'acl': []})
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.save_path = '/testing'
         acl.loaded = True
         acl.save_predefined(PREDEFINED_XML, client=client)
@@ -675,7 +675,7 @@ class Test_ACL(unittest.TestCase):
         PREDEFINED = 'publicRead'
         connection = _Connection({'acl': []})
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.save_path = '/testing'
         acl.loaded = True
         acl._PREDEFINED_QUERY_PARAM = 'alternate'
@@ -696,7 +696,7 @@ class Test_ACL(unittest.TestCase):
         STICKY = {'entity': 'allUsers', 'role': ROLE2}
         connection = _Connection({'acl': [STICKY]})
         client = _Client(connection)
-        acl = self._makeOne()
+        acl = self._make_one()
         acl.save_path = '/testing'
         acl.loaded = True
         acl.entity('allUsers', ROLE1)
@@ -717,13 +717,13 @@ class Test_BucketACL(unittest.TestCase):
         from google.cloud.storage.acl import BucketACL
         return BucketACL
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         NAME = 'name'
         bucket = _Bucket(NAME)
-        acl = self._makeOne(bucket)
+        acl = self._make_one(bucket)
         self.assertEqual(acl.entities, {})
         self.assertFalse(acl.loaded)
         self.assertIs(acl.bucket, bucket)
@@ -738,13 +738,13 @@ class Test_DefaultObjectACL(unittest.TestCase):
         from google.cloud.storage.acl import DefaultObjectACL
         return DefaultObjectACL
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         NAME = 'name'
         bucket = _Bucket(NAME)
-        acl = self._makeOne(bucket)
+        acl = self._make_one(bucket)
         self.assertEqual(acl.entities, {})
         self.assertFalse(acl.loaded)
         self.assertIs(acl.bucket, bucket)
@@ -759,7 +759,7 @@ class Test_ObjectACL(unittest.TestCase):
         from google.cloud.storage.acl import ObjectACL
         return ObjectACL
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
@@ -767,7 +767,7 @@ class Test_ObjectACL(unittest.TestCase):
         BLOB_NAME = 'blob-name'
         bucket = _Bucket(NAME)
         blob = _Blob(bucket, BLOB_NAME)
-        acl = self._makeOne(blob)
+        acl = self._make_one(blob)
         self.assertEqual(acl.entities, {})
         self.assertFalse(acl.loaded)
         self.assertIs(acl.blob, blob)

--- a/storage/unit_tests/test_acl.py
+++ b/storage/unit_tests/test_acl.py
@@ -17,7 +17,8 @@ import unittest
 
 class Test_ACLEntity(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.storage.acl import _ACLEntity
         return _ACLEntity
 
@@ -126,7 +127,8 @@ class Test_ACLEntity(unittest.TestCase):
 
 class Test_ACL(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.storage.acl import ACL
         return ACL
 
@@ -710,7 +712,8 @@ class Test_ACL(unittest.TestCase):
 
 class Test_BucketACL(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.storage.acl import BucketACL
         return BucketACL
 
@@ -730,7 +733,8 @@ class Test_BucketACL(unittest.TestCase):
 
 class Test_DefaultObjectACL(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.storage.acl import DefaultObjectACL
         return DefaultObjectACL
 
@@ -750,7 +754,8 @@ class Test_DefaultObjectACL(unittest.TestCase):
 
 class Test_ObjectACL(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.storage.acl import ObjectACL
         return ObjectACL
 

--- a/storage/unit_tests/test_batch.py
+++ b/storage/unit_tests/test_batch.py
@@ -22,7 +22,7 @@ class TestMIMEApplicationHTTP(unittest.TestCase):
         from google.cloud.storage.batch import MIMEApplicationHTTP
         return MIMEApplicationHTTP
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_body_None(self):
@@ -32,7 +32,7 @@ class TestMIMEApplicationHTTP(unittest.TestCase):
             "DELETE /path/to/api HTTP/1.1",
             "",
             ]
-        mah = self._makeOne(METHOD, PATH, {}, None)
+        mah = self._make_one(METHOD, PATH, {}, None)
         self.assertEqual(mah.get_content_type(), 'application/http')
         self.assertEqual(mah.get_payload().splitlines(), LINES)
 
@@ -48,7 +48,7 @@ class TestMIMEApplicationHTTP(unittest.TestCase):
             "",
             "ABC",
             ]
-        mah = self._makeOne(METHOD, PATH, HEADERS, BODY)
+        mah = self._make_one(METHOD, PATH, HEADERS, BODY)
         self.assertEqual(mah.get_payload().splitlines(), LINES)
 
     def test_ctor_body_dict(self):
@@ -63,7 +63,7 @@ class TestMIMEApplicationHTTP(unittest.TestCase):
             '',
             '{"foo": "bar"}',
             ]
-        mah = self._makeOne(METHOD, PATH, HEADERS, BODY)
+        mah = self._make_one(METHOD, PATH, HEADERS, BODY)
         self.assertEqual(mah.get_payload().splitlines(), LINES)
 
 
@@ -74,14 +74,14 @@ class TestBatch(unittest.TestCase):
         from google.cloud.storage.batch import Batch
         return Batch
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         http = _HTTP()
         connection = _Connection(http=http)
         client = _Client(connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         self.assertIs(batch._client, client)
         self.assertEqual(len(batch._requests), 0)
         self.assertEqual(len(batch._target_objects), 0)
@@ -91,13 +91,13 @@ class TestBatch(unittest.TestCase):
         project = 'PROJECT'
         credentials = _Credentials()
         client = Client(project=project, credentials=credentials)
-        batch1 = self._makeOne(client)
+        batch1 = self._make_one(client)
         self.assertIsNone(batch1.current())
 
         client._push_batch(batch1)
         self.assertIs(batch1.current(), batch1)
 
-        batch2 = self._makeOne(client)
+        batch2 = self._make_one(client)
         client._push_batch(batch2)
         self.assertIs(batch1.current(), batch2)
 
@@ -107,7 +107,7 @@ class TestBatch(unittest.TestCase):
         expected = _Response()
         http = _HTTP((expected, ''))
         connection = _Connection(http=http)
-        batch = self._makeOne(connection)
+        batch = self._make_one(connection)
         target = _MockObject()
         response, content = batch._make_request('GET', URL,
                                                 target_object=target)
@@ -132,7 +132,7 @@ class TestBatch(unittest.TestCase):
         URL = 'http://example.com/api'
         http = _HTTP()  # no requests expected
         connection = _Connection(http=http)
-        batch = self._makeOne(connection)
+        batch = self._make_one(connection)
         target = _MockObject()
         response, content = batch._make_request('POST', URL, data={'foo': 1},
                                                 target_object=target)
@@ -157,7 +157,7 @@ class TestBatch(unittest.TestCase):
         URL = 'http://example.com/api'
         http = _HTTP()  # no requests expected
         connection = _Connection(http=http)
-        batch = self._makeOne(connection)
+        batch = self._make_one(connection)
         target = _MockObject()
         response, content = batch._make_request('PATCH', URL, data={'foo': 1},
                                                 target_object=target)
@@ -182,7 +182,7 @@ class TestBatch(unittest.TestCase):
         URL = 'http://example.com/api'
         http = _HTTP()  # no requests expected
         connection = _Connection(http=http)
-        batch = self._makeOne(connection)
+        batch = self._make_one(connection)
         target = _MockObject()
         response, content = batch._make_request('DELETE', URL,
                                                 target_object=target)
@@ -206,7 +206,7 @@ class TestBatch(unittest.TestCase):
         URL = 'http://example.com/api'
         http = _HTTP()  # no requests expected
         connection = _Connection(http=http)
-        batch = self._makeOne(connection)
+        batch = self._make_one(connection)
         batch._MAX_BATCH_SIZE = 1
         batch._requests.append(('POST', URL, {}, {'bar': 2}))
         self.assertRaises(ValueError,
@@ -216,7 +216,7 @@ class TestBatch(unittest.TestCase):
     def test_finish_empty(self):
         http = _HTTP()  # no requests expected
         connection = _Connection(http=http)
-        batch = self._makeOne(connection)
+        batch = self._make_one(connection)
         self.assertRaises(ValueError, batch.finish)
         self.assertIs(connection.http, http)
 
@@ -261,7 +261,7 @@ class TestBatch(unittest.TestCase):
         http = _HTTP((expected, _THREE_PART_MIME_RESPONSE))
         connection = _Connection(http=http)
         client = _Client(connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         batch.API_BASE_URL = 'http://api.example.com'
         batch._do_request('POST', URL, {}, {'foo': 1, 'bar': 2}, None)
         batch._do_request('PATCH', URL, {}, {'bar': 3}, None)
@@ -311,7 +311,7 @@ class TestBatch(unittest.TestCase):
         http = _HTTP((expected, _TWO_PART_MIME_RESPONSE_WITH_FAIL))
         connection = _Connection(http=http)
         client = _Client(connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         batch.API_BASE_URL = 'http://api.example.com'
         batch._requests.append(('GET', URL, {}, None))
         self.assertRaises(ValueError, batch.finish)
@@ -324,7 +324,7 @@ class TestBatch(unittest.TestCase):
         http = _HTTP((expected, _TWO_PART_MIME_RESPONSE_WITH_FAIL))
         connection = _Connection(http=http)
         client = _Client(connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         batch.API_BASE_URL = 'http://api.example.com'
         target1 = _MockObject()
         target2 = _MockObject()
@@ -365,7 +365,7 @@ class TestBatch(unittest.TestCase):
         http = _HTTP((expected, 'NOT A MIME_RESPONSE'))
         connection = _Connection(http=http)
         client = _Client(connection)
-        batch = self._makeOne(client)
+        batch = self._make_one(client)
         batch._requests.append(('POST', URL, {}, {'foo': 1, 'bar': 2}))
         batch._requests.append(('PATCH', URL, {}, {'bar': 3}))
         batch._requests.append(('DELETE', URL, {}, None))
@@ -387,7 +387,7 @@ class TestBatch(unittest.TestCase):
         target1 = _MockObject()
         target2 = _MockObject()
         target3 = _MockObject()
-        with self._makeOne(client) as batch:
+        with self._make_one(client) as batch:
             self.assertEqual(list(client._batch_stack), [batch])
             batch._make_request('POST', URL, {'foo': 1, 'bar': 2},
                                 target_object=target1)
@@ -424,7 +424,7 @@ class TestBatch(unittest.TestCase):
         target2 = _MockObject()
         target3 = _MockObject()
         try:
-            with self._makeOne(client) as batch:
+            with self._make_one(client) as batch:
                 self.assertEqual(list(client._batch_stack), [batch])
                 batch._make_request('POST', URL, {'foo': 1, 'bar': 2},
                                     target_object=target1)
@@ -539,23 +539,23 @@ Content-Length: 0
 
 class Test__FutureDict(unittest.TestCase):
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         from google.cloud.storage.batch import _FutureDict
         return _FutureDict(*args, **kw)
 
     def test_get(self):
-        future = self._makeOne()
+        future = self._make_one()
         self.assertRaises(KeyError, future.get, None)
 
     def test___getitem__(self):
-        future = self._makeOne()
+        future = self._make_one()
         value = orig_value = object()
         with self.assertRaises(KeyError):
             value = future[None]
         self.assertIs(value, orig_value)
 
     def test___setitem__(self):
-        future = self._makeOne()
+        future = self._make_one()
         with self.assertRaises(KeyError):
             future[None] = None
 

--- a/storage/unit_tests/test_batch.py
+++ b/storage/unit_tests/test_batch.py
@@ -23,7 +23,7 @@ class TestMIMEApplicationHTTP(unittest.TestCase):
         return MIMEApplicationHTTP
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_body_None(self):
         METHOD = 'DELETE'
@@ -75,7 +75,7 @@ class TestBatch(unittest.TestCase):
         return Batch
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         http = _HTTP()

--- a/storage/unit_tests/test_batch.py
+++ b/storage/unit_tests/test_batch.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestMIMEApplicationHTTP(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.storage.batch import MIMEApplicationHTTP
         return MIMEApplicationHTTP
 
@@ -68,7 +69,8 @@ class TestMIMEApplicationHTTP(unittest.TestCase):
 
 class TestBatch(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.storage.batch import Batch
         return Batch
 

--- a/storage/unit_tests/test_batch.py
+++ b/storage/unit_tests/test_batch.py
@@ -448,13 +448,13 @@ class TestBatch(unittest.TestCase):
 
 class Test__unpack_batch_response(unittest.TestCase):
 
-    def _callFUT(self, response, content):
+    def _call_fut(self, response, content):
         from google.cloud.storage.batch import _unpack_batch_response
         return _unpack_batch_response(response, content)
 
     def _unpack_helper(self, response, content):
         import httplib2
-        result = list(self._callFUT(response, content))
+        result = list(self._call_fut(response, content))
         self.assertEqual(len(result), 3)
         response0 = httplib2.Response({
             'content-length': '20',

--- a/storage/unit_tests/test_blob.py
+++ b/storage/unit_tests/test_blob.py
@@ -17,7 +17,7 @@ import unittest
 
 class Test_Blob(unittest.TestCase):
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         from google.cloud.storage.blob import Blob
         properties = kw.pop('properties', None)
         blob = Blob(*args, **kw)
@@ -28,7 +28,7 @@ class Test_Blob(unittest.TestCase):
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
         properties = {'key': 'value'}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertIs(blob.bucket, bucket)
         self.assertEqual(blob.name, BLOB_NAME)
         self.assertEqual(blob._properties, properties)
@@ -40,7 +40,7 @@ class Test_Blob(unittest.TestCase):
         KEY = b'01234567890123456789012345678901'  # 32 bytes
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, encryption_key=KEY)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, encryption_key=KEY)
         self.assertEqual(blob._encryption_key, KEY)
 
     def test_chunk_size_ctor(self):
@@ -48,13 +48,13 @@ class Test_Blob(unittest.TestCase):
         BLOB_NAME = 'blob-name'
         BUCKET = object()
         chunk_size = 10 * Blob._CHUNK_SIZE_MULTIPLE
-        blob = self._makeOne(BLOB_NAME, bucket=BUCKET, chunk_size=chunk_size)
+        blob = self._make_one(BLOB_NAME, bucket=BUCKET, chunk_size=chunk_size)
         self.assertEqual(blob._chunk_size, chunk_size)
 
     def test_chunk_size_getter(self):
         BLOB_NAME = 'blob-name'
         BUCKET = object()
-        blob = self._makeOne(BLOB_NAME, bucket=BUCKET)
+        blob = self._make_one(BLOB_NAME, bucket=BUCKET)
         self.assertIsNone(blob.chunk_size)
         VALUE = object()
         blob._chunk_size = VALUE
@@ -63,7 +63,7 @@ class Test_Blob(unittest.TestCase):
     def test_chunk_size_setter(self):
         BLOB_NAME = 'blob-name'
         BUCKET = object()
-        blob = self._makeOne(BLOB_NAME, bucket=BUCKET)
+        blob = self._make_one(BLOB_NAME, bucket=BUCKET)
         self.assertIsNone(blob._chunk_size)
         blob._CHUNK_SIZE_MULTIPLE = 10
         blob.chunk_size = 20
@@ -72,7 +72,7 @@ class Test_Blob(unittest.TestCase):
     def test_chunk_size_setter_bad_value(self):
         BLOB_NAME = 'blob-name'
         BUCKET = object()
-        blob = self._makeOne(BLOB_NAME, bucket=BUCKET)
+        blob = self._make_one(BLOB_NAME, bucket=BUCKET)
         self.assertIsNone(blob._chunk_size)
         blob._CHUNK_SIZE_MULTIPLE = 10
         with self.assertRaises(ValueError):
@@ -81,7 +81,7 @@ class Test_Blob(unittest.TestCase):
     def test_acl_property(self):
         from google.cloud.storage.acl import ObjectACL
         FAKE_BUCKET = _Bucket()
-        blob = self._makeOne(None, bucket=FAKE_BUCKET)
+        blob = self._make_one(None, bucket=FAKE_BUCKET)
         acl = blob.acl
         self.assertIsInstance(acl, ObjectACL)
         self.assertIs(acl, blob._acl)
@@ -89,30 +89,30 @@ class Test_Blob(unittest.TestCase):
     def test_path_no_bucket(self):
         FAKE_BUCKET = object()
         NAME = 'blob-name'
-        blob = self._makeOne(NAME, bucket=FAKE_BUCKET)
+        blob = self._make_one(NAME, bucket=FAKE_BUCKET)
         self.assertRaises(AttributeError, getattr, blob, 'path')
 
     def test_path_no_name(self):
         bucket = _Bucket()
-        blob = self._makeOne(None, bucket=bucket)
+        blob = self._make_one(None, bucket=bucket)
         self.assertRaises(ValueError, getattr, blob, 'path')
 
     def test_path_normal(self):
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertEqual(blob.path, '/b/name/o/%s' % BLOB_NAME)
 
     def test_path_w_slash_in_name(self):
         BLOB_NAME = 'parent/child'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertEqual(blob.path, '/b/name/o/parent%2Fchild')
 
     def test_public_url(self):
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertEqual(blob.public_url,
                          'https://storage.googleapis.com/name/%s' %
                          BLOB_NAME)
@@ -120,7 +120,7 @@ class Test_Blob(unittest.TestCase):
     def test_public_url_w_slash_in_name(self):
         BLOB_NAME = 'parent/child'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertEqual(
             blob.public_url,
             'https://storage.googleapis.com/name/parent%2Fchild')
@@ -134,7 +134,7 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         URI = ('http://example.com/abucket/a-blob-name?Signature=DEADBEEF'
                '&Expiration=2014-10-16T20:34:37.000Z')
 
@@ -173,7 +173,7 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         URI = ('http://example.com/abucket/a-blob-name?Signature=DEADBEEF'
                '&Expiration=2014-10-16T20:34:37.000Z')
 
@@ -211,7 +211,7 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         URI = ('http://example.com/abucket/a-blob-name?Signature=DEADBEEF'
                '&Expiration=2014-10-16T20:34:37.000Z')
 
@@ -242,7 +242,7 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         URI = ('http://example.com/abucket/a-blob-name?Signature=DEADBEEF'
                '&Expiration=2014-10-16T20:34:37.000Z')
 
@@ -272,7 +272,7 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection(not_found_response)
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(NONESUCH, bucket=bucket)
+        blob = self._make_one(NONESUCH, bucket=bucket)
         self.assertFalse(blob.exists())
 
     def test_exists_hit(self):
@@ -282,7 +282,7 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection(found_response)
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
         self.assertTrue(blob.exists())
 
@@ -293,7 +293,7 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection(not_found_response)
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
         blob.delete()
         self.assertFalse(blob.exists())
@@ -319,7 +319,7 @@ class Test_Blob(unittest.TestCase):
         connection._responses = [(reload_response, {"mediaLink": MEDIA_LINK})]
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         fh = BytesIO()
         blob.download_to_file(fh)
         self.assertEqual(fh.getvalue(), b'abcdef')
@@ -342,7 +342,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket(client)
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         if chunk_size is not None:
             blob._CHUNK_SIZE_MULTIPLE = 1
             blob.chunk_size = chunk_size
@@ -377,7 +377,7 @@ class Test_Blob(unittest.TestCase):
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK,
                       'updated': '2014-12-06T13:13:50.690Z'}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 3
 
@@ -415,7 +415,7 @@ class Test_Blob(unittest.TestCase):
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK,
                       'updated': '2014-12-06T13:13:50.690Z'}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties,
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties,
                              encryption_key=KEY)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 3
@@ -453,7 +453,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket(client)
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 3
         fetched = blob.download_as_string()
@@ -464,7 +464,7 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         file_obj = object()
         with self.assertRaises(ValueError):
             blob.upload_from_file(file_obj, size=None)
@@ -489,7 +489,7 @@ class Test_Blob(unittest.TestCase):
         )
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = chunk_size
 
@@ -537,7 +537,7 @@ class Test_Blob(unittest.TestCase):
         )
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
 
@@ -670,7 +670,7 @@ class Test_Blob(unittest.TestCase):
         )
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
 
@@ -747,7 +747,7 @@ class Test_Blob(unittest.TestCase):
         )
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
 
@@ -805,7 +805,7 @@ class Test_Blob(unittest.TestCase):
         )
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
 
@@ -860,7 +860,7 @@ class Test_Blob(unittest.TestCase):
         )
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket,
+        blob = self._make_one(BLOB_NAME, bucket=bucket,
                              properties=properties, encryption_key=KEY)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
@@ -913,7 +913,7 @@ class Test_Blob(unittest.TestCase):
         )
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket,
+        blob = self._make_one(BLOB_NAME, bucket=bucket,
                              properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
@@ -982,7 +982,7 @@ class Test_Blob(unittest.TestCase):
         )
         client = _Client(connection)
         bucket = _Bucket(client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
         blob.upload_from_string(DATA)
@@ -1022,7 +1022,7 @@ class Test_Blob(unittest.TestCase):
         )
         client = _Client(connection)
         bucket = _Bucket(client=client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
         blob.upload_from_string(DATA)
@@ -1065,7 +1065,7 @@ class Test_Blob(unittest.TestCase):
         )
         client = _Client(connection)
         bucket = _Bucket(client=client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, encryption_key=KEY)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, encryption_key=KEY)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
         blob.upload_from_string(DATA)
@@ -1099,7 +1099,7 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection(after)
         client = _Client(connection)
         bucket = _Bucket(client=client)
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         blob.acl.loaded = True
         blob.make_public()
         self.assertEqual(list(blob.acl), permissive)
@@ -1117,9 +1117,9 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         bucket = _Bucket(client=client)
-        source_1 = self._makeOne(SOURCE_1, bucket=bucket)
-        source_2 = self._makeOne(SOURCE_2, bucket=bucket)
-        destination = self._makeOne(DESTINATION, bucket=bucket)
+        source_1 = self._make_one(SOURCE_1, bucket=bucket)
+        source_2 = self._make_one(SOURCE_2, bucket=bucket)
+        destination = self._make_one(DESTINATION, bucket=bucket)
 
         with self.assertRaises(ValueError):
             destination.compose(sources=[source_1, source_2])
@@ -1136,9 +1136,9 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection(after)
         client = _Client(connection)
         bucket = _Bucket(client=client)
-        source_1 = self._makeOne(SOURCE_1, bucket=bucket)
-        source_2 = self._makeOne(SOURCE_2, bucket=bucket)
-        destination = self._makeOne(DESTINATION, bucket=bucket)
+        source_1 = self._make_one(SOURCE_1, bucket=bucket)
+        source_2 = self._make_one(SOURCE_2, bucket=bucket)
+        destination = self._make_one(DESTINATION, bucket=bucket)
         destination.content_type = 'text/plain'
 
         destination.compose(sources=[source_1, source_2])
@@ -1172,9 +1172,9 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection(after)
         client = _Client(connection)
         bucket = _Bucket(client=client)
-        source_1 = self._makeOne(SOURCE_1, bucket=bucket)
-        source_2 = self._makeOne(SOURCE_2, bucket=bucket)
-        destination = self._makeOne(DESTINATION, bucket=bucket)
+        source_1 = self._make_one(SOURCE_1, bucket=bucket)
+        source_2 = self._make_one(SOURCE_2, bucket=bucket)
+        destination = self._make_one(DESTINATION, bucket=bucket)
         destination.content_type = 'text/plain'
         destination.content_language = 'en-US'
         destination.metadata = {'my-key': 'my-value'}
@@ -1219,9 +1219,9 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection(response)
         client = _Client(connection)
         source_bucket = _Bucket(client=client)
-        source_blob = self._makeOne(SOURCE_BLOB, bucket=source_bucket)
+        source_blob = self._make_one(SOURCE_BLOB, bucket=source_bucket)
         dest_bucket = _Bucket(client=client, name=DEST_BUCKET)
-        dest_blob = self._makeOne(DEST_BLOB, bucket=dest_bucket)
+        dest_blob = self._make_one(DEST_BLOB, bucket=dest_bucket)
 
         token, rewritten, size = dest_blob.rewrite(source_blob)
 
@@ -1267,8 +1267,8 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection(response)
         client = _Client(connection)
         bucket = _Bucket(client=client)
-        plain = self._makeOne(BLOB_NAME, bucket=bucket)
-        encrypted = self._makeOne(BLOB_NAME, bucket=bucket, encryption_key=KEY)
+        plain = self._make_one(BLOB_NAME, bucket=bucket)
+        encrypted = self._make_one(BLOB_NAME, bucket=bucket, encryption_key=KEY)
 
         token, rewritten, size = encrypted.rewrite(plain)
 
@@ -1320,9 +1320,9 @@ class Test_Blob(unittest.TestCase):
         connection = _Connection(response)
         client = _Client(connection)
         bucket = _Bucket(client=client)
-        source = self._makeOne(
+        source = self._make_one(
             BLOB_NAME, bucket=bucket, encryption_key=SOURCE_KEY)
-        dest = self._makeOne(BLOB_NAME, bucket=bucket, encryption_key=DEST_KEY)
+        dest = self._make_one(BLOB_NAME, bucket=bucket, encryption_key=DEST_KEY)
 
         token, rewritten, size = dest.rewrite(source, token=TOKEN)
 
@@ -1360,14 +1360,14 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         CACHE_CONTROL = 'no-cache'
         properties = {'cacheControl': CACHE_CONTROL}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.cache_control, CACHE_CONTROL)
 
     def test_cache_control_setter(self):
         BLOB_NAME = 'blob-name'
         CACHE_CONTROL = 'no-cache'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertIsNone(blob.cache_control)
         blob.cache_control = CACHE_CONTROL
         self.assertEqual(blob.cache_control, CACHE_CONTROL)
@@ -1375,19 +1375,19 @@ class Test_Blob(unittest.TestCase):
     def test_component_count(self):
         BUCKET = object()
         COMPONENT_COUNT = 42
-        blob = self._makeOne('blob-name', bucket=BUCKET,
+        blob = self._make_one('blob-name', bucket=BUCKET,
                              properties={'componentCount': COMPONENT_COUNT})
         self.assertEqual(blob.component_count, COMPONENT_COUNT)
 
     def test_component_count_unset(self):
         BUCKET = object()
-        blob = self._makeOne('blob-name', bucket=BUCKET)
+        blob = self._make_one('blob-name', bucket=BUCKET)
         self.assertIsNone(blob.component_count)
 
     def test_component_count_string_val(self):
         BUCKET = object()
         COMPONENT_COUNT = 42
-        blob = self._makeOne(
+        blob = self._make_one(
             'blob-name', bucket=BUCKET,
             properties={'componentCount': str(COMPONENT_COUNT)})
         self.assertEqual(blob.component_count, COMPONENT_COUNT)
@@ -1397,14 +1397,14 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         CONTENT_DISPOSITION = 'Attachment; filename=example.jpg'
         properties = {'contentDisposition': CONTENT_DISPOSITION}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.content_disposition, CONTENT_DISPOSITION)
 
     def test_content_disposition_setter(self):
         BLOB_NAME = 'blob-name'
         CONTENT_DISPOSITION = 'Attachment; filename=example.jpg'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertIsNone(blob.content_disposition)
         blob.content_disposition = CONTENT_DISPOSITION
         self.assertEqual(blob.content_disposition, CONTENT_DISPOSITION)
@@ -1414,14 +1414,14 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         CONTENT_ENCODING = 'gzip'
         properties = {'contentEncoding': CONTENT_ENCODING}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.content_encoding, CONTENT_ENCODING)
 
     def test_content_encoding_setter(self):
         BLOB_NAME = 'blob-name'
         CONTENT_ENCODING = 'gzip'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertIsNone(blob.content_encoding)
         blob.content_encoding = CONTENT_ENCODING
         self.assertEqual(blob.content_encoding, CONTENT_ENCODING)
@@ -1431,14 +1431,14 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         CONTENT_LANGUAGE = 'pt-BR'
         properties = {'contentLanguage': CONTENT_LANGUAGE}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.content_language, CONTENT_LANGUAGE)
 
     def test_content_language_setter(self):
         BLOB_NAME = 'blob-name'
         CONTENT_LANGUAGE = 'pt-BR'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertIsNone(blob.content_language)
         blob.content_language = CONTENT_LANGUAGE
         self.assertEqual(blob.content_language, CONTENT_LANGUAGE)
@@ -1448,14 +1448,14 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         CONTENT_TYPE = 'image/jpeg'
         properties = {'contentType': CONTENT_TYPE}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.content_type, CONTENT_TYPE)
 
     def test_content_type_setter(self):
         BLOB_NAME = 'blob-name'
         CONTENT_TYPE = 'image/jpeg'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertIsNone(blob.content_type)
         blob.content_type = CONTENT_TYPE
         self.assertEqual(blob.content_type, CONTENT_TYPE)
@@ -1465,14 +1465,14 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         CRC32C = 'DEADBEEF'
         properties = {'crc32c': CRC32C}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.crc32c, CRC32C)
 
     def test_crc32c_setter(self):
         BLOB_NAME = 'blob-name'
         CRC32C = 'DEADBEEF'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertIsNone(blob.crc32c)
         blob.crc32c = CRC32C
         self.assertEqual(blob.crc32c, CRC32C)
@@ -1482,25 +1482,25 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         ETAG = 'ETAG'
         properties = {'etag': ETAG}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.etag, ETAG)
 
     def test_generation(self):
         BUCKET = object()
         GENERATION = 42
-        blob = self._makeOne('blob-name', bucket=BUCKET,
+        blob = self._make_one('blob-name', bucket=BUCKET,
                              properties={'generation': GENERATION})
         self.assertEqual(blob.generation, GENERATION)
 
     def test_generation_unset(self):
         BUCKET = object()
-        blob = self._makeOne('blob-name', bucket=BUCKET)
+        blob = self._make_one('blob-name', bucket=BUCKET)
         self.assertIsNone(blob.generation)
 
     def test_generation_string_val(self):
         BUCKET = object()
         GENERATION = 42
-        blob = self._makeOne('blob-name', bucket=BUCKET,
+        blob = self._make_one('blob-name', bucket=BUCKET,
                              properties={'generation': str(GENERATION)})
         self.assertEqual(blob.generation, GENERATION)
 
@@ -1509,7 +1509,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         ID = 'ID'
         properties = {'id': ID}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.id, ID)
 
     def test_md5_hash_getter(self):
@@ -1517,14 +1517,14 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         MD5_HASH = 'DEADBEEF'
         properties = {'md5Hash': MD5_HASH}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.md5_hash, MD5_HASH)
 
     def test_md5_hash_setter(self):
         BLOB_NAME = 'blob-name'
         MD5_HASH = 'DEADBEEF'
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertIsNone(blob.md5_hash)
         blob.md5_hash = MD5_HASH
         self.assertEqual(blob.md5_hash, MD5_HASH)
@@ -1534,7 +1534,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         MEDIA_LINK = 'http://example.com/media/'
         properties = {'mediaLink': MEDIA_LINK}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.media_link, MEDIA_LINK)
 
     def test_metadata_getter(self):
@@ -1542,14 +1542,14 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         METADATA = {'foo': 'Foo'}
         properties = {'metadata': METADATA}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.metadata, METADATA)
 
     def test_metadata_setter(self):
         BLOB_NAME = 'blob-name'
         METADATA = {'foo': 'Foo'}
         bucket = _Bucket()
-        blob = self._makeOne(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertIsNone(blob.metadata)
         blob.metadata = METADATA
         self.assertEqual(blob.metadata, METADATA)
@@ -1557,19 +1557,19 @@ class Test_Blob(unittest.TestCase):
     def test_metageneration(self):
         BUCKET = object()
         METAGENERATION = 42
-        blob = self._makeOne('blob-name', bucket=BUCKET,
+        blob = self._make_one('blob-name', bucket=BUCKET,
                              properties={'metageneration': METAGENERATION})
         self.assertEqual(blob.metageneration, METAGENERATION)
 
     def test_metageneration_unset(self):
         BUCKET = object()
-        blob = self._makeOne('blob-name', bucket=BUCKET)
+        blob = self._make_one('blob-name', bucket=BUCKET)
         self.assertIsNone(blob.metageneration)
 
     def test_metageneration_string_val(self):
         BUCKET = object()
         METAGENERATION = 42
-        blob = self._makeOne(
+        blob = self._make_one(
             'blob-name', bucket=BUCKET,
             properties={'metageneration': str(METAGENERATION)})
         self.assertEqual(blob.metageneration, METAGENERATION)
@@ -1579,7 +1579,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         OWNER = {'entity': 'project-owner-12345', 'entityId': '23456'}
         properties = {'owner': OWNER}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         owner = blob.owner
         self.assertEqual(owner['entity'], 'project-owner-12345')
         self.assertEqual(owner['entityId'], '23456')
@@ -1589,25 +1589,25 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         SELF_LINK = 'http://example.com/self/'
         properties = {'selfLink': SELF_LINK}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.self_link, SELF_LINK)
 
     def test_size(self):
         BUCKET = object()
         SIZE = 42
-        blob = self._makeOne('blob-name', bucket=BUCKET,
+        blob = self._make_one('blob-name', bucket=BUCKET,
                              properties={'size': SIZE})
         self.assertEqual(blob.size, SIZE)
 
     def test_size_unset(self):
         BUCKET = object()
-        blob = self._makeOne('blob-name', bucket=BUCKET)
+        blob = self._make_one('blob-name', bucket=BUCKET)
         self.assertIsNone(blob.size)
 
     def test_size_string_val(self):
         BUCKET = object()
         SIZE = 42
-        blob = self._makeOne('blob-name', bucket=BUCKET,
+        blob = self._make_one('blob-name', bucket=BUCKET,
                              properties={'size': str(SIZE)})
         self.assertEqual(blob.size, SIZE)
 
@@ -1616,7 +1616,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         STORAGE_CLASS = 'http://example.com/self/'
         properties = {'storageClass': STORAGE_CLASS}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.storage_class, STORAGE_CLASS)
 
     def test_time_deleted(self):
@@ -1628,12 +1628,12 @@ class Test_Blob(unittest.TestCase):
         TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
         TIME_DELETED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {'timeDeleted': TIME_DELETED}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.time_deleted, TIMESTAMP)
 
     def test_time_deleted_unset(self):
         BUCKET = object()
-        blob = self._makeOne('blob-name', bucket=BUCKET)
+        blob = self._make_one('blob-name', bucket=BUCKET)
         self.assertIsNone(blob.time_deleted)
 
     def test_updated(self):
@@ -1645,12 +1645,12 @@ class Test_Blob(unittest.TestCase):
         TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
         UPDATED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {'updated': UPDATED}
-        blob = self._makeOne(BLOB_NAME, bucket=bucket, properties=properties)
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.updated, TIMESTAMP)
 
     def test_updated_unset(self):
         BUCKET = object()
-        blob = self._makeOne('blob-name', bucket=BUCKET)
+        blob = self._make_one('blob-name', bucket=BUCKET)
         self.assertIsNone(blob.updated)
 
 

--- a/storage/unit_tests/test_blob.py
+++ b/storage/unit_tests/test_blob.py
@@ -416,7 +416,7 @@ class Test_Blob(unittest.TestCase):
         properties = {'mediaLink': MEDIA_LINK,
                       'updated': '2014-12-06T13:13:50.690Z'}
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties,
-                             encryption_key=KEY)
+                              encryption_key=KEY)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 3
 
@@ -861,7 +861,7 @@ class Test_Blob(unittest.TestCase):
         client = _Client(connection)
         bucket = _Bucket(client)
         blob = self._make_one(BLOB_NAME, bucket=bucket,
-                             properties=properties, encryption_key=KEY)
+                              properties=properties, encryption_key=KEY)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
 
@@ -914,7 +914,7 @@ class Test_Blob(unittest.TestCase):
         client = _Client(connection)
         bucket = _Bucket(client)
         blob = self._make_one(BLOB_NAME, bucket=bucket,
-                             properties=properties)
+                              properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 5
 
@@ -1268,7 +1268,8 @@ class Test_Blob(unittest.TestCase):
         client = _Client(connection)
         bucket = _Bucket(client=client)
         plain = self._make_one(BLOB_NAME, bucket=bucket)
-        encrypted = self._make_one(BLOB_NAME, bucket=bucket, encryption_key=KEY)
+        encrypted = self._make_one(BLOB_NAME, bucket=bucket,
+                                   encryption_key=KEY)
 
         token, rewritten, size = encrypted.rewrite(plain)
 
@@ -1322,7 +1323,8 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket(client=client)
         source = self._make_one(
             BLOB_NAME, bucket=bucket, encryption_key=SOURCE_KEY)
-        dest = self._make_one(BLOB_NAME, bucket=bucket, encryption_key=DEST_KEY)
+        dest = self._make_one(BLOB_NAME, bucket=bucket,
+                              encryption_key=DEST_KEY)
 
         token, rewritten, size = dest.rewrite(source, token=TOKEN)
 
@@ -1376,7 +1378,7 @@ class Test_Blob(unittest.TestCase):
         BUCKET = object()
         COMPONENT_COUNT = 42
         blob = self._make_one('blob-name', bucket=BUCKET,
-                             properties={'componentCount': COMPONENT_COUNT})
+                              properties={'componentCount': COMPONENT_COUNT})
         self.assertEqual(blob.component_count, COMPONENT_COUNT)
 
     def test_component_count_unset(self):
@@ -1489,7 +1491,7 @@ class Test_Blob(unittest.TestCase):
         BUCKET = object()
         GENERATION = 42
         blob = self._make_one('blob-name', bucket=BUCKET,
-                             properties={'generation': GENERATION})
+                              properties={'generation': GENERATION})
         self.assertEqual(blob.generation, GENERATION)
 
     def test_generation_unset(self):
@@ -1501,7 +1503,7 @@ class Test_Blob(unittest.TestCase):
         BUCKET = object()
         GENERATION = 42
         blob = self._make_one('blob-name', bucket=BUCKET,
-                             properties={'generation': str(GENERATION)})
+                              properties={'generation': str(GENERATION)})
         self.assertEqual(blob.generation, GENERATION)
 
     def test_id(self):
@@ -1558,7 +1560,7 @@ class Test_Blob(unittest.TestCase):
         BUCKET = object()
         METAGENERATION = 42
         blob = self._make_one('blob-name', bucket=BUCKET,
-                             properties={'metageneration': METAGENERATION})
+                              properties={'metageneration': METAGENERATION})
         self.assertEqual(blob.metageneration, METAGENERATION)
 
     def test_metageneration_unset(self):
@@ -1596,7 +1598,7 @@ class Test_Blob(unittest.TestCase):
         BUCKET = object()
         SIZE = 42
         blob = self._make_one('blob-name', bucket=BUCKET,
-                             properties={'size': SIZE})
+                              properties={'size': SIZE})
         self.assertEqual(blob.size, SIZE)
 
     def test_size_unset(self):
@@ -1608,7 +1610,7 @@ class Test_Blob(unittest.TestCase):
         BUCKET = object()
         SIZE = 42
         blob = self._make_one('blob-name', bucket=BUCKET,
-                             properties={'size': str(SIZE)})
+                              properties={'size': str(SIZE)})
         self.assertEqual(blob.size, SIZE)
 
     def test_storage_class(self):

--- a/storage/unit_tests/test_bucket.py
+++ b/storage/unit_tests/test_bucket.py
@@ -17,7 +17,7 @@ import unittest
 
 class Test_Bucket(unittest.TestCase):
 
-    def _makeOne(self, client=None, name=None, properties=None):
+    def _make_one(self, client=None, name=None, properties=None):
         from google.cloud.storage.bucket import Bucket
         if client is None:
             connection = _Connection()
@@ -29,7 +29,7 @@ class Test_Bucket(unittest.TestCase):
     def test_ctor(self):
         NAME = 'name'
         properties = {'key': 'value'}
-        bucket = self._makeOne(name=NAME, properties=properties)
+        bucket = self._make_one(name=NAME, properties=properties)
         self.assertEqual(bucket.name, NAME)
         self.assertEqual(bucket._properties, properties)
         self.assertFalse(bucket._acl.loaded)
@@ -45,7 +45,7 @@ class Test_Bucket(unittest.TestCase):
         CHUNK_SIZE = 1024 * 1024
         KEY = b'01234567890123456789012345678901'  # 32 bytes
 
-        bucket = self._makeOne(name=BUCKET_NAME)
+        bucket = self._make_one(name=BUCKET_NAME)
         blob = bucket.blob(
             BLOB_NAME, chunk_size=CHUNK_SIZE, encryption_key=KEY)
         self.assertIsInstance(blob, Blob)
@@ -68,7 +68,7 @@ class Test_Bucket(unittest.TestCase):
                 raise NotFound(args)
 
         BUCKET_NAME = 'bucket-name'
-        bucket = self._makeOne(name=BUCKET_NAME)
+        bucket = self._make_one(name=BUCKET_NAME)
         client = _Client(_FakeConnection)
         self.assertFalse(bucket.exists(client=client))
         expected_called_kwargs = {
@@ -94,7 +94,7 @@ class Test_Bucket(unittest.TestCase):
                 return object()
 
         BUCKET_NAME = 'bucket-name'
-        bucket = self._makeOne(name=BUCKET_NAME)
+        bucket = self._make_one(name=BUCKET_NAME)
         client = _Client(_FakeConnection)
         self.assertTrue(bucket.exists(client=client))
         expected_called_kwargs = {
@@ -114,7 +114,7 @@ class Test_Bucket(unittest.TestCase):
         connection = _Connection(DATA)
         PROJECT = 'PROJECT'
         client = _Client(connection, project=PROJECT)
-        bucket = self._makeOne(client=client, name=BUCKET_NAME)
+        bucket = self._make_one(client=client, name=BUCKET_NAME)
         bucket.create()
 
         kw, = connection._requested
@@ -148,7 +148,7 @@ class Test_Bucket(unittest.TestCase):
         }
         connection = _Connection(DATA)
         client = _Client(connection, project=PROJECT)
-        bucket = self._makeOne(client=client, name=BUCKET_NAME)
+        bucket = self._make_one(client=client, name=BUCKET_NAME)
         bucket.cors = CORS
         bucket.lifecycle_rules = LIFECYCLE_RULES
         bucket.location = LOCATION
@@ -164,25 +164,25 @@ class Test_Bucket(unittest.TestCase):
 
     def test_acl_property(self):
         from google.cloud.storage.acl import BucketACL
-        bucket = self._makeOne()
+        bucket = self._make_one()
         acl = bucket.acl
         self.assertIsInstance(acl, BucketACL)
         self.assertIs(acl, bucket._acl)
 
     def test_default_object_acl_property(self):
         from google.cloud.storage.acl import DefaultObjectACL
-        bucket = self._makeOne()
+        bucket = self._make_one()
         acl = bucket.default_object_acl
         self.assertIsInstance(acl, DefaultObjectACL)
         self.assertIs(acl, bucket._default_object_acl)
 
     def test_path_no_name(self):
-        bucket = self._makeOne()
+        bucket = self._make_one()
         self.assertRaises(ValueError, getattr, bucket, 'path')
 
     def test_path_w_name(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         self.assertEqual(bucket.path, '/b/%s' % NAME)
 
     def test_get_blob_miss(self):
@@ -190,7 +190,7 @@ class Test_Bucket(unittest.TestCase):
         NONESUCH = 'nonesuch'
         connection = _Connection()
         client = _Client(connection)
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         result = bucket.get_blob(NONESUCH, client=client)
         self.assertIsNone(result)
         kw, = connection._requested
@@ -202,7 +202,7 @@ class Test_Bucket(unittest.TestCase):
         BLOB_NAME = 'blob-name'
         connection = _Connection({'name': BLOB_NAME})
         client = _Client(connection)
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         blob = bucket.get_blob(BLOB_NAME, client=client)
         self.assertIs(blob.bucket, bucket)
         self.assertEqual(blob.name, BLOB_NAME)
@@ -214,7 +214,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         connection = _Connection({'items': []})
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         iterator = bucket.list_blobs()
         blobs = list(iterator)
         self.assertEqual(blobs, [])
@@ -243,7 +243,7 @@ class Test_Bucket(unittest.TestCase):
         }
         connection = _Connection({'items': []})
         client = _Client(connection)
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         iterator = bucket.list_blobs(
             max_results=MAX_RESULTS,
             page_token=PAGE_TOKEN,
@@ -265,7 +265,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         connection = _Connection({'items': []})
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         iterator = bucket.list_blobs()
         blobs = list(iterator)
         self.assertEqual(blobs, [])
@@ -279,7 +279,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         connection = _Connection()
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         self.assertRaises(NotFound, bucket.delete)
         expected_cw = [{
             'method': 'DELETE',
@@ -294,7 +294,7 @@ class Test_Bucket(unittest.TestCase):
         connection = _Connection(GET_BLOBS_RESP)
         connection._delete_bucket = True
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         result = bucket.delete(force=True)
         self.assertIsNone(result)
         expected_cw = [{
@@ -319,7 +319,7 @@ class Test_Bucket(unittest.TestCase):
                                  DELETE_BLOB2_RESP)
         connection._delete_bucket = True
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         result = bucket.delete(force=True)
         self.assertIsNone(result)
         expected_cw = [{
@@ -337,7 +337,7 @@ class Test_Bucket(unittest.TestCase):
         connection = _Connection(GET_BLOBS_RESP)
         connection._delete_bucket = True
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         result = bucket.delete(force=True)
         self.assertIsNone(result)
         expected_cw = [{
@@ -360,7 +360,7 @@ class Test_Bucket(unittest.TestCase):
         connection = _Connection(GET_BLOBS_RESP)
         connection._delete_bucket = True
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
 
         # Make the Bucket refuse to delete with 2 objects.
         bucket._MAX_OBJECTS_FOR_ITERATION = 1
@@ -373,7 +373,7 @@ class Test_Bucket(unittest.TestCase):
         NONESUCH = 'nonesuch'
         connection = _Connection()
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         self.assertRaises(NotFound, bucket.delete_blob, NONESUCH)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'DELETE')
@@ -384,7 +384,7 @@ class Test_Bucket(unittest.TestCase):
         BLOB_NAME = 'blob-name'
         connection = _Connection({})
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         result = bucket.delete_blob(BLOB_NAME)
         self.assertIsNone(result)
         kw, = connection._requested
@@ -395,7 +395,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         connection = _Connection()
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         bucket.delete_blobs([])
         self.assertEqual(connection._requested, [])
 
@@ -404,7 +404,7 @@ class Test_Bucket(unittest.TestCase):
         BLOB_NAME = 'blob-name'
         connection = _Connection({})
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         bucket.delete_blobs([BLOB_NAME])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
@@ -418,7 +418,7 @@ class Test_Bucket(unittest.TestCase):
         NONESUCH = 'nonesuch'
         connection = _Connection({})
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         self.assertRaises(NotFound, bucket.delete_blobs, [BLOB_NAME, NONESUCH])
         kw = connection._requested
         self.assertEqual(len(kw), 2)
@@ -433,7 +433,7 @@ class Test_Bucket(unittest.TestCase):
         NONESUCH = 'nonesuch'
         connection = _Connection({})
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         errors = []
         bucket.delete_blobs([BLOB_NAME, NONESUCH], errors.append)
         self.assertEqual(errors, [NONESUCH])
@@ -455,8 +455,8 @@ class Test_Bucket(unittest.TestCase):
 
         connection = _Connection({})
         client = _Client(connection)
-        source = self._makeOne(client=client, name=SOURCE)
-        dest = self._makeOne(client=client, name=DEST)
+        source = self._make_one(client=client, name=SOURCE)
+        dest = self._make_one(client=client, name=DEST)
         blob = _Blob()
         new_blob = source.copy_blob(blob, dest)
         self.assertIs(new_blob.bucket, dest)
@@ -484,8 +484,8 @@ class Test_Bucket(unittest.TestCase):
 
         connection = _Connection({}, {})
         client = _Client(connection)
-        source = self._makeOne(client=client, name=SOURCE)
-        dest = self._makeOne(client=client, name=DEST)
+        source = self._make_one(client=client, name=SOURCE)
+        dest = self._make_one(client=client, name=DEST)
         blob = _Blob()
         new_blob = source.copy_blob(blob, dest, NEW_NAME, client=client,
                                     preserve_acl=False)
@@ -511,8 +511,8 @@ class Test_Bucket(unittest.TestCase):
 
         connection = _Connection({})
         client = _Client(connection)
-        source = self._makeOne(client=client, name=SOURCE)
-        dest = self._makeOne(client=client, name=DEST)
+        source = self._make_one(client=client, name=SOURCE)
+        dest = self._make_one(client=client, name=DEST)
         blob = _Blob()
         new_blob = source.copy_blob(blob, dest, NEW_NAME)
         self.assertIs(new_blob.bucket, dest)
@@ -531,7 +531,7 @@ class Test_Bucket(unittest.TestCase):
         DATA = {'name': NEW_BLOB_NAME}
         connection = _Connection(DATA)
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=BUCKET_NAME)
+        bucket = self._make_one(client=client, name=BUCKET_NAME)
 
         class _Blob(object):
 
@@ -552,24 +552,24 @@ class Test_Bucket(unittest.TestCase):
     def test_etag(self):
         ETAG = 'ETAG'
         properties = {'etag': ETAG}
-        bucket = self._makeOne(properties=properties)
+        bucket = self._make_one(properties=properties)
         self.assertEqual(bucket.etag, ETAG)
 
     def test_id(self):
         ID = 'ID'
         properties = {'id': ID}
-        bucket = self._makeOne(properties=properties)
+        bucket = self._make_one(properties=properties)
         self.assertEqual(bucket.id, ID)
 
     def test_location_getter(self):
         NAME = 'name'
         before = {'location': 'AS'}
-        bucket = self._makeOne(name=NAME, properties=before)
+        bucket = self._make_one(name=NAME, properties=before)
         self.assertEqual(bucket.location, 'AS')
 
     def test_location_setter(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         self.assertIsNone(bucket.location)
         bucket.location = 'AS'
         self.assertEqual(bucket.location, 'AS')
@@ -580,7 +580,7 @@ class Test_Bucket(unittest.TestCase):
         LC_RULE = {'action': {'type': 'Delete'}, 'condition': {'age': 42}}
         rules = [LC_RULE]
         properties = {'lifecycle': {'rule': rules}}
-        bucket = self._makeOne(name=NAME, properties=properties)
+        bucket = self._make_one(name=NAME, properties=properties)
         self.assertEqual(bucket.lifecycle_rules, rules)
         # Make sure it's a copy
         self.assertIsNot(bucket.lifecycle_rules, rules)
@@ -589,7 +589,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         LC_RULE = {'action': {'type': 'Delete'}, 'condition': {'age': 42}}
         rules = [LC_RULE]
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         self.assertEqual(bucket.lifecycle_rules, [])
         bucket.lifecycle_rules = rules
         self.assertEqual(bucket.lifecycle_rules, rules)
@@ -604,7 +604,7 @@ class Test_Bucket(unittest.TestCase):
             'responseHeader': ['Content-Type'],
         }
         properties = {'cors': [CORS_ENTRY, {}]}
-        bucket = self._makeOne(name=NAME, properties=properties)
+        bucket = self._make_one(name=NAME, properties=properties)
         entries = bucket.cors
         self.assertEqual(len(entries), 2)
         self.assertEqual(entries[0], CORS_ENTRY)
@@ -620,7 +620,7 @@ class Test_Bucket(unittest.TestCase):
             'origin': ['127.0.0.1'],
             'responseHeader': ['Content-Type'],
         }
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
 
         self.assertEqual(bucket.cors, [])
         bucket.cors = [CORS_ENTRY]
@@ -637,7 +637,7 @@ class Test_Bucket(unittest.TestCase):
                 'logObjectPrefix': LOG_PREFIX,
             },
         }
-        bucket = self._makeOne(name=NAME, properties=before)
+        bucket = self._make_one(name=NAME, properties=before)
         info = bucket.get_logging()
         self.assertEqual(info['logBucket'], LOG_BUCKET)
         self.assertEqual(info['logObjectPrefix'], LOG_PREFIX)
@@ -646,7 +646,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         LOG_BUCKET = 'logs'
         before = {'logging': None}
-        bucket = self._makeOne(name=NAME, properties=before)
+        bucket = self._make_one(name=NAME, properties=before)
         self.assertIsNone(bucket.get_logging())
         bucket.enable_logging(LOG_BUCKET)
         info = bucket.get_logging()
@@ -658,7 +658,7 @@ class Test_Bucket(unittest.TestCase):
         LOG_BUCKET = 'logs'
         LOG_PFX = 'pfx'
         before = {'logging': None}
-        bucket = self._makeOne(name=NAME, properties=before)
+        bucket = self._make_one(name=NAME, properties=before)
         self.assertIsNone(bucket.get_logging())
         bucket.enable_logging(LOG_BUCKET, LOG_PFX)
         info = bucket.get_logging()
@@ -668,7 +668,7 @@ class Test_Bucket(unittest.TestCase):
     def test_disable_logging(self):
         NAME = 'name'
         before = {'logging': {'logBucket': 'logs', 'logObjectPrefix': 'pfx'}}
-        bucket = self._makeOne(name=NAME, properties=before)
+        bucket = self._make_one(name=NAME, properties=before)
         self.assertIsNotNone(bucket.get_logging())
         bucket.disable_logging()
         self.assertIsNone(bucket.get_logging())
@@ -676,23 +676,23 @@ class Test_Bucket(unittest.TestCase):
     def test_metageneration(self):
         METAGENERATION = 42
         properties = {'metageneration': METAGENERATION}
-        bucket = self._makeOne(properties=properties)
+        bucket = self._make_one(properties=properties)
         self.assertEqual(bucket.metageneration, METAGENERATION)
 
     def test_metageneration_unset(self):
-        bucket = self._makeOne()
+        bucket = self._make_one()
         self.assertIsNone(bucket.metageneration)
 
     def test_metageneration_string_val(self):
         METAGENERATION = 42
         properties = {'metageneration': str(METAGENERATION)}
-        bucket = self._makeOne(properties=properties)
+        bucket = self._make_one(properties=properties)
         self.assertEqual(bucket.metageneration, METAGENERATION)
 
     def test_owner(self):
         OWNER = {'entity': 'project-owner-12345', 'entityId': '23456'}
         properties = {'owner': OWNER}
-        bucket = self._makeOne(properties=properties)
+        bucket = self._make_one(properties=properties)
         owner = bucket.owner
         self.assertEqual(owner['entity'], 'project-owner-12345')
         self.assertEqual(owner['entityId'], '23456')
@@ -700,76 +700,76 @@ class Test_Bucket(unittest.TestCase):
     def test_project_number(self):
         PROJECT_NUMBER = 12345
         properties = {'projectNumber': PROJECT_NUMBER}
-        bucket = self._makeOne(properties=properties)
+        bucket = self._make_one(properties=properties)
         self.assertEqual(bucket.project_number, PROJECT_NUMBER)
 
     def test_project_number_unset(self):
-        bucket = self._makeOne()
+        bucket = self._make_one()
         self.assertIsNone(bucket.project_number)
 
     def test_project_number_string_val(self):
         PROJECT_NUMBER = 12345
         properties = {'projectNumber': str(PROJECT_NUMBER)}
-        bucket = self._makeOne(properties=properties)
+        bucket = self._make_one(properties=properties)
         self.assertEqual(bucket.project_number, PROJECT_NUMBER)
 
     def test_self_link(self):
         SELF_LINK = 'http://example.com/self/'
         properties = {'selfLink': SELF_LINK}
-        bucket = self._makeOne(properties=properties)
+        bucket = self._make_one(properties=properties)
         self.assertEqual(bucket.self_link, SELF_LINK)
 
     def test_storage_class_getter(self):
         STORAGE_CLASS = 'http://example.com/self/'
         properties = {'storageClass': STORAGE_CLASS}
-        bucket = self._makeOne(properties=properties)
+        bucket = self._make_one(properties=properties)
         self.assertEqual(bucket.storage_class, STORAGE_CLASS)
 
     def test_storage_class_setter_invalid(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         with self.assertRaises(ValueError):
             bucket.storage_class = 'BOGUS'
         self.assertFalse('storageClass' in bucket._changes)
 
     def test_storage_class_setter_STANDARD(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         bucket.storage_class = 'STANDARD'
         self.assertEqual(bucket.storage_class, 'STANDARD')
         self.assertTrue('storageClass' in bucket._changes)
 
     def test_storage_class_setter_NEARLINE(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         bucket.storage_class = 'NEARLINE'
         self.assertEqual(bucket.storage_class, 'NEARLINE')
         self.assertTrue('storageClass' in bucket._changes)
 
     def test_storage_class_setter_COLDLINE(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         bucket.storage_class = 'COLDLINE'
         self.assertEqual(bucket.storage_class, 'COLDLINE')
         self.assertTrue('storageClass' in bucket._changes)
 
     def test_storage_class_setter_MULTI_REGIONAL(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         bucket.storage_class = 'MULTI_REGIONAL'
         self.assertEqual(bucket.storage_class, 'MULTI_REGIONAL')
         self.assertTrue('storageClass' in bucket._changes)
 
     def test_storage_class_setter_REGIONAL(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         bucket.storage_class = 'REGIONAL'
         self.assertEqual(bucket.storage_class, 'REGIONAL')
         self.assertTrue('storageClass' in bucket._changes)
 
     def test_storage_class_setter_DURABLE_REDUCED_AVAILABILITY(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         bucket.storage_class = 'DURABLE_REDUCED_AVAILABILITY'
         self.assertEqual(bucket.storage_class, 'DURABLE_REDUCED_AVAILABILITY')
         self.assertTrue('storageClass' in bucket._changes)
@@ -781,27 +781,27 @@ class Test_Bucket(unittest.TestCase):
         TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
         TIME_CREATED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {'timeCreated': TIME_CREATED}
-        bucket = self._makeOne(properties=properties)
+        bucket = self._make_one(properties=properties)
         self.assertEqual(bucket.time_created, TIMESTAMP)
 
     def test_time_created_unset(self):
-        bucket = self._makeOne()
+        bucket = self._make_one()
         self.assertIsNone(bucket.time_created)
 
     def test_versioning_enabled_getter_missing(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         self.assertEqual(bucket.versioning_enabled, False)
 
     def test_versioning_enabled_getter(self):
         NAME = 'name'
         before = {'versioning': {'enabled': True}}
-        bucket = self._makeOne(name=NAME, properties=before)
+        bucket = self._make_one(name=NAME, properties=before)
         self.assertEqual(bucket.versioning_enabled, True)
 
     def test_versioning_enabled_setter(self):
         NAME = 'name'
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         self.assertFalse(bucket.versioning_enabled)
         bucket.versioning_enabled = True
         self.assertTrue(bucket.versioning_enabled)
@@ -810,7 +810,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         UNSET = {'website': {'mainPageSuffix': None,
                              'notFoundPage': None}}
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         bucket.configure_website()
         self.assertEqual(bucket._properties, UNSET)
 
@@ -818,7 +818,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         WEBSITE_VAL = {'website': {'mainPageSuffix': 'html',
                                    'notFoundPage': '404.html'}}
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         bucket.configure_website('html', '404.html')
         self.assertEqual(bucket._properties, WEBSITE_VAL)
 
@@ -826,7 +826,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         UNSET = {'website': {'mainPageSuffix': None,
                              'notFoundPage': None}}
-        bucket = self._makeOne(name=NAME)
+        bucket = self._make_one(name=NAME)
         bucket.disable_website()
         self.assertEqual(bucket._properties, UNSET)
 
@@ -837,7 +837,7 @@ class Test_Bucket(unittest.TestCase):
         after = {'acl': permissive, 'defaultObjectAcl': []}
         connection = _Connection(after)
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = True
         bucket.make_public()
@@ -865,7 +865,7 @@ class Test_Bucket(unittest.TestCase):
             # to consume.
             connection = _Connection(after1, after1, after2)
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = default_object_acl_loaded
         bucket.make_public(future=True)
@@ -930,7 +930,7 @@ class Test_Bucket(unittest.TestCase):
         after = {'acl': permissive, 'defaultObjectAcl': []}
         connection = _Connection(after, {'items': [{'name': BLOB_NAME}]})
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = True
 
@@ -968,7 +968,7 @@ class Test_Bucket(unittest.TestCase):
         }
         connection = _Connection(AFTER, GET_BLOBS_RESP)
         client = _Client(connection)
-        bucket = self._makeOne(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=NAME)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = True
 
@@ -982,7 +982,7 @@ class Test_Bucket(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         name = 'name'
-        bucket = self._makeOne(client=client, name=name)
+        bucket = self._make_one(client=client, name=name)
         iterator = bucket.list_blobs()
         page = Page(iterator, (), None)
         iterator._page = page
@@ -999,7 +999,7 @@ class Test_Bucket(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         name = 'name'
-        bucket = self._makeOne(client=client, name=name)
+        bucket = self._make_one(client=client, name=name)
 
         def dummy_response():
             return response
@@ -1033,7 +1033,7 @@ class Test_Bucket(unittest.TestCase):
         connection = _Connection()
         client = _Client(connection)
         name = 'name'
-        bucket = self._makeOne(client=client, name=name)
+        bucket = self._make_one(client=client, name=name)
         responses = [response1, response2]
 
         def dummy_response():

--- a/storage/unit_tests/test_client.py
+++ b/storage/unit_tests/test_client.py
@@ -23,7 +23,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor_connection_type(self):
         from google.cloud.storage._http import Connection

--- a/storage/unit_tests/test_client.py
+++ b/storage/unit_tests/test_client.py
@@ -22,7 +22,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor_connection_type(self):
@@ -31,7 +31,7 @@ class TestClient(unittest.TestCase):
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
 
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         self.assertEqual(client.project, PROJECT)
         self.assertIsInstance(client.connection, Connection)
         self.assertIs(client.connection.credentials, CREDENTIALS)
@@ -44,7 +44,7 @@ class TestClient(unittest.TestCase):
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
 
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         batch1 = Batch(client)
         batch2 = Batch(client)
         client._push_batch(batch1)
@@ -62,7 +62,7 @@ class TestClient(unittest.TestCase):
     def test_connection_setter(self):
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         client._connection = None  # Unset the value from the constructor
         client.connection = connection = object()
         self.assertIs(client._connection, connection)
@@ -70,13 +70,13 @@ class TestClient(unittest.TestCase):
     def test_connection_setter_when_set(self):
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         self.assertRaises(ValueError, setattr, client, 'connection', None)
 
     def test_connection_getter_no_batch(self):
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         self.assertIs(client.connection, client._connection)
         self.assertIsNone(client.current_batch)
 
@@ -84,7 +84,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage.batch import Batch
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         batch = Batch(client)
         client._push_batch(batch)
         self.assertIsNot(client.connection, client._connection)
@@ -98,7 +98,7 @@ class TestClient(unittest.TestCase):
         CREDENTIALS = _Credentials()
         BUCKET_NAME = 'BUCKET_NAME'
 
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         bucket = client.bucket(BUCKET_NAME)
         self.assertIsInstance(bucket, Bucket)
         self.assertIs(bucket.client, client)
@@ -110,7 +110,7 @@ class TestClient(unittest.TestCase):
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
 
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         batch = client.batch()
         self.assertIsInstance(batch, Batch)
         self.assertIs(batch._client, client)
@@ -120,7 +120,7 @@ class TestClient(unittest.TestCase):
 
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         NONESUCH = 'nonesuch'
         URI = '/'.join([
@@ -143,7 +143,7 @@ class TestClient(unittest.TestCase):
 
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BLOB_NAME = 'blob-name'
         URI = '/'.join([
@@ -167,7 +167,7 @@ class TestClient(unittest.TestCase):
     def test_lookup_bucket_miss(self):
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         NONESUCH = 'nonesuch'
         URI = '/'.join([
@@ -191,7 +191,7 @@ class TestClient(unittest.TestCase):
 
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BLOB_NAME = 'blob-name'
         URI = '/'.join([
@@ -217,7 +217,7 @@ class TestClient(unittest.TestCase):
 
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BLOB_NAME = 'blob-name'
         URI = '/'.join([
@@ -240,7 +240,7 @@ class TestClient(unittest.TestCase):
 
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BLOB_NAME = 'blob-name'
         URI = '/'.join([
@@ -266,7 +266,7 @@ class TestClient(unittest.TestCase):
 
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         EXPECTED_QUERY = {
             'project': [PROJECT],
@@ -298,7 +298,7 @@ class TestClient(unittest.TestCase):
         from six.moves.urllib.parse import urlparse
         PROJECT = 'PROJECT'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BUCKET_NAME = 'bucket-name'
         query_params = urlencode({'project': PROJECT, 'projection': 'noAcl'})
@@ -327,7 +327,7 @@ class TestClient(unittest.TestCase):
 
         PROJECT = 'foo-bar'
         CREDENTIALS = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         MAX_RESULTS = 10
         PAGE_TOKEN = 'ABCD'
@@ -375,7 +375,7 @@ class TestClient(unittest.TestCase):
 
         project = 'PROJECT'
         credentials = _Credentials()
-        client = self._makeOne(project=project, credentials=credentials)
+        client = self._make_one(project=project, credentials=credentials)
         iterator = client.list_buckets()
         page = Page(iterator, (), None)
         iterator._page = page
@@ -387,7 +387,7 @@ class TestClient(unittest.TestCase):
 
         project = 'PROJECT'
         credentials = _Credentials()
-        client = self._makeOne(project=project, credentials=credentials)
+        client = self._make_one(project=project, credentials=credentials)
 
         blob_name = 'blob-name'
         response = {'items': [{'name': blob_name}]}

--- a/storage/unit_tests/test_client.py
+++ b/storage/unit_tests/test_client.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestClient(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.storage.client import Client
         return Client
 

--- a/translate/unit_tests/test_client.py
+++ b/translate/unit_tests/test_client.py
@@ -25,7 +25,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         from google.cloud.translate.connection import Connection

--- a/translate/unit_tests/test_client.py
+++ b/translate/unit_tests/test_client.py
@@ -24,7 +24,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.translate.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
@@ -32,7 +32,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.translate.client import ENGLISH_ISO_639
 
         http = object()
-        client = self._makeOne(self.KEY, http=http)
+        client = self._make_one(self.KEY, http=http)
         self.assertIsInstance(client.connection, Connection)
         self.assertIsNone(client.connection.credentials)
         self.assertIs(client.connection.http, http)
@@ -43,7 +43,7 @@ class TestClient(unittest.TestCase):
 
         http = object()
         target = 'es'
-        client = self._makeOne(self.KEY, http=http, target_language=target)
+        client = self._make_one(self.KEY, http=http, target_language=target)
         self.assertIsInstance(client.connection, Connection)
         self.assertIsNone(client.connection.credentials)
         self.assertIs(client.connection.http, http)
@@ -52,7 +52,7 @@ class TestClient(unittest.TestCase):
     def test_get_languages(self):
         from google.cloud.translate.client import ENGLISH_ISO_639
 
-        client = self._makeOne(self.KEY)
+        client = self._make_one(self.KEY)
         supported = [
             {'language': 'en', 'name': 'English'},
             {'language': 'af', 'name': 'Afrikaans'},
@@ -77,7 +77,7 @@ class TestClient(unittest.TestCase):
                          {'key': self.KEY, 'target': ENGLISH_ISO_639})
 
     def test_get_languages_no_target(self):
-        client = self._makeOne(self.KEY, target_language=None)
+        client = self._make_one(self.KEY, target_language=None)
         supported = [
             {'language': 'en'},
             {'language': 'af'},
@@ -101,7 +101,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], {'key': self.KEY})
 
     def test_get_languages_explicit_target(self):
-        client = self._makeOne(self.KEY)
+        client = self._make_one(self.KEY)
         target_language = 'en'
         supported = [
             {'language': 'en', 'name': 'Spanish'},
@@ -127,7 +127,7 @@ class TestClient(unittest.TestCase):
                          {'key': self.KEY, 'target': target_language})
 
     def test_detect_language_bad_result(self):
-        client = self._makeOne(self.KEY)
+        client = self._make_one(self.KEY)
         value = 'takoy'
         conn = client.connection = _Connection({})
 
@@ -146,7 +146,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_detect_language_single_value(self):
-        client = self._makeOne(self.KEY)
+        client = self._make_one(self.KEY)
         value = 'takoy'
         detection = {
             'confidence': 1.0,
@@ -176,7 +176,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_detect_language_multiple_values(self):
-        client = self._makeOne(self.KEY)
+        client = self._make_one(self.KEY)
         value1 = u'fa\xe7ade'  # facade (with a cedilla)
         detection1 = {
             'confidence': 0.6166008,
@@ -217,7 +217,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_detect_language_multiple_results(self):
-        client = self._makeOne(self.KEY)
+        client = self._make_one(self.KEY)
         value = 'soy'
         detection1 = {
             'confidence': 0.81496066,
@@ -242,7 +242,7 @@ class TestClient(unittest.TestCase):
             client.detect_language(value)
 
     def test_translate_bad_result(self):
-        client = self._makeOne(self.KEY)
+        client = self._make_one(self.KEY)
         value = 'hvala ti'
         conn = client.connection = _Connection({})
 
@@ -262,7 +262,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_translate_defaults(self):
-        client = self._makeOne(self.KEY)
+        client = self._make_one(self.KEY)
         value = 'hvala ti'
         translation = {
             'detectedSourceLanguage': 'hr',
@@ -292,7 +292,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_translate_multiple(self):
-        client = self._makeOne(self.KEY)
+        client = self._make_one(self.KEY)
         value1 = 'hvala ti'
         translation1 = {
             'detectedSourceLanguage': 'hr',
@@ -329,7 +329,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_translate_explicit(self):
-        client = self._makeOne(self.KEY)
+        client = self._make_one(self.KEY)
         value = 'thank you'
         target_language = 'eo'
         source_language = 'en'

--- a/translate/unit_tests/test_client.py
+++ b/translate/unit_tests/test_client.py
@@ -19,7 +19,8 @@ class TestClient(unittest.TestCase):
 
     KEY = 'abc-123-my-key'
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.translate.client import Client
         return Client
 

--- a/translate/unit_tests/test_connection.py
+++ b/translate/unit_tests/test_connection.py
@@ -23,7 +23,7 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
         conn = self._makeOne()

--- a/translate/unit_tests/test_connection.py
+++ b/translate/unit_tests/test_connection.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.translate.connection import Connection
         return Connection
 

--- a/translate/unit_tests/test_connection.py
+++ b/translate/unit_tests/test_connection.py
@@ -22,11 +22,11 @@ class TestConnection(unittest.TestCase):
         from google.cloud.translate.connection import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._makeOne()
+        conn = self._make_one()
         URI = '/'.join([
             conn.API_BASE_URL,
             'language',
@@ -39,7 +39,7 @@ class TestConnection(unittest.TestCase):
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
-        conn = self._makeOne()
+        conn = self._make_one()
         query_params = [('q', 'val1'), ('q', 'val2')]
         uri = conn.build_api_url('/foo', query_params=query_params)
         scheme, netloc, path, qs, _ = urlsplit(uri)

--- a/vision/unit_tests/test_client.py
+++ b/vision/unit_tests/test_client.py
@@ -31,12 +31,12 @@ class TestClient(unittest.TestCase):
         from google.cloud.vision.client import Client
         return Client
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         creds = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=creds)
+        client = self._make_one(project=PROJECT, credentials=creds)
         self.assertEqual(client.project, PROJECT)
 
     def test_face_annotation(self):
@@ -60,7 +60,7 @@ class TestClient(unittest.TestCase):
             ]
         }
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         features = [Feature(feature_type=FeatureTypes.FACE_DETECTION,
@@ -76,7 +76,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.vision.image import Image
 
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT,
+        client = self._make_one(project=PROJECT,
                                credentials=credentials)
         image = client.image(source_uri=IMAGE_SOURCE)
         self.assertIsInstance(image, Image)
@@ -86,7 +86,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import FACE_DETECTION_RESPONSE
         RETURNED = FACE_DETECTION_RESPONSE
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         image = client.image(source_uri=IMAGE_SOURCE)
@@ -103,7 +103,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import FACE_DETECTION_RESPONSE
         RETURNED = FACE_DETECTION_RESPONSE
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         image = client.image(content=IMAGE_CONTENT)
@@ -122,7 +122,7 @@ class TestClient(unittest.TestCase):
             LABEL_DETECTION_RESPONSE as RETURNED)
 
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         image = client.image(source_uri=IMAGE_SOURCE)
@@ -144,7 +144,7 @@ class TestClient(unittest.TestCase):
             LANDMARK_DETECTION_RESPONSE as RETURNED)
 
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         image = client.image(source_uri=IMAGE_SOURCE)
@@ -166,7 +166,7 @@ class TestClient(unittest.TestCase):
             LANDMARK_DETECTION_RESPONSE as RETURNED)
 
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         image = client.image(content=IMAGE_CONTENT)
@@ -183,7 +183,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import LOGO_DETECTION_RESPONSE
         RETURNED = LOGO_DETECTION_RESPONSE
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         image = client.image(source_uri=IMAGE_SOURCE)
@@ -200,7 +200,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import LOGO_DETECTION_RESPONSE
         RETURNED = LOGO_DETECTION_RESPONSE
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         image = client.image(content=IMAGE_CONTENT)
@@ -218,7 +218,7 @@ class TestClient(unittest.TestCase):
             TEXT_DETECTION_RESPONSE as RETURNED)
 
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         image = client.image(source_uri=IMAGE_SOURCE)
@@ -240,7 +240,7 @@ class TestClient(unittest.TestCase):
 
         RETURNED = SAFE_SEARCH_DETECTION_RESPONSE
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         image = client.image(source_uri=IMAGE_SOURCE)
@@ -260,7 +260,7 @@ class TestClient(unittest.TestCase):
 
         RETURNED = IMAGE_PROPERTIES_RESPONSE
         credentials = _Credentials()
-        client = self._makeOne(project=PROJECT, credentials=credentials)
+        client = self._make_one(project=PROJECT, credentials=credentials)
         client.connection = _Connection(RETURNED)
 
         image = client.image(source_uri=IMAGE_SOURCE)
@@ -284,7 +284,7 @@ class TestVisionRequest(unittest.TestCase):
         from google.cloud.vision.client import VisionRequest
         return VisionRequest
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_make_vision_request(self):
@@ -292,14 +292,14 @@ class TestVisionRequest(unittest.TestCase):
 
         feature = Feature(feature_type=FeatureTypes.FACE_DETECTION,
                           max_results=3)
-        vision_request = self._makeOne(IMAGE_CONTENT, feature)
+        vision_request = self._make_one(IMAGE_CONTENT, feature)
         self.assertEqual(IMAGE_CONTENT, vision_request.image)
         self.assertEqual(FeatureTypes.FACE_DETECTION,
                          vision_request.features[0].feature_type)
 
     def test_make_vision_request_with_bad_feature(self):
         with self.assertRaises(TypeError):
-            self._makeOne(IMAGE_CONTENT, 'nonsensefeature')
+            self._make_one(IMAGE_CONTENT, 'nonsensefeature')
 
 
 class _Credentials(object):

--- a/vision/unit_tests/test_client.py
+++ b/vision/unit_tests/test_client.py
@@ -77,7 +77,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _Credentials()
         client = self._make_one(project=PROJECT,
-                               credentials=credentials)
+                                credentials=credentials)
         image = client.image(source_uri=IMAGE_SOURCE)
         self.assertIsInstance(image, Image)
 

--- a/vision/unit_tests/test_client.py
+++ b/vision/unit_tests/test_client.py
@@ -32,7 +32,7 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
         creds = _Credentials()
@@ -285,7 +285,7 @@ class TestVisionRequest(unittest.TestCase):
         return VisionRequest
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_make_vision_request(self):
         from google.cloud.vision.feature import Feature, FeatureTypes

--- a/vision/unit_tests/test_client.py
+++ b/vision/unit_tests/test_client.py
@@ -26,7 +26,8 @@ B64_IMAGE_CONTENT = _bytes_to_unicode(base64.b64encode(IMAGE_CONTENT))
 
 
 class TestClient(unittest.TestCase):
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.vision.client import Client
         return Client
 
@@ -278,7 +279,8 @@ class TestClient(unittest.TestCase):
 
 
 class TestVisionRequest(unittest.TestCase):
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.vision.client import VisionRequest
         return VisionRequest
 

--- a/vision/unit_tests/test_connection.py
+++ b/vision/unit_tests/test_connection.py
@@ -23,12 +23,12 @@ class TestConnection(unittest.TestCase):
         return Connection
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
         creds = _Credentials()
         conn = self._makeOne(creds)
-        klass = self._getTargetClass()
+        klass = self._get_target_class()
         self.assertEqual(conn.credentials._scopes, klass.SCOPE)
 
 

--- a/vision/unit_tests/test_connection.py
+++ b/vision/unit_tests/test_connection.py
@@ -17,7 +17,8 @@ import unittest
 
 class TestConnection(unittest.TestCase):
 
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.vision.connection import Connection
         return Connection
 

--- a/vision/unit_tests/test_connection.py
+++ b/vision/unit_tests/test_connection.py
@@ -22,12 +22,12 @@ class TestConnection(unittest.TestCase):
         from google.cloud.vision.connection import Connection
         return Connection
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
         creds = _Credentials()
-        conn = self._makeOne(creds)
+        conn = self._make_one(creds)
         klass = self._get_target_class()
         self.assertEqual(conn.credentials._scopes, klass.SCOPE)
 

--- a/vision/unit_tests/test_entity.py
+++ b/vision/unit_tests/test_entity.py
@@ -16,7 +16,8 @@ import unittest
 
 
 class TestEntityAnnotation(unittest.TestCase):
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.vision.entity import EntityAnnotation
         return EntityAnnotation
 

--- a/vision/unit_tests/test_entity.py
+++ b/vision/unit_tests/test_entity.py
@@ -25,7 +25,7 @@ class TestEntityAnnotation(unittest.TestCase):
         from unit_tests._fixtures import LOGO_DETECTION_RESPONSE
 
         LOGO = LOGO_DETECTION_RESPONSE['responses'][0]['logoAnnotations'][0]
-        entity_class = self._getTargetClass()
+        entity_class = self._get_target_class()
         logo = entity_class.from_api_repr(LOGO)
 
         self.assertEqual('/m/05b5c', logo.mid)

--- a/vision/unit_tests/test_face.py
+++ b/vision/unit_tests/test_face.py
@@ -16,7 +16,8 @@ import unittest
 
 
 class TestFace(unittest.TestCase):
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.vision.face import Face
         return Face
 

--- a/vision/unit_tests/test_face.py
+++ b/vision/unit_tests/test_face.py
@@ -24,7 +24,7 @@ class TestFace(unittest.TestCase):
     def setUp(self):
         from unit_tests._fixtures import FACE_DETECTION_RESPONSE
         self.FACE_ANNOTATIONS = FACE_DETECTION_RESPONSE['responses'][0]
-        self.face_class = self._getTargetClass()
+        self.face_class = self._get_target_class()
         self.face = self.face_class.from_api_repr(
             self.FACE_ANNOTATIONS['faceAnnotations'][0])
 

--- a/vision/unit_tests/test_feature.py
+++ b/vision/unit_tests/test_feature.py
@@ -16,7 +16,8 @@ import unittest
 
 
 class TestFeature(unittest.TestCase):
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.vision.feature import Feature
         return Feature
 

--- a/vision/unit_tests/test_feature.py
+++ b/vision/unit_tests/test_feature.py
@@ -21,22 +21,22 @@ class TestFeature(unittest.TestCase):
         from google.cloud.vision.feature import Feature
         return Feature
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_construct_feature(self):
         from google.cloud.vision.feature import FeatureTypes
-        feature = self._makeOne(FeatureTypes.LABEL_DETECTION)
+        feature = self._make_one(FeatureTypes.LABEL_DETECTION)
         self.assertEqual(1, feature.max_results)
         self.assertEqual('LABEL_DETECTION', feature.feature_type)
 
-        feature = self._makeOne(FeatureTypes.FACE_DETECTION, 3)
+        feature = self._make_one(FeatureTypes.FACE_DETECTION, 3)
         self.assertEqual(3, feature.max_results)
         self.assertEqual('FACE_DETECTION', feature.feature_type)
 
     def test_feature_as_dict(self):
         from google.cloud.vision.feature import FeatureTypes
-        feature = self._makeOne(FeatureTypes.FACE_DETECTION, max_results=5)
+        feature = self._make_one(FeatureTypes.FACE_DETECTION, max_results=5)
         EXPECTED = {
             'type': 'FACE_DETECTION',
             'maxResults': 5
@@ -45,5 +45,5 @@ class TestFeature(unittest.TestCase):
 
     def test_bad_feature_type(self):
         with self.assertRaises(AttributeError):
-            self._makeOne('something_not_feature_type',
+            self._make_one('something_not_feature_type',
                           max_results=5)

--- a/vision/unit_tests/test_feature.py
+++ b/vision/unit_tests/test_feature.py
@@ -46,4 +46,4 @@ class TestFeature(unittest.TestCase):
     def test_bad_feature_type(self):
         with self.assertRaises(AttributeError):
             self._make_one('something_not_feature_type',
-                          max_results=5)
+                           max_results=5)

--- a/vision/unit_tests/test_feature.py
+++ b/vision/unit_tests/test_feature.py
@@ -22,7 +22,7 @@ class TestFeature(unittest.TestCase):
         return Feature
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_construct_feature(self):
         from google.cloud.vision.feature import FeatureTypes

--- a/vision/unit_tests/test_image.py
+++ b/vision/unit_tests/test_image.py
@@ -25,7 +25,8 @@ CLIENT_MOCK = {'source': ''}
 
 
 class TestVisionImage(unittest.TestCase):
-    def _getTargetClass(self):
+    @staticmethod
+    def _get_target_class():
         from google.cloud.vision.image import Image
         return Image
 

--- a/vision/unit_tests/test_image.py
+++ b/vision/unit_tests/test_image.py
@@ -31,7 +31,7 @@ class TestVisionImage(unittest.TestCase):
         return Image
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        return self._get_target_class()(*args, **kw)
 
     def test_image_source_type_content(self):
         image = self._makeOne(CLIENT_MOCK, content=IMAGE_CONTENT)

--- a/vision/unit_tests/test_image.py
+++ b/vision/unit_tests/test_image.py
@@ -30,11 +30,11 @@ class TestVisionImage(unittest.TestCase):
         from google.cloud.vision.image import Image
         return Image
 
-    def _makeOne(self, *args, **kw):
+    def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
     def test_image_source_type_content(self):
-        image = self._makeOne(CLIENT_MOCK, content=IMAGE_CONTENT)
+        image = self._make_one(CLIENT_MOCK, content=IMAGE_CONTENT)
 
         _AS_DICT = {
             'content': B64_IMAGE_CONTENT
@@ -45,7 +45,7 @@ class TestVisionImage(unittest.TestCase):
         self.assertEqual(_AS_DICT, image.as_dict())
 
     def test_image_source_type_google_cloud_storage(self):
-        image = self._makeOne(CLIENT_MOCK, source_uri=IMAGE_SOURCE)
+        image = self._make_one(CLIENT_MOCK, source_uri=IMAGE_SOURCE)
 
         _AS_DICT = {
             'source': {
@@ -58,13 +58,13 @@ class TestVisionImage(unittest.TestCase):
         self.assertEqual(_AS_DICT, image.as_dict())
 
     def test_cannot_set_both_source_and_content(self):
-        image = self._makeOne(CLIENT_MOCK, content=IMAGE_CONTENT)
+        image = self._make_one(CLIENT_MOCK, content=IMAGE_CONTENT)
 
         self.assertEqual(B64_IMAGE_CONTENT, image.content)
         with self.assertRaises(AttributeError):
             image.source = IMAGE_SOURCE
 
-        image = self._makeOne(CLIENT_MOCK, source_uri=IMAGE_SOURCE)
+        image = self._make_one(CLIENT_MOCK, source_uri=IMAGE_SOURCE)
         self.assertEqual(IMAGE_SOURCE, image.source)
         with self.assertRaises(AttributeError):
             image.content = IMAGE_CONTENT


### PR DESCRIPTION
From discussion with @tseaver in #2681

Most of this PR was created from the command line, see the commit messages for the commands used to create the commits.

I also wanted to turn off the `no-self-use` disable in the test Pylint RC but it had too many offenders left to put in this PR.