### PR TITLE
Dropping usage of _Monkey in favor of mock.patch.

### DIFF
--- a/bigquery/tox.ini
+++ b/bigquery/tox.ini
@@ -7,6 +7,7 @@ localdeps =
     pip install --quiet --upgrade {toxinidir}/../core
 deps =
     pytest
+    mock
 covercmd =
     py.test --quiet \
       --cov=google.cloud.bigquery \

--- a/bigquery/unit_tests/test_table.py
+++ b/bigquery/unit_tests/test_table.py
@@ -1640,11 +1640,10 @@ class TestTable(unittest.TestCase, _SchemaBase):
     def test_upload_from_file_resumable_with_400(self):
         import csv
         import datetime
+        import mock
         from six.moves.http_client import BAD_REQUEST
-        from google.cloud.bigquery import table as MUT
         from google.cloud.exceptions import BadRequest
         from google.cloud._helpers import UTC
-        from google.cloud._testing import _Monkey
         from google.cloud._testing import _NamedTemporaryFile
         WHEN_TS = 1437767599.006
         WHEN = datetime.datetime.utcfromtimestamp(WHEN_TS).replace(
@@ -1665,7 +1664,8 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         table = self._make_one(self.TABLE_NAME, dataset=dataset)
 
-        with _Monkey(MUT, _UploadConfig=_UploadConfig):
+        with mock.patch('google.cloud.bigquery.table._UploadConfig',
+                        new=_UploadConfig):
             with _NamedTemporaryFile() as temp:
                 with open(temp.name, 'w') as file_obj:
                     writer = csv.writer(file_obj)
@@ -1680,11 +1680,10 @@ class TestTable(unittest.TestCase, _SchemaBase):
     # pylint: disable=too-many-statements
     def test_upload_from_file_w_explicit_client_resumable(self):
         import json
+        import mock
         from six.moves.http_client import OK
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
-        from google.cloud._testing import _Monkey
-        from google.cloud.bigquery import table as MUT
 
         UPLOAD_PATH = 'https://example.com/upload/test'
         initial_response = {'status': OK, 'location': UPLOAD_PATH}
@@ -1703,7 +1702,8 @@ class TestTable(unittest.TestCase, _SchemaBase):
             simple_multipart = True
             simple_path = u''  # force resumable
 
-        with _Monkey(MUT, _UploadConfig=_UploadConfig):
+        with mock.patch('google.cloud.bigquery.table._UploadConfig',
+                        new=_UploadConfig):
             orig_requested, PATH, BODY = self._upload_from_file_helper(
                 allow_jagged_rows=False,
                 allow_quoted_newlines=False,

--- a/datastore/tox.ini
+++ b/datastore/tox.ini
@@ -7,6 +7,7 @@ localdeps =
     pip install --quiet --upgrade {toxinidir}/../core
 deps =
     pytest
+    mock
 covercmd =
     py.test --quiet \
       --cov=google.cloud.datastore \

--- a/storage/tox.ini
+++ b/storage/tox.ini
@@ -7,6 +7,7 @@ localdeps =
     pip install --quiet --upgrade {toxinidir}/../core
 deps =
     pytest
+    mock
 covercmd =
     py.test --quiet \
       --cov=google.cloud.storage \

--- a/storage/unit_tests/test__helpers.py
+++ b/storage/unit_tests/test__helpers.py
@@ -140,8 +140,7 @@ class Test__base64_md5hash(unittest.TestCase):
         self.assertEqual(SIGNED_CONTENT, b'kBiQqOnIz21aGlQrIp/r/w==')
 
     def test_it_with_stubs(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.storage import _helpers as MUT
+        import mock
 
         class _Buffer(object):
 
@@ -159,7 +158,10 @@ class Test__base64_md5hash(unittest.TestCase):
         BUFFER = _Buffer([b'', BYTES_TO_SIGN])
         MD5 = _MD5(DIGEST_VAL)
 
-        with _Monkey(MUT, base64=BASE64, md5=MD5):
+        patch = mock.patch.multiple(
+            'google.cloud.storage._helpers',
+            base64=BASE64, md5=MD5)
+        with patch:
             SIGNED_CONTENT = self._call_fut(BUFFER)
 
         self.assertEqual(BUFFER._block_sizes, [8192, 8192])

--- a/storage/unit_tests/test_bucket.py
+++ b/storage/unit_tests/test_bucket.py
@@ -893,9 +893,8 @@ class Test_Bucket(unittest.TestCase):
         self._make_public_w_future_helper(default_object_acl_loaded=False)
 
     def test_make_public_recursive(self):
-        from google.cloud._testing import _Monkey
+        import mock
         from google.cloud.storage.acl import _ACLEntity
-        from google.cloud.storage import bucket as MUT
 
         _saved = []
 
@@ -934,7 +933,8 @@ class Test_Bucket(unittest.TestCase):
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = True
 
-        with _Monkey(MUT, _item_to_blob=item_to_blob):
+        with mock.patch('google.cloud.storage.bucket._item_to_blob',
+                        new=item_to_blob):
             bucket.make_public(recursive=True)
         self.assertEqual(list(bucket.acl), permissive)
         self.assertEqual(list(bucket.default_object_acl), [])

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 [testing]
 deps =
     pytest
+    mock
 passenv =
     CI_*
     CIRCLE*


### PR DESCRIPTION
This was done only in bigquery, datastore and storage packages. Still needs updates in bigtable, core, logging, monitoring, pubsub and speech.

From discussion with @tseaver in #2681.