### PR TITLE
Add stability information to streaming results.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -178,6 +178,7 @@
   Client <speech-client>
   speech-encoding
   speech-operation
+  speech-result
   speech-sample
   speech-alternative
 

--- a/docs/speech-result.rst
+++ b/docs/speech-result.rst
@@ -1,0 +1,7 @@
+Speech Result
+=============
+
+.. automodule:: google.cloud.speech.result
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/speech-usage.rst
+++ b/docs/speech-usage.rst
@@ -171,10 +171,10 @@ speech data to possible text alternatives on the fly.
     ...     sample = client.sample(content=stream,
     ...                            encoding=speech.Encoding.LINEAR16,
     ...                            sample_rate=16000)
-    ...     alternatives = list(client.streaming_recognize(sample))
-    >>> print(alternatives[0].transcript)
+    ...     results = list(client.streaming_recognize(sample))
+    >>> print(results[0].alternatives[0].transcript)
     'hello'
-    >>> print(alternatives[0].confidence)
+    >>> print(results[0].alternatives[0].confidence)
     0.973458576
 
 
@@ -196,10 +196,10 @@ See: `Single Utterance`_
     ...                            sample_rate=16000)
     ...     responses = client.streaming_recognize(sample,
     ...                                            single_utterance=True)
-    ...     alternatives = list(responses)
-    >>> print(alternatives[0].transcript)
+    ...     results = list(responses)
+    >>> print(results[0].alternatives[0].transcript)
     hello
-    >>> print(alternatives[0].confidence)
+    >>> print(results[0].alternatives[0].confidence)
     0.96523453546
 
 
@@ -214,20 +214,28 @@ If ``interim_results`` is set to :data:`True`, interim results
     ...     sample = client.sample(content=stream,
     ...                            encoding=speech.Encoding.LINEAR16,
     ...                            sample_rate=16000)
-    ...     for alternatives in client.streaming_recognize(sample,
-    ...                                                    interim_results=True):
+    ...     for results in client.streaming_recognize(sample,
+    ...                                                interim_results=True):
     ...         print('=' * 20)
-    ...         print(alternatives[0].transcript)
-    ...         print(alternatives[0].confidence)
+    ...         print(results[0].alternatives[0].transcript)
+    ...         print(results[0].alternatives[0].confidence)
+    ...         print(results[0].is_final)
+    ...         print(results[0].stability)
     ====================
     'he'
     None
+    False
+    0.113245
     ====================
     'hell'
     None
+    False
+    0.132454
     ====================
     'hello'
     0.973458576
+    True
+    0.982345
 
 
 .. _Single Utterance: https://cloud.google.com/speech/reference/rpc/google.cloud.speech.v1beta1#streamingrecognitionconfig

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -27,6 +27,7 @@ from google.cloud.speech.alternative import Alternative
 from google.cloud.speech.connection import Connection
 from google.cloud.speech.encoding import Encoding
 from google.cloud.speech.operation import Operation
+from google.cloud.speech.result import StreamingSpeechResult
 from google.cloud.speech.sample import Sample
 
 
@@ -170,7 +171,8 @@ class Client(BaseClient):
             Streaming recognition requests are limited to 1 minute of audio.
             See: https://cloud.google.com/speech/limits#content
 
-        Yields: list of :class:`~google.cloud.speech.alternative.Alternatives`
+        Yields: Instance of
+                :class:`~google.cloud.speech.result.StreamingSpeechResult`
                 containing results and metadata from the streaming request.
 
         :type sample: :class:`~google.cloud.speech.sample.Sample`
@@ -242,8 +244,7 @@ class Client(BaseClient):
         for response in responses:
             for result in response.results:
                 if result.is_final or interim_results:
-                    yield [Alternative.from_pb(alternative)
-                           for alternative in result.alternatives]
+                    yield StreamingSpeechResult.from_pb(result)
 
     def sync_recognize(self, sample, language_code=None,
                        max_alternatives=None, profanity_filter=None,

--- a/speech/google/cloud/speech/result.py
+++ b/speech/google/cloud/speech/result.py
@@ -1,0 +1,54 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Speech result representations."""
+
+from google.cloud.speech.alternative import Alternative
+
+
+class StreamingSpeechResult(object):
+    """Streaming speech result representation.
+
+    :type alternatives: list
+    :param alternatives: List of
+                         :class:`~google.cloud.speech.alternative.Alternative`.
+
+    :type is_final: bool
+    :param is_final: Boolean indicator of results finality.
+
+    :type stability: float
+    :param stability: 0.0-1.0 stability score for the results returned.
+    """
+    def __init__(self, alternatives, is_final=False, stability=0.0):
+        self.alternatives = alternatives
+        self.is_final = is_final
+        self.stability = stability
+
+    @classmethod
+    def from_pb(cls, response):
+        """Factory: construct instance of ``StreamingSpeechResult``.
+
+        :type response: :class:`~google.cloud.grpc.speech.v1beta1\
+                               .cloud_speech_pb2.StreamingRecognizeResult`
+        :param response: Instance of ``StreamingRecognizeResult`` protobuf.
+
+        :rtype: :class:`~google.cloud.speech.result.StreamingSpeechResult`
+        :returns: Instance of ``StreamingSpeechResult``.
+        """
+        alternatives = [Alternative.from_pb(alternative)
+                        for alternative in response.alternatives]
+        is_final = response.is_final
+        stability = response.stability
+        return cls(alternatives=alternatives, is_final=is_final,
+                   stability=stability)

--- a/system_tests/speech.py
+++ b/system_tests/speech.py
@@ -127,15 +127,15 @@ class TestSpeechClient(unittest.TestCase):
                                           single_utterance=single_utterance,
                                           interim_results=interim_results)
 
-    def _check_results(self, results, num_results=1):
-        self.assertEqual(len(results), num_results)
-        top_result = results[0]
+    def _check_results(self, alternatives, num_results=1):
+        self.assertEqual(len(alternatives), num_results)
+        top_result = alternatives[0]
         self.assertIsInstance(top_result, Alternative)
         self.assertEqual(top_result.transcript,
                          'hello ' + self.ASSERT_TEXT)
         self.assertGreater(top_result.confidence, 0.90)
         if num_results == 2:
-            second_alternative = results[1]
+            second_alternative = alternatives[1]
             self.assertIsInstance(second_alternative, Alternative)
             self.assertEqual(second_alternative.transcript, self.ASSERT_TEXT)
             self.assertIsNone(second_alternative.confidence)
@@ -192,7 +192,7 @@ class TestSpeechClient(unittest.TestCase):
 
         with open(AUDIO_FILE, 'rb') as file_obj:
             for results in self._make_streaming_request(file_obj):
-                self._check_results(results)
+                self._check_results(results.alternatives)
 
     def test_stream_recognize_interim_results(self):
         if not Config.USE_GAX:
@@ -207,12 +207,12 @@ class TestSpeechClient(unittest.TestCase):
                                                      interim_results=True)
             responses = list(recognize)
             for response in responses:
-                if response[0].transcript:
-                    self.assertIn(response[0].transcript,
+                if response.alternatives[0].transcript:
+                    self.assertIn(response.alternatives[0].transcript,
                                   extras + self.ASSERT_TEXT)
 
             self.assertGreater(len(responses), 5)
-            self._check_results(responses[-1])
+            self._check_results(responses[-1].alternatives)
 
     def test_stream_recognize_single_utterance(self):
         if not Config.USE_GAX:
@@ -221,4 +221,4 @@ class TestSpeechClient(unittest.TestCase):
         with open(AUDIO_FILE, 'rb') as file_obj:
             for results in self._make_streaming_request(
                     file_obj, single_utterance=False):
-                self._check_results(results)
+                self._check_results(results.alternatives)


### PR DESCRIPTION
Towards #2522.

This changes the surface, since `is_final` and `stability` are per-result and not a per-alternative.
