### PR TITLE
Fix bug with speech streaming speech_context.

### DIFF
--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -329,7 +329,8 @@ def _stream_requests(sample, language_code=None, max_alternatives=None,
     """
     config_request = _make_streaming_request(
         sample, language_code=language_code, max_alternatives=max_alternatives,
-        profanity_filter=profanity_filter, speech_context=speech_context,
+        profanity_filter=profanity_filter,
+        speech_context=SpeechContext(phrases=speech_context),
         single_utterance=single_utterance, interim_results=interim_results)
 
     # The config request MUST go first and not contain any audio data.

--- a/speech/unit_tests/test__gax.py
+++ b/speech/unit_tests/test__gax.py
@@ -131,8 +131,6 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
         from google.cloud import speech
         from google.cloud.speech.sample import Sample
         from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import (
-            SpeechContext)
-        from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import (
             StreamingRecognitionConfig)
         from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import (
             StreamingRecognizeRequest)
@@ -143,7 +141,7 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
         language_code = 'US-en'
         max_alternatives = 2
         profanity_filter = True
-        speech_context = SpeechContext(phrases=self.HINTS)
+        speech_context = self.HINTS
         single_utterance = True
         interim_results = False
         streaming_requests = self._callFUT(sample, language_code,

--- a/system_tests/speech.py
+++ b/system_tests/speech.py
@@ -125,7 +125,8 @@ class TestSpeechClient(unittest.TestCase):
                                sample_rate=16000)
         return client.streaming_recognize(sample,
                                           single_utterance=single_utterance,
-                                          interim_results=interim_results)
+                                          interim_results=interim_results,
+                                          speech_context=['hello', 'google'])
 
     def _check_results(self, results, num_results=1):
         self.assertEqual(len(results), num_results)


### PR DESCRIPTION
I believe this is the correct resolution to 
> Update SpeechContext in tests. See: #2700.

mentioned in #2522.

Speech streaming wasn't converting the list of hints to an instance of `SpeechContext` before flight.