### PR TITLE
Adding CircleCI config to gh-pages branch.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,4 @@
+general:
+  branches:
+    ignore:
+      - gh-pages


### PR DESCRIPTION
This way CircleCI can ignore this branch for builds.

I'm fairly certain this will mean we now serve the file https://googlecloudplatform.github.io/google-cloud-python/circle.yml which makes me sad. Also empirically it seems that CircleCI won't pick up `.circle.yml`, only `circle.yml`, so we don't really have a choice.

And this is annoying:
https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/tree/gh-pages