### PR TITLE
Passing through COVERALLS_REPO_TOKEN to tox coveralls env.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,11 @@ envlist =
 [testing]
 deps =
     pytest
+passenv =
+    CI_*
+    CIRCLE*
+    GOOGLE_*
+    TRAVIS*
 localdeps =
     pip install --upgrade \
         {toxinidir}/core \
@@ -130,7 +135,8 @@ skip_install =
     py34: True
     py35: True
     cover: True
-passenv = CI_* CIRCLE* TRAVIS* GOOGLE_CLOUD_*
+passenv =
+    {[testing]passenv}
 
 [testenv:cover]
 commands =
@@ -157,7 +163,9 @@ ignore_errors = True
 deps =
     {[testenv:umbrella-cover]deps}
     coveralls
-passenv = {[testenv:system-tests]passenv}
+passenv =
+    {[testing]passenv}
+    COVERALLS_REPO_TOKEN
 
 [testenv:json-docs]
 basepython =
@@ -190,7 +198,10 @@ deps =
     {[testing]deps}
     Sphinx
     sphinx_rtd_theme
-passenv = {[testenv:system-tests]passenv} SPHINX_RELEASE READTHEDOCS
+passenv =
+    {[testing]passenv}
+    SPHINX_RELEASE
+    READTHEDOCS
 
 [testenv:docs-doc2dash]
 basepython = {[testenv:docs]basepython}
@@ -226,7 +237,8 @@ deps =
     {[testing]deps}
     pycodestyle >= 2.1.0
     pylint >= 1.6.4
-passenv = {[testenv:system-tests]passenv}
+passenv =
+    {[testing]passenv}
 
 [testenv:system-tests]
 basepython =
@@ -236,7 +248,9 @@ commands =
     python {toxinidir}/system_tests/attempt_system_tests.py {posargs}
 deps =
     {[testing]deps}
-passenv = CI_* CIRCLE* GOOGLE_* TRAVIS* encrypted_*
+passenv =
+    {[testing]passenv}
+    encrypted_*
 
 [testenv:system-tests3]
 basepython =
@@ -246,7 +260,8 @@ commands =
     python {toxinidir}/system_tests/attempt_system_tests.py {posargs}
 deps =
     {[testing]deps}
-passenv = {[testenv:system-tests]passenv}
+passenv =
+    {[testenv:system-tests]passenv}
 
 [emulator]
 deps =
@@ -254,8 +269,6 @@ deps =
     psutil
 setenv =
     GOOGLE_CLOUD_NO_PRINT=true
-passenv =
-    GOOGLE_CLOUD_DISABLE_GRPC
 emulatorcmd =
     python {toxinidir}/system_tests/run_emulator.py
 
@@ -263,19 +276,19 @@ emulatorcmd =
 commands =
     {[emulator]emulatorcmd} --package=datastore
 setenv = {[emulator]setenv}
-passenv = {[emulator]passenv}
+passenv = {[testing]passenv}
 deps = {[emulator]deps}
 
 [testenv:pubsub-emulator]
 commands =
     {[emulator]emulatorcmd} --package=pubsub
 setenv = {[emulator]setenv}
-passenv = {[emulator]passenv}
+passenv = {[testing]passenv}
 deps = {[emulator]deps}
 
 [testenv:bigtable-emulator]
 commands =
     {[emulator]emulatorcmd} --package=bigtable
 setenv = {[emulator]setenv}
-passenv = {[emulator]passenv}
+passenv = {[testing]passenv}
 deps = {[emulator]deps}


### PR DESCRIPTION
Also re-factoring the tox config a little bit to reuse a base passenv rather than passing around the system-tests passenv everywhere.

See https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/119 for an example failure that shouldn't have failed (since the env. var. is set in the CircleCI UI).