### PR TITLE
Removing local dependencies from lint tox env.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -135,6 +135,7 @@ skip_install =
     py34: True
     py35: True
     cover: True
+    lint: True
 passenv =
     {[testing]passenv}
 
@@ -230,7 +231,6 @@ verbose = 1
 basepython =
     python2.7
 commands =
-    {[testing]localdeps}
     python {toxinidir}/scripts/pycodestyle_on_repo.py
     python {toxinidir}/scripts/run_pylint.py
 deps =


### PR DESCRIPTION
Also skipping the install (which would install from PyPI if the localdeps weren't added). The deps are not needed since the lint tools just reads the source.