### PR TITLE
Move speech methods to sample.

### DIFF
--- a/docs/speech-usage.rst
+++ b/docs/speech-usage.rst
@@ -61,7 +61,7 @@ See: `Speech Asynchronous Recognize`_
     >>> sample = client.sample(source_uri='gs://my-bucket/recording.flac',
     ...                        encoding=speech.Encoding.LINEAR16,
     ...                        sample_rate=44100)
-    >>> operation = client.async_recognize(sample, max_alternatives=2)
+    >>> operation = sample.async_recognize(max_alternatives=2)
     >>> retry_count = 100
     >>> while retry_count > 0 and not operation.complete:
     ...     retry_count -= 1
@@ -94,8 +94,7 @@ Great Britian.
     >>> sample = client.sample(source_uri='gs://my-bucket/recording.flac',
     ...                        encoding=speech.Encoding.FLAC,
     ...                        sample_rate=44100)
-    >>> operation = client.async_recognize(sample, max_alternatives=2)
-    >>> alternatives = client.sync_recognize(
+    >>> alternatives = sample.sync_recognize(
     ...     speech.Encoding.FLAC, 16000,
     ...     source_uri='gs://my-bucket/recording.flac', language_code='en-GB',
     ...     max_alternatives=2)
@@ -119,7 +118,7 @@ Example of using the profanity filter.
     >>> sample = client.sample(source_uri='gs://my-bucket/recording.flac',
     ...                        encoding=speech.Encoding.FLAC,
     ...                        sample_rate=44100)
-    >>> alternatives = client.sync_recognize(sample, max_alternatives=1,
+    >>> alternatives = sample.sync_recognize(max_alternatives=1,
     ...                                      profanity_filter=True)
     >>> for alternative in alternatives:
     ...     print('=' * 20)
@@ -141,7 +140,7 @@ words to the vocabulary of the recognizer.
     ...                        encoding=speech.Encoding.FLAC,
     ...                        sample_rate=44100)
     >>> hints = ['hi', 'good afternoon']
-    >>> alternatives = client.sync_recognize(sample, max_alternatives=2,
+    >>> alternatives = sample.sync_recognize(max_alternatives=2,
     ...                                      speech_context=hints)
     >>> for alternative in alternatives:
     ...     print('=' * 20)
@@ -171,7 +170,7 @@ speech data to possible text alternatives on the fly.
     ...     sample = client.sample(content=stream,
     ...                            encoding=speech.Encoding.LINEAR16,
     ...                            sample_rate=16000)
-    ...     results = list(client.streaming_recognize(sample))
+    ...     results = list(sample.streaming_recognize())
     >>> print(results[0].alternatives[0].transcript)
     'hello'
     >>> print(results[0].alternatives[0].confidence)
@@ -194,8 +193,7 @@ See: `Single Utterance`_
     ...     sample = client.sample(content=stream,
     ...                            encoding=speech.Encoding.LINEAR16,
     ...                            sample_rate=16000)
-    ...     responses = client.streaming_recognize(sample,
-    ...                                            single_utterance=True)
+    ...     responses = sample.streaming_recognize(single_utterance=True)
     ...     results = list(responses)
     >>> print(results[0].alternatives[0].transcript)
     hello
@@ -214,8 +212,7 @@ If ``interim_results`` is set to :data:`True`, interim results
     ...     sample = client.sample(content=stream,
     ...                            encoding=speech.Encoding.LINEAR16,
     ...                            sample_rate=16000)
-    ...     for results in client.streaming_recognize(sample,
-    ...                                                interim_results=True):
+    ...     for results in sample.streaming_recognize(interim_results=True):
     ...         print('=' * 20)
     ...         print(results[0].alternatives[0].transcript)
     ...         print(results[0].alternatives[0].confidence)

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -122,7 +122,6 @@ class TestClient(unittest.TestCase):
 
         from google.cloud import speech
         from google.cloud.speech.alternative import Alternative
-        from google.cloud.speech.sample import Sample
         from unit_tests._fixtures import SYNC_RECOGNIZE_RESPONSE
 
         _AUDIO_CONTENT = _to_bytes(self.AUDIO_CONTENT)
@@ -151,11 +150,10 @@ class TestClient(unittest.TestCase):
 
         encoding = speech.Encoding.FLAC
 
-        sample = Sample(content=self.AUDIO_CONTENT, encoding=encoding,
-                        sample_rate=self.SAMPLE_RATE)
+        sample = client.sample(content=self.AUDIO_CONTENT, encoding=encoding,
+                               sample_rate=self.SAMPLE_RATE)
 
-        response = client.sync_recognize(sample,
-                                         language_code='EN',
+        response = sample.sync_recognize(language_code='EN',
                                          max_alternatives=2,
                                          profanity_filter=True,
                                          speech_context=self.HINTS)
@@ -177,7 +175,6 @@ class TestClient(unittest.TestCase):
     def test_sync_recognize_source_uri_without_optional_params_no_gax(self):
         from google.cloud import speech
         from google.cloud.speech.alternative import Alternative
-        from google.cloud.speech.sample import Sample
         from unit_tests._fixtures import SYNC_RECOGNIZE_RESPONSE
 
         RETURNED = SYNC_RECOGNIZE_RESPONSE
@@ -196,10 +193,10 @@ class TestClient(unittest.TestCase):
 
         encoding = speech.Encoding.FLAC
 
-        sample = Sample(source_uri=self.AUDIO_SOURCE_URI, encoding=encoding,
-                        sample_rate=self.SAMPLE_RATE)
+        sample = client.sample(source_uri=self.AUDIO_SOURCE_URI,
+                               encoding=encoding, sample_rate=self.SAMPLE_RATE)
 
-        response = client.sync_recognize(sample)
+        response = sample.sync_recognize()
 
         self.assertEqual(len(client.connection._requested), 1)
         req = client.connection._requested[0]
@@ -217,26 +214,24 @@ class TestClient(unittest.TestCase):
 
     def test_sync_recognize_with_empty_results_no_gax(self):
         from google.cloud import speech
-        from google.cloud.speech.sample import Sample
         from unit_tests._fixtures import SYNC_RECOGNIZE_EMPTY_RESPONSE
 
         credentials = _Credentials()
         client = self._make_one(credentials=credentials, use_gax=False)
         client.connection = _Connection(SYNC_RECOGNIZE_EMPTY_RESPONSE)
 
-        sample = Sample(source_uri=self.AUDIO_SOURCE_URI,
-                        encoding=speech.Encoding.FLAC,
-                        sample_rate=self.SAMPLE_RATE)
+        sample = client.sample(source_uri=self.AUDIO_SOURCE_URI,
+                               encoding=speech.Encoding.FLAC,
+                               sample_rate=self.SAMPLE_RATE)
 
         with self.assertRaises(ValueError):
-            client.sync_recognize(sample)
+            sample.sync_recognize()
 
     def test_sync_recognize_with_empty_results_gax(self):
         from google.cloud._testing import _Monkey
 
         from google.cloud import speech
         from google.cloud.speech import _gax
-        from google.cloud.speech.sample import Sample
 
         credentials = _Credentials()
         client = self._make_one(credentials=credentials, use_gax=True)
@@ -268,12 +263,12 @@ class TestClient(unittest.TestCase):
             channel_args,
             [(credentials, _gax.DEFAULT_USER_AGENT, host)])
 
-        sample = Sample(source_uri=self.AUDIO_SOURCE_URI,
-                        encoding=speech.Encoding.FLAC,
-                        sample_rate=self.SAMPLE_RATE)
+        sample = client.sample(source_uri=self.AUDIO_SOURCE_URI,
+                               encoding=speech.Encoding.FLAC,
+                               sample_rate=self.SAMPLE_RATE)
 
         with self.assertRaises(ValueError):
-            client.sync_recognize(sample)
+            sample.sync_recognize()
 
     def test_sync_recognize_with_gax(self):
         from google.cloud._testing import _Monkey
@@ -326,7 +321,7 @@ class TestClient(unittest.TestCase):
             channel_args,
             [(creds, _gax.DEFAULT_USER_AGENT, host)])
 
-        results = client.sync_recognize(sample)
+        results = sample.sync_recognize()
 
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].transcript,
@@ -340,22 +335,20 @@ class TestClient(unittest.TestCase):
 
     def test_async_supported_encodings(self):
         from google.cloud import speech
-        from google.cloud.speech.sample import Sample
 
         credentials = _Credentials()
         client = self._make_one(credentials=credentials)
         client.connection = _Connection({})
 
-        sample = Sample(source_uri=self.AUDIO_SOURCE_URI,
-                        encoding=speech.Encoding.FLAC,
-                        sample_rate=self.SAMPLE_RATE)
+        sample = client.sample(source_uri=self.AUDIO_SOURCE_URI,
+                               encoding=speech.Encoding.FLAC,
+                               sample_rate=self.SAMPLE_RATE)
         with self.assertRaises(ValueError):
-            client.async_recognize(sample)
+            sample.async_recognize()
 
     def test_async_recognize_no_gax(self):
         from google.cloud import speech
         from google.cloud.speech.operation import Operation
-        from google.cloud.speech.sample import Sample
         from unit_tests._fixtures import ASYNC_RECOGNIZE_RESPONSE
 
         RETURNED = ASYNC_RECOGNIZE_RESPONSE
@@ -364,10 +357,10 @@ class TestClient(unittest.TestCase):
         client = self._make_one(credentials=credentials, use_gax=False)
         client.connection = _Connection(RETURNED)
 
-        sample = Sample(source_uri=self.AUDIO_SOURCE_URI,
-                        encoding=speech.Encoding.LINEAR16,
-                        sample_rate=self.SAMPLE_RATE)
-        operation = client.async_recognize(sample)
+        sample = client.sample(source_uri=self.AUDIO_SOURCE_URI,
+                               encoding=speech.Encoding.LINEAR16,
+                               sample_rate=self.SAMPLE_RATE)
+        operation = sample.async_recognize()
         self.assertIsInstance(operation, Operation)
         self.assertIs(operation.client, client)
         self.assertEqual(operation.caller_metadata,
@@ -416,20 +409,24 @@ class TestClient(unittest.TestCase):
                     low_level.SERVICE_ADDRESS)
         self.assertEqual(channel_args, [expected])
 
-        operation = client.async_recognize(sample)
+        operation = sample.async_recognize()
         self.assertIsInstance(operation, Operation)
         self.assertFalse(operation.complete)
         self.assertIsNone(operation.response)
 
     def test_streaming_depends_on_gax(self):
+        from google.cloud import speech
         from google.cloud._testing import _Monkey
 
         credentials = _Credentials()
         client = self._make_one(credentials=credentials, use_gax=False)
         client.connection = _Connection()
+        sample = client.sample(content=self.AUDIO_CONTENT,
+                               encoding=speech.Encoding.LINEAR16,
+                               sample_rate=self.SAMPLE_RATE)
 
         with self.assertRaises(EnvironmentError):
-            list(client.streaming_recognize({}))
+            list(sample.streaming_recognize())
 
     def test_streaming_closed_stream(self):
         from io import BytesIO
@@ -469,7 +466,7 @@ class TestClient(unittest.TestCase):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 
         with self.assertRaises(ValueError):
-            list(client.streaming_recognize(sample))
+            list(sample.streaming_recognize())
 
     def test_stream_recognize_interim_results(self):
         from io import BytesIO
@@ -478,7 +475,7 @@ class TestClient(unittest.TestCase):
 
         from google.cloud.speech import _gax
         from google.cloud.speech.encoding import Encoding
-        from google.cloud.speech.client import StreamingSpeechResult
+        from google.cloud.speech.result import StreamingSpeechResult
 
         stream = BytesIO(b'Some audio data...')
         credentials = _Credentials()
@@ -524,8 +521,7 @@ class TestClient(unittest.TestCase):
                                encoding=Encoding.LINEAR16,
                                sample_rate=self.SAMPLE_RATE)
 
-        results = list(client.streaming_recognize(sample,
-                                                  interim_results=True))
+        results = list(sample.streaming_recognize(interim_results=True))
 
         self.assertEqual(len(results), 3)
         self.assertIsInstance(results[0], StreamingSpeechResult)
@@ -598,7 +594,7 @@ class TestClient(unittest.TestCase):
                                encoding=Encoding.LINEAR16,
                                sample_rate=self.SAMPLE_RATE)
 
-        results = list(client.streaming_recognize(sample))
+        results = list(sample.streaming_recognize())
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].alternatives[0].transcript,
                          alternatives[0]['transcript'])
@@ -642,7 +638,7 @@ class TestClient(unittest.TestCase):
                                encoding=Encoding.LINEAR16,
                                sample_rate=self.SAMPLE_RATE)
 
-        results = list(client.streaming_recognize(sample))
+        results = list(sample.streaming_recognize())
         self.assertEqual(results, [])
 
     def test_speech_api_with_gax(self):

--- a/system_tests/speech.py
+++ b/system_tests/speech.py
@@ -98,8 +98,7 @@ class TestSpeechClient(unittest.TestCase):
                                source_uri=source_uri,
                                encoding=speech.Encoding.LINEAR16,
                                sample_rate=16000)
-        return client.sync_recognize(sample,
-                                     language_code='en-US',
+        return sample.sync_recognize(language_code='en-US',
                                      max_alternatives=max_alternatives,
                                      profanity_filter=True,
                                      speech_context=['Google', 'cloud'])
@@ -111,8 +110,7 @@ class TestSpeechClient(unittest.TestCase):
                                source_uri=source_uri,
                                encoding=speech.Encoding.LINEAR16,
                                sample_rate=16000)
-        return client.async_recognize(sample,
-                                      language_code='en-US',
+        return sample.async_recognize(language_code='en-US',
                                       max_alternatives=max_alternatives,
                                       profanity_filter=True,
                                       speech_context=['Google', 'cloud'])
@@ -123,8 +121,7 @@ class TestSpeechClient(unittest.TestCase):
         sample = client.sample(content=file_obj,
                                encoding=speech.Encoding.LINEAR16,
                                sample_rate=16000)
-        return client.streaming_recognize(sample,
-                                          single_utterance=single_utterance,
+        return sample.streaming_recognize(single_utterance=single_utterance,
                                           interim_results=interim_results,
                                           speech_context=['hello', 'google'])
 


### PR DESCRIPTION
Cleans up the surface a little bit but moving `sync_recognize`, `async_recognize` and `streaming_recognize` to the `Sample` class.

Fixes #2516.