### PR TITLE
Swap _Monkey for mock.patch().

### DIFF
--- a/monitoring/tox.ini
+++ b/monitoring/tox.ini
@@ -7,6 +7,7 @@ localdeps =
     pip install --quiet --upgrade {toxinidir}/../core
 deps =
     pytest
+    mock
 covercmd =
     py.test --quiet \
       --cov=google.cloud.monitoring \

--- a/monitoring/unit_tests/test_client.py
+++ b/monitoring/unit_tests/test_client.py
@@ -185,8 +185,7 @@ class TestClient(unittest.TestCase):
 
     def test_timeseries_factory_gauge(self):
         import datetime
-        from google.cloud._testing import _Monkey
-        import google.cloud.monitoring.client
+        import mock
         from google.cloud._helpers import _datetime_to_rfc3339
         METRIC_TYPE = 'custom.googleapis.com/my_metric'
         METRIC_LABELS = {
@@ -222,7 +221,8 @@ class TestClient(unittest.TestCase):
         TIME2_STR = _datetime_to_rfc3339(TIME2, ignore_zone=False)
         # Construct a time series assuming a gauge metric using the current
         # time
-        with _Monkey(google.cloud.monitoring.client, _UTCNOW=lambda: TIME2):
+        with mock.patch('google.cloud.monitoring.client._UTCNOW',
+                        new=lambda: TIME2):
             timeseries_no_end = client.time_series(metric, resource, VALUE)
 
         self.assertEqual(timeseries_no_end.points[0].end_time, TIME2_STR)

--- a/monitoring/unit_tests/test_query.py
+++ b/monitoring/unit_tests/test_query.py
@@ -129,8 +129,7 @@ class TestQuery(unittest.TestCase):
 
     def test_constructor_default_end_time(self):
         import datetime
-        from google.cloud._testing import _Monkey
-        from google.cloud.monitoring import query as MUT
+        import mock
 
         MINUTES = 5
         NOW, T0, T1 = [
@@ -140,7 +139,8 @@ class TestQuery(unittest.TestCase):
         ]
 
         client = _Client(project=PROJECT, connection=_Connection())
-        with _Monkey(MUT, _UTCNOW=lambda: NOW):
+        with mock.patch('google.cloud.monitoring.query._UTCNOW',
+                        new=lambda: NOW):
             query = self._make_one(client, METRIC_TYPE, minutes=MINUTES)
 
         self.assertEqual(query._start_time, T0)


### PR DESCRIPTION
Drops `_Monkey` usage from Monitoring API tests in favor of `mock.patch()`.