### PR TITLE
Switch from oauth2client to google-auth

### DIFF
--- a/bigquery/unit_tests/test_client.py
+++ b/bigquery/unit_tests/test_client.py
@@ -499,16 +499,7 @@ class TestClient(unittest.TestCase):
 
 
 class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
+    pass
 
 
 class _Connection(object):

--- a/bigquery/unit_tests/test_client.py
+++ b/bigquery/unit_tests/test_client.py
@@ -28,7 +28,7 @@ class TestClient(unittest.TestCase):
     def test_ctor(self):
         from google.cloud.bigquery._http import Connection
         PROJECT = 'PROJECT'
-        creds = _Credentials()
+        creds = object()
         http = object()
         client = self._make_one(project=PROJECT, credentials=creds, http=http)
         self.assertIsInstance(client._connection, Connection)
@@ -57,7 +57,7 @@ class TestClient(unittest.TestCase):
                  'friendlyName': 'Two'},
             ]
         }
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(PROJECT_1, creds)
         conn = client._connection = _Connection(DATA)
 
@@ -86,7 +86,7 @@ class TestClient(unittest.TestCase):
         PATH = 'projects'
         TOKEN = 'TOKEN'
         DATA = {}
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(PROJECT, creds)
         conn = client._connection = _Connection(DATA)
 
@@ -128,7 +128,7 @@ class TestClient(unittest.TestCase):
                  'friendlyName': 'Two'},
             ]
         }
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(PROJECT, creds)
         conn = client._connection = _Connection(DATA)
 
@@ -156,7 +156,7 @@ class TestClient(unittest.TestCase):
         PATH = 'projects/%s/datasets' % PROJECT
         TOKEN = 'TOKEN'
         DATA = {}
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(PROJECT, creds)
         conn = client._connection = _Connection(DATA)
 
@@ -180,7 +180,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigquery.dataset import Dataset
         PROJECT = 'PROJECT'
         DATASET = 'dataset_name'
-        creds = _Credentials()
+        creds = object()
         http = object()
         client = self._make_one(project=PROJECT, credentials=creds, http=http)
         dataset = client.dataset(DATASET)
@@ -190,7 +190,7 @@ class TestClient(unittest.TestCase):
 
     def test_job_from_resource_unknown_type(self):
         PROJECT = 'PROJECT'
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(PROJECT, creds)
         with self.assertRaises(ValueError):
             client.job_from_resource({'configuration': {'nonesuch': {}}})
@@ -304,7 +304,7 @@ class TestClient(unittest.TestCase):
                 LOAD_DATA,
             ]
         }
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(PROJECT, creds)
         conn = client._connection = _Connection(DATA)
 
@@ -360,7 +360,7 @@ class TestClient(unittest.TestCase):
                 LOAD_DATA,
             ]
         }
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(PROJECT, creds)
         conn = client._connection = _Connection(DATA)
 
@@ -388,7 +388,7 @@ class TestClient(unittest.TestCase):
         PATH = 'projects/%s/jobs' % PROJECT
         DATA = {}
         TOKEN = 'TOKEN'
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(PROJECT, creds)
         conn = client._connection = _Connection(DATA)
 
@@ -419,7 +419,7 @@ class TestClient(unittest.TestCase):
         DATASET = 'dataset_name'
         DESTINATION = 'destination_table'
         SOURCE_URI = 'http://example.com/source.csv'
-        creds = _Credentials()
+        creds = object()
         http = object()
         client = self._make_one(project=PROJECT, credentials=creds, http=http)
         dataset = client.dataset(DATASET)
@@ -438,7 +438,7 @@ class TestClient(unittest.TestCase):
         DATASET = 'dataset_name'
         SOURCE = 'source_table'
         DESTINATION = 'destination_table'
-        creds = _Credentials()
+        creds = object()
         http = object()
         client = self._make_one(project=PROJECT, credentials=creds, http=http)
         dataset = client.dataset(DATASET)
@@ -458,7 +458,7 @@ class TestClient(unittest.TestCase):
         DATASET = 'dataset_name'
         SOURCE = 'source_table'
         DESTINATION = 'gs://bucket_name/object_name'
-        creds = _Credentials()
+        creds = object()
         http = object()
         client = self._make_one(project=PROJECT, credentials=creds, http=http)
         dataset = client.dataset(DATASET)
@@ -475,7 +475,7 @@ class TestClient(unittest.TestCase):
         PROJECT = 'PROJECT'
         JOB = 'job_name'
         QUERY = 'select count(*) from persons'
-        creds = _Credentials()
+        creds = object()
         http = object()
         client = self._make_one(project=PROJECT, credentials=creds, http=http)
         job = client.run_async_query(JOB, QUERY)
@@ -488,7 +488,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigquery.query import QueryResults
         PROJECT = 'PROJECT'
         QUERY = 'select count(*) from persons'
-        creds = _Credentials()
+        creds = object()
         http = object()
         client = self._make_one(project=PROJECT, credentials=creds, http=http)
         job = client.run_sync_query(QUERY)
@@ -496,10 +496,6 @@ class TestClient(unittest.TestCase):
         self.assertIs(job._client, client)
         self.assertIsNone(job.name)
         self.assertEqual(job.query, QUERY)
-
-
-class _Credentials(object):
-    pass
 
 
 class _Connection(object):

--- a/bigtable/tox.ini
+++ b/bigtable/tox.ini
@@ -7,6 +7,7 @@ localdeps =
     pip install --quiet --upgrade {toxinidir}/../core
 deps =
     {toxinidir}/../core
+    mock
     pytest
 covercmd =
     py.test --quiet \

--- a/bigtable/unit_tests/test_client.py
+++ b/bigtable/unit_tests/test_client.py
@@ -289,6 +289,11 @@ class TestClient(unittest.TestCase):
                      _make_table_stub=mock_make_table_stub):
             return self._make_one(*args, **kwargs)
 
+    def _make_credentials(self):
+        import mock
+        import google.auth.credentials
+        return mock.Mock(spec=google.auth.credentials.Scoped)
+
     def _constructor_test_helper(self, expected_scopes, creds,
                                  read_only=False, admin=False,
                                  user_agent=None, expected_creds=None):
@@ -320,10 +325,11 @@ class TestClient(unittest.TestCase):
             self.assertSequenceEqual(mock_make_operations_stub.calls, [])
             self.assertSequenceEqual(mock_make_table_stub.calls, [])
 
-        expected_creds = expected_creds or creds
+        expected_creds = expected_creds or creds.with_scopes.return_value
         self.assertIs(client._credentials, expected_creds)
+
         if expected_scopes is not None:
-            self.assertEqual(client._credentials.scopes, expected_scopes)
+            creds.with_scopes.assert_called_once_with(expected_scopes)
 
         self.assertEqual(client.project, self.PROJECT)
         self.assertEqual(client.user_agent, user_agent)
@@ -345,7 +351,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigtable import client as MUT
 
         expected_scopes = [MUT.DATA_SCOPE]
-        creds = object()
+        creds = self._make_credentials()
         self._constructor_test_helper(expected_scopes, creds)
 
     def test_constructor_custom_user_agent(self):
@@ -353,7 +359,7 @@ class TestClient(unittest.TestCase):
 
         CUSTOM_USER_AGENT = 'custom-application'
         expected_scopes = [MUT.DATA_SCOPE]
-        creds = object()
+        creds = self._make_credentials()
         self._constructor_test_helper(expected_scopes, creds,
                                       user_agent=CUSTOM_USER_AGENT)
 
@@ -361,18 +367,18 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigtable import client as MUT
 
         expected_scopes = [MUT.DATA_SCOPE, MUT.ADMIN_SCOPE]
-        creds = object()
+        creds = self._make_credentials()
         self._constructor_test_helper(expected_scopes, creds, admin=True)
 
     def test_constructor_with_read_only(self):
         from google.cloud.bigtable import client as MUT
 
         expected_scopes = [MUT.READ_ONLY_SCOPE]
-        creds = object()
+        creds = self._make_credentials()
         self._constructor_test_helper(expected_scopes, creds, read_only=True)
 
     def test_constructor_both_admin_and_read_only(self):
-        creds = object()
+        creds = self._make_credentials()
         with self.assertRaises(ValueError):
             self._constructor_test_helper([], creds, admin=True,
                                           read_only=True)
@@ -381,18 +387,21 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud.bigtable import client as MUT
 
-        creds = object()
+        creds = self._make_credentials()
         expected_scopes = [MUT.DATA_SCOPE]
 
         def mock_get_credentials():
             return creds
 
         with _Monkey(MUT, get_credentials=mock_get_credentials):
-            self._constructor_test_helper(expected_scopes, None,
-                                          expected_creds=creds)
+            self._constructor_test_helper(
+                None, None,
+                expected_creds=creds.with_scopes.return_value)
+
+        creds.with_scopes.assert_called_once_with(expected_scopes)
 
     def test_constructor_credentials_wo_create_scoped(self):
-        creds = object()
+        creds = self._make_credentials()
         expected_scopes = None
         self._constructor_test_helper(expected_scopes, creds)
 
@@ -400,7 +409,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud.bigtable import client as MUT
 
-        credentials = object()
+        credentials = self._make_credentials()
         client = self._make_oneWithMocks(
             project=self.PROJECT,
             credentials=credentials,

--- a/bigtable/unit_tests/test_client.py
+++ b/bigtable/unit_tests/test_client.py
@@ -26,7 +26,7 @@ class Test__make_data_stub(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud.bigtable import client as MUT
 
-        credentials = _Credentials()
+        credentials = object()
         user_agent = 'you-sir-age-int'
         client = _Client(credentials, user_agent)
 
@@ -86,7 +86,7 @@ class Test__make_instance_stub(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud.bigtable import client as MUT
 
-        credentials = _Credentials()
+        credentials = object()
         user_agent = 'you-sir-age-int'
         client = _Client(credentials, user_agent)
 
@@ -148,7 +148,7 @@ class Test__make_operations_stub(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud.bigtable import client as MUT
 
-        credentials = _Credentials()
+        credentials = object()
         user_agent = 'you-sir-age-int'
         client = _Client(credentials, user_agent)
 
@@ -210,7 +210,7 @@ class Test__make_table_stub(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud.bigtable import client as MUT
 
-        credentials = _Credentials()
+        credentials = object()
         user_agent = 'you-sir-age-int'
         client = _Client(credentials, user_agent)
 
@@ -345,7 +345,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigtable import client as MUT
 
         expected_scopes = [MUT.DATA_SCOPE]
-        creds = _Credentials()
+        creds = object()
         self._constructor_test_helper(expected_scopes, creds)
 
     def test_constructor_custom_user_agent(self):
@@ -353,7 +353,7 @@ class TestClient(unittest.TestCase):
 
         CUSTOM_USER_AGENT = 'custom-application'
         expected_scopes = [MUT.DATA_SCOPE]
-        creds = _Credentials()
+        creds = object()
         self._constructor_test_helper(expected_scopes, creds,
                                       user_agent=CUSTOM_USER_AGENT)
 
@@ -361,18 +361,18 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigtable import client as MUT
 
         expected_scopes = [MUT.DATA_SCOPE, MUT.ADMIN_SCOPE]
-        creds = _Credentials()
+        creds = object()
         self._constructor_test_helper(expected_scopes, creds, admin=True)
 
     def test_constructor_with_read_only(self):
         from google.cloud.bigtable import client as MUT
 
         expected_scopes = [MUT.READ_ONLY_SCOPE]
-        creds = _Credentials()
+        creds = object()
         self._constructor_test_helper(expected_scopes, creds, read_only=True)
 
     def test_constructor_both_admin_and_read_only(self):
-        creds = _Credentials()
+        creds = object()
         with self.assertRaises(ValueError):
             self._constructor_test_helper([], creds, admin=True,
                                           read_only=True)
@@ -381,7 +381,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud.bigtable import client as MUT
 
-        creds = _Credentials()
+        creds = object()
         expected_scopes = [MUT.DATA_SCOPE]
 
         def mock_get_credentials():
@@ -400,7 +400,7 @@ class TestClient(unittest.TestCase):
         from google.cloud._testing import _Monkey
         from google.cloud.bigtable import client as MUT
 
-        credentials = _Credentials('value')
+        credentials = object()
         client = self._make_oneWithMocks(
             project=self.PROJECT,
             credentials=credentials,
@@ -447,14 +447,14 @@ class TestClient(unittest.TestCase):
         self._copy_test_helper(read_only=True)
 
     def test_credentials_getter(self):
-        credentials = _Credentials()
+        credentials = object()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
                                          credentials=credentials)
         self.assertIs(client.credentials, credentials)
 
     def test_project_name_property(self):
-        credentials = _Credentials()
+        credentials = object()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
                                          credentials=credentials)
@@ -462,14 +462,14 @@ class TestClient(unittest.TestCase):
         self.assertEqual(client.project_name, project_name)
 
     def test_instance_stub_getter(self):
-        credentials = _Credentials()
+        credentials = object()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
                                          credentials=credentials, admin=True)
         self.assertIs(client._instance_stub, client._instance_stub_internal)
 
     def test_instance_stub_non_admin_failure(self):
-        credentials = _Credentials()
+        credentials = object()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
                                          credentials=credentials, admin=False)
@@ -477,7 +477,7 @@ class TestClient(unittest.TestCase):
             getattr(client, '_instance_stub')
 
     def test_operations_stub_getter(self):
-        credentials = _Credentials()
+        credentials = object()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
                                          credentials=credentials, admin=True)
@@ -485,7 +485,7 @@ class TestClient(unittest.TestCase):
                       client._operations_stub_internal)
 
     def test_operations_stub_non_admin_failure(self):
-        credentials = _Credentials()
+        credentials = object()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
                                          credentials=credentials, admin=False)
@@ -493,14 +493,14 @@ class TestClient(unittest.TestCase):
             getattr(client, '_operations_stub')
 
     def test_table_stub_getter(self):
-        credentials = _Credentials()
+        credentials = object()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
                                          credentials=credentials, admin=True)
         self.assertIs(client._table_stub, client._table_stub_internal)
 
     def test_table_stub_non_admin_failure(self):
-        credentials = _Credentials()
+        credentials = object()
         project = 'PROJECT'
         client = self._make_oneWithMocks(project=project,
                                          credentials=credentials, admin=False)
@@ -516,7 +516,7 @@ class TestClient(unittest.TestCase):
         PROJECT = 'PROJECT'
         INSTANCE_ID = 'instance-id'
         DISPLAY_NAME = 'display-name'
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_oneWithMocks(project=PROJECT,
                                          credentials=credentials)
 
@@ -538,7 +538,7 @@ class TestClient(unittest.TestCase):
         DISPLAY_NAME = 'display-name'
         LOCATION_ID = 'locname'
         SERVE_NODES = 5
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_oneWithMocks(project=PROJECT,
                                          credentials=credentials)
 
@@ -569,7 +569,7 @@ class TestClient(unittest.TestCase):
         INSTANCE_NAME2 = (
             'projects/' + self.PROJECT + '/instances/' + INSTANCE_ID2)
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_oneWithMocks(
             project=self.PROJECT,
             credentials=credentials,
@@ -617,22 +617,6 @@ class TestClient(unittest.TestCase):
             (request_pb,),
             {},
         )])
-
-
-class _Credentials(object):
-
-    scopes = None
-
-    def __init__(self, access_token=None):
-        self._access_token = access_token
-        self._tokens = []
-
-    def create_scoped(self, scope):
-        self.scopes = scope
-        return self
-
-    def __eq__(self, other):
-        return self._access_token == other._access_token
 
 
 class _Client(object):

--- a/core/google/cloud/_helpers.py
+++ b/core/google/cloud/_helpers.py
@@ -30,9 +30,10 @@ import google.auth
 from google.protobuf import timestamp_pb2
 import google_auth_httplib2
 
-try:  # pragma: NO COVER
+try:
     import grpc
-    from google.auth.transport.grpc import AuthMetadataPlugin
+    from google.auth.transport.grpc import (
+        AuthMetadataPlugin)  # pragma: NO COVER
 except ImportError:
     grpc = None
     AuthMetadataPlugin = None

--- a/core/google/cloud/_helpers.py
+++ b/core/google/cloud/_helpers.py
@@ -22,27 +22,18 @@ from __future__ import absolute_import
 
 import calendar
 import datetime
-import json
 import os
 import re
-import socket
 from threading import local as Local
 
+import google.auth
 from google.protobuf import timestamp_pb2
-try:
-    from google.appengine.api import app_identity
-except ImportError:
-    app_identity = None
 try:
     import grpc
 except ImportError:  # pragma: NO COVER
     grpc = None
 import six
 from six.moves import http_client
-from six.moves import configparser
-
-from google.cloud.environment_vars import PROJECT
-from google.cloud.environment_vars import CREDENTIALS
 
 
 _NOW = datetime.datetime.utcnow  # To be replaced by tests.
@@ -168,134 +159,13 @@ def _ensure_tuple_or_list(arg_name, tuple_or_list):
     return list(tuple_or_list)
 
 
-def _app_engine_id():
-    """Gets the App Engine application ID if it can be inferred.
-
-    :rtype: str or ``NoneType``
-    :returns: App Engine application ID if running in App Engine,
-              else ``None``.
-    """
-    if app_identity is None:
-        return None
-
-    return app_identity.get_application_id()
-
-
-def _file_project_id():
-    """Gets the project ID from the credentials file if one is available.
-
-    :rtype: str or ``NoneType``
-    :returns: Project ID from JSON credentials file if value exists,
-              else ``None``.
-    """
-    credentials_file_path = os.getenv(CREDENTIALS)
-    if credentials_file_path:
-        with open(credentials_file_path, 'rb') as credentials_file:
-            credentials_json = credentials_file.read()
-            credentials = json.loads(credentials_json.decode('utf-8'))
-            return credentials.get('project_id')
-
-
-def _get_nix_config_path():
-    """Get the ``gcloud`` CLI config path on *nix systems.
-
-    :rtype: str
-    :returns: The filename on a *nix system containing the CLI
-              config file.
-    """
-    return os.path.join(_USER_ROOT, '.config', _GCLOUD_CONFIG_FILE)
-
-
-def _get_windows_config_path():
-    """Get the ``gcloud`` CLI config path on Windows systems.
-
-    :rtype: str
-    :returns: The filename on a Windows system containing the CLI
-              config file.
-    """
-    appdata_dir = os.getenv('APPDATA', '')
-    return os.path.join(appdata_dir, _GCLOUD_CONFIG_FILE)
-
-
-def _default_service_project_id():
-    """Retrieves the project ID from the gcloud command line tool.
-
-    This assumes the ``.config`` directory is stored
-    - in ~/.config on *nix systems
-    - in the %APPDATA% directory on Windows systems
-
-    Additionally, the ${HOME} / "~" directory may not be present on Google
-    App Engine, so this may be conditionally ignored.
-
-    Files that cannot be opened with configparser are silently ignored; this is
-    designed so that you can specify a list of potential configuration file
-    locations.
-
-    :rtype: str or ``NoneType``
-    :returns: Project-ID from default configuration file else ``None``
-    """
-    search_paths = []
-    if _USER_ROOT is not None:
-        search_paths.append(_get_nix_config_path())
-
-    if os.name == 'nt':
-        search_paths.append(_get_windows_config_path())
-
-    config = configparser.RawConfigParser()
-    config.read(search_paths)
-
-    if config.has_section(_GCLOUD_CONFIG_SECTION):
-        try:
-            return config.get(_GCLOUD_CONFIG_SECTION, _GCLOUD_CONFIG_KEY)
-        except configparser.NoOptionError:
-            return None
-
-
-def _compute_engine_id():
-    """Gets the Compute Engine project ID if it can be inferred.
-
-    Uses 169.254.169.254 for the metadata server to avoid request
-    latency from DNS lookup.
-
-    See https://cloud.google.com/compute/docs/metadata#metadataserver
-    for information about this IP address. (This IP is also used for
-    Amazon EC2 instances, so the metadata flavor is crucial.)
-
-    See https://github.com/google/oauth2client/issues/93 for context about
-    DNS latency.
-
-    :rtype: str or ``NoneType``
-    :returns: Compute Engine project ID if the metadata service is available,
-              else ``None``.
-    """
-    host = '169.254.169.254'
-    uri_path = '/computeMetadata/v1/project/project-id'
-    headers = {'Metadata-Flavor': 'Google'}
-    connection = http_client.HTTPConnection(host, timeout=0.1)
-
-    try:
-        connection.request('GET', uri_path, headers=headers)
-        response = connection.getresponse()
-        if response.status == 200:
-            return response.read()
-    except socket.error:  # socket.timeout or socket.error(64, 'Host is down')
-        pass
-    finally:
-        connection.close()
-
-
-def _get_production_project():
-    """Gets the production project if it can be inferred."""
-    return os.getenv(PROJECT)
-
-
 def _determine_default_project(project=None):
     """Determine default project ID explicitly or implicitly as fall-back.
 
     In implicit case, supports three environments. In order of precedence, the
     implicit environments are:
 
-    * GOOGLE_CLOUD_PROJECT environment variable
+    * GOOGLE_CLOUD_PROJECT and GCLOUD_PROJECT environment variable
     * GOOGLE_APPLICATION_CREDENTIALS JSON file
     * Get default service project from
       ``$ gcloud beta auth application-default login``
@@ -309,20 +179,7 @@ def _determine_default_project(project=None):
     :returns: Default project if it can be determined.
     """
     if project is None:
-        project = _get_production_project()
-
-    if project is None:
-        project = _file_project_id()
-
-    if project is None:
-        project = _default_service_project_id()
-
-    if project is None:
-        project = _app_engine_id()
-
-    if project is None:
-        project = _compute_engine_id()
-
+        _, project = google.auth.default()
     return project
 
 

--- a/core/google/cloud/_helpers.py
+++ b/core/google/cloud/_helpers.py
@@ -465,7 +465,7 @@ def make_secure_channel(credentials, user_agent, host):
 
     Uses / depends on gRPC.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
+    :type credentials: :class:`google.auth.credentials.Credentials`
     :param credentials: The OAuth2 Credentials to use for creating
                         access tokens.
 
@@ -501,7 +501,7 @@ def make_secure_stub(credentials, user_agent, stub_class, host):
 
     Uses / depends on gRPC.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
+    :type credentials: :class:`google.auth.credentials.Credentials`
     :param credentials: The OAuth2 Credentials to use for creating
                         access tokens.
 

--- a/core/google/cloud/_helpers.py
+++ b/core/google/cloud/_helpers.py
@@ -169,15 +169,8 @@ def _ensure_tuple_or_list(arg_name, tuple_or_list):
 def _determine_default_project(project=None):
     """Determine default project ID explicitly or implicitly as fall-back.
 
-    In implicit case, supports three environments. In order of precedence, the
-    implicit environments are:
-
-    * GOOGLE_CLOUD_PROJECT and GCLOUD_PROJECT environment variable
-    * GOOGLE_APPLICATION_CREDENTIALS JSON file
-    * Get default service project from
-      ``$ gcloud beta auth application-default login``
-    * Google App Engine application ID
-    * Google Compute Engine project ID (from metadata server)
+    See :func:`google.auth.default` for details on how the default project
+    is determined.
 
     :type project: str
     :param project: Optional. The project name to use as default.

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -61,9 +61,9 @@ class Connection(object):
     object will also need to be able to add a bearer token to API
     requests and handle token refresh on 401 errors.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
+    :type credentials: :class:`google.auth.credentials.Credentials` or
                        :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for this connection.
+    :param credentials: The credentials to use for this connection.
 
     :type http: :class:`httplib2.Http` or class that defines ``request()``.
     :param http: An optional HTTP object to make requests.
@@ -86,7 +86,7 @@ class Connection(object):
     def credentials(self):
         """Getter for current credentials.
 
-        :rtype: :class:`oauth2client.client.OAuth2Credentials` or
+        :rtype: :class:`google.auth.credentials.Credentials` or
                 :class:`NoneType`
         :returns: The credentials object associated with this connection.
         """

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -14,7 +14,7 @@
 
 """Base classes for client used to interact with Google Cloud APIs."""
 
-from oauth2client.service_account import ServiceAccountCredentials
+from google.oauth2 import service_account
 import six
 
 from google.cloud._helpers import _determine_default_project
@@ -55,43 +55,8 @@ class _ClientFactoryMixin(object):
         """
         if 'credentials' in kwargs:
             raise TypeError('credentials must not be in keyword arguments')
-        credentials = ServiceAccountCredentials.from_json_keyfile_name(
+        credentials = service_account.Credentials.from_service_account_file(
             json_credentials_path)
-        kwargs['credentials'] = credentials
-        return cls(*args, **kwargs)
-
-    @classmethod
-    def from_service_account_p12(cls, client_email, private_key_path,
-                                 *args, **kwargs):
-        """Factory to retrieve P12 credentials while creating client.
-
-        .. note::
-          Unless you have an explicit reason to use a PKCS12 key for your
-          service account, we recommend using a JSON key.
-
-        :type client_email: str
-        :param client_email: The e-mail attached to the service account.
-
-        :type private_key_path: str
-        :param private_key_path: The path to a private key file (this file was
-                                 given to you when you created the service
-                                 account). This file must be in P12 format.
-
-        :type args: tuple
-        :param args: Remaining positional arguments to pass to constructor.
-
-        :type kwargs: dict
-        :param kwargs: Remaining keyword arguments to pass to constructor.
-
-        :rtype: :class:`google.cloud.client.Client`
-        :returns: The client created with the retrieved P12 credentials.
-        :raises: :class:`TypeError` if there is a conflict with the kwargs
-                 and the credentials created by the factory.
-        """
-        if 'credentials' in kwargs:
-            raise TypeError('credentials must not be in keyword arguments')
-        credentials = ServiceAccountCredentials.from_p12_keyfile(
-            client_email, private_key_path)
         kwargs['credentials'] = credentials
         return cls(*args, **kwargs)
 

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -67,7 +67,7 @@ class Client(_ClientFactoryMixin):
     Assumes that the associated ``_connection_class`` only accepts
     ``http`` and ``credentials`` in its constructor.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
+    :type credentials: :class:`google.auth.credentials.Credentials` or
                        :class:`NoneType`
     :param credentials: The OAuth2 Credentials to use for the connection
                         owned by this client. If not passed (and if no ``http``
@@ -130,7 +130,7 @@ class JSONClient(Client, _ClientProjectMixin):
                     passed falls back to the default inferred from the
                     environment.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
+    :type credentials: :class:`google.auth.credentials.Credentials` or
                        :class:`NoneType`
     :param credentials: The OAuth2 Credentials to use for the connection
                         owned by this client. If not passed (and if no ``http``

--- a/core/google/cloud/credentials.py
+++ b/core/google/cloud/credentials.py
@@ -43,7 +43,7 @@ def get_credentials():
 def _get_signed_query_params(credentials, expiration, string_to_sign):
     """Gets query parameters for creating a signed URL.
 
-    :type credentials: :class:`oauth2client.client.AssertionCredentials`
+    :type credentials: :class:`google.auth.credentials.Credentials`
     :param credentials: The credentials used to create a private key
                         for signing text.
 
@@ -113,10 +113,8 @@ def generate_signed_url(credentials, resource, expiration,
 
     .. note::
 
-        Assumes ``credentials`` implements a ``sign_blob()`` method that takes
-        bytes to sign and returns a pair of the key ID (unused here) and the
-        signed bytes (this is abstract in the base class
-        :class:`oauth2client.client.AssertionCredentials`). Also assumes
+        Assumes ``credentials`` implements the
+        :class:`google.auth.credentials.Signing` interface. Also assumes
         ``credentials`` has a ``service_account_email`` property which
         identifies the credentials.
 
@@ -133,7 +131,7 @@ def generate_signed_url(credentials, resource, expiration,
                    google-cloud-python/issues/922
     .. _reference: https://cloud.google.com/storage/docs/reference-headers
 
-    :type credentials: :class:`oauth2client.appengine.AppAssertionCredentials`
+    :type credentials: :class:`google.auth.credentials.Signing`
     :param credentials: Credentials object with an associated private key to
                         sign text.
 

--- a/core/google/cloud/credentials.py
+++ b/core/google/cloud/credentials.py
@@ -43,7 +43,7 @@ def get_credentials():
 def _get_signed_query_params(credentials, expiration, string_to_sign):
     """Gets query parameters for creating a signed URL.
 
-    :type credentials: :class:`google.auth.credentials.Credentials`
+    :type credentials: :class:`google.auth.credentials.Signer`
     :param credentials: The credentials used to create a private key
                         for signing text.
 
@@ -69,7 +69,7 @@ def _get_signed_query_params(credentials, expiration, string_to_sign):
 
     signature_bytes = credentials.sign_bytes(string_to_sign)
     signature = base64.b64encode(signature_bytes)
-    service_account_name = credentials.service_account_email
+    service_account_name = credentials.signer_email
     return {
         'GoogleAccessId': service_account_name,
         'Expires': str(expiration),

--- a/core/google/cloud/credentials.py
+++ b/core/google/cloud/credentials.py
@@ -30,58 +30,9 @@ from google.cloud._helpers import _microseconds_from_datetime
 def get_credentials():
     """Gets credentials implicitly from the current environment.
 
-    .. note::
+    Uses :func:`google.auth.default()`.
 
-        You should not need to use this function directly. Instead, use a
-        helper method which uses this method under the hood.
-
-    Checks environment in order of precedence:
-
-    * Google App Engine (production and testing)
-    * Environment variable :envvar:`GOOGLE_APPLICATION_CREDENTIALS` pointing to
-      a file with stored credentials information.
-    * Stored "well known" file associated with ``gcloud`` command line tool.
-    * Google Compute Engine production environment.
-
-    The file referred to in :envvar:`GOOGLE_APPLICATION_CREDENTIALS` is
-    expected to contain information about credentials that are ready to use.
-    This means either service account information or user account information
-    with a ready-to-use refresh token:
-
-    .. code:: json
-
-      {
-          'type': 'authorized_user',
-          'client_id': '...',
-          'client_secret': '...',
-          'refresh_token': '...'
-      }
-
-    or
-
-    .. code:: json
-
-      {
-          'type': 'service_account',
-          'project_id': '...',
-          'private_key_id': '...',
-          'private_key': '...',
-          'client_email': '...',
-          'client_id': '...',
-          'auth_uri': '...',
-          'token_uri': '...',
-          'auth_provider_x509_cert_url': '...',
-          'client_x509_cert_url': '...'
-      }
-
-    The second of these is simply a JSON key downloaded from the Google APIs
-    console. The first is a close cousin of the "client secrets" JSON file
-    used by :mod:`oauth2client.clientsecrets` but differs in formatting.
-
-    :rtype: :class:`oauth2client.client.GoogleCredentials`,
-            :class:`oauth2client.contrib.appengine.AppAssertionCredentials`,
-            :class:`oauth2client.contrib.gce.AppAssertionCredentials`,
-            :class:`oauth2client.service_account.ServiceAccountCredentials`
+    :rtype: :class:`google.auth.credentials.Credentials`,
     :returns: A new credentials instance corresponding to the implicit
               environment.
     """

--- a/core/google/cloud/environment_vars.py
+++ b/core/google/cloud/environment_vars.py
@@ -18,9 +18,6 @@ These enable many types of implicit behavior in both production
 and tests.
 """
 
-PROJECT = 'GOOGLE_CLOUD_PROJECT'
-"""Environment variable defining default project."""
-
 GCD_DATASET = 'DATASTORE_DATASET'
 """Environment variable defining default dataset ID under GCD."""
 
@@ -32,9 +29,6 @@ PUBSUB_EMULATOR = 'PUBSUB_EMULATOR_HOST'
 
 BIGTABLE_EMULATOR = 'BIGTABLE_EMULATOR_HOST'
 """Environment variable defining host for Bigtable emulator."""
-
-CREDENTIALS = 'GOOGLE_APPLICATION_CREDENTIALS'
-"""Environment variable defining location of Google credentials."""
 
 DISABLE_GRPC = 'GOOGLE_CLOUD_DISABLE_GRPC'
 """Environment variable acting as flag to disable gRPC.

--- a/core/google/cloud/streaming/http_wrapper.py
+++ b/core/google/cloud/streaming/http_wrapper.py
@@ -90,7 +90,7 @@ def _httplib2_debug_level(http_request, level, http=None):
     old_level = httplib2.debuglevel
     http_levels = {}
     httplib2.debuglevel = level
-    if http is not None and hasattr(http, 'connections'):
+    if http is not None and getattr(http, 'connections', None) is not None:
         for connection_key, connection in http.connections.items():
             # httplib2 stores two kinds of values in this dict, connection
             # classes and instances. Since the connection types are all

--- a/core/google/cloud/streaming/http_wrapper.py
+++ b/core/google/cloud/streaming/http_wrapper.py
@@ -90,7 +90,7 @@ def _httplib2_debug_level(http_request, level, http=None):
     old_level = httplib2.debuglevel
     http_levels = {}
     httplib2.debuglevel = level
-    if http is not None:
+    if http is not None and hasattr(http, 'connections'):
         for connection_key, connection in http.connections.items():
             # httplib2 stores two kinds of values in this dict, connection
             # classes and instances. Since the connection types are all

--- a/core/setup.py
+++ b/core/setup.py
@@ -53,7 +53,7 @@ REQUIREMENTS = [
     'httplib2 >= 0.9.1',
     'googleapis-common-protos >= 1.3.4',
     'protobuf >= 3.0.0',
-    'google-auth >= 0.3.0, < 2.0.0dev',
+    'google-auth >= 0.3.2, < 2.0.0dev',
     'google-auth-httplib2',
     'six',
 ]

--- a/core/setup.py
+++ b/core/setup.py
@@ -53,7 +53,7 @@ REQUIREMENTS = [
     'httplib2 >= 0.9.1',
     'googleapis-common-protos >= 1.3.4',
     'protobuf >= 3.0.0',
-    'google-auth >= 0.3.2, < 2.0.0dev',
+    'google-auth >= 0.4.0, < 2.0.0dev',
     'google-auth-httplib2',
     'six',
 ]

--- a/core/setup.py
+++ b/core/setup.py
@@ -52,7 +52,6 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'httplib2 >= 0.9.1',
     'googleapis-common-protos >= 1.3.4',
-    'oauth2client >= 3.0.0, < 4.0.0dev',
     'protobuf >= 3.0.0',
     'google-auth >= 0.3.0, < 2.0.0dev',
     'google-auth-httplib2',

--- a/core/setup.py
+++ b/core/setup.py
@@ -54,6 +54,8 @@ REQUIREMENTS = [
     'googleapis-common-protos >= 1.3.4',
     'oauth2client >= 3.0.0, < 4.0.0dev',
     'protobuf >= 3.0.0',
+    'google-auth >= 0.3.0, < 2.0.0dev',
+    'google-auth-httplib2',
     'six',
 ]
 

--- a/core/tox.ini
+++ b/core/tox.ini
@@ -4,6 +4,7 @@ envlist =
 
 [testing]
 deps =
+    mock
     pytest
 covercmd =
     py.test --quiet \

--- a/core/unit_tests/test__helpers.py
+++ b/core/unit_tests/test__helpers.py
@@ -133,7 +133,7 @@ class Test__determine_default_project(unittest.TestCase):
         from google.cloud._helpers import _determine_default_project
         return _determine_default_project(project=project)
 
-    def test(self):
+    def test_it(self):
         with mock.patch('google.auth.default', autospec=True) as default:
             default.return_value = (
                 mock.sentinel.credentials, mock.sentinel.project)

--- a/core/unit_tests/test__http.py
+++ b/core/unit_tests/test__http.py
@@ -113,8 +113,7 @@ class TestJSONConnection(unittest.TestCase):
         self.assertIsNone(conn.credentials)
 
     def test_ctor_explicit(self):
-        credentials = mock.sentinel.credentials
-        conn = self._make_one(credentials)
+        conn = self._make_one(mock.sentinel.credentials)
         self.assertIs(conn.credentials, mock.sentinel.credentials)
 
     def test_http_w_existing(self):

--- a/core/unit_tests/test__http.py
+++ b/core/unit_tests/test__http.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestConnection(unittest.TestCase):
 
@@ -31,11 +33,14 @@ class TestConnection(unittest.TestCase):
         self.assertIsNone(conn.credentials)
 
     def test_ctor_explicit(self):
-        credentials = _Credentials()
-        self.assertEqual(credentials._create_scoped_calls, 0)
+        import google.auth.credentials
+
+        credentials = mock.Mock(spec=google.auth.credentials.Scoped)
+
         conn = self._make_one(credentials)
-        self.assertEqual(credentials._create_scoped_calls, 1)
-        self.assertIs(conn.credentials, credentials)
+
+        credentials.with_scopes.assert_called_once_with(conn.SCOPE)
+        self.assertIs(conn.credentials, credentials.with_scopes.return_value)
         self.assertIsNone(conn._http)
 
     def test_ctor_explicit_http(self):
@@ -61,13 +66,15 @@ class TestConnection(unittest.TestCase):
         self.assertIsInstance(conn.http, httplib2.Http)
 
     def test_http_w_creds(self):
-        import httplib2
+        import google.auth.credentials
+        import google_auth_httplib2
 
-        authorized = object()
-        credentials = _Credentials(authorized)
+        credentials = mock.Mock(spec=google.auth.credentials.Credentials)
+
         conn = self._make_one(credentials)
-        self.assertIs(conn.http, authorized)
-        self.assertIsInstance(credentials._called_with, httplib2.Http)
+
+        self.assertIsInstance(conn.http, google_auth_httplib2.AuthorizedHttp)
+        self.assertIs(conn.http.credentials, credentials)
 
     def test_user_agent_format(self):
         from pkg_resources import get_distribution
@@ -75,37 +82,6 @@ class TestConnection(unittest.TestCase):
             get_distribution('google-cloud-core').version)
         conn = self._make_one()
         self.assertEqual(conn.USER_AGENT, expected_ua)
-
-    def test__create_scoped_credentials_with_scoped_credentials(self):
-        klass = self._get_target_class()
-        scoped_creds = object()
-        scope = 'google-specific-scope'
-        credentials = _Credentials(scoped=scoped_creds)
-
-        result = klass._create_scoped_credentials(credentials, scope)
-        self.assertIs(result, scoped_creds)
-        self.assertEqual(credentials._create_scoped_calls, 1)
-        self.assertEqual(credentials._scopes, [scope])
-
-    def test__create_scoped_credentials_without_scope_required(self):
-        klass = self._get_target_class()
-        credentials = _Credentials()
-
-        result = klass._create_scoped_credentials(credentials, None)
-        self.assertIs(result, credentials)
-        self.assertEqual(credentials._create_scoped_calls, 1)
-        self.assertEqual(credentials._scopes, [])
-
-    def test__create_scoped_credentials_non_scoped_credentials(self):
-        klass = self._get_target_class()
-        credentials = object()
-        result = klass._create_scoped_credentials(credentials, None)
-        self.assertIs(result, credentials)
-
-    def test__create_scoped_credentials_no_credentials(self):
-        klass = self._get_target_class()
-        result = klass._create_scoped_credentials(None, None)
-        self.assertIsNone(result)
 
 
 class TestJSONConnection(unittest.TestCase):
@@ -137,9 +113,9 @@ class TestJSONConnection(unittest.TestCase):
         self.assertIsNone(conn.credentials)
 
     def test_ctor_explicit(self):
-        credentials = _Credentials()
+        credentials = mock.sentinel.credentials
         conn = self._make_one(credentials)
-        self.assertIs(conn.credentials, credentials)
+        self.assertIs(conn.credentials, mock.sentinel.credentials)
 
     def test_http_w_existing(self):
         conn = self._make_one()
@@ -152,13 +128,15 @@ class TestJSONConnection(unittest.TestCase):
         self.assertIsInstance(conn.http, httplib2.Http)
 
     def test_http_w_creds(self):
-        import httplib2
+        import google.auth.credentials
+        import google_auth_httplib2
 
-        authorized = object()
-        credentials = _Credentials(authorized)
+        credentials = mock.Mock(spec=google.auth.credentials.Credentials)
+
         conn = self._make_one(credentials)
-        self.assertIs(conn.http, authorized)
-        self.assertIsInstance(credentials._called_with, httplib2.Http)
+
+        self.assertIsInstance(conn.http, google_auth_httplib2.AuthorizedHttp)
+        self.assertIs(conn.http.credentials, credentials)
 
     def test_build_api_url_no_extra_query_params(self):
         conn = self._makeMockOne()
@@ -437,25 +415,3 @@ class _Http(object):
     def request(self, **kw):
         self._called_with = kw
         return self._response, self._content
-
-
-class _Credentials(object):
-
-    def __init__(self, authorized=None, scoped=None):
-        self._authorized = authorized
-        self._scoped = scoped
-        self._scoped_required = scoped is not None
-        self._create_scoped_calls = 0
-        self._scopes = []
-
-    def authorize(self, http):
-        self._called_with = http
-        return self._authorized
-
-    def create_scoped_required(self):
-        self._create_scoped_calls += 1
-        return self._scoped_required
-
-    def create_scoped(self, scope):
-        self._scopes.append(scope)
-        return self._scoped

--- a/core/unit_tests/test_client.py
+++ b/core/unit_tests/test_client.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class Test_ClientFactoryMixin(unittest.TestCase):
 
@@ -74,45 +76,26 @@ class TestClient(unittest.TestCase):
         self.assertIs(client_obj._connection.http, HTTP)
 
     def test_from_service_account_json(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud import client
-
         KLASS = self._get_target_class()
-        MOCK_FILENAME = 'foo.path'
-        mock_creds = _MockServiceAccountCredentials()
-        with _Monkey(client, ServiceAccountCredentials=mock_creds):
-            client_obj = KLASS.from_service_account_json(MOCK_FILENAME)
 
-        self.assertIs(client_obj._connection.credentials, mock_creds._result)
-        self.assertEqual(mock_creds.json_called, [MOCK_FILENAME])
+        constructor_patch = mock.patch(
+            'google.oauth2.service_account.Credentials.'
+            'from_service_account_file')
 
-    def test_from_service_account_json_fail(self):
+        with constructor_patch as constructor:
+            client_obj = KLASS.from_service_account_json(
+                mock.sentinel.filename)
+
+        self.assertIs(
+            client_obj._connection.credentials, constructor.return_value)
+        constructor.assert_called_once_with(mock.sentinel.filename)
+
+    def test_from_service_account_json_bad_args(self):
         KLASS = self._get_target_class()
-        CREDENTIALS = object()
-        self.assertRaises(TypeError, KLASS.from_service_account_json, None,
-                          credentials=CREDENTIALS)
 
-    def test_from_service_account_p12(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud import client
-
-        KLASS = self._get_target_class()
-        CLIENT_EMAIL = 'phred@example.com'
-        MOCK_FILENAME = 'foo.path'
-        mock_creds = _MockServiceAccountCredentials()
-        with _Monkey(client, ServiceAccountCredentials=mock_creds):
-            client_obj = KLASS.from_service_account_p12(CLIENT_EMAIL,
-                                                        MOCK_FILENAME)
-
-        self.assertIs(client_obj._connection.credentials, mock_creds._result)
-        self.assertEqual(mock_creds.p12_called,
-                         [(CLIENT_EMAIL, MOCK_FILENAME)])
-
-    def test_from_service_account_p12_fail(self):
-        KLASS = self._get_target_class()
-        CREDENTIALS = object()
-        self.assertRaises(TypeError, KLASS.from_service_account_p12, None,
-                          None, credentials=CREDENTIALS)
+        with self.assertRaises(TypeError):
+            KLASS.from_service_account_json(
+                mock.sentinel.filename, credentials=mock.sentinel.credentials)
 
 
 class TestJSONClient(unittest.TestCase):
@@ -214,19 +197,3 @@ class _MockConnection(object):
     def __init__(self, credentials=None, http=None):
         self.credentials = credentials
         self.http = http
-
-
-class _MockServiceAccountCredentials(object):
-
-    def __init__(self):
-        self.p12_called = []
-        self.json_called = []
-        self._result = object()
-
-    def from_p12_keyfile(self, email, path):
-        self.p12_called.append((email, path))
-        return self._result
-
-    def from_json_keyfile_name(self, path):
-        self.json_called.append(path)
-        return self._result

--- a/core/unit_tests/test_credentials.py
+++ b/core/unit_tests/test_credentials.py
@@ -52,12 +52,12 @@ class Test_generate_signed_url(unittest.TestCase):
         RESOURCE = '/name/path'
         SIGNED = base64.b64encode(b'DEADBEEF')
         CREDENTIALS = mock.Mock(spec=google.auth.credentials.Signing)
-        CREDENTIALS.service_account_email = 'service@example.com'
+        CREDENTIALS.signer_email = 'service@example.com'
 
         def _get_signed_query_params(*args):
             credentials, expiration = args[:2]
             return {
-                'GoogleAccessId': credentials.service_account_email,
+                'GoogleAccessId': credentials.signer_email,
                 'Expires': str(expiration),
                 'Signature': SIGNED,
             }
@@ -78,7 +78,7 @@ class Test_generate_signed_url(unittest.TestCase):
         self.assertEqual(params.pop('Signature'), [SIGNED.decode('ascii')])
         self.assertEqual(params.pop('Expires'), ['1000'])
         self.assertEqual(params.pop('GoogleAccessId'),
-                         [CREDENTIALS.service_account_email])
+                         [CREDENTIALS.signer_email])
         if response_type is not None:
             self.assertEqual(params.pop('response-content-type'),
                              [response_type])
@@ -130,7 +130,7 @@ class Test__get_signed_query_params(unittest.TestCase):
         SIG_BYTES = b'DEADBEEF'
         ACCOUNT_NAME = mock.sentinel.service_account_email
         CREDENTIALS = mock.Mock(spec=google.auth.credentials.Signing)
-        CREDENTIALS.service_account_email = ACCOUNT_NAME
+        CREDENTIALS.signer_email = ACCOUNT_NAME
         CREDENTIALS.sign_bytes.return_value = SIG_BYTES
         EXPIRATION = 100
         STRING_TO_SIGN = 'dummy_signature'

--- a/core/unit_tests/test_credentials.py
+++ b/core/unit_tests/test_credentials.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class Test_get_credentials(unittest.TestCase):
 
@@ -22,15 +24,13 @@ class Test_get_credentials(unittest.TestCase):
         return credentials.get_credentials()
 
     def test_it(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud import credentials as MUT
-
-        client = _Client()
-        with _Monkey(MUT, client=client):
+        with mock.patch('google.auth.default', autospec=True) as default:
+            default.return_value = (
+                mock.sentinel.credentials, mock.sentinel.project)
             found = self._call_fut()
-        self.assertIsInstance(found, _Credentials)
-        self.assertIs(found, client._signed)
-        self.assertTrue(client._get_app_default_called)
+
+        self.assertIs(found, mock.sentinel.credentials)
+        default.assert_called_once_with()
 
 
 class Test_generate_signed_url(unittest.TestCase):
@@ -44,13 +44,15 @@ class Test_generate_signed_url(unittest.TestCase):
         import base64
         from six.moves.urllib.parse import parse_qs
         from six.moves.urllib.parse import urlsplit
+        import google.auth.credentials
         from google.cloud._testing import _Monkey
         from google.cloud import credentials as MUT
 
         ENDPOINT = 'http://api.example.com'
         RESOURCE = '/name/path'
         SIGNED = base64.b64encode(b'DEADBEEF')
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = mock.Mock(spec=google.auth.credentials.Signing)
+        CREDENTIALS.service_account_email = 'service@example.com'
 
         def _get_signed_query_params(*args):
             credentials, expiration = args[:2]
@@ -104,10 +106,11 @@ class Test_generate_signed_url(unittest.TestCase):
 class Test_generate_signed_url_exception(unittest.TestCase):
     def test_with_google_credentials(self):
         import time
+        import google.auth.credentials
         from google.cloud.credentials import generate_signed_url
         RESOURCE = '/name/path'
 
-        credentials = _GoogleCredentials()
+        credentials = mock.Mock(spec=google.auth.credentials.Credentials)
         expiration = int(time.time() + 5)
         self.assertRaises(AttributeError, generate_signed_url, credentials,
                           resource=RESOURCE, expiration=expiration)
@@ -122,11 +125,13 @@ class Test__get_signed_query_params(unittest.TestCase):
 
     def test_it(self):
         import base64
+        import google.auth.credentials
 
         SIG_BYTES = b'DEADBEEF'
-        ACCOUNT_NAME = object()
-        CREDENTIALS = _Credentials(sign_result=SIG_BYTES,
-                                   service_account_email=ACCOUNT_NAME)
+        ACCOUNT_NAME = mock.sentinel.service_account_email
+        CREDENTIALS = mock.Mock(spec=google.auth.credentials.Signing)
+        CREDENTIALS.service_account_email = ACCOUNT_NAME
+        CREDENTIALS.sign_bytes.return_value = SIG_BYTES
         EXPIRATION = 100
         STRING_TO_SIGN = 'dummy_signature'
         result = self._call_fut(CREDENTIALS, EXPIRATION,
@@ -137,7 +142,7 @@ class Test__get_signed_query_params(unittest.TestCase):
             'Expires': str(EXPIRATION),
             'Signature': base64.b64encode(b'DEADBEEF'),
         })
-        self.assertEqual(CREDENTIALS._signed, [STRING_TO_SIGN])
+        CREDENTIALS.sign_bytes.assert_called_once_with(STRING_TO_SIGN)
 
 
 class Test__get_expiration_seconds(unittest.TestCase):
@@ -221,36 +226,3 @@ class Test__get_expiration_seconds(unittest.TestCase):
             result = self._call_fut(expiration_as_delta)
 
         self.assertEqual(result, utc_seconds + 86400)
-
-
-class _Credentials(object):
-
-    def __init__(self, service_account_email='testing@example.com',
-                 sign_result=''):
-        self.service_account_email = service_account_email
-        self._sign_result = sign_result
-        self._signed = []
-
-    def sign_blob(self, bytes_to_sign):
-        self._signed.append(bytes_to_sign)
-        return None, self._sign_result
-
-
-class _GoogleCredentials(object):
-
-    def __init__(self, service_account_email='testing@example.com'):
-        self.service_account_email = service_account_email
-
-
-class _Client(object):
-
-    def __init__(self):
-        self._signed = _Credentials()
-
-        class GoogleCredentials(object):
-            @staticmethod
-            def get_application_default():
-                self._get_app_default_called = True
-                return self._signed
-
-        self.GoogleCredentials = GoogleCredentials

--- a/datastore/unit_tests/test__http.py
+++ b/datastore/unit_tests/test__http.py
@@ -455,9 +455,7 @@ class TestConnection(unittest.TestCase):
 
     def test_ctor_explicit(self):
         class Creds(object):
-
-            def create_scoped_required(self):
-                return False
+            pass
 
         creds = Creds()
         conn = self._make_one(creds)
@@ -475,23 +473,12 @@ class TestConnection(unittest.TestCase):
         self.assertIsInstance(conn.http, httplib2.Http)
 
     def test_http_w_creds(self):
-        import httplib2
-
-        authorized = object()
-
         class Creds(object):
-
-            def authorize(self, http):
-                self._called_with = http
-                return authorized
-
-            def create_scoped_required(self):
-                return False
+            pass
 
         creds = Creds()
         conn = self._make_one(creds)
-        self.assertIs(conn.http, authorized)
-        self.assertIsInstance(creds._called_with, httplib2.Http)
+        self.assertIs(conn.http.credentials, creds)
 
     def test_build_api_url_w_default_base_version(self):
         PROJECT = 'PROJECT'

--- a/dns/unit_tests/test_client.py
+++ b/dns/unit_tests/test_client.py
@@ -30,7 +30,7 @@ class TestClient(unittest.TestCase):
 
     def test_ctor(self):
         from google.cloud.dns.connection import Connection
-        creds = _Credentials()
+        creds = object()
         http = object()
         client = self._make_one(project=self.PROJECT, credentials=creds,
                                 http=http)
@@ -58,7 +58,7 @@ class TestClient(unittest.TestCase):
         }
         CONVERTED = {key: int(value)
                      for key, value in DATA['quota'].items()}
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(self.PROJECT, creds)
         conn = client._connection = _Connection(DATA)
 
@@ -93,7 +93,7 @@ class TestClient(unittest.TestCase):
                      for key, value in DATA['quota'].items()}
         WITH_KIND = {'quota': DATA['quota'].copy()}
         WITH_KIND['quota']['kind'] = 'dns#quota'
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(self.PROJECT, creds)
         conn = client._connection = _Connection(WITH_KIND)
 
@@ -130,7 +130,7 @@ class TestClient(unittest.TestCase):
                  'dnsName': DNS_2},
             ]
         }
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(self.PROJECT, creds)
         conn = client._connection = _Connection(DATA)
 
@@ -175,7 +175,7 @@ class TestClient(unittest.TestCase):
                  'dnsName': DNS_2},
             ]
         }
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(self.PROJECT, creds)
         conn = client._connection = _Connection(DATA)
 
@@ -203,7 +203,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.dns.zone import ManagedZone
         DESCRIPTION = 'DESCRIPTION'
         DNS_NAME = 'test.example.com'
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(self.PROJECT, creds)
         zone = client.zone(self.ZONE_NAME, DNS_NAME, DESCRIPTION)
         self.assertIsInstance(zone, ManagedZone)
@@ -215,7 +215,7 @@ class TestClient(unittest.TestCase):
     def test_zone_w_dns_name_wo_description(self):
         from google.cloud.dns.zone import ManagedZone
         DNS_NAME = 'test.example.com'
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(self.PROJECT, creds)
         zone = client.zone(self.ZONE_NAME, DNS_NAME)
         self.assertIsInstance(zone, ManagedZone)
@@ -226,7 +226,7 @@ class TestClient(unittest.TestCase):
 
     def test_zone_wo_dns_name(self):
         from google.cloud.dns.zone import ManagedZone
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(self.PROJECT, creds)
         zone = client.zone(self.ZONE_NAME)
         self.assertIsInstance(zone, ManagedZone)
@@ -234,19 +234,6 @@ class TestClient(unittest.TestCase):
         self.assertIsNone(zone.dns_name)
         self.assertIsNone(zone.description)
         self.assertIs(zone._client, client)
-
-
-class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
 
 
 class _Connection(object):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -289,4 +289,5 @@ intersphinx_mapping = {
     'oauth2client': ('http://oauth2client.readthedocs.io/en/latest', None),
     'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
     'python': ('https://docs.python.org/2', None),
+    'google-auth': ('https://google-auth.readthedocs.io/en/stable', None),
 }

--- a/error_reporting/unit_tests/test_client.py
+++ b/error_reporting/unit_tests/test_client.py
@@ -38,14 +38,14 @@ class TestClient(unittest.TestCase):
     VERSION = 'myversion'
 
     def test_ctor_default(self):
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         target = self._make_one(project=self.PROJECT,
                                 credentials=CREDENTIALS)
         self.assertEquals(target.service, target.DEFAULT_SERVICE)
         self.assertEquals(target.version, None)
 
     def test_ctor_params(self):
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         target = self._make_one(project=self.PROJECT,
                                 credentials=CREDENTIALS,
                                 service=self.SERVICE,
@@ -54,7 +54,7 @@ class TestClient(unittest.TestCase):
         self.assertEquals(target.version, self.VERSION)
 
     def test_report_exception(self):
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         target = self._make_one(project=self.PROJECT,
                                 credentials=CREDENTIALS)
 
@@ -74,7 +74,7 @@ class TestClient(unittest.TestCase):
         self.assertIn('test_client.py', payload['message'])
 
     def test_report_exception_with_service_version_in_constructor(self):
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         SERVICE = "notdefault"
         VERSION = "notdefaultversion"
         target = self._make_one(project=self.PROJECT,
@@ -109,7 +109,7 @@ class TestClient(unittest.TestCase):
         self.assertEquals(payload['context']['user'], USER)
 
     def test_report(self):
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         target = self._make_one(project=self.PROJECT,
                                 credentials=CREDENTIALS)
 
@@ -126,19 +126,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(report_location['functionName'], 'test_report')
         self.assertGreater(report_location['lineNumber'], 100)
         self.assertLess(report_location['lineNumber'], 150)
-
-
-class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
 
 
 class _Logger(object):

--- a/language/unit_tests/test_client.py
+++ b/language/unit_tests/test_client.py
@@ -17,10 +17,9 @@ import unittest
 
 def make_mock_credentials():
     import mock
-    from oauth2client.client import GoogleCredentials
+    from google.auth import credentials
 
-    credentials = mock.Mock(spec=GoogleCredentials)
-    credentials.create_scoped_required.return_value = False
+    credentials = mock.Mock(spec=credentials.Credentials)
     return credentials
 
 

--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -151,7 +151,6 @@ class BackgroundThreadTransport(Transport):
 
     def __init__(self, client, name):
         http = copy.deepcopy(client._connection.http)
-        http = client._connection.credentials.authorize(http)
         self.client = client.__class__(client.project,
                                        client._connection.credentials, http)
         logger = self.client.logger(name)

--- a/logging/unit_tests/handlers/transports/test_background_thread.py
+++ b/logging/unit_tests/handlers/transports/test_background_thread.py
@@ -158,9 +158,7 @@ class _Batch(object):
 
 
 class _Credentials(object):
-
-    def authorize(self, _):
-        pass
+    pass
 
 
 class _Connection(object):

--- a/logging/unit_tests/handlers/transports/test_background_thread.py
+++ b/logging/unit_tests/handlers/transports/test_background_thread.py
@@ -157,15 +157,11 @@ class _Batch(object):
         del self.entries[:]
 
 
-class _Credentials(object):
-    pass
-
-
 class _Connection(object):
 
     def __init__(self):
         self.http = None
-        self.credentials = _Credentials()
+        self.credentials = object()
 
 
 class _Logger(object):

--- a/logging/unit_tests/test__http.py
+++ b/logging/unit_tests/test__http.py
@@ -29,7 +29,7 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
-        creds = _Credentials()
+        creds = object()
         conn = self._make_one(creds)
         self.assertEqual(conn.credentials, creds)
 
@@ -756,10 +756,6 @@ class Test_MetricsAPI(unittest.TestCase):
         self.assertEqual(conn._called_with['method'], 'DELETE')
         path = '/projects/%s/metrics/%s' % (self.PROJECT, self.METRIC_NAME)
         self.assertEqual(conn._called_with['path'], path)
-
-
-class _Credentials(object):
-    pass
 
 
 class _Connection(object):

--- a/logging/unit_tests/test__http.py
+++ b/logging/unit_tests/test__http.py
@@ -31,8 +31,7 @@ class TestConnection(unittest.TestCase):
     def test_default_url(self):
         creds = _Credentials()
         conn = self._make_one(creds)
-        klass = self._get_target_class()
-        self.assertEqual(conn.credentials._scopes, klass.SCOPE)
+        self.assertEqual(conn.credentials, creds)
 
 
 class Test_LoggingAPI(unittest.TestCase):
@@ -760,16 +759,7 @@ class Test_MetricsAPI(unittest.TestCase):
 
 
 class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
+    pass
 
 
 class _Connection(object):

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -35,14 +35,14 @@ class TestClient(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         self.assertEqual(client.project, self.PROJECT)
 
     def test_logging_api_wo_gax(self):
         from google.cloud.logging._http import _LoggingAPI
 
-        client = self._make_one(self.PROJECT, credentials=_Credentials(),
+        client = self._make_one(self.PROJECT, credentials=object(),
                                 use_gax=False)
         conn = client._connection = object()
         api = client.logging_api
@@ -63,7 +63,7 @@ class TestClient(unittest.TestCase):
             clients.append(client_obj)
             return api_obj
 
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds,
                                 use_gax=True)
 
@@ -83,7 +83,7 @@ class TestClient(unittest.TestCase):
         import mock
         from google.cloud.logging._http import _LoggingAPI
 
-        creds = _Credentials()
+        creds = object()
         patch = mock.patch(
             'google.cloud.logging.client._USE_GAX',
             new=True)
@@ -98,7 +98,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging._http import _SinksAPI
 
         client = self._make_one(
-            self.PROJECT, credentials=_Credentials(),
+            self.PROJECT, credentials=object(),
             use_gax=False)
 
         conn = client._connection = object()
@@ -120,7 +120,7 @@ class TestClient(unittest.TestCase):
             clients.append(client_obj)
             return api_obj
 
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds,
                                 use_gax=True)
 
@@ -140,7 +140,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging._http import _MetricsAPI
 
         client = self._make_one(
-            self.PROJECT, credentials=_Credentials(),
+            self.PROJECT, credentials=object(),
             use_gax=False)
 
         conn = client._connection = object()
@@ -162,7 +162,7 @@ class TestClient(unittest.TestCase):
             clients.append(client_obj)
             return api_obj
 
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds,
                                 use_gax=True)
 
@@ -180,7 +180,7 @@ class TestClient(unittest.TestCase):
 
     def test_logger(self):
         from google.cloud.logging.logger import Logger
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         logger = client.logger(self.LOGGER_NAME)
         self.assertIsInstance(logger, Logger)
@@ -204,7 +204,7 @@ class TestClient(unittest.TestCase):
             'logName': 'projects/%s/logs/%s' % (
                 self.PROJECT, self.LOGGER_NAME),
         }]
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds,
                                 use_gax=False)
         returned = {
@@ -269,7 +269,7 @@ class TestClient(unittest.TestCase):
             'logName': 'projects/%s/logs/%s' % (
                 self.PROJECT, self.LOGGER_NAME),
         }]
-        client = self._make_one(self.PROJECT, credentials=_Credentials(),
+        client = self._make_one(self.PROJECT, credentials=object(),
                                 use_gax=False)
         returned = {'entries': ENTRIES}
         client._connection = _Connection(returned)
@@ -320,7 +320,7 @@ class TestClient(unittest.TestCase):
 
     def test_sink_defaults(self):
         from google.cloud.logging.sink import Sink
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         sink = client.sink(self.SINK_NAME)
         self.assertIsInstance(sink, Sink)
@@ -332,7 +332,7 @@ class TestClient(unittest.TestCase):
 
     def test_sink_explicit(self):
         from google.cloud.logging.sink import Sink
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         sink = client.sink(self.SINK_NAME, self.FILTER, self.DESTINATION_URI)
         self.assertIsInstance(sink, Sink)
@@ -355,7 +355,7 @@ class TestClient(unittest.TestCase):
             'filter': FILTER,
             'destination': self.DESTINATION_URI,
         }]
-        client = self._make_one(project=PROJECT, credentials=_Credentials(),
+        client = self._make_one(project=PROJECT, credentials=object(),
                                 use_gax=False)
         returned = {
             'sinks': SINKS,
@@ -401,7 +401,7 @@ class TestClient(unittest.TestCase):
             'filter': FILTER,
             'destination': self.DESTINATION_URI,
         }]
-        client = self._make_one(project=PROJECT, credentials=_Credentials(),
+        client = self._make_one(project=PROJECT, credentials=object(),
                                 use_gax=False)
         returned = {
             'sinks': SINKS,
@@ -437,7 +437,7 @@ class TestClient(unittest.TestCase):
 
     def test_metric_defaults(self):
         from google.cloud.logging.metric import Metric
-        creds = _Credentials()
+        creds = object()
 
         client_obj = self._make_one(project=self.PROJECT, credentials=creds)
         metric = client_obj.metric(self.METRIC_NAME)
@@ -450,7 +450,7 @@ class TestClient(unittest.TestCase):
 
     def test_metric_explicit(self):
         from google.cloud.logging.metric import Metric
-        creds = _Credentials()
+        creds = object()
 
         client_obj = self._make_one(project=self.PROJECT, credentials=creds)
         metric = client_obj.metric(self.METRIC_NAME, self.FILTER,
@@ -471,7 +471,7 @@ class TestClient(unittest.TestCase):
             'description': self.DESCRIPTION,
         }]
         client = self._make_one(
-            project=self.PROJECT, credentials=_Credentials(),
+            project=self.PROJECT, credentials=object(),
             use_gax=False)
         returned = {
             'metrics': metrics,
@@ -513,7 +513,7 @@ class TestClient(unittest.TestCase):
             'description': self.DESCRIPTION,
         }]
         client = self._make_one(
-            project=self.PROJECT, credentials=_Credentials(),
+            project=self.PROJECT, credentials=object(),
             use_gax=False)
         returned = {
             'metrics': metrics,
@@ -557,7 +557,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging.handlers import AppEngineHandler
 
         client = self._make_one(project=self.PROJECT,
-                                credentials=_Credentials(),
+                                credentials=object(),
                                 use_gax=False)
 
         with _Monkey(_MUT, _LOG_PATH_TEMPLATE='{pid}'):
@@ -573,7 +573,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging.handlers import ContainerEngineHandler
 
         client = self._make_one(project=self.PROJECT,
-                                credentials=_Credentials(),
+                                credentials=object(),
                                 use_gax=False)
 
         with _Monkey(os, environ={_CONTAINER_ENGINE_ENV: 'True'}):
@@ -587,7 +587,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging.handlers import CloudLoggingHandler
 
         http_mock = mock.Mock(spec=httplib2.Http)
-        credentials = _Credentials()
+        credentials = object()
         deepcopy = mock.Mock(return_value=http_mock)
 
         with mock.patch('copy.deepcopy', new=deepcopy):
@@ -607,7 +607,7 @@ class TestClient(unittest.TestCase):
         deepcopy = mock.Mock(return_value=http_mock)
         setup_logging = mock.Mock()
 
-        credentials = _Credentials()
+        credentials = object()
 
         with mock.patch('copy.deepcopy', new=deepcopy):
             with mock.patch('google.cloud.logging.client.setup_logging',
@@ -619,10 +619,6 @@ class TestClient(unittest.TestCase):
                 deepcopy.assert_called_once_with(client._connection.http)
 
         setup_logging.assert_called()
-
-
-class _Credentials(object):
-    pass
 
 
 class _Connection(object):

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -598,7 +598,6 @@ class TestClient(unittest.TestCase):
             deepcopy.assert_called_once_with(client._connection.http)
 
         self.assertIsInstance(handler, CloudLoggingHandler)
-        self.assertTrue(credentials.authorized, http_mock)
 
     def test_setup_logging(self):
         import httplib2
@@ -620,23 +619,10 @@ class TestClient(unittest.TestCase):
                 deepcopy.assert_called_once_with(client._connection.http)
 
         setup_logging.assert_called()
-        self.assertTrue(credentials.authorized, http_mock)
 
 
 class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
-
-    def authorize(self, http):
-        self.authorized = http
+    pass
 
 
 class _Connection(object):

--- a/monitoring/unit_tests/test_client.py
+++ b/monitoring/unit_tests/test_client.py
@@ -624,15 +624,7 @@ class TestClient(unittest.TestCase):
 
 
 class _Credentials(object):
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
+    pass
 
 
 class _Connection(object):

--- a/monitoring/unit_tests/test_client.py
+++ b/monitoring/unit_tests/test_client.py
@@ -85,7 +85,7 @@ class TestClient(unittest.TestCase):
 
         RESPONSE = {'timeSeries': [SERIES1, SERIES2]}
 
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         connection = client._connection = _Connection(RESPONSE)
 
         # A simple query. In practice, it can be very convenient to let the
@@ -138,7 +138,7 @@ class TestClient(unittest.TestCase):
         VALUE_TYPE = 'DOUBLE'
         DESCRIPTION = 'This is my metric.'
 
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         client._connection = _Connection()   # For safety's sake.
         descriptor = client.metric_descriptor(TYPE,
                                               metric_kind=METRIC_KIND,
@@ -164,7 +164,7 @@ class TestClient(unittest.TestCase):
             'instance_name': 'my-instance'
         }
 
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         client._connection = _Connection()   # For safety's sake.
         metric = client.metric(TYPE, LABELS)
         self.assertEqual(metric.type, TYPE)
@@ -177,7 +177,7 @@ class TestClient(unittest.TestCase):
             'zone': 'us-central1-f'
         }
 
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         client._connection = _Connection()   # For safety's sake.
         resource = client.resource(TYPE, LABELS)
         self.assertEqual(resource.type, TYPE)
@@ -202,7 +202,7 @@ class TestClient(unittest.TestCase):
         TIME1 = datetime.datetime.utcnow()
         TIME1_STR = _datetime_to_rfc3339(TIME1, ignore_zone=False)
 
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         client._connection = _Connection()   # For safety's sake.
         metric = client.metric(METRIC_TYPE, METRIC_LABELS)
         resource = client.resource(RESOURCE_TYPE, RESOURCE_LABELS)
@@ -242,7 +242,7 @@ class TestClient(unittest.TestCase):
             'zone': 'us-central1-f'
         }
 
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         client._connection = _Connection()   # For safety's sake.
         resource = client.resource(RESOURCE_TYPE, RESOURCE_LABELS)
 
@@ -296,7 +296,7 @@ class TestClient(unittest.TestCase):
 
         # This test is identical to TestMetricDescriptor.test_fetch()
         # except for the following three lines.
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         connection = client._connection = _Connection(METRIC_DESCRIPTOR)
         descriptor = client.fetch_metric_descriptor(TYPE)
 
@@ -340,7 +340,7 @@ class TestClient(unittest.TestCase):
 
         # This test is identical to TestMetricDescriptor.test_list()
         # except for the following three lines.
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         connection = client._connection = _Connection(RESPONSE)
         descriptors = client.list_metric_descriptors()
 
@@ -385,7 +385,7 @@ class TestClient(unittest.TestCase):
 
         # This test is identical to TestResourceDescriptor.test_fetch()
         # except for the following three lines.
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         connection = client._connection = _Connection(RESOURCE_DESCRIPTOR)
         descriptor = client.fetch_resource_descriptor(TYPE)
 
@@ -433,7 +433,7 @@ class TestClient(unittest.TestCase):
 
         # This test is identical to TestResourceDescriptor.test_list()
         # except for the following three lines.
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         connection = client._connection = _Connection(RESPONSE)
         descriptors = client.list_resource_descriptors()
 
@@ -460,7 +460,7 @@ class TestClient(unittest.TestCase):
         FILTER = 'resource.type = "gce_instance"'
         IS_CLUSTER = False
 
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         group = client.group(GROUP_ID, display_name=DISPLAY_NAME,
                              parent_id=PARENT_ID, filter_string=FILTER,
                              is_cluster=IS_CLUSTER)
@@ -472,7 +472,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(group.is_cluster, IS_CLUSTER)
 
     def test_group_defaults(self):
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         group = client.group()
 
         self.assertIsNone(group.id)
@@ -499,7 +499,7 @@ class TestClient(unittest.TestCase):
             'isCluster': IS_CLUSTER
         }
 
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         connection = client._connection = _Connection(GROUP)
         group = client.fetch_group(GROUP_ID)
 
@@ -532,7 +532,7 @@ class TestClient(unittest.TestCase):
         RESPONSE = {
             'group': [GROUP],
         }
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
         connection = client._connection = _Connection(RESPONSE)
         groups = client.list_groups()
 
@@ -552,7 +552,7 @@ class TestClient(unittest.TestCase):
 
     def test_write_time_series(self):
         PATH = '/projects/{project}/timeSeries/'.format(project=PROJECT)
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
 
         RESOURCE_TYPE = 'gce_instance'
         RESOURCE_LABELS = {
@@ -594,7 +594,7 @@ class TestClient(unittest.TestCase):
     def test_write_point(self):
         import datetime
         PATH = '/projects/{project}/timeSeries/'.format(project=PROJECT)
-        client = self._make_one(project=PROJECT, credentials=_Credentials())
+        client = self._make_one(project=PROJECT, credentials=object())
 
         RESOURCE_TYPE = 'gce_instance'
         RESOURCE_LABELS = {
@@ -621,10 +621,6 @@ class TestClient(unittest.TestCase):
         client.write_point(METRIC, RESOURCE, VALUE, TIMESTAMP)
         request, = connection._requested
         self.assertEqual(request, expected_request)
-
-
-class _Credentials(object):
-    pass
 
 
 class _Connection(object):

--- a/monitoring/unit_tests/test_connection.py
+++ b/monitoring/unit_tests/test_connection.py
@@ -28,18 +28,8 @@ class TestConnection(unittest.TestCase):
     def test_constructor(self):
         credentials = _Credentials()
         connection = self._make_one(credentials)
-        self.assertEqual(connection.credentials._scopes,
-                         self._get_target_class().SCOPE)
+        self.assertEqual(connection.credentials, credentials)
 
 
 class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
+    pass

--- a/monitoring/unit_tests/test_connection.py
+++ b/monitoring/unit_tests/test_connection.py
@@ -26,10 +26,6 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
-        credentials = _Credentials()
+        credentials = object()
         connection = self._make_one(credentials)
         self.assertEqual(connection.credentials, credentials)
-
-
-class _Credentials(object):
-    pass

--- a/pubsub/unit_tests/test__gax.py
+++ b/pubsub/unit_tests/test__gax.py
@@ -1219,7 +1219,4 @@ class _Client(object):
 
 
 class _Credentials(object):
-
-    @staticmethod
-    def create_scoped_required():
-        return False
+    pass

--- a/pubsub/unit_tests/test__gax.py
+++ b/pubsub/unit_tests/test__gax.py
@@ -430,7 +430,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
                                 push_config=push_cfg_pb)
         response = _GAXPageIterator([sub_pb])
         gax_api = _GAXSubscriberAPI(_list_subscriptions_response=response)
-        creds = _Credentials()
+        creds = object()
         client = Client(project=self.PROJECT, credentials=creds)
         api = self._make_one(gax_api, client)
 
@@ -476,7 +476,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([sub_pb], page_token=NEW_TOKEN)
         gax_api = _GAXSubscriberAPI(_list_subscriptions_response=response)
         client = _Client(self.PROJECT)
-        creds = _Credentials()
+        creds = object()
         client = Client(project=self.PROJECT, credentials=creds)
         api = self._make_one(gax_api, client)
 
@@ -914,7 +914,7 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
 
         mock_publisher_api.SERVICE_ADDRESS = host
 
-        creds = _Credentials()
+        creds = object()
         connection = _Connection(in_emulator=False,
                                  credentials=creds)
         patch = mock.patch.multiple(
@@ -986,7 +986,7 @@ class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
 
         mock_subscriber_api.SERVICE_ADDRESS = host
 
-        creds = _Credentials()
+        creds = object()
         connection = _Connection(in_emulator=False,
                                  credentials=creds)
         patch = mock.patch.multiple(
@@ -1216,7 +1216,3 @@ class _Client(object):
 
     def __init__(self, project):
         self.project = project
-
-
-class _Credentials(object):
-    pass

--- a/pubsub/unit_tests/test__http.py
+++ b/pubsub/unit_tests/test__http.py
@@ -454,7 +454,7 @@ class Test_SubscriberAPI(_Base):
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         RETURNED = {'subscriptions': [SUB_INFO]}
         connection = _Connection(RETURNED)
-        creds = _Credentials()
+        creds = object()
         client = Client(project=self.PROJECT, credentials=creds)
         client._connection = connection
         api = self._make_one(client)
@@ -497,7 +497,7 @@ class Test_SubscriberAPI(_Base):
             'nextPageToken': 'TOKEN2',
         }
         connection = _Connection(RETURNED)
-        creds = _Credentials()
+        creds = object()
         client = Client(project=self.PROJECT, credentials=creds)
         client._connection = connection
         api = self._make_one(client)
@@ -902,7 +902,3 @@ class _Client(object):
     def __init__(self, connection, project):
         self._connection = connection
         self.project = project
-
-
-class _Credentials(object):
-    pass

--- a/pubsub/unit_tests/test__http.py
+++ b/pubsub/unit_tests/test__http.py
@@ -905,7 +905,4 @@ class _Client(object):
 
 
 class _Credentials(object):
-
-    @staticmethod
-    def create_scoped_required():
-        return False
+    pass

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -351,16 +351,7 @@ class TestClient(unittest.TestCase):
 
 
 class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
+    pass
 
 
 class _Iterator(object):

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -33,7 +33,7 @@ class TestClient(unittest.TestCase):
     def test_publisher_api_wo_gax(self):
         from google.cloud.pubsub._http import _PublisherAPI
 
-        creds = _Credentials()
+        creds = object()
 
         client = self._make_one(
             project=self.PROJECT, credentials=creds,
@@ -52,7 +52,7 @@ class TestClient(unittest.TestCase):
         import mock
         from google.cloud.pubsub._http import _PublisherAPI
 
-        creds = _Credentials()
+        creds = object()
         with mock.patch('google.cloud.pubsub.client._USE_GAX',
                         new=True):
             client = self._make_one(project=self.PROJECT, credentials=creds,
@@ -78,7 +78,7 @@ class TestClient(unittest.TestCase):
                 self._wrapped = _wrapped
                 self._client = client
 
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(
             project=self.PROJECT, credentials=creds,
             use_gax=True)
@@ -102,7 +102,7 @@ class TestClient(unittest.TestCase):
     def test_subscriber_api_wo_gax(self):
         from google.cloud.pubsub._http import _SubscriberAPI
 
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(
             project=self.PROJECT, credentials=creds,
             use_gax=False)
@@ -132,7 +132,7 @@ class TestClient(unittest.TestCase):
                 self._wrapped = _wrapped
                 self._client = client
 
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(
             project=self.PROJECT, credentials=creds,
             use_gax=True)
@@ -155,7 +155,7 @@ class TestClient(unittest.TestCase):
 
     def test_iam_policy_api(self):
         from google.cloud.pubsub._http import _IAMPolicyAPI
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         conn = client._connection = object()
         api = client.iam_policy_api
@@ -168,7 +168,7 @@ class TestClient(unittest.TestCase):
     def test_list_topics_no_paging(self):
         from google.cloud.pubsub.topic import Topic
 
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         client._connection = object()
         api = _FauxPublisherAPI(items=[Topic(self.TOPIC_NAME, client)])
@@ -191,7 +191,7 @@ class TestClient(unittest.TestCase):
         TOKEN1 = 'TOKEN1'
         TOKEN2 = 'TOKEN2'
         SIZE = 1
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         client._connection = object()
         api = _FauxPublisherAPI([Topic(self.TOPIC_NAME, client)], TOKEN2)
@@ -209,7 +209,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(api._listed_topics, (self.PROJECT, 1, TOKEN1))
 
     def test_list_topics_missing_key(self):
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         client._connection = object()
         api = _FauxPublisherAPI()
@@ -229,7 +229,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.pubsub.topic import Topic
 
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds,
                                 use_gax=False)
         returned = {'subscriptions': [SUB_INFO]}
@@ -267,7 +267,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.pubsub.topic import Topic
 
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=self.PROJECT, credentials=creds,
                                 use_gax=False)
 
@@ -320,7 +320,7 @@ class TestClient(unittest.TestCase):
 
     def test_list_subscriptions_w_missing_key(self):
         PROJECT = 'PROJECT'
-        creds = _Credentials()
+        creds = object()
 
         client = self._make_one(project=PROJECT, credentials=creds)
         client._connection = object()
@@ -338,7 +338,7 @@ class TestClient(unittest.TestCase):
     def test_topic(self):
         PROJECT = 'PROJECT'
         TOPIC_NAME = 'TOPIC_NAME'
-        creds = _Credentials()
+        creds = object()
 
         client_obj = self._make_one(project=PROJECT, credentials=creds)
         new_topic = client_obj.topic(TOPIC_NAME)
@@ -348,10 +348,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(new_topic.full_name,
                          'projects/%s/topics/%s' % (PROJECT, TOPIC_NAME))
         self.assertFalse(new_topic.timestamp_messages)
-
-
-class _Credentials(object):
-    pass
 
 
 class _Iterator(object):

--- a/resource_manager/unit_tests/test_client.py
+++ b/resource_manager/unit_tests/test_client.py
@@ -29,7 +29,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.resource_manager.connection import Connection
 
         http = object()
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials, http=http)
         self.assertIsInstance(client._connection, Connection)
         self.assertEqual(client._connection._credentials, credentials)
@@ -38,7 +38,7 @@ class TestClient(unittest.TestCase):
     def test_new_project_factory(self):
         from google.cloud.resource_manager.project import Project
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
         project_id = 'project_id'
         name = object()
@@ -66,7 +66,7 @@ class TestClient(unittest.TestCase):
             'lifecycleState': 'ACTIVE',
         }
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
         # Patch the connection with one we can easily control.
         client._connection = _Connection(project_resource)
@@ -81,7 +81,7 @@ class TestClient(unittest.TestCase):
     def test_list_projects_return_type(self):
         from google.cloud.iterator import HTTPIterator
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
         # Patch the connection with one we can easily control.
         client._connection = _Connection({})
@@ -90,7 +90,7 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(results, HTTPIterator)
 
     def test_list_projects_no_paging(self):
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
 
         PROJECT_ID = 'project-id'
@@ -118,7 +118,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(project.status, STATUS)
 
     def test_list_projects_with_paging(self):
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
 
         PROJECT_ID1 = 'project-id'
@@ -181,7 +181,7 @@ class TestClient(unittest.TestCase):
         })
 
     def test_list_projects_with_filter(self):
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
 
         PROJECT_ID = 'project-id'
@@ -220,7 +220,7 @@ class TestClient(unittest.TestCase):
     def test_page_empty_response(self):
         from google.cloud.iterator import Page
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
         iterator = client.list_projects()
         page = Page(iterator, (), None)
@@ -246,7 +246,7 @@ class TestClient(unittest.TestCase):
             'lifecycleState': project_lifecycle_state,
         }
         response = {'projects': [api_resource]}
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
 
         def dummy_response():
@@ -266,10 +266,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(project.number, project_number)
         self.assertEqual(project.labels, project_labels)
         self.assertEqual(project.status, project_lifecycle_state)
-
-
-class _Credentials(object):
-    pass
 
 
 class _Connection(object):

--- a/resource_manager/unit_tests/test_client.py
+++ b/resource_manager/unit_tests/test_client.py
@@ -269,16 +269,7 @@ class TestClient(unittest.TestCase):
 
 
 class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
+    pass
 
 
 class _Connection(object):

--- a/runtimeconfig/unit_tests/test_client.py
+++ b/runtimeconfig/unit_tests/test_client.py
@@ -28,7 +28,7 @@ class TestClient(unittest.TestCase):
     def test_config(self):
         PROJECT = 'PROJECT'
         CONFIG_NAME = 'config_name'
-        creds = _Credentials()
+        creds = object()
 
         client_obj = self._make_one(project=PROJECT, credentials=creds)
         new_config = client_obj.config(CONFIG_NAME)
@@ -38,7 +38,3 @@ class TestClient(unittest.TestCase):
         self.assertEqual(new_config.full_name,
                          'projects/%s/configs/%s' % (PROJECT, CONFIG_NAME))
         self.assertFalse(new_config.description)
-
-
-class _Credentials(object):
-    pass

--- a/runtimeconfig/unit_tests/test_client.py
+++ b/runtimeconfig/unit_tests/test_client.py
@@ -41,13 +41,4 @@ class TestClient(unittest.TestCase):
 
 
 class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
+    pass

--- a/runtimeconfig/unit_tests/test_connection.py
+++ b/runtimeconfig/unit_tests/test_connection.py
@@ -28,18 +28,8 @@ class TestConnection(unittest.TestCase):
     def test_default_url(self):
         creds = _Credentials()
         conn = self._make_one(creds)
-        klass = self._get_target_class()
-        self.assertEqual(conn.credentials._scopes, klass.SCOPE)
+        self.assertEqual(conn.credentials, creds)
 
 
 class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
+    pass

--- a/runtimeconfig/unit_tests/test_connection.py
+++ b/runtimeconfig/unit_tests/test_connection.py
@@ -26,10 +26,6 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
-        creds = _Credentials()
+        creds = object()
         conn = self._make_one(creds)
         self.assertEqual(conn.credentials, creds)
-
-
-class _Credentials(object):
-    pass

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -725,20 +725,7 @@ class _MockGAPICSpeechAPI(object):
 
 
 class _Credentials(object):
-
-    _scopes = ('https://www.googleapis.com/auth/cloud-platform',)
-
-    def __init__(self, authorized=None):
-        self._authorized = authorized
-        self._create_scoped_calls = 0
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
+    pass
 
 
 class _Connection(object):

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -79,7 +79,7 @@ class TestClient(unittest.TestCase):
     def test_ctor(self):
         from google.cloud.speech.connection import Connection
 
-        creds = _Credentials()
+        creds = object()
         http = object()
         client = self._make_one(credentials=creds, http=http)
         self.assertIsInstance(client._connection, Connection)
@@ -87,7 +87,7 @@ class TestClient(unittest.TestCase):
         self.assertTrue(client._connection.http is http)
 
     def test_ctor_use_gax_preset(self):
-        creds = _Credentials()
+        creds = object()
         http = object()
         client = self._make_one(credentials=creds, http=http, use_gax=True)
         self.assertTrue(client._use_gax)
@@ -96,7 +96,7 @@ class TestClient(unittest.TestCase):
         from google.cloud import speech
         from google.cloud.speech.sample import Sample
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
 
         sample = client.sample(source_uri=self.AUDIO_SOURCE_URI,
@@ -144,7 +144,7 @@ class TestClient(unittest.TestCase):
                 'content': _B64_AUDIO_CONTENT,
             }
         }
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials, use_gax=False)
         client._connection = _Connection(RETURNED)
 
@@ -187,7 +187,7 @@ class TestClient(unittest.TestCase):
                 'uri': self.AUDIO_SOURCE_URI,
             }
         }
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials, use_gax=False)
         client._connection = _Connection(RETURNED)
 
@@ -216,7 +216,7 @@ class TestClient(unittest.TestCase):
         from google.cloud import speech
         from unit_tests._fixtures import SYNC_RECOGNIZE_EMPTY_RESPONSE
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials, use_gax=False)
         client._connection = _Connection(SYNC_RECOGNIZE_EMPTY_RESPONSE)
 
@@ -233,7 +233,7 @@ class TestClient(unittest.TestCase):
         from google.cloud import speech
         from google.cloud.speech import _gax
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials, use_gax=True)
         client._connection = _Connection()
         client._connection.credentials = credentials
@@ -276,7 +276,7 @@ class TestClient(unittest.TestCase):
         from google.cloud import speech
         from google.cloud.speech import _gax
 
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(credentials=creds, use_gax=True)
         client._connection = _Connection()
         client._connection.credentials = creds
@@ -336,7 +336,7 @@ class TestClient(unittest.TestCase):
     def test_async_supported_encodings(self):
         from google.cloud import speech
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
         client._connection = _Connection({})
 
@@ -353,7 +353,7 @@ class TestClient(unittest.TestCase):
 
         RETURNED = ASYNC_RECOGNIZE_RESPONSE
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials, use_gax=False)
         client._connection = _Connection(RETURNED)
 
@@ -375,7 +375,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech import _gax
         from google.cloud.speech.operation import Operation
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials,
                                 use_gax=True)
         client._connection = _Connection()
@@ -416,9 +416,8 @@ class TestClient(unittest.TestCase):
 
     def test_streaming_depends_on_gax(self):
         from google.cloud import speech
-        from google.cloud._testing import _Monkey
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials, use_gax=False)
         client.connection = _Connection()
         sample = client.sample(content=self.AUDIO_CONTENT,
@@ -437,7 +436,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.encoding import Encoding
 
         stream = BytesIO(b'Some audio data...')
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
         client.connection = _Connection()
         client.connection.credentials = credentials
@@ -478,7 +477,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.result import StreamingSpeechResult
 
         stream = BytesIO(b'Some audio data...')
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
         client.connection = _Connection()
         client.connection.credentials = credentials
@@ -554,7 +553,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.encoding import Encoding
 
         stream = BytesIO(b'Some audio data...')
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
         client.connection = _Connection()
         client.connection.credentials = credentials
@@ -610,7 +609,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.encoding import Encoding
 
         stream = BytesIO(b'Some audio data...')
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(credentials=credentials)
         client.connection = _Connection()
         client.connection.credentials = credentials
@@ -646,7 +645,7 @@ class TestClient(unittest.TestCase):
 
         from google.cloud.speech import _gax
 
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(credentials=creds, use_gax=True)
         client._connection = _Connection()
         client._connection.credentials = creds
@@ -679,14 +678,14 @@ class TestClient(unittest.TestCase):
         from google.cloud._http import Connection
         from google.cloud.speech.client import _JSONSpeechAPI
 
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(credentials=creds, use_gax=False)
         self.assertIsNone(client._speech_api)
         self.assertIsInstance(client.speech_api, _JSONSpeechAPI)
         self.assertIsInstance(client.speech_api._connection, Connection)
 
     def test_speech_api_preset(self):
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(credentials=creds)
         fake_api = object()
         client._speech_api = fake_api
@@ -722,10 +721,6 @@ class _MockGAPICSpeechAPI(object):
         self._requests = requests
         for response in self._response:
             yield response
-
-
-class _Credentials(object):
-    pass
 
 
 class _Connection(object):

--- a/storage/unit_tests/test_batch.py
+++ b/storage/unit_tests/test_batch.py
@@ -89,7 +89,7 @@ class TestBatch(unittest.TestCase):
     def test_current(self):
         from google.cloud.storage.client import Client
         project = 'PROJECT'
-        credentials = _Credentials()
+        credentials = object()
         client = Client(project=project, credentials=credentials)
         batch1 = self._make_one(client)
         self.assertIsNone(batch1.current())
@@ -378,7 +378,7 @@ class TestBatch(unittest.TestCase):
         expected['content-type'] = 'multipart/mixed; boundary="DEADBEEF="'
         http = _HTTP((expected, _THREE_PART_MIME_RESPONSE))
         project = 'PROJECT'
-        credentials = _Credentials()
+        credentials = object()
         client = Client(project=project, credentials=credentials)
         client._base_connection._http = http
 
@@ -414,7 +414,7 @@ class TestBatch(unittest.TestCase):
         http = _HTTP()
         connection = _Connection(http=http)
         project = 'PROJECT'
-        credentials = _Credentials()
+        credentials = object()
         client = Client(project=project, credentials=credentials)
         client._base_connection = connection
 
@@ -599,16 +599,3 @@ class _Client(object):
 
     def __init__(self, connection):
         self._base_connection = connection
-
-
-class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self

--- a/storage/unit_tests/test_client.py
+++ b/storage/unit_tests/test_client.py
@@ -29,7 +29,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage._http import Connection
 
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
 
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         self.assertEqual(client.project, PROJECT)
@@ -42,7 +42,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage.batch import Batch
 
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
 
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         batch1 = Batch(client)
@@ -61,7 +61,7 @@ class TestClient(unittest.TestCase):
 
     def test__connection_setter(self):
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         client._base_connection = None  # Unset the value from the constructor
         client._connection = connection = object()
@@ -69,13 +69,13 @@ class TestClient(unittest.TestCase):
 
     def test__connection_setter_when_set(self):
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         self.assertRaises(ValueError, setattr, client, '_connection', None)
 
     def test__connection_getter_no_batch(self):
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         self.assertIs(client._connection, client._base_connection)
         self.assertIsNone(client.current_batch)
@@ -83,7 +83,7 @@ class TestClient(unittest.TestCase):
     def test__connection_getter_with_batch(self):
         from google.cloud.storage.batch import Batch
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         batch = Batch(client)
         client._push_batch(batch)
@@ -95,7 +95,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage.bucket import Bucket
 
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         BUCKET_NAME = 'BUCKET_NAME'
 
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
@@ -108,7 +108,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage.batch import Batch
 
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
 
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
         batch = client.batch()
@@ -119,7 +119,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.exceptions import NotFound
 
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         NONESUCH = 'nonesuch'
@@ -142,7 +142,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage.bucket import Bucket
 
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BLOB_NAME = 'blob-name'
@@ -166,7 +166,7 @@ class TestClient(unittest.TestCase):
 
     def test_lookup_bucket_miss(self):
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         NONESUCH = 'nonesuch'
@@ -190,7 +190,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage.bucket import Bucket
 
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BLOB_NAME = 'blob-name'
@@ -216,7 +216,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.exceptions import Conflict
 
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BLOB_NAME = 'blob-name'
@@ -239,7 +239,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage.bucket import Bucket
 
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BLOB_NAME = 'blob-name'
@@ -265,7 +265,7 @@ class TestClient(unittest.TestCase):
         from six.moves.urllib.parse import urlparse
 
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         EXPECTED_QUERY = {
@@ -297,7 +297,7 @@ class TestClient(unittest.TestCase):
         from six.moves.urllib.parse import urlencode
         from six.moves.urllib.parse import urlparse
         PROJECT = 'PROJECT'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BUCKET_NAME = 'bucket-name'
@@ -326,7 +326,7 @@ class TestClient(unittest.TestCase):
         from six.moves.urllib.parse import urlparse
 
         PROJECT = 'foo-bar'
-        CREDENTIALS = _Credentials()
+        CREDENTIALS = object()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         MAX_RESULTS = 10
@@ -374,7 +374,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.iterator import Page
 
         project = 'PROJECT'
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=project, credentials=credentials)
         iterator = client.list_buckets()
         page = Page(iterator, (), None)
@@ -386,7 +386,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage.bucket import Bucket
 
         project = 'PROJECT'
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=project, credentials=credentials)
 
         blob_name = 'blob-name'
@@ -404,19 +404,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(page.remaining, 0)
         self.assertIsInstance(bucket, Bucket)
         self.assertEqual(bucket.name, blob_name)
-
-
-class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
 
 
 class _Http(object):

--- a/system_tests/attempt_system_tests.py
+++ b/system_tests/attempt_system_tests.py
@@ -50,7 +50,7 @@ import os
 import subprocess
 import sys
 
-from google.cloud.environment_vars import CREDENTIALS
+from google.auth.environment_vars import CREDENTIALS
 
 from run_system_test import FailedSystemTestModule
 from run_system_test import run_module_tests

--- a/system_tests/system_test_utils.py
+++ b/system_tests/system_test_utils.py
@@ -17,7 +17,7 @@ import os
 import sys
 import time
 
-from google.cloud.environment_vars import CREDENTIALS as TEST_CREDENTIALS
+from google.auth.environment_vars import CREDENTIALS as TEST_CREDENTIALS
 
 
 # From shell environ. May be None.

--- a/vision/unit_tests/test_client.py
+++ b/vision/unit_tests/test_client.py
@@ -35,7 +35,7 @@ class TestClient(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_ctor(self):
-        creds = _Credentials()
+        creds = object()
         client = self._make_one(project=PROJECT, credentials=creds)
         self.assertEqual(client.project, PROJECT)
 
@@ -59,7 +59,7 @@ class TestClient(unittest.TestCase):
                 }
             ]
         }
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -75,7 +75,7 @@ class TestClient(unittest.TestCase):
     def test_image_with_client(self):
         from google.cloud.vision.image import Image
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT,
                                 credentials=credentials)
         image = client.image(source_uri=IMAGE_SOURCE)
@@ -92,7 +92,7 @@ class TestClient(unittest.TestCase):
         logos = copy.deepcopy(LOGO_DETECTION_RESPONSE['responses'][0])
         returned['responses'][0]['logoAnnotations'] = logos['logoAnnotations']
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(returned)
 
@@ -139,7 +139,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.vision.face import Face
         from unit_tests._fixtures import FACE_DETECTION_RESPONSE
         RETURNED = FACE_DETECTION_RESPONSE
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -156,7 +156,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.vision.face import Face
         from unit_tests._fixtures import FACE_DETECTION_RESPONSE
         RETURNED = FACE_DETECTION_RESPONSE
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -174,7 +174,7 @@ class TestClient(unittest.TestCase):
         RETURNED = {
             'responses': [{}]
         }
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -193,7 +193,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import (
             LABEL_DETECTION_RESPONSE as RETURNED)
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -214,7 +214,7 @@ class TestClient(unittest.TestCase):
         RETURNED = {
             'responses': [{}]
         }
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -228,7 +228,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import (
             LANDMARK_DETECTION_RESPONSE as RETURNED)
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -250,7 +250,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import (
             LANDMARK_DETECTION_RESPONSE as RETURNED)
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -267,7 +267,7 @@ class TestClient(unittest.TestCase):
         RETURNED = {
             'responses': [{}]
         }
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -280,7 +280,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.vision.entity import EntityAnnotation
         from unit_tests._fixtures import LOGO_DETECTION_RESPONSE
         RETURNED = LOGO_DETECTION_RESPONSE
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -297,7 +297,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.vision.entity import EntityAnnotation
         from unit_tests._fixtures import LOGO_DETECTION_RESPONSE
         RETURNED = LOGO_DETECTION_RESPONSE
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -315,7 +315,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import (
             TEXT_DETECTION_RESPONSE as RETURNED)
 
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -337,7 +337,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import SAFE_SEARCH_DETECTION_RESPONSE
 
         RETURNED = SAFE_SEARCH_DETECTION_RESPONSE
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -356,7 +356,7 @@ class TestClient(unittest.TestCase):
         RETURNED = {
             'responses': [{}]
         }
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -370,7 +370,7 @@ class TestClient(unittest.TestCase):
         from unit_tests._fixtures import IMAGE_PROPERTIES_RESPONSE
 
         RETURNED = IMAGE_PROPERTIES_RESPONSE
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -392,7 +392,7 @@ class TestClient(unittest.TestCase):
         RETURNED = {
             'responses': [{}]
         }
-        credentials = _Credentials()
+        credentials = object()
         client = self._make_one(project=PROJECT, credentials=credentials)
         client._connection = _Connection(RETURNED)
 
@@ -424,19 +424,6 @@ class TestVisionRequest(unittest.TestCase):
     def test_make_vision_request_with_bad_feature(self):
         with self.assertRaises(TypeError):
             self._make_one(IMAGE_CONTENT, 'nonsensefeature')
-
-
-class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
 
 
 class _Connection(object):

--- a/vision/unit_tests/test_connection.py
+++ b/vision/unit_tests/test_connection.py
@@ -26,20 +26,6 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
-        creds = _Credentials()
+        creds = object()
         conn = self._make_one(creds)
-        klass = self._get_target_class()
-        self.assertEqual(conn.credentials._scopes, klass.SCOPE)
-
-
-class _Credentials(object):
-
-    _scopes = None
-
-    @staticmethod
-    def create_scoped_required():
-        return True
-
-    def create_scoped(self, scope):
-        self._scopes = scope
-        return self
+        self.assertEqual(conn.credentials, creds)


### PR DESCRIPTION
- Removes all use of oauth2client from every package and tests.
- Updates core to use google-auth's default credentials, project ID, and scoping logic.
- Updates bigtable to use google-auth's scoping logic.