### PR TITLE
Removing use of _Monkey in pubsub and logging.

### DIFF
--- a/logging/tox.ini
+++ b/logging/tox.ini
@@ -7,6 +7,7 @@ localdeps =
     pip install --quiet --upgrade {toxinidir}/../core
 deps =
     pytest
+    mock
 covercmd =
     py.test --quiet \
       --cov=google.cloud.logging \

--- a/logging/unit_tests/test__gax.py
+++ b/logging/unit_tests/test__gax.py
@@ -1069,8 +1069,9 @@ class Test_make_gax_logging_api(unittest.TestCase):
         return make_gax_logging_api(client)
 
     def test_it(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.logging import _gax as MUT
+        import mock
+        from google.cloud.logging._gax import _LoggingAPI
+        from google.cloud.logging._gax import DEFAULT_USER_AGENT
 
         creds = object()
         client = _Client(creds)
@@ -1090,15 +1091,18 @@ class Test_make_gax_logging_api(unittest.TestCase):
         host = 'foo.apis.invalid'
         generated_api.SERVICE_ADDRESS = host
 
-        with _Monkey(MUT, LoggingServiceV2Api=generated_api,
-                     make_secure_channel=make_channel):
+        patch = mock.patch.multiple(
+            'google.cloud.logging._gax',
+            LoggingServiceV2Api=generated_api,
+            make_secure_channel=make_channel)
+        with patch:
             logging_api = self._call_fut(client)
 
         self.assertEqual(channels, [channel_obj])
         self.assertEqual(channel_args,
-                         [(creds, MUT.DEFAULT_USER_AGENT, host)])
+                         [(creds, DEFAULT_USER_AGENT, host)])
 
-        self.assertIsInstance(logging_api, MUT._LoggingAPI)
+        self.assertIsInstance(logging_api, _LoggingAPI)
         self.assertIs(logging_api._gax_api, generated)
         self.assertIs(logging_api._client, client)
 
@@ -1111,8 +1115,9 @@ class Test_make_gax_metrics_api(unittest.TestCase):
         return make_gax_metrics_api(client)
 
     def test_it(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.logging import _gax as MUT
+        import mock
+        from google.cloud.logging._gax import _MetricsAPI
+        from google.cloud.logging._gax import DEFAULT_USER_AGENT
 
         creds = object()
         client = _Client(creds)
@@ -1132,15 +1137,18 @@ class Test_make_gax_metrics_api(unittest.TestCase):
         host = 'foo.apis.invalid'
         generated_api.SERVICE_ADDRESS = host
 
-        with _Monkey(MUT, MetricsServiceV2Api=generated_api,
-                     make_secure_channel=make_channel):
+        patch = mock.patch.multiple(
+            'google.cloud.logging._gax',
+            MetricsServiceV2Api=generated_api,
+            make_secure_channel=make_channel)
+        with patch:
             metrics_api = self._call_fut(client)
 
         self.assertEqual(channels, [channel_obj])
         self.assertEqual(channel_args,
-                         [(creds, MUT.DEFAULT_USER_AGENT, host)])
+                         [(creds, DEFAULT_USER_AGENT, host)])
 
-        self.assertIsInstance(metrics_api, MUT._MetricsAPI)
+        self.assertIsInstance(metrics_api, _MetricsAPI)
         self.assertIs(metrics_api._gax_api, generated)
         self.assertIs(metrics_api._client, client)
 
@@ -1153,8 +1161,9 @@ class Test_make_gax_sinks_api(unittest.TestCase):
         return make_gax_sinks_api(client)
 
     def test_it(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.logging import _gax as MUT
+        import mock
+        from google.cloud.logging._gax import _SinksAPI
+        from google.cloud.logging._gax import DEFAULT_USER_AGENT
 
         creds = object()
         client = _Client(creds)
@@ -1174,15 +1183,18 @@ class Test_make_gax_sinks_api(unittest.TestCase):
         host = 'foo.apis.invalid'
         generated_api.SERVICE_ADDRESS = host
 
-        with _Monkey(MUT, ConfigServiceV2Api=generated_api,
-                     make_secure_channel=make_channel):
+        patch = mock.patch.multiple(
+            'google.cloud.logging._gax',
+            ConfigServiceV2Api=generated_api,
+            make_secure_channel=make_channel)
+        with patch:
             sinks_api = self._call_fut(client)
 
         self.assertEqual(channels, [channel_obj])
         self.assertEqual(channel_args,
-                         [(creds, MUT.DEFAULT_USER_AGENT, host)])
+                         [(creds, DEFAULT_USER_AGENT, host)])
 
-        self.assertIsInstance(sinks_api, MUT._SinksAPI)
+        self.assertIsInstance(sinks_api, _SinksAPI)
         self.assertIs(sinks_api._gax_api, generated)
         self.assertIs(sinks_api._client, client)
 

--- a/logging/unit_tests/test__helpers.py
+++ b/logging/unit_tests/test__helpers.py
@@ -28,14 +28,15 @@ class Test_entry_from_resource(unittest.TestCase):
             self._call_fut({}, None, {})
 
     def _payload_helper(self, key, class_name):
-        from google.cloud._testing import _Monkey
-        import google.cloud.logging._helpers as MUT
+        import mock
 
         resource = {key: 'yup'}
         client = object()
         loggers = {}
         mock_class = EntryMock()
-        with _Monkey(MUT, **{class_name: mock_class}):
+
+        name = 'google.cloud.logging._helpers.' + class_name
+        with mock.patch(name, new=mock_class):
             result = self._call_fut(resource, client, loggers)
 
         self.assertIs(result, mock_class.sentinel)

--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -54,8 +54,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
     def test_logging_api_w_gax(self):
-        from google.cloud.logging import client as MUT
-        from google.cloud._testing import _Monkey
+        import mock
 
         clients = []
         api_obj = object()
@@ -68,7 +67,10 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=self.PROJECT, credentials=creds,
                                 use_gax=True)
 
-        with _Monkey(MUT, make_gax_logging_api=make_api):
+        patch = mock.patch(
+            'google.cloud.logging.client.make_gax_logging_api',
+            new=make_api)
+        with patch:
             api = client.logging_api
 
         self.assertIs(api, api_obj)
@@ -78,12 +80,14 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
     def test_no_gax_ctor(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.logging import client as MUT
+        import mock
         from google.cloud.logging._http import _LoggingAPI
 
         creds = _Credentials()
-        with _Monkey(MUT, _USE_GAX=True):
+        patch = mock.patch(
+            'google.cloud.logging.client._USE_GAX',
+            new=True)
+        with patch:
             client = self._make_one(project=self.PROJECT, credentials=creds,
                                     use_gax=False)
 
@@ -92,11 +96,10 @@ class TestClient(unittest.TestCase):
 
     def test_sinks_api_wo_gax(self):
         from google.cloud.logging._http import _SinksAPI
-        from google.cloud.logging import client as MUT
-        from google.cloud._testing import _Monkey
 
-        with _Monkey(MUT, _USE_GAX=False):
-            client = self._make_one(self.PROJECT, credentials=_Credentials())
+        client = self._make_one(
+            self.PROJECT, credentials=_Credentials(),
+            use_gax=False)
 
         conn = client.connection = object()
         api = client.sinks_api
@@ -108,8 +111,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
     def test_sinks_api_w_gax(self):
-        from google.cloud.logging import client as MUT
-        from google.cloud._testing import _Monkey
+        import mock
 
         clients = []
         api_obj = object()
@@ -122,7 +124,10 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=self.PROJECT, credentials=creds,
                                 use_gax=True)
 
-        with _Monkey(MUT, make_gax_sinks_api=make_api):
+        patch = mock.patch(
+            'google.cloud.logging.client.make_gax_sinks_api',
+            new=make_api)
+        with patch:
             api = client.sinks_api
 
         self.assertIs(api, api_obj)
@@ -133,11 +138,10 @@ class TestClient(unittest.TestCase):
 
     def test_metrics_api_wo_gax(self):
         from google.cloud.logging._http import _MetricsAPI
-        from google.cloud.logging import client as MUT
-        from google.cloud._testing import _Monkey
 
-        with _Monkey(MUT, _USE_GAX=False):
-            client = self._make_one(self.PROJECT, credentials=_Credentials())
+        client = self._make_one(
+            self.PROJECT, credentials=_Credentials(),
+            use_gax=False)
 
         conn = client.connection = object()
         api = client.metrics_api
@@ -149,8 +153,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
     def test_metrics_api_w_gax(self):
-        from google.cloud.logging import client as MUT
-        from google.cloud._testing import _Monkey
+        import mock
 
         clients = []
         api_obj = object()
@@ -163,7 +166,10 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=self.PROJECT, credentials=creds,
                                 use_gax=True)
 
-        with _Monkey(MUT, make_gax_metrics_api=make_api):
+        patch = mock.patch(
+            'google.cloud.logging.client.make_gax_metrics_api',
+            new=make_api)
+        with patch:
             api = client.metrics_api
 
         self.assertIs(api, api_obj)

--- a/pubsub/tox.ini
+++ b/pubsub/tox.ini
@@ -7,6 +7,7 @@ localdeps =
     pip install --quiet --upgrade {toxinidir}/../core
 deps =
     pytest
+    mock
 covercmd =
     py.test --quiet \
       --cov=google.cloud.pubsub \

--- a/pubsub/unit_tests/test__gax.py
+++ b/pubsub/unit_tests/test__gax.py
@@ -877,8 +877,8 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
         return make_gax_publisher_api(connection)
 
     def test_live_api(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.pubsub import _gax as MUT
+        import mock
+        from google.cloud.pubsub._gax import DEFAULT_USER_AGENT
 
         channels = []
         channel_args = []
@@ -899,18 +899,20 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
         creds = _Credentials()
         connection = _Connection(in_emulator=False,
                                  credentials=creds)
-        with _Monkey(MUT, PublisherApi=mock_publisher_api,
-                     make_secure_channel=make_channel):
+        patch = mock.patch.multiple(
+            'google.cloud.pubsub._gax',
+            PublisherApi=mock_publisher_api,
+            make_secure_channel=make_channel)
+        with patch:
             result = self._call_fut(connection)
 
         self.assertIs(result, mock_result)
         self.assertEqual(channels, [channel_obj])
         self.assertEqual(channel_args,
-                         [(creds, MUT.DEFAULT_USER_AGENT, host)])
+                         [(creds, DEFAULT_USER_AGENT, host)])
 
     def test_emulator(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.pubsub import _gax as MUT
+        import mock
 
         channels = []
         mock_result = object()
@@ -927,8 +929,11 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
 
         host = 'CURR_HOST:1234'
         connection = _Connection(in_emulator=True, host=host)
-        with _Monkey(MUT, PublisherApi=mock_publisher_api,
-                     insecure_channel=mock_insecure_channel):
+        patch = mock.patch.multiple(
+            'google.cloud.pubsub._gax',
+            PublisherApi=mock_publisher_api,
+            insecure_channel=mock_insecure_channel)
+        with patch:
             result = self._call_fut(connection)
 
         self.assertIs(result, mock_result)
@@ -944,8 +949,8 @@ class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
         return make_gax_subscriber_api(connection)
 
     def test_live_api(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.pubsub import _gax as MUT
+        import mock
+        from google.cloud.pubsub._gax import DEFAULT_USER_AGENT
 
         channels = []
         channel_args = []
@@ -966,18 +971,20 @@ class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
         creds = _Credentials()
         connection = _Connection(in_emulator=False,
                                  credentials=creds)
-        with _Monkey(MUT, SubscriberApi=mock_subscriber_api,
-                     make_secure_channel=make_channel):
+        patch = mock.patch.multiple(
+            'google.cloud.pubsub._gax',
+            SubscriberApi=mock_subscriber_api,
+            make_secure_channel=make_channel)
+        with patch:
             result = self._call_fut(connection)
 
         self.assertIs(result, mock_result)
         self.assertEqual(channels, [channel_obj])
         self.assertEqual(channel_args,
-                         [(creds, MUT.DEFAULT_USER_AGENT, host)])
+                         [(creds, DEFAULT_USER_AGENT, host)])
 
     def test_emulator(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.pubsub import _gax as MUT
+        import mock
 
         channels = []
         mock_result = object()
@@ -994,8 +1001,11 @@ class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
 
         host = 'CURR_HOST:1234'
         connection = _Connection(in_emulator=True, host=host)
-        with _Monkey(MUT, SubscriberApi=mock_subscriber_api,
-                     insecure_channel=mock_insecure_channel):
+        patch = mock.patch.multiple(
+            'google.cloud.pubsub._gax',
+            SubscriberApi=mock_subscriber_api,
+            insecure_channel=mock_insecure_channel)
+        with patch:
             result = self._call_fut(connection)
 
         self.assertIs(result, mock_result)

--- a/pubsub/unit_tests/test__http.py
+++ b/pubsub/unit_tests/test__http.py
@@ -42,14 +42,13 @@ class TestConnection(_Base):
         self.assertEqual(conn.api_base_url, klass.API_BASE_URL)
 
     def test_custom_url_from_env(self):
-        import os
-        from google.cloud._testing import _Monkey
+        import mock
         from google.cloud.environment_vars import PUBSUB_EMULATOR
 
         HOST = 'localhost:8187'
         fake_environ = {PUBSUB_EMULATOR: HOST}
 
-        with _Monkey(os, getenv=fake_environ.get):
+        with mock.patch('os.environ', new=fake_environ):
             conn = self._make_one()
 
         klass = self._get_target_class()

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -32,12 +32,12 @@ class TestClient(unittest.TestCase):
 
     def test_publisher_api_wo_gax(self):
         from google.cloud.pubsub._http import _PublisherAPI
-        from google.cloud.pubsub import client as MUT
-        from google.cloud._testing import _Monkey
+
         creds = _Credentials()
 
-        with _Monkey(MUT, _USE_GAX=False):
-            client = self._make_one(project=self.PROJECT, credentials=creds)
+        client = self._make_one(
+            project=self.PROJECT, credentials=creds,
+            use_gax=False)
 
         conn = client.connection = object()
         api = client.publisher_api
@@ -49,12 +49,12 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
     def test_no_gax_ctor(self):
-        from google.cloud._testing import _Monkey
+        import mock
         from google.cloud.pubsub._http import _PublisherAPI
-        from google.cloud.pubsub import client as MUT
 
         creds = _Credentials()
-        with _Monkey(MUT, _USE_GAX=True):
+        with mock.patch('google.cloud.pubsub.client._USE_GAX',
+                        new=True):
             client = self._make_one(project=self.PROJECT, credentials=creds,
                                     use_gax=False)
 
@@ -63,8 +63,7 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(api, _PublisherAPI)
 
     def test_publisher_api_w_gax(self):
-        from google.cloud.pubsub import client as MUT
-        from google.cloud._testing import _Monkey
+        import mock
 
         wrapped = object()
         _called_with = []
@@ -80,11 +79,15 @@ class TestClient(unittest.TestCase):
                 self._client = client
 
         creds = _Credentials()
+        client = self._make_one(
+            project=self.PROJECT, credentials=creds,
+            use_gax=True)
 
-        with _Monkey(MUT, _USE_GAX=True,
-                     make_gax_publisher_api=_generated_api,
-                     GAXPublisherAPI=_GaxPublisherAPI):
-            client = self._make_one(project=self.PROJECT, credentials=creds)
+        patch = mock.patch.multiple(
+            'google.cloud.pubsub.client',
+            make_gax_publisher_api=_generated_api,
+            GAXPublisherAPI=_GaxPublisherAPI)
+        with patch:
             api = client.publisher_api
 
         self.assertIsInstance(api, _GaxPublisherAPI)
@@ -98,12 +101,11 @@ class TestClient(unittest.TestCase):
 
     def test_subscriber_api_wo_gax(self):
         from google.cloud.pubsub._http import _SubscriberAPI
-        from google.cloud.pubsub import client as MUT
-        from google.cloud._testing import _Monkey
-        creds = _Credentials()
 
-        with _Monkey(MUT, _USE_GAX=False):
-            client = self._make_one(project=self.PROJECT, credentials=creds)
+        creds = _Credentials()
+        client = self._make_one(
+            project=self.PROJECT, credentials=creds,
+            use_gax=False)
 
         conn = client.connection = object()
         api = client.subscriber_api
@@ -115,8 +117,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
     def test_subscriber_api_w_gax(self):
-        from google.cloud.pubsub import client as MUT
-        from google.cloud._testing import _Monkey
+        import mock
 
         wrapped = object()
         _called_with = []
@@ -132,11 +133,15 @@ class TestClient(unittest.TestCase):
                 self._client = client
 
         creds = _Credentials()
+        client = self._make_one(
+            project=self.PROJECT, credentials=creds,
+            use_gax=True)
 
-        with _Monkey(MUT, _USE_GAX=True,
-                     make_gax_subscriber_api=_generated_api,
-                     GAXSubscriberAPI=_GaxSubscriberAPI):
-            client = self._make_one(project=self.PROJECT, credentials=creds)
+        patch = mock.patch.multiple(
+            'google.cloud.pubsub.client',
+            make_gax_subscriber_api=_generated_api,
+            GAXSubscriberAPI=_GaxSubscriberAPI)
+        with patch:
             api = client.subscriber_api
 
         self.assertIsInstance(api, _GaxSubscriberAPI)

--- a/pubsub/unit_tests/test_topic.py
+++ b/pubsub/unit_tests/test_topic.py
@@ -136,9 +136,9 @@ class TestTopic(unittest.TestCase):
 
     def test_publish_single_bytes_wo_attrs_w_add_timestamp_alt_client(self):
         import datetime
-        from google.cloud.pubsub import topic as MUT
+        import mock
         from google.cloud._helpers import _RFC3339_MICROS
-        from google.cloud._testing import _Monkey
+
         NOW = datetime.datetime.utcnow()
 
         def _utcnow():
@@ -157,7 +157,7 @@ class TestTopic(unittest.TestCase):
 
         topic = self._make_one(self.TOPIC_NAME, client=client1,
                                timestamp_messages=True)
-        with _Monkey(MUT, _NOW=_utcnow):
+        with mock.patch('google.cloud.pubsub.topic._NOW', new=_utcnow):
             msgid = topic.publish(PAYLOAD, client=client2)
 
         self.assertEqual(msgid, MSGID)


### PR DESCRIPTION
PS I didn't run `tox -e lint` locally, so fingers crossed. Naughty naughty.