### PR TITLE
Fixing accidental removal of {localdeps}

### DIFF
--- a/bigquery/tox.ini
+++ b/bigquery/tox.ini
@@ -18,6 +18,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -26,6 +27,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/bigtable/tox.ini
+++ b/bigtable/tox.ini
@@ -17,6 +17,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -25,6 +26,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/datastore/tox.ini
+++ b/datastore/tox.ini
@@ -18,6 +18,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -26,6 +27,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/dns/tox.ini
+++ b/dns/tox.ini
@@ -17,6 +17,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -25,6 +26,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,6 +9,7 @@ error_reporting/
 monitoring/
 pubsub/
 resource_manager/
+runtimeconfig/
 speech/
 storage/
 translate/

--- a/error_reporting/tox.ini
+++ b/error_reporting/tox.ini
@@ -20,6 +20,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -28,6 +29,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/language/tox.ini
+++ b/language/tox.ini
@@ -17,6 +17,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -25,6 +26,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/logging/tox.ini
+++ b/logging/tox.ini
@@ -18,6 +18,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -26,6 +27,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/monitoring/tox.ini
+++ b/monitoring/tox.ini
@@ -17,6 +17,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -26,6 +27,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testing]deps}

--- a/pubsub/tox.ini
+++ b/pubsub/tox.ini
@@ -18,6 +18,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -26,6 +27,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/resource_manager/tox.ini
+++ b/resource_manager/tox.ini
@@ -17,6 +17,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -25,6 +26,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/runtimeconfig/tox.ini
+++ b/runtimeconfig/tox.ini
@@ -17,6 +17,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -25,6 +26,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/speech/tox.ini
+++ b/speech/tox.ini
@@ -17,6 +17,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -25,6 +26,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/storage/tox.ini
+++ b/storage/tox.ini
@@ -18,6 +18,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -26,6 +27,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,24 @@ envlist =
 
 [testing]
 deps =
-    pytest
+    {toxinidir}/core
+    {toxinidir}/bigtable
+    {toxinidir}/storage
+    {toxinidir}/datastore
+    {toxinidir}/bigquery
+    {toxinidir}/pubsub
+    {toxinidir}/logging
+    {toxinidir}/dns
+    {toxinidir}/language
+    {toxinidir}/error_reporting
+    {toxinidir}/resource_manager
+    {toxinidir}/monitoring
+    {toxinidir}/vision
+    {toxinidir}/translate
+    {toxinidir}/speech
+    {toxinidir}/runtimeconfig
     mock
+    pytest
 passenv =
     CI_*
     CIRCLE*

--- a/translate/tox.ini
+++ b/translate/tox.ini
@@ -18,6 +18,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -26,6 +27,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}

--- a/vision/tox.ini
+++ b/vision/tox.ini
@@ -17,6 +17,7 @@ covercmd =
 
 [testenv]
 commands =
+    {[testing]localdeps}
     py.test --quiet {posargs} unit_tests
 deps =
     {[testing]deps}
@@ -25,6 +26,7 @@ deps =
 basepython =
     python2.7
 commands =
+    {[testing]localdeps}
     {[testing]covercmd}
 deps =
     {[testenv]deps}


### PR DESCRIPTION
Also

- adding RTD  dependency for runtimeconfig.
- adding local paths to umbrella tox config "deps"
  as was done in #2733.