### PR TITLE
Adding ability to run doctests with datastore system tests.

### DIFF
--- a/datastore/google/cloud/datastore/__init__.py
+++ b/datastore/google/cloud/datastore/__init__.py
@@ -16,14 +16,26 @@
 
 You'll typically use these to get started with the API:
 
-.. code-block:: python
+.. testsetup:: constructors
 
-  from google.cloud import datastore
+  import os
+  os.environ['GOOGLE_CLOUD_PROJECT'] = u'my-project'
 
-  client = datastore.Client()
-  key = client.key('EntityKind', 1234)
-  entity = datastore.Entity(key)
-  query = client.query(kind='EntityKind')
+.. doctest:: constructors
+
+  >>> from google.cloud import datastore
+  >>>
+  >>> client = datastore.Client()
+  >>> print(client.project)
+  my-project
+  >>> key = client.key('EntityKind', 1234)
+  >>> key
+  <Key('EntityKind', 1234), project=my-project>
+  >>> entity = datastore.Entity(key)
+  >>> entity['answer'] = 42
+  >>> entity
+  <Entity('EntityKind', 1234) {'answer': 42}>
+  >>> query = client.query(kind='EntityKind')
 
 The main concepts with this API are:
 

--- a/datastore/google/cloud/datastore/entity.py
+++ b/datastore/google/cloud/datastore/entity.py
@@ -144,7 +144,7 @@ class Entity(dict):
 
     def __repr__(self):
         if self.key:
-            return '<Entity%s %s>' % (self.key.path,
+            return '<Entity%s %s>' % (self.key._flat_path,
                                       super(Entity, self).__repr__())
         else:
-            return '<Entity %s>' % (super(Entity, self).__repr__())
+            return '<Entity %s>' % (super(Entity, self).__repr__(),)

--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -380,7 +380,7 @@ class Key(object):
         return self._parent
 
     def __repr__(self):
-        return '<Key%s, project=%s>' % (self.path, self.project)
+        return '<Key%s, project=%s>' % (self._flat_path, self.project)
 
 
 def _validate_project(project, parent):

--- a/datastore/unit_tests/test_entity.py
+++ b/datastore/unit_tests/test_entity.py
@@ -190,10 +190,13 @@ class TestEntity(unittest.TestCase):
 
     def test___repr___w_key_non_empty(self):
         key = _Key()
-        key._path = '/bar/baz'
+        flat_path = ('bar', 12, 'baz', 'himom')
+        key._flat_path = flat_path
         entity = self._make_one(key=key)
-        entity['foo'] = 'Foo'
-        self.assertEqual(repr(entity), "<Entity/bar/baz {'foo': 'Foo'}>")
+        entity_vals = {'foo': 'Foo'}
+        entity.update(entity_vals)
+        expected = '<Entity%s %s>' % (flat_path, entity_vals)
+        self.assertEqual(repr(entity), expected)
 
 
 class _Key(object):
@@ -206,7 +209,3 @@ class _Key(object):
 
     def __init__(self, project=_PROJECT):
         self.project = project
-
-    @property
-    def path(self):
-        return self._path

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -14,6 +14,8 @@
 
 import datetime
 import os
+import pkgutil
+import tempfile
 import unittest
 
 import httplib2
@@ -29,6 +31,23 @@ import clear_datastore
 import populate_datastore
 from system_test_utils import EmulatorCreds
 from system_test_utils import unique_resource_id
+
+
+SPHINX_CONF = """\
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+]
+"""
+
+SPHINX_SECTION_TEMPLATE = """\
+Section %02d
+===========
+
+.. automodule:: google.cloud.%s
+  :members:
+
+"""
 
 
 class Config(object):
@@ -495,3 +514,59 @@ class TestDatastoreTransaction(TestDatastore):
                 # transaction.
                 entity_in_txn[contention_prop_name] = u'inside'
                 txn.put(entity_in_txn)
+
+
+class TestDoctest(unittest.TestCase):
+
+    def _submodules(self):
+        pkg_iter = pkgutil.iter_modules(datastore.__path__)
+        result = []
+        for _, mod_name, ispkg in pkg_iter:
+            if mod_name == '_generated':
+                self.assertTrue(ispkg)
+            else:
+                self.assertFalse(ispkg)
+                result.append(mod_name)
+
+        self.assertNotIn('__init__', result)
+        return result
+
+    @staticmethod
+    def _add_section(index, mod_name, file_obj):
+        mod_part = 'datastore'
+        if mod_name != '__init__':
+            mod_part += '.' + mod_name
+        content = SPHINX_SECTION_TEMPLATE % (index, mod_part)
+        file_obj.write(content)
+
+    def _make_temp_docs(self):
+        docs_dir = tempfile.mkdtemp(prefix='datastore-')
+
+        conf_file = os.path.join(docs_dir, 'conf.py')
+
+        with open(conf_file, 'w') as file_obj:
+            file_obj.write(SPHINX_CONF)
+
+        index_file = os.path.join(docs_dir, 'contents.rst')
+        datastore_modules = self._submodules()
+        with open(index_file, 'w') as file_obj:
+            self._add_section(0, '__init__', file_obj)
+            for index, datastore_module in enumerate(datastore_modules):
+                self._add_section(index + 1, datastore_module, file_obj)
+
+        return docs_dir
+
+    def test_it(self):
+        from sphinx import application
+
+        docs_dir = self._make_temp_docs()
+        outdir = os.path.join(docs_dir, 'doctest', 'out')
+        doctreedir = os.path.join(docs_dir, 'doctest', 'doctrees')
+
+        app = application.Sphinx(
+            srcdir=docs_dir, confdir=docs_dir,
+            outdir=outdir, doctreedir=doctreedir,
+            buildername='doctest', warningiserror=True, parallel=1)
+
+        app.build()
+        self.assertEqual(app.statuscode, 0)

--- a/tox.ini
+++ b/tox.ini
@@ -265,6 +265,7 @@ commands =
     python {toxinidir}/system_tests/attempt_system_tests.py {posargs}
 deps =
     {[testing]deps}
+    Sphinx
 passenv =
     {[testing]passenv}
     encrypted_*
@@ -273,10 +274,9 @@ passenv =
 basepython =
     python3.4
 commands =
-    {[testing]localdeps}
-    python {toxinidir}/system_tests/attempt_system_tests.py {posargs}
+    {[testenv:system-tests]commands}
 deps =
-    {[testing]deps}
+    {[testenv:system-tests]deps}
 passenv =
     {[testenv:system-tests]passenv}
 


### PR DESCRIPTION
Since Travis / CircleCI won't run this by default, here is some sample output:

```
$ tox -e system-tests -- datastore
GLOB sdist-make: .../setup.py
system-tests inst-nodeps: .../.tox/dist/google-cloud-0.21.0.zip
...
system-tests runtests: commands[1] | python 
    .../system_tests/attempt_system_tests.py datastore
test_it (datastore.TestDoctest) ... Running Sphinx v1.4.8
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [doctest]: targets for 1 source files that are out of date
updating environment: 1 added, 0 changed, 0 removed
reading sources... [100%] contents
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
running tests...

Document: contents
------------------
1 items passed all tests:
   9 tests in constructors
9 tests in 1 items.
9 passed and 0 failed.
Test passed.

Doctest summary
===============
    9 tests
    0 failures in tests
    0 failures in setup code
    0 failures in cleanup code
build succeeded.
ok

----------------------------------------------------------------------
Ran 1 test in 1.088s

OK
____________________________________ summary ____________________________________
  system-tests: commands succeeded
  congratulations :)
```