### PR TITLE
Update tox to run system tests under Python 3.5 instead of 3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -271,7 +271,7 @@ passenv =
 
 [testenv:system-tests3]
 basepython =
-    python3.4
+    python3.5
 commands =
     {[testing]localdeps}
     python {toxinidir}/system_tests/attempt_system_tests.py {posargs}


### PR DESCRIPTION
Addresses #2670 

CC @jonparrott @dhermes 