### PR TITLE
Set core version compatible specifier to packages.

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
 ]
 
 setup(

--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
     'grpcio >= 1.0.0, < 2.0dev',
 ]
 

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
     'grpcio >= 1.0.0, < 2.0dev',
 ]
 

--- a/dns/setup.py
+++ b/dns/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
 ]
 
 setup(

--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
     'google-cloud-logging >= 0.21.0',
 ]
 

--- a/language/setup.py
+++ b/language/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
 ]
 
 setup(

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
     'grpcio >= 1.0.0, < 2.0dev',
     'google-gax >= 0.14.1, < 0.15dev',
     'gapic-google-logging-v2 >= 0.10.1, < 0.11dev',

--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
 ]
 
 setup(

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
     'grpcio >= 1.0.0, < 2.0dev',
     'google-gax >= 0.14.1, < 0.15dev',
     'gapic-google-pubsub-v1 >= 0.10.1, < 0.11dev',

--- a/resource_manager/setup.py
+++ b/resource_manager/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
 ]
 
 setup(

--- a/runtimeconfig/setup.py
+++ b/runtimeconfig/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
 ]
 
 setup(

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
 ]
 
 setup(

--- a/translate/setup.py
+++ b/translate/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
 ]
 
 setup(

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -50,7 +50,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0',
+    'google-cloud-core >= 0.21.0, < 0.22dev',
 ]
 
 setup(


### PR DESCRIPTION
Installing a prior version of a package or umbrella pulls in an incompatible version of `google-cloud-core` since it has a version specifier of `>=`.

Ref: https://www.python.org/dev/peps/pep-0440/#compatible-release
Fixes #2742.