### PR TITLE
datastore: Support decoding empty arrays

### DIFF
--- a/datastore/google/cloud/datastore/helpers.py
+++ b/datastore/google/cloud/datastore/helpers.py
@@ -138,12 +138,12 @@ def entity_from_protobuf(pb):
         if is_list:
             exclude_values = set(value_pb.exclude_from_indexes
                                  for value_pb in value_pb.array_value.values)
-            if len(exclude_values) != 1:
+            if len(exclude_values) > 1:
                 raise ValueError('For an array_value, subvalues must either '
                                  'all be indexed or all excluded from '
                                  'indexes.')
 
-            if exclude_values.pop():
+            if len(exclude_values) > 0 and exclude_values.pop():
                 exclude_from_indexes.append(prop_name)
         else:
             if value_pb.exclude_from_indexes:


### PR DESCRIPTION
When the `array_value` is empty, the set also becomes empty which triggers the existing condition `len(exclude_values) != 0`.

This patch changes this condition to permit empty array values to pass through.