### PR TITLE
Fixed grammar in comments and docs.

### DIFF
--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -19,7 +19,7 @@ This is the base from which all interactions with the API occur.
 In the hierarchy of API concepts
 
 * a :class:`Client` owns an :class:`.Instance`
-* a :class:`.Instance` owns a :class:`~google.cloud.bigtable.table.Table`
+* an :class:`.Instance` owns a :class:`~google.cloud.bigtable.table.Table`
 * a :class:`~google.cloud.bigtable.table.Table` owns a
   :class:`~.column_family.ColumnFamily`
 * a :class:`~google.cloud.bigtable.table.Table` owns a :class:`~.row.Row`

--- a/bigtable/google/cloud/bigtable/instance.py
+++ b/bigtable/google/cloud/bigtable/instance.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""User friendly container for Google Cloud Bigtable Instance."""
+"""User-friendly container for Google Cloud Bigtable Instance."""
 
 
 import re
@@ -67,7 +67,7 @@ def _prepare_create_request(instance):
 class Instance(object):
     """Representation of a Google Cloud Bigtable Instance.
 
-    We can use a :class:`Instance` to:
+    We can use an :class:`Instance` to:
 
     * :meth:`reload` itself
     * :meth:`create` itself
@@ -123,10 +123,10 @@ class Instance(object):
 
     @classmethod
     def from_pb(cls, instance_pb, client):
-        """Creates a instance instance from a protobuf.
+        """Creates an instance instance from a protobuf.
 
         :type instance_pb: :class:`instance_pb2.Instance`
-        :param instance_pb: A instance protobuf object.
+        :param instance_pb: An instance protobuf object.
 
         :type client: :class:`Client <google.cloud.bigtable.client.Client>`
         :param client: The client that owns the instance.
@@ -261,7 +261,7 @@ class Instance(object):
     def delete(self):
         """Delete this instance.
 
-        Marks a instance and all of its tables for permanent deletion
+        Marks an instance and all of its tables for permanent deletion
         in 7 days.
 
         Immediately upon completion of the request:

--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""User friendly container for Google Cloud Bigtable Row."""
+"""User-friendly container for Google Cloud Bigtable Row."""
 
 
 import struct
@@ -657,7 +657,7 @@ class AppendRow(Row):
     The first works by appending bytes and the second by incrementing an
     integer (stored in the cell as 8 bytes). In either case, if the
     cell is empty, assumes the default empty value (empty string for
-    bytes or and 0 for integer).
+    bytes or 0 for integer).
 
     :type row_key: bytes
     :param row_key: The key for the current row.

--- a/docs/bigtable-client-intro.rst
+++ b/docs/bigtable-client-intro.rst
@@ -65,7 +65,7 @@ API requests, you'll need to pass the ``admin`` argument:
 Read-Only Mode
 --------------
 
-If on the other hand, you only have (or want) read access to the data,
+If, on the other hand, you only have (or want) read access to the data,
 you can pass the ``read_only`` argument:
 
 .. code:: python
@@ -81,7 +81,7 @@ Next Step
 ---------
 
 After a :class:`Client <google.cloud.bigtable.client.Client>`, the next highest-level
-object is a :class:`Instance <google.cloud.bigtable.instance.Instance>`. You'll need
+object is an :class:`Instance <google.cloud.bigtable.instance.Instance>`. You'll need
 one before you can interact with tables or data.
 
 Head next to learn about the :doc:`bigtable-instance-api`.

--- a/docs/bigtable-data-api.rst
+++ b/docs/bigtable-data-api.rst
@@ -17,7 +17,7 @@ Cells vs. Columns vs. Column Families
 * Each cell lies in a column (**not** a column family). A column is really
   just a more **specific** modifier within a column family. A column
   can be present in every column family, in only one or anywhere in between.
-* Within a column family there can be many columns. For example within
+* Within a column family there can be many columns. For example, within
   the column family ``foo`` we could have columns ``bar`` and ``baz``.
   These would typically be represented as ``foo:bar`` and ``foo:baz``.
 
@@ -106,8 +106,8 @@ Direct mutations can be added via one of four methods
   If the ``timestamp`` is omitted, the current time on the Google Cloud
   Bigtable server will be used when the cell is stored.
 
-  The value can either by bytes or an integer (which will be converted to
-  bytes as a signed 64-bit integer).
+  The value can either be bytes or an integer, which will be converted to
+  bytes as a signed 64-bit integer.
 
 * :meth:`delete_cell() <google.cloud.bigtable.row.DirectRow.delete_cell>` deletes
   all cells (i.e. for all timestamps) in a given column
@@ -129,7 +129,7 @@ Direct mutations can be added via one of four methods
 
 * :meth:`delete_cells() <google.cloud.bigtable.row.DirectRow.delete_cells>` does
   the same thing as
-  :meth:`delete_cell() <google.cloud.bigtable.row.DirectRow.delete_cell>`
+  :meth:`delete_cell() <google.cloud.bigtable.row.DirectRow.delete_cell>`,
   but accepts a list of columns in a column family rather than a single one.
 
   .. code:: python

--- a/docs/bigtable-instance-api.rst
+++ b/docs/bigtable-instance-api.rst
@@ -18,7 +18,7 @@ If you want a comprehensive list of all existing instances, make a
 Instance Factory
 ----------------
 
-To create a :class:`Instance <google.cloud.bigtable.instance.Instance>` object:
+To create an :class:`Instance <google.cloud.bigtable.instance.Instance>` object:
 
 .. code:: python
 
@@ -57,7 +57,7 @@ Check on Current Operation
 
 .. note::
 
-    When modifying a instance (via a `CreateInstance`_ request), the Bigtable
+    When modifying an instance (via a `CreateInstance`_ request), the Bigtable
     API will return a `long-running operation`_ and a corresponding
     :class:`Operation <google.cloud.bigtable.instance.Operation>` object
     will be returned by

--- a/docs/bigtable-row-filters.rst
+++ b/docs/bigtable-row-filters.rst
@@ -6,7 +6,7 @@ It is possible to use a
 when adding mutations to a
 :class:`ConditionalRow <google.cloud.bigtable.row.ConditionalRow>` and when
 reading row data with :meth:`read_row() <google.cloud.bigtable.table.Table.read_row>`
-:meth:`read_rows() <google.cloud.bigtable.table.Table.read_rows>`.
+or :meth:`read_rows() <google.cloud.bigtable.table.Table.read_rows>`.
 
 As laid out in the `RowFilter definition`_, the following basic filters
 are provided:

--- a/docs/bigtable-table-api.rst
+++ b/docs/bigtable-table-api.rst
@@ -1,7 +1,7 @@
 Table Admin API
 ===============
 
-After creating a :class:`Instance <google.cloud.bigtable.instance.Instance>`, you can
+After creating an :class:`Instance <google.cloud.bigtable.instance.Instance>`, you can
 interact with individual tables, groups of tables or column families within
 a table.
 
@@ -42,7 +42,7 @@ with :meth:`create() <google.cloud.bigtable.table.Table.create>`:
 
     table.create()
 
-If you would to initially split the table into several tablets (Tablets are
+If you would like to initially split the table into several tablets (tablets are
 similar to HBase regions):
 
 .. code:: python

--- a/docs/bigtable-usage.rst
+++ b/docs/bigtable-usage.rst
@@ -11,9 +11,9 @@ Get started by learning about the
 
 In the hierarchy of API concepts
 
-* a :class:`Client <google.cloud.bigtable.client.Client>` owns a
-  :class:`Cluster <google.cloud.bigtable.instance.Instance`
-* a :class:`Cluster <google.cloud.bigtable.instance.Instance` owns a
+* a :class:`Client <google.cloud.bigtable.client.Client>` owns an
+  :class:`Instance <google.cloud.bigtable.instance.Instance>`
+* an :class:`Instance <google.cloud.bigtable.instance.Instance>` owns a
   :class:`Table <google.cloud.bigtable.table.Table>`
 * a :class:`Table <google.cloud.bigtable.table.Table>` owns a
   :class:`ColumnFamily <google.cloud.bigtable.column_family.ColumnFamily>`


### PR DESCRIPTION
Summary of edits:
* "a instance" -> "an instance" consistency (some are correct, some not)
* removed extraneous words, added missing words in sentences
* minor grammatical edits for readability