### PR TITLE
Expect vision response data to have missing keys.

### DIFF
--- a/vision/google/cloud/vision/color.py
+++ b/vision/google/cloud/vision/color.py
@@ -36,8 +36,9 @@ class ImagePropertiesAnnotation(object):
         :rtype: :class:`~google.cloud.vision.color.ImagePropertiesAnnotation`.
         :returns: Populated instance of ``ImagePropertiesAnnotation``.
         """
-        colors = [ColorInformation.from_api_repr(color) for color in
-                  response['dominantColors']['colors']]
+        raw_colors = response.get('dominantColors', {}).get('colors', ())
+        colors = [ColorInformation.from_api_repr(color)
+                  for color in raw_colors]
         return cls(colors)
 
     @property
@@ -85,10 +86,10 @@ class Color(object):
         :rtype: :class:`~google.cloud.vision.color.Color`
         :returns: Instance of :class:`~google.cloud.vision.color.Color`.
         """
-        red = response['red']
-        green = response['green']
-        blue = response['blue']
-        alpha = response.get('alpha')
+        red = response.get('red', 0)
+        green = response.get('green', 0)
+        blue = response.get('blue', 0)
+        alpha = response.get('alpha', 0.0)
 
         return cls(red, green, blue, alpha)
 
@@ -157,9 +158,9 @@ class ColorInformation(object):
         :rtype: :class:`~google.cloud.vision.color.ColorInformation`
         :returns: Instance of ``ColorInformation``.
         """
-        color = Color.from_api_repr(response['color'])
-        score = response['score']
-        pixel_fraction = response['pixelFraction']
+        color = Color.from_api_repr(response.get('color'))
+        score = response.get('score')
+        pixel_fraction = response.get('pixelFraction')
 
         return cls(color, score, pixel_fraction)
 

--- a/vision/unit_tests/test_color.py
+++ b/vision/unit_tests/test_color.py
@@ -1,0 +1,47 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+
+class TestColor(unittest.TestCase):
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.vision.color import Color
+        return Color
+
+    def test_rgb_color_data(self):
+        colors = {
+            'red': 255,
+            'green': 255,
+            'blue': 255,
+            'alpha': 0.5,
+        }
+        color_class = self._get_target_class()
+        colors = color_class.from_api_repr(colors)
+
+        self.assertEqual(colors.red, 255)
+        self.assertEqual(colors.green, 255)
+        self.assertEqual(colors.blue, 255)
+        self.assertEqual(colors.alpha, 0.5)
+
+    def test_missing_rgb_values(self):
+        colors = {}
+        color_class = self._get_target_class()
+        colors = color_class.from_api_repr(colors)
+
+        self.assertEqual(colors.red, 0)
+        self.assertEqual(colors.green, 0)
+        self.assertEqual(colors.blue, 0)
+        self.assertEqual(colors.alpha, 0.0)


### PR DESCRIPTION
Fixes #2757 

I didn't add tests for the other classes, but I can if needed. Honestly, I'm not sure if and when to count on the data being there so my strategy was to try and default to `None`.