### PR TITLE
Move emotions to Face class.

### DIFF
--- a/docs/vision-usage.rst
+++ b/docs/vision-usage.rst
@@ -75,15 +75,16 @@ was detected.
     >>> client = vision.Client()
     >>> image = client.image(source_uri='gs://my-test-bucket/image.jpg')
     >>> faces = image.detect_faces(limit=10)
-    >>> faces[0].landmarks.left_eye.landmark_type
+    >>> first_face = faces[0]
+    >>> first_face.landmarks.left_eye.landmark_type
     'LEFT_EYE'
-    >>> faces[0].landmarks.left_eye.position.x_coordinate
+    >>> first_face.landmarks.left_eye.position.x_coordinate
     1301.2404
-    >>> faces[0].detection_confidence
+    >>> first_face.detection_confidence
     0.9863683
-    >>> faces[0].joy_likelihood
+    >>> first_face.joy
     0.54453093
-    >>> faces[0].anger_likelihood
+    >>> first_face.anger
     0.02545464
 
 

--- a/vision/google/cloud/vision/face.py
+++ b/vision/google/cloud/vision/face.py
@@ -101,7 +101,17 @@ class Emotions(object):
                    anger_likelihood)
 
     @property
-    def joy_likelihood(self):
+    def anger(self):
+        """Likelihood of anger in detected face.
+
+        :rtype: str
+        :returns: String derived from
+                  :class:`~google.cloud.vision.face.Likelihood`.
+        """
+        return self._anger_likelihood
+
+    @property
+    def joy(self):
         """Likelihood of joy in detected face.
 
         :rtype: str
@@ -111,7 +121,7 @@ class Emotions(object):
         return self._joy_likelihood
 
     @property
-    def sorrow_likelihood(self):
+    def sorrow(self):
         """Likelihood of sorrow in detected face.
 
         :rtype: str
@@ -121,7 +131,7 @@ class Emotions(object):
         return self._sorrow_likelihood
 
     @property
-    def surprise_likelihood(self):
+    def surprise(self):
         """Likelihood of surprise in detected face.
 
         :rtype: str
@@ -129,16 +139,6 @@ class Emotions(object):
                   :class:`~google.cloud.vision.face.Likelihood`.
         """
         return self._surprise_likelihood
-
-    @property
-    def anger_likelihood(self):
-        """Likelihood of anger in detected face.
-
-        :rtype: str
-        :returns: String derived from
-                  :class:`~google.cloud.vision.face.Likelihood`.
-        """
-        return self._anger_likelihood
 
 
 class Face(object):
@@ -181,6 +181,16 @@ class Face(object):
         return cls(angles, bounds, detection_confidence, emotions, fd_bounds,
                    headwear_likelihood, image_properties, landmarks,
                    landmarking_confidence)
+
+    @property
+    def anger(self):
+        """Accessor to likelihood that the detected face is angry.
+
+        :rtype: str
+        :returns: String derived from
+                  :class:`~google.cloud.vision.face.Likelihood`.
+        """
+        return self.emotions.anger
 
     @property
     def angles(self):
@@ -230,7 +240,7 @@ class Face(object):
         return self._fd_bounds
 
     @property
-    def headwear_likelihood(self):
+    def headwear(self):
         """Headwear likelihood.
 
         :rtype: :class:`~google.cloud.vision.face.Likelihood`
@@ -247,6 +257,16 @@ class Face(object):
         :returns: ``FaceImageProperties`` object with image properties.
         """
         return self._image_properties
+
+    @property
+    def joy(self):
+        """Likelihood of joy in detected face.
+
+        :rtype: str
+        :returns: String derived from
+                  :class:`~google.cloud.vision.face.Likelihood`.
+        """
+        return self.emotions.joy
 
     @property
     def landmarks(self):
@@ -266,6 +286,26 @@ class Face(object):
                   determining the landmarks on a face.
         """
         return self._landmarking_confidence
+
+    @property
+    def sorrow(self):
+        """Likelihood of sorrow in detected face.
+
+        :rtype: str
+        :returns: String derived from
+                  :class:`~google.cloud.vision.face.Likelihood`.
+        """
+        return self.emotions.sorrow
+
+    @property
+    def surprise(self):
+        """Likelihood of surprise in detected face.
+
+        :rtype: str
+        :returns: String derived from
+                  :class:`~google.cloud.vision.face.Likelihood`.
+        """
+        return self.emotions.surprise
 
 
 class FaceImageProperties(object):
@@ -289,7 +329,7 @@ class FaceImageProperties(object):
         return cls(blurred_likelihood, underexposed_likelihood)
 
     @property
-    def blurred_likelihood(self):
+    def blurred(self):
         """Likelihood of the image being blurred.
 
         :rtype: str
@@ -299,7 +339,7 @@ class FaceImageProperties(object):
         return self._blurred_likelihood
 
     @property
-    def underexposed_likelihood(self):
+    def underexposed(self):
         """Likelihood that the image used for detection was underexposed.
 
         :rtype: str

--- a/vision/unit_tests/test_face.py
+++ b/vision/unit_tests/test_face.py
@@ -44,13 +44,13 @@ class TestFace(unittest.TestCase):
     def test_facial_emotions(self):
         from google.cloud.vision.face import Likelihood
         self.assertEqual(Likelihood.VERY_LIKELY,
-                         self.face.emotions.joy_likelihood)
+                         self.face.joy)
         self.assertEqual(Likelihood.VERY_UNLIKELY,
-                         self.face.emotions.sorrow_likelihood)
+                         self.face.sorrow)
         self.assertEqual(Likelihood.VERY_UNLIKELY,
-                         self.face.emotions.surprise_likelihood)
+                         self.face.surprise)
         self.assertEqual(Likelihood.VERY_UNLIKELY,
-                         self.face.emotions.anger_likelihood)
+                         self.face.anger)
 
     def test_faciale_angles(self):
         self.assertEqual(-0.43419784, self.face.angles.roll)
@@ -60,11 +60,11 @@ class TestFace(unittest.TestCase):
     def test_face_headware_and_blur_and_underexposed(self):
         from google.cloud.vision.face import Likelihood
         self.assertEqual(Likelihood.VERY_UNLIKELY,
-                         self.face.image_properties.blurred_likelihood)
+                         self.face.image_properties.blurred)
         self.assertEqual(Likelihood.VERY_UNLIKELY,
-                         self.face.headwear_likelihood)
+                         self.face.headwear)
         self.assertEqual(Likelihood.VERY_UNLIKELY,
-                         self.face.image_properties.underexposed_likelihood)
+                         self.face.image_properties.underexposed)
 
     def test_face_bounds(self):
         self.assertEqual(4, len(self.face.bounds.vertices))


### PR DESCRIPTION
Towards: #2753.

This is a breaking change for Vision since the names of the accessors are changing.

Is there a place we should keep track of that for releases and such?