### PR TITLE
Add Link to Slack Community

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,11 @@ See `CONTRIBUTING`_ for more information on how to get started.
 
 .. _CONTRIBUTING: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/CONTRIBUTING.rst
 
+Community
+---------
+
+Google Cloud Platform Python developers hang out in [Slack](https://googlecloud-community.slack.com) in the #python channel (get an invitation [here](https://gcp-slack.appspot.com/)). 
+
 License
 -------
 


### PR DESCRIPTION
@jonparrott and I hang out here, it might be worth adding a link, sometimes people have smaller discussions that people feel weird filing issues for.

Maybe people think this fragments the discussion which should stay on Issues? I could see it going either way, but Kubernetes seems to have had success with Slack. /cc @jgeewax 