### PR TITLE
Add filename parameter to client image proxy.

### DIFF
--- a/vision/google/cloud/vision/client.py
+++ b/vision/google/cloud/vision/client.py
@@ -106,11 +106,14 @@ class Client(JSONClient):
 
         return response['responses'][0]
 
-    def image(self, content=None, source_uri=None):
+    def image(self, content=None, filename=None, source_uri=None):
         """Get instance of Image using current client.
 
         :type content: bytes
         :param content: Byte stream of an image.
+
+        :type filename: str
+        :param filename: Filename to image.
 
         :type source_uri: str
         :param source_uri: Google Cloud Storage URI of image.
@@ -118,4 +121,5 @@ class Client(JSONClient):
         :rtype: :class:`~google.cloud.vision.image.Image`
         :returns: Image instance with the current client attached.
         """
-        return Image(client=self, content=content, source_uri=source_uri)
+        return Image(client=self, content=content, filename=filename,
+                     source_uri=source_uri)

--- a/vision/unit_tests/test_client.py
+++ b/vision/unit_tests/test_client.py
@@ -72,14 +72,40 @@ class TestClient(unittest.TestCase):
                          client._connection._requested[0]['data'])
         self.assertTrue('faceAnnotations' in response)
 
-    def test_image_with_client(self):
+    def test_image_with_client_gcs_source(self):
         from google.cloud.vision.image import Image
 
         credentials = _Credentials()
         client = self._make_one(project=PROJECT,
                                 credentials=credentials)
-        image = client.image(source_uri=IMAGE_SOURCE)
-        self.assertIsInstance(image, Image)
+        gcs_image = client.image(source_uri=IMAGE_SOURCE)
+        self.assertIsInstance(gcs_image, Image)
+        self.assertEqual(gcs_image.source, IMAGE_SOURCE)
+
+    def test_image_with_client_raw_content(self):
+        from google.cloud.vision.image import Image
+
+        credentials = _Credentials()
+        client = self._make_one(project=PROJECT,
+                                credentials=credentials)
+        raw_image = client.image(content=IMAGE_CONTENT)
+        self.assertIsInstance(raw_image, Image)
+        self.assertEqual(raw_image.content, B64_IMAGE_CONTENT)
+
+    def test_image_with_client_filename(self):
+        from mock import mock_open
+        from mock import patch
+        from google.cloud.vision.image import Image
+
+        credentials = _Credentials()
+        client = self._make_one(project=PROJECT,
+                                credentials=credentials)
+        with patch('google.cloud.vision.image.open',
+                   mock_open(read_data=IMAGE_CONTENT)) as m:
+            file_image = client.image(filename='my_image.jpg')
+        m.assert_called_once_with('my_image.jpg', 'rb')
+        self.assertIsInstance(file_image, Image)
+        self.assertEqual(file_image.content, B64_IMAGE_CONTENT)
 
     def test_multiple_detection_from_content(self):
         import copy


### PR DESCRIPTION
Towards #2753 

Essentially I forgot to add this to the `client.image()` proxy.