### PR TITLE
Upgrading GAPIC deps to 0.14 series.

### DIFF
--- a/logging/google/cloud/logging/_gax.py
+++ b/logging/google/cloud/logging/_gax.py
@@ -16,19 +16,19 @@
 
 import functools
 
-from google.cloud.gapic.logging.v2.config_service_v2_api import (
-    ConfigServiceV2Api)
-from google.cloud.gapic.logging.v2.logging_service_v2_api import (
-    LoggingServiceV2Api)
-from google.cloud.gapic.logging.v2.metrics_service_v2_api import (
-    MetricsServiceV2Api)
+from google.cloud.gapic.logging.v2.config_service_v2_client import (
+    ConfigServiceV2Client)
+from google.cloud.gapic.logging.v2.logging_service_v2_client import (
+    LoggingServiceV2Client)
+from google.cloud.gapic.logging.v2.metrics_service_v2_client import (
+    MetricsServiceV2Client)
 from google.gax import CallOptions
 from google.gax import INITIAL_PAGE
 from google.gax.errors import GaxError
 from google.gax.grpc import exc_to_code
-from google.logging.v2.logging_config_pb2 import LogSink
-from google.logging.v2.logging_metrics_pb2 import LogMetric
-from google.logging.v2.log_entry_pb2 import LogEntry
+from google.cloud.grpc.logging.v2.logging_config_pb2 import LogSink
+from google.cloud.grpc.logging.v2.logging_metrics_pb2 import LogMetric
+from google.cloud.grpc.logging.v2.log_entry_pb2 import LogEntry
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.json_format import ParseDict
 from grpc import StatusCode
@@ -48,7 +48,7 @@ class _LoggingAPI(object):
     """Helper mapping logging-related APIs.
 
     :type gax_api:
-        :class:`google.logging.v2.logging_service_v2_api.LoggingServiceV2Api`
+        :class:`.logging_service_v2_client.LoggingServiceV2Client`
     :param gax_api: API object used to make GAX requests.
 
     :type client: :class:`~google.cloud.logging.client.Client`
@@ -92,7 +92,7 @@ class _LoggingAPI(object):
             page_token = INITIAL_PAGE
         options = CallOptions(page_token=page_token)
         page_iter = self._gax_api.list_log_entries(
-            projects, filter_=filter_, order_by=order_by,
+            [], project_ids=projects, filter_=filter_, order_by=order_by,
             page_size=page_size, options=options)
 
         # We attach a mutable loggers dictionary so that as Logger
@@ -152,7 +152,7 @@ class _SinksAPI(object):
     """Helper mapping sink-related APIs.
 
     :type gax_api:
-        :class:`google.logging.v2.config_service_v2_api.ConfigServiceV2Api`
+        :class:`.config_service_v2_client.ConfigServiceV2Client`
     :param gax_api: API object used to make GAX requests.
 
     :type client: :class:`~google.cloud.logging.client.Client`
@@ -300,7 +300,8 @@ class _MetricsAPI(object):
     """Helper mapping sink-related APIs.
 
     :type gax_api:
-        :class:`google.logging.v2.metrics_service_v2_api.MetricsServiceV2Api`
+        :class:`.metrics_service_v2_client.MetricsServiceV2Client`
+
     :param gax_api: API object used to make GAX requests.
 
     :type client: :class:`~google.cloud.logging.client.Client`
@@ -471,7 +472,7 @@ def _item_to_entry(iterator, entry_pb, loggers):
     :type iterator: :class:`~google.cloud.iterator.Iterator`
     :param iterator: The iterator that is currently in use.
 
-    :type entry_pb: :class:`~google.logging.v2.log_entry_pb2.LogEntry`
+    :type entry_pb: :class:`.log_entry_pb2.LogEntry`
     :param entry_pb: Log entry protobuf returned from the API.
 
     :type loggers: dict
@@ -494,7 +495,7 @@ def _item_to_sink(iterator, log_sink_pb):
     :param iterator: The iterator that is currently in use.
 
     :type log_sink_pb:
-        :class:`~google.logging.v2.logging_config_pb2.LogSink`
+        :class:`.logging_config_pb2.LogSink`
     :param log_sink_pb: Sink protobuf returned from the API.
 
     :rtype: :class:`~google.cloud.logging.sink.Sink`
@@ -511,7 +512,7 @@ def _item_to_metric(iterator, log_metric_pb):
     :param iterator: The iterator that is currently in use.
 
     :type log_metric_pb:
-        :class:`~google.logging.v2.logging_metrics_pb2.LogMetric`
+        :class:`.logging_metrics_pb2.LogMetric`
     :param log_metric_pb: Metric protobuf returned from the API.
 
     :rtype: :class:`~google.cloud.logging.metric.Metric`
@@ -532,8 +533,8 @@ def make_gax_logging_api(client):
     """
     channel = make_secure_channel(
         client._connection.credentials, DEFAULT_USER_AGENT,
-        LoggingServiceV2Api.SERVICE_ADDRESS)
-    generated = LoggingServiceV2Api(channel=channel)
+        LoggingServiceV2Client.SERVICE_ADDRESS)
+    generated = LoggingServiceV2Client(channel=channel)
     return _LoggingAPI(generated, client)
 
 
@@ -548,8 +549,8 @@ def make_gax_metrics_api(client):
     """
     channel = make_secure_channel(
         client._connection.credentials, DEFAULT_USER_AGENT,
-        MetricsServiceV2Api.SERVICE_ADDRESS)
-    generated = MetricsServiceV2Api(channel=channel)
+        MetricsServiceV2Client.SERVICE_ADDRESS)
+    generated = MetricsServiceV2Client(channel=channel)
     return _MetricsAPI(generated, client)
 
 
@@ -564,6 +565,6 @@ def make_gax_sinks_api(client):
     """
     channel = make_secure_channel(
         client._connection.credentials, DEFAULT_USER_AGENT,
-        ConfigServiceV2Api.SERVICE_ADDRESS)
-    generated = ConfigServiceV2Api(channel=channel)
+        ConfigServiceV2Client.SERVICE_ADDRESS)
+    generated = ConfigServiceV2Client(channel=channel)
     return _SinksAPI(generated, client)

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -51,10 +51,7 @@ SETUP_BASE = {
 
 REQUIREMENTS = [
     'google-cloud-core >= 0.21.0, < 0.22dev',
-    'grpcio >= 1.0.0, < 2.0dev',
-    'google-gax >= 0.14.1, < 0.15dev',
-    'gapic-google-logging-v2 >= 0.10.1, < 0.11dev',
-    'grpc-google-logging-v2 >= 0.10.1, < 0.11dev',
+    'gapic-google-cloud-logging-v2 >= 0.14.0, < 0.15dev',
 ]
 
 setup(

--- a/logging/unit_tests/test__gax.py
+++ b/logging/unit_tests/test__gax.py
@@ -58,7 +58,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
 
         from google.api.monitored_resource_pb2 import MonitoredResource
         from google.gax import INITIAL_PAGE
-        from google.logging.v2.log_entry_pb2 import LogEntry
+        from google.cloud.grpc.logging.v2.log_entry_pb2 import LogEntry
 
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud._helpers import UTC
@@ -103,8 +103,9 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         self.assertIsNone(entry.severity)
         self.assertIsNone(entry.http_request)
 
-        projects, filter_, order_by, page_size, options = (
+        resource_names, projects, filter_, order_by, page_size, options = (
             gax_api._list_log_entries_called_with)
+        self.assertEqual(resource_names, [])
         self.assertEqual(projects, [self.PROJECT])
         self.assertEqual(filter_, self.FILTER)
         self.assertEqual(order_by, DESCENDING)
@@ -115,7 +116,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         import datetime
 
         from google.api.monitored_resource_pb2 import MonitoredResource
-        from google.logging.v2.log_entry_pb2 import LogEntry
+        from google.cloud.grpc.logging.v2.log_entry_pb2 import LogEntry
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud._helpers import UTC
         from google.cloud._testing import _GAXPageIterator
@@ -158,8 +159,9 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         self.assertIsNone(entry.severity)
         self.assertIsNone(entry.http_request)
 
-        projects, filter_, order_by, page_size, options = (
+        resource_names, projects, filter_, order_by, page_size, options = (
             gax_api._list_log_entries_called_with)
+        self.assertEqual(resource_names, [])
         self.assertEqual(projects, [self.PROJECT])
         self.assertEqual(filter_, '')
         self.assertEqual(order_by, '')
@@ -205,8 +207,9 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
 
     def _make_log_entry_with_extras(self, labels, iid, type_url, now):
         from google.api.monitored_resource_pb2 import MonitoredResource
-        from google.logging.v2.log_entry_pb2 import LogEntry
-        from google.logging.v2.log_entry_pb2 import LogEntryOperation
+        from google.cloud.grpc.logging.v2.log_entry_pb2 import LogEntry
+        from google.cloud.grpc.logging.v2.log_entry_pb2 import (
+            LogEntryOperation)
         from google.logging.type.http_request_pb2 import HttpRequest
         from google.logging.type.log_severity_pb2 import WARNING
         from google.protobuf.any_pb2 import Any
@@ -311,8 +314,9 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
             'cacheHit': entry_pb.http_request.cache_hit,
         })
 
-        projects, filter_, order_by, page_size, options = (
+        resource_names, projects, filter_, order_by, page_size, options = (
             gax_api._list_log_entries_called_with)
+        self.assertEqual(resource_names, [])
         self.assertEqual(projects, [self.PROJECT])
         self.assertEqual(filter_, '')
         self.assertEqual(order_by, '')
@@ -320,7 +324,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         self.assertEqual(options.page_token, TOKEN)
 
     def test_write_entries_single(self):
-        from google.logging.v2.log_entry_pb2 import LogEntry
+        from google.cloud.grpc.logging.v2.log_entry_pb2 import LogEntry
         TEXT = 'TEXT'
         ENTRY = {
             'logName': self.LOG_PATH,
@@ -353,7 +357,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         # pylint: disable=too-many-statements
         from datetime import datetime
         from google.logging.type.log_severity_pb2 import WARNING
-        from google.logging.v2.log_entry_pb2 import LogEntry
+        from google.cloud.grpc.logging.v2.log_entry_pb2 import LogEntry
         from google.cloud._helpers import UTC, _pb_timestamp_to_datetime
         NOW = datetime.utcnow().replace(tzinfo=UTC)
         TEXT = 'TEXT'
@@ -448,7 +452,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         # pylint: disable=too-many-statements
         import datetime
         from google.logging.type.log_severity_pb2 import WARNING
-        from google.logging.v2.log_entry_pb2 import LogEntry
+        from google.cloud.grpc.logging.v2.log_entry_pb2 import LogEntry
         from google.protobuf.any_pb2 import Any
         from google.cloud._helpers import _datetime_to_rfc3339, UTC
         TEXT = 'TEXT'
@@ -616,7 +620,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
     def test_list_sinks_no_paging(self):
         import six
         from google.gax import INITIAL_PAGE
-        from google.logging.v2.logging_config_pb2 import LogSink
+        from google.cloud.grpc.logging.v2.logging_config_pb2 import LogSink
         from google.cloud._testing import _GAXPageIterator
         from google.cloud.logging.sink import Sink
 
@@ -651,7 +655,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
         self.assertEqual(options.page_token, INITIAL_PAGE)
 
     def test_list_sinks_w_paging(self):
-        from google.logging.v2.logging_config_pb2 import LogSink
+        from google.cloud.grpc.logging.v2.logging_config_pb2 import LogSink
         from google.cloud._testing import _GAXPageIterator
         from google.cloud.logging.sink import Sink
 
@@ -707,7 +711,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
                 self.DESTINATION_URI)
 
     def test_sink_create_ok(self):
-        from google.logging.v2.logging_config_pb2 import LogSink
+        from google.cloud.grpc.logging.v2.logging_config_pb2 import LogSink
         gax_api = _GAXSinksAPI()
         api = self._make_one(gax_api, None)
 
@@ -740,7 +744,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
             api.sink_get(self.PROJECT, self.SINK_NAME)
 
     def test_sink_get_hit(self):
-        from google.logging.v2.logging_config_pb2 import LogSink
+        from google.cloud.grpc.logging.v2.logging_config_pb2 import LogSink
 
         RESPONSE = {
             'name': self.SINK_PATH,
@@ -782,7 +786,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
                 self.DESTINATION_URI)
 
     def test_sink_update_hit(self):
-        from google.logging.v2.logging_config_pb2 import LogSink
+        from google.cloud.grpc.logging.v2.logging_config_pb2 import LogSink
 
         response = LogSink(name=self.SINK_NAME,
                            destination=self.DESTINATION_URI,
@@ -848,7 +852,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
     def test_list_metrics_no_paging(self):
         import six
         from google.gax import INITIAL_PAGE
-        from google.logging.v2.logging_metrics_pb2 import LogMetric
+        from google.cloud.grpc.logging.v2.logging_metrics_pb2 import LogMetric
         from google.cloud._testing import _GAXPageIterator
         from google.cloud.logging.metric import Metric
 
@@ -883,7 +887,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
         self.assertEqual(options.page_token, INITIAL_PAGE)
 
     def test_list_metrics_w_paging(self):
-        from google.logging.v2.logging_metrics_pb2 import LogMetric
+        from google.cloud.grpc.logging.v2.logging_metrics_pb2 import LogMetric
         from google.cloud._testing import _GAXPageIterator
         from google.cloud.logging.metric import Metric
 
@@ -939,7 +943,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
                 self.DESCRIPTION)
 
     def test_metric_create_ok(self):
-        from google.logging.v2.logging_metrics_pb2 import LogMetric
+        from google.cloud.grpc.logging.v2.logging_metrics_pb2 import LogMetric
         gax_api = _GAXMetricsAPI()
         api = self._make_one(gax_api, None)
 
@@ -972,7 +976,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
             api.metric_get(self.PROJECT, self.METRIC_NAME)
 
     def test_metric_get_hit(self):
-        from google.logging.v2.logging_metrics_pb2 import LogMetric
+        from google.cloud.grpc.logging.v2.logging_metrics_pb2 import LogMetric
 
         RESPONSE = {
             'name': self.METRIC_PATH,
@@ -1014,7 +1018,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
                 self.DESCRIPTION)
 
     def test_metric_update_hit(self):
-        from google.logging.v2.logging_metrics_pb2 import LogMetric
+        from google.cloud.grpc.logging.v2.logging_metrics_pb2 import LogMetric
 
         response = LogMetric(name=self.METRIC_NAME,
                              description=self.DESCRIPTION,
@@ -1093,7 +1097,7 @@ class Test_make_gax_logging_api(unittest.TestCase):
 
         patch = mock.patch.multiple(
             'google.cloud.logging._gax',
-            LoggingServiceV2Api=generated_api,
+            LoggingServiceV2Client=generated_api,
             make_secure_channel=make_channel)
         with patch:
             logging_api = self._call_fut(client)
@@ -1139,7 +1143,7 @@ class Test_make_gax_metrics_api(unittest.TestCase):
 
         patch = mock.patch.multiple(
             'google.cloud.logging._gax',
-            MetricsServiceV2Api=generated_api,
+            MetricsServiceV2Client=generated_api,
             make_secure_channel=make_channel)
         with patch:
             metrics_api = self._call_fut(client)
@@ -1185,7 +1189,7 @@ class Test_make_gax_sinks_api(unittest.TestCase):
 
         patch = mock.patch.multiple(
             'google.cloud.logging._gax',
-            ConfigServiceV2Api=generated_api,
+            ConfigServiceV2Client=generated_api,
             make_secure_channel=make_channel)
         with patch:
             sinks_api = self._call_fut(client)
@@ -1204,9 +1208,11 @@ class _GAXLoggingAPI(_GAXBaseAPI):
     _delete_not_found = False
 
     def list_log_entries(
-            self, projects, filter_, order_by, page_size, options):
+            self, resource_names, project_ids, filter_,
+            order_by, page_size, options):
         self._list_log_entries_called_with = (
-            projects, filter_, order_by, page_size, options)
+            resource_names, project_ids, filter_,
+            order_by, page_size, options)
         return self._list_log_entries_response
 
     def write_log_entries(self, entries, log_name, resource, labels,

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -16,15 +16,15 @@
 
 import functools
 
-from google.cloud.gapic.pubsub.v1.publisher_api import PublisherApi
-from google.cloud.gapic.pubsub.v1.subscriber_api import SubscriberApi
+from google.cloud.gapic.pubsub.v1.publisher_client import PublisherClient
+from google.cloud.gapic.pubsub.v1.subscriber_client import SubscriberClient
 from google.gax import CallOptions
 from google.gax import INITIAL_PAGE
 from google.gax.errors import GaxError
 from google.gax.grpc import exc_to_code
 from google.protobuf.json_format import MessageToDict
-from google.pubsub.v1.pubsub_pb2 import PubsubMessage
-from google.pubsub.v1.pubsub_pb2 import PushConfig
+from google.cloud.grpc.pubsub.v1.pubsub_pb2 import PubsubMessage
+from google.cloud.grpc.pubsub.v1.pubsub_pb2 import PushConfig
 from grpc import insecure_channel
 from grpc import StatusCode
 
@@ -43,7 +43,7 @@ from google.cloud.pubsub.topic import Topic
 class _PublisherAPI(object):
     """Helper mapping publisher-related APIs.
 
-    :type gax_api: :class:`google.pubsub.v1.publisher_api.PublisherApi`
+    :type gax_api: :class:`.publisher_client.PublisherClient`
     :param gax_api: API object used to make GAX requests.
 
     :type client: :class:`~google.cloud.pubsub.client.Client`
@@ -223,7 +223,7 @@ class _PublisherAPI(object):
 class _SubscriberAPI(object):
     """Helper mapping subscriber-related APIs.
 
-    :type gax_api: :class:`google.pubsub.v1.publisher_api.SubscriberApi`
+    :type gax_api: :class:`.publisher_client.SubscriberClient`
     :param gax_api: API object used to make GAX requests.
 
     :type client: :class:`~google.cloud.pubsub.client.Client`
@@ -522,18 +522,17 @@ def make_gax_publisher_api(connection):
     :type connection: :class:`~google.cloud.pubsub._http.Connection`
     :param connection: The connection that holds configuration details.
 
-    :rtype: :class:`~google.cloud.pubsub.v1.publisher_api.PublisherApi`
+    :rtype: :class:`.publisher_client.PublisherClient`
     :returns: A publisher API instance with the proper connection
               configuration.
-    :rtype: :class:`~google.cloud.pubsub.v1.subscriber_api.SubscriberApi`
     """
     if connection.in_emulator:
         channel = insecure_channel(connection.host)
     else:
         channel = make_secure_channel(
             connection.credentials, DEFAULT_USER_AGENT,
-            PublisherApi.SERVICE_ADDRESS)
-    return PublisherApi(channel=channel)
+            PublisherClient.SERVICE_ADDRESS)
+    return PublisherClient(channel=channel)
 
 
 def make_gax_subscriber_api(connection):
@@ -546,7 +545,7 @@ def make_gax_subscriber_api(connection):
     :type connection: :class:`~google.cloud.pubsub._http.Connection`
     :param connection: The connection that holds configuration details.
 
-    :rtype: :class:`~google.cloud.pubsub.v1.subscriber_api.SubscriberApi`
+    :rtype: :class:`.subscriber_client.SubscriberClient`
     :returns: A subscriber API instance with the proper connection
               configuration.
     """
@@ -555,8 +554,8 @@ def make_gax_subscriber_api(connection):
     else:
         channel = make_secure_channel(
             connection.credentials, DEFAULT_USER_AGENT,
-            SubscriberApi.SERVICE_ADDRESS)
-    return SubscriberApi(channel=channel)
+            SubscriberClient.SERVICE_ADDRESS)
+    return SubscriberClient(channel=channel)
 
 
 def _item_to_topic(iterator, resource):
@@ -565,7 +564,7 @@ def _item_to_topic(iterator, resource):
     :type iterator: :class:`~google.cloud.iterator.Iterator`
     :param iterator: The iterator that is currently in use.
 
-    :type resource: :class:`google.pubsub.v1.pubsub_pb2.Topic`
+    :type resource: :class:`.pubsub_pb2.Topic`
     :param resource: A topic returned from the API.
 
     :rtype: :class:`~google.cloud.pubsub.topic.Topic`
@@ -607,7 +606,7 @@ def _item_to_sub_for_client(iterator, sub_pb, topics):
     :type iterator: :class:`~google.cloud.iterator.Iterator`
     :param iterator: The iterator that is currently in use.
 
-    :type sub_pb: :class:`~google.pubsub.v1.pubsub_pb2.Subscription`
+    :type sub_pb: :class:`.pubsub_pb2.Subscription`
     :param sub_pb: A subscription returned from the API.
 
     :type topics: dict

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -51,10 +51,7 @@ SETUP_BASE = {
 
 REQUIREMENTS = [
     'google-cloud-core >= 0.21.0, < 0.22dev',
-    'grpcio >= 1.0.0, < 2.0dev',
-    'google-gax >= 0.14.1, < 0.15dev',
-    'gapic-google-pubsub-v1 >= 0.10.1, < 0.11dev',
-    'grpc-google-pubsub-v1 >= 0.10.1, < 0.11dev',
+    'gapic-google-cloud-pubsub-v1 >= 0.14.0, < 0.15dev',
 ]
 
 setup(

--- a/pubsub/unit_tests/test__gax.py
+++ b/pubsub/unit_tests/test__gax.py
@@ -416,8 +416,9 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_list_subscriptions_no_paging(self):
         from google.gax import INITIAL_PAGE
-        from google.pubsub.v1.pubsub_pb2 import PushConfig
-        from google.pubsub.v1.pubsub_pb2 import Subscription as SubscriptionPB
+        from google.cloud.grpc.pubsub.v1.pubsub_pb2 import PushConfig
+        from google.cloud.grpc.pubsub.v1.pubsub_pb2 import (
+            Subscription as SubscriptionPB)
         from google.cloud._testing import _GAXPageIterator
         from google.cloud.pubsub.client import Client
         from google.cloud.pubsub.subscription import Subscription
@@ -458,8 +459,9 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         self.assertIs(options.page_token, INITIAL_PAGE)
 
     def test_list_subscriptions_with_paging(self):
-        from google.pubsub.v1.pubsub_pb2 import PushConfig
-        from google.pubsub.v1.pubsub_pb2 import Subscription as SubscriptionPB
+        from google.cloud.grpc.pubsub.v1.pubsub_pb2 import PushConfig
+        from google.cloud.grpc.pubsub.v1.pubsub_pb2 import (
+            Subscription as SubscriptionPB)
         from google.cloud._testing import _GAXPageIterator
         from google.cloud.pubsub.client import Client
         from google.cloud.pubsub.subscription import Subscription
@@ -505,7 +507,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         self.assertEqual(options.page_token, TOKEN)
 
     def test_subscription_create(self):
-        from google.pubsub.v1.pubsub_pb2 import Subscription
+        from google.cloud.grpc.pubsub.v1.pubsub_pb2 import Subscription
 
         sub_pb = Subscription(name=self.SUB_PATH, topic=self.TOPIC_PATH)
         gax_api = _GAXSubscriberAPI(_create_subscription_response=sub_pb)
@@ -564,8 +566,8 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         self.assertIsNone(options)
 
     def test_subscription_get_hit(self):
-        from google.pubsub.v1.pubsub_pb2 import PushConfig
-        from google.pubsub.v1.pubsub_pb2 import Subscription
+        from google.cloud.grpc.pubsub.v1.pubsub_pb2 import PushConfig
+        from google.cloud.grpc.pubsub.v1.pubsub_pb2 import Subscription
 
         push_cfg_pb = PushConfig(push_endpoint=self.PUSH_ENDPOINT)
         sub_pb = Subscription(name=self.SUB_PATH, topic=self.TOPIC_PATH,
@@ -919,7 +921,7 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
                                  credentials=creds)
         patch = mock.patch.multiple(
             'google.cloud.pubsub._gax',
-            PublisherApi=mock_publisher_api,
+            PublisherClient=mock_publisher_api,
             make_secure_channel=make_channel)
         with patch:
             result = self._call_fut(connection)
@@ -949,7 +951,7 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
         connection = _Connection(in_emulator=True, host=host)
         patch = mock.patch.multiple(
             'google.cloud.pubsub._gax',
-            PublisherApi=mock_publisher_api,
+            PublisherClient=mock_publisher_api,
             insecure_channel=mock_insecure_channel)
         with patch:
             result = self._call_fut(connection)
@@ -991,7 +993,7 @@ class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
                                  credentials=creds)
         patch = mock.patch.multiple(
             'google.cloud.pubsub._gax',
-            SubscriberApi=mock_subscriber_api,
+            SubscriberClient=mock_subscriber_api,
             make_secure_channel=make_channel)
         with patch:
             result = self._call_fut(connection)
@@ -1021,7 +1023,7 @@ class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
         connection = _Connection(in_emulator=True, host=host)
         patch = mock.patch.multiple(
             'google.cloud.pubsub._gax',
-            SubscriberApi=mock_subscriber_api,
+            SubscriberClient=mock_subscriber_api,
             insecure_channel=mock_insecure_channel)
         with patch:
             result = self._call_fut(connection)

--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -15,7 +15,7 @@
 """GAX/GAPIC module for managing Speech API requests."""
 
 
-from google.cloud.gapic.speech.v1beta1.speech_api import SpeechApi
+from google.cloud.gapic.speech.v1beta1.speech_client import SpeechClient
 from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import RecognitionAudio
 from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import RecognitionConfig
 from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import SpeechContext
@@ -42,8 +42,8 @@ class GAPICSpeechAPI(object):
         credentials = self._client._connection.credentials
         channel = make_secure_channel(
             credentials, DEFAULT_USER_AGENT,
-            SpeechApi.SERVICE_ADDRESS)
-        self._gapic_api = SpeechApi(channel=channel)
+            SpeechClient.SERVICE_ADDRESS)
+        self._gapic_api = SpeechClient(channel=channel)
         self._operations_stub = make_secure_stub(
             credentials,
             DEFAULT_USER_AGENT,

--- a/speech/setup.py
+++ b/speech/setup.py
@@ -48,10 +48,9 @@ SETUP_BASE = {
     ],
 }
 
-
 REQUIREMENTS = [
     'google-cloud-core >= 0.21.0',
-    'gapic-google-cloud-speech-v1beta1 >= 0.11.1, < 0.12.0',
+    'gapic-google-cloud-speech-v1beta1 >= 0.14.0, < 0.15dev',
 ]
 
 setup(

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -252,7 +252,7 @@ class TestClient(unittest.TestCase):
         host = 'foo.apis.invalid'
         speech_api.SERVICE_ADDRESS = host
 
-        with _Monkey(_gax, SpeechApi=speech_api,
+        with _Monkey(_gax, SpeechClient=speech_api,
                      make_secure_channel=make_channel):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 
@@ -310,7 +310,7 @@ class TestClient(unittest.TestCase):
                                encoding=speech.Encoding.FLAC,
                                sample_rate=self.SAMPLE_RATE)
 
-        with _Monkey(_gax, SpeechApi=speech_api,
+        with _Monkey(_gax, SpeechClient=speech_api,
                      make_secure_channel=make_channel):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 
@@ -398,7 +398,7 @@ class TestClient(unittest.TestCase):
         host = 'foo.apis.invalid'
         speech_api.SERVICE_ADDRESS = host
 
-        with _Monkey(_gax, SpeechApi=speech_api,
+        with _Monkey(_gax, SpeechClient=speech_api,
                      make_secure_channel=make_channel):
             api = client.speech_api
 
@@ -461,7 +461,7 @@ class TestClient(unittest.TestCase):
                                encoding=Encoding.LINEAR16,
                                sample_rate=self.SAMPLE_RATE)
 
-        with _Monkey(_gax, SpeechApi=speech_api,
+        with _Monkey(_gax, SpeechClient=speech_api,
                      make_secure_channel=make_channel):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 
@@ -513,7 +513,7 @@ class TestClient(unittest.TestCase):
         host = 'foo.apis.invalid'
         speech_api.SERVICE_ADDRESS = host
 
-        with _Monkey(_gax, SpeechApi=speech_api,
+        with _Monkey(_gax, SpeechClient=speech_api,
                      make_secure_channel=make_channel):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 
@@ -586,7 +586,7 @@ class TestClient(unittest.TestCase):
         host = 'foo.apis.invalid'
         speech_api.SERVICE_ADDRESS = host
 
-        with _Monkey(_gax, SpeechApi=speech_api,
+        with _Monkey(_gax, SpeechClient=speech_api,
                      make_secure_channel=make_channel):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 
@@ -630,7 +630,7 @@ class TestClient(unittest.TestCase):
         host = 'foo.apis.invalid'
         speech_api.SERVICE_ADDRESS = host
 
-        with _Monkey(_gax, SpeechApi=speech_api,
+        with _Monkey(_gax, SpeechClient=speech_api,
                      make_secure_channel=make_channel):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 
@@ -664,7 +664,7 @@ class TestClient(unittest.TestCase):
         host = 'foo.apis.invalid'
         speech_api.SERVICE_ADDRESS = host
 
-        with _Monkey(_gax, SpeechApi=speech_api,
+        with _Monkey(_gax, SpeechClient=speech_api,
                      make_secure_channel=make_channel):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 


### PR DESCRIPTION
In the process, ditching **hard** deps on protobufs, `grpcio`, and `google-gax` in those packages. Also had
to upgrade calls to `list_log_entries()` based on: https://github.com/googleapis/api-client-staging/pull/118/files/2bcd2875a578ae525d2aabb862cf9c131b4665f5#r90422054

/cc @geigerj @bjwatson 

@waprin I could not for the life of me figure out how to use `resource_names` instead of the deprecated `project_ids`. Can you explain? (Trying `foo` --> `project/foo` did not work)