### PR TITLE
Cutting new releases for BigQuery, Language and Core.

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -50,12 +50,12 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0, < 0.22dev',
+    'google-cloud-core >= 0.22.0, < 0.23dev',
 ]
 
 setup(
     name='google-cloud-bigquery',
-    version='0.21.0',
+    version='0.22.0',
     description='Python Client for Google BigQuery',
     long_description=README,
     namespace_packages=[

--- a/core/setup.py
+++ b/core/setup.py
@@ -60,7 +60,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-core',
-    version='0.21.0',
+    version='0.22.0',
     description='API Client library for Google Cloud: Core Helpers',
     long_description=README,
     namespace_packages=[

--- a/language/setup.py
+++ b/language/setup.py
@@ -50,12 +50,12 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.21.0, < 0.22dev',
+    'google-cloud-core >= 0.22.0, < 0.23dev',
 ]
 
 setup(
     name='google-cloud-language',
-    version='0.21.0',
+    version='0.22.0',
     description='Python Client for Google Cloud Natural Language',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
H/T to

- @jmdobry for #2798 forcing the NL release
- @tseaver for #2809, #2806, #2805, #2803, #2776, #2787 and #2789 forcing the BQ release
- @jonparrott #2808, #2801, #2726 forcing the core release

Proposed tags after merge:

- `bigquery-0.22.0`
- `core-0.22.0`
- `language-0.22.0`

I'll start going through `$ git log 0.21.0..HEAD -- bigquery/ core/ language/` now to figure out release notes.