### PR TITLE
Fix 'BYTES' field handling on Py3k.

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -18,12 +18,15 @@ import base64
 from collections import OrderedDict
 import datetime
 
+import six
+
 from google.cloud._helpers import _date_from_iso8601_date
 from google.cloud._helpers import _datetime_from_microseconds
 from google.cloud._helpers import _datetime_to_rfc3339
 from google.cloud._helpers import _microseconds_from_datetime
 from google.cloud._helpers import _RFC3339_NO_FRACTION
 from google.cloud._helpers import _time_from_iso8601_time_naive
+from google.cloud._helpers import _to_bytes
 
 
 def _not_null(value, field):
@@ -57,7 +60,8 @@ def _string_from_json(value, _):
 def _bytes_from_json(value, field):
     """Base64-decode value"""
     if _not_null(value, field):
-        return base64.decodestring(value)
+        return base64.decodestring(
+            _to_bytes(value) if isinstance(value, six.text_type) else value)
 
 
 def _timestamp_from_json(value, field):

--- a/bigquery/unit_tests/test__helpers.py
+++ b/bigquery/unit_tests/test__helpers.py
@@ -135,10 +135,17 @@ class Test_bytes_from_json(unittest.TestCase):
         with self.assertRaises(TypeError):
             self._call_fut(None, _Field('REQUIRED'))
 
-    def test_w_base64_encoded_value(self):
+    def test_w_base64_encoded_bytes(self):
         import base64
         expected = b'Wonderful!'
         encoded = base64.encodestring(expected)
+        coerced = self._call_fut(encoded, object())
+        self.assertEqual(coerced, expected)
+
+    def test_w_base64_encoded_text(self):
+        import base64
+        expected = b'Wonderful!'
+        encoded = base64.encodestring(expected).decode('ascii')
         coerced = self._call_fut(encoded, object())
         self.assertEqual(coerced, expected)
 


### PR DESCRIPTION
JSON decodes the base64-encoded bits as text, which cannot be passed to 'base64.decodestring' on Py3k.

`tox -e system-tests3` was failing for me locally before this patch, and passes with it.