### PR TITLE
Support authenticated local non-TLS for datastore and pubsub

### DIFF
--- a/core/google/cloud/environment_vars.py
+++ b/core/google/cloud/environment_vars.py
@@ -18,6 +18,10 @@ These enable many types of implicit behavior in both production
 and tests.
 """
 
+AUTH_LOCAL = 'GOOGLE_AUTH_LOCAL_TRAFFIC'
+"""Environment variable which, if true, will allow authorization header to be
+present in insecure local traffic."""
+
 GCD_DATASET = 'DATASTORE_DATASET'
 """Environment variable defining default dataset ID under GCD."""
 

--- a/pubsub/google/cloud/pubsub/_gax.py
+++ b/pubsub/google/cloud/pubsub/_gax.py
@@ -100,7 +100,7 @@ class _PublisherAPI(object):
                     exists
         """
         try:
-            topic_pb = self._gax_api.create_topic(topic_path)
+            topic_pb = self._gax_api.create_topic(topic_path, options=self._client._metadata_option)
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.FAILED_PRECONDITION:
                 raise Conflict(topic_path)
@@ -123,7 +123,7 @@ class _PublisherAPI(object):
                     exist
         """
         try:
-            topic_pb = self._gax_api.get_topic(topic_path)
+            topic_pb = self._gax_api.get_topic(topic_path, options=self._client._metadata_option)
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(topic_path)
@@ -165,7 +165,7 @@ class _PublisherAPI(object):
         :raises: :exc:`google.cloud.exceptions.NotFound` if the topic does not
                     exist
         """
-        options = CallOptions(is_bundling=False)
+        options = CallOptions(is_bundling=False, **self._client._metadata_option.kwargs)
         message_pbs = [_message_pb_from_mapping(message)
                        for message in messages]
         try:
@@ -204,7 +204,7 @@ class _PublisherAPI(object):
         """
         if page_token is None:
             page_token = INITIAL_PAGE
-        options = CallOptions(page_token=page_token)
+        options = CallOptions(page_token=page_token, **self._client._metadata_option.kwargs)
         topic_path = topic.full_name
         try:
             page_iter = self._gax_api.list_topic_subscriptions(
@@ -258,7 +258,7 @@ class _SubscriberAPI(object):
         """
         if page_token is None:
             page_token = INITIAL_PAGE
-        options = CallOptions(page_token=page_token)
+        options = CallOptions(page_token=page_token, **self._client._metadata_option.kwargs)
         path = 'projects/%s' % (project,)
         page_iter = self._gax_api.list_subscriptions(
             path, page_size=page_size, options=options)
@@ -312,7 +312,7 @@ class _SubscriberAPI(object):
         try:
             sub_pb = self._gax_api.create_subscription(
                 subscription_path, topic_path,
-                push_config=push_config, ack_deadline_seconds=ack_deadline)
+                push_config=push_config, ack_deadline_seconds=ack_deadline, options=self._client._metadata_option)
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.FAILED_PRECONDITION:
                 raise Conflict(topic_path)
@@ -334,7 +334,7 @@ class _SubscriberAPI(object):
         :returns: ``Subscription`` resource returned from the API.
         """
         try:
-            sub_pb = self._gax_api.get_subscription(subscription_path)
+            sub_pb = self._gax_api.get_subscription(subscription_path, options=self._client._metadata_option)
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(subscription_path)
@@ -353,7 +353,7 @@ class _SubscriberAPI(object):
             ``projects/<PROJECT>/subscriptions/<SUB_NAME>``.
         """
         try:
-            self._gax_api.delete_subscription(subscription_path)
+            self._gax_api.delete_subscription(subscription_path, options=self._client._metadata_option)
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(subscription_path)
@@ -378,7 +378,7 @@ class _SubscriberAPI(object):
         """
         push_config = PushConfig(push_endpoint=push_endpoint)
         try:
-            self._gax_api.modify_push_config(subscription_path, push_config)
+            self._gax_api.modify_push_config(subscription_path, push_config, options=self._client._metadata_option)
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(subscription_path)
@@ -411,7 +411,8 @@ class _SubscriberAPI(object):
         try:
             response_pb = self._gax_api.pull(
                 subscription_path, max_messages,
-                return_immediately=return_immediately)
+                return_immediately=return_immediately,
+                options=self._client._metadata_option)
         except GaxError as exc:
             code = exc_to_code(exc.cause)
             if code == StatusCode.NOT_FOUND:
@@ -441,7 +442,7 @@ class _SubscriberAPI(object):
         :param ack_ids: ack IDs of messages being acknowledged
         """
         try:
-            self._gax_api.acknowledge(subscription_path, ack_ids)
+            self._gax_api.acknowledge(subscription_path, ack_ids, options=self._client._metadata_option)
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(subscription_path)
@@ -468,7 +469,7 @@ class _SubscriberAPI(object):
         """
         try:
             self._gax_api.modify_ack_deadline(
-                subscription_path, ack_ids, ack_deadline)
+                subscription_path, ack_ids, ack_deadline, options=self._client._metadata_option)
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(subscription_path)

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -16,6 +16,7 @@
 
 import os
 
+from google.cloud._helpers import get_authorization_metadata
 from google.cloud.client import JSONClient
 from google.cloud.environment_vars import DISABLE_GRPC
 from google.cloud.pubsub._http import Connection
@@ -29,6 +30,7 @@ try:
     from google.cloud.pubsub._gax import _SubscriberAPI as GAXSubscriberAPI
     from google.cloud.pubsub._gax import make_gax_publisher_api
     from google.cloud.pubsub._gax import make_gax_subscriber_api
+    from google.gax import CallOptions
 except ImportError:  # pragma: NO COVER
     _HAVE_GAX = False
     GAXPublisherAPI = None
@@ -76,6 +78,11 @@ class Client(JSONClient):
             self._use_gax = _USE_GAX
         else:
             self._use_gax = use_gax
+        metadata = get_authorization_metadata(self._connection.credentials, self._connection.host)
+        if metadata is None:
+          self._metadata_option = None
+        else:
+          self._metadata_option = CallOptions(metadata=[metadata])
 
     _connection_class = Connection
     _publisher_api = _subscriber_api = _iam_policy_api = None


### PR DESCRIPTION
Hello, this is a very early stab at the foundation of a change in line with some internal discussion.

My goal is to
1. validate the approach
2. make sure it works for HTTP, not just GRPC (I wanted to validate it first)
3. get guidance on how to test this
4. extend this to the rest of veneer

Implementation wise, one remaining thing is to add a catchall env variable.... but that is trivial to add. I wanted to validate the approach.

And 3... I'm not sure if we have integration tests or what. Things like this change are always tricky to test, so any guidance is very welcome!