### PR TITLE
Converting remaining datastore snippets to doctests

### DIFF
--- a/datastore/google/cloud/datastore/__init__.py
+++ b/datastore/google/cloud/datastore/__init__.py
@@ -18,17 +18,17 @@ You'll typically use these to get started with the API:
 
 .. doctest:: constructors
 
-  >>> from google.cloud import datastore
-  >>>
-  >>> client = datastore.Client()
-  >>> key = client.key('EntityKind', 1234)
-  >>> key
-  <Key('EntityKind', 1234), project=...>
-  >>> entity = datastore.Entity(key)
-  >>> entity['answer'] = 42
-  >>> entity
-  <Entity('EntityKind', 1234) {'answer': 42}>
-  >>> query = client.query(kind='EntityKind')
+   >>> from google.cloud import datastore
+   >>>
+   >>> client = datastore.Client()
+   >>> key = client.key('EntityKind', 1234)
+   >>> key
+   <Key('EntityKind', 1234), project=...>
+   >>> entity = datastore.Entity(key)
+   >>> entity['answer'] = 42
+   >>> entity
+   <Entity('EntityKind', 1234) {'answer': 42}>
+   >>> query = client.query(kind='EntityKind')
 
 The main concepts with this API are:
 

--- a/datastore/google/cloud/datastore/entity.py
+++ b/datastore/google/cloud/datastore/entity.py
@@ -40,30 +40,48 @@ class Entity(dict):
     Use :meth:`~google.cloud.datastore.client.Client.get` to retrieve an
     existing entity:
 
-    .. code-block:: python
+    .. testsetup:: entity-ctor
 
-      >>> from google.cloud import datastore
-      >>> client = datastore.Client()
-      >>> client.get(key)
-      <Entity[{'kind': 'EntityKind', id: 1234}] {'property': 'value'}>
+       from google.cloud import datastore
+       from datastore import Config  # system tests
+
+       client = datastore.Client()
+       key = client.key('EntityKind', 1234, namespace='_Doctest')
+       entity = datastore.Entity(key=key)
+       entity['property'] = 'value'
+       Config.TO_DELETE.append(entity)
+
+       client.put(entity)
+
+    .. doctest:: entity-ctor
+
+       >>> client.get(key)
+       <Entity(u'EntityKind', 1234L) {u'property': 'value'}>
 
     You can the set values on the entity just like you would on any
     other dictionary.
 
-    .. code-block:: python
+    .. doctest:: entity-ctor
 
-      >>> entity['age'] = 20
-      >>> entity['name'] = 'JJ'
-      >>> entity
-      <Entity[{'kind': 'EntityKind', id: 1234}] {'age': 20, 'name': 'JJ'}>
+       >>> entity['age'] = 20
+       >>> entity['name'] = 'JJ'
 
-    And you can convert an entity to a regular Python dictionary with the
-    ``dict`` builtin:
+    And you can treat an entity like a regular Python dictionary:
 
-    .. code-block:: python
+    .. testsetup:: entity-dict
 
-      >>> dict(entity)
-      {'age': 20, 'name': 'JJ'}
+       from google.cloud import datastore
+
+       entity = datastore.Entity()
+       entity['age'] = 20
+       entity['name'] = 'JJ'
+
+    .. doctest:: entity-dict
+
+       >>> sorted(entity.keys())
+       ['age', 'name']
+       >>> sorted(entity.items())
+       [('age', 20), ('name', 'JJ')]
 
     .. note::
 

--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -23,30 +23,50 @@ from google.cloud.datastore._generated import entity_pb2 as _entity_pb2
 class Key(object):
     """An immutable representation of a datastore Key.
 
-    To create a basic key:
+    .. testsetup:: key-ctor
 
-    .. code-block:: python
+       from google.cloud import datastore
 
-      >>> Key('EntityKind', 1234)
-      <Key[{'kind': 'EntityKind', 'id': 1234}]>
-      >>> Key('EntityKind', 'foo')
-      <Key[{'kind': 'EntityKind', 'name': 'foo'}]>
+       project = 'my-special-pony'
+       client = datastore.Client(project=project)
+       Key = datastore.Key
+
+       parent_key = client.key('Parent', 'foo')
+
+    To create a basic key directly:
+
+    .. doctest:: key-ctor
+
+       >>> Key('EntityKind', 1234, project=project)
+       <Key('EntityKind', 1234), project=...>
+       >>> Key('EntityKind', 'foo', project=project)
+       <Key('EntityKind', 'foo'), project=...>
+
+    Though typical usage comes via the
+    :meth:`~google.cloud.datastore.client.Client.key` factory:
+
+    .. doctest:: key-ctor
+
+       >>> client.key('EntityKind', 1234)
+       <Key('EntityKind', 1234), project=...>
+       >>> client.key('EntityKind', 'foo')
+       <Key('EntityKind', 'foo'), project=...>
 
     To create a key with a parent:
 
-    .. code-block:: python
+    .. doctest:: key-ctor
 
-      >>> Key('Parent', 'foo', 'Child', 1234)
-      <Key[{'kind': 'Parent', 'name': 'foo'}, {'kind': 'Child', 'id': 1234}]>
-      >>> Key('Child', 1234, parent=parent_key)
-      <Key[{'kind': 'Parent', 'name': 'foo'}, {'kind': 'Child', 'id': 1234}]>
+       >>> client.key('Parent', 'foo', 'Child', 1234)
+       <Key('Parent', 'foo', 'Child', 1234), project=...>
+       >>> client.key('Child', 1234, parent=parent_key)
+       <Key('Parent', 'foo', 'Child', 1234), project=...>
 
     To create a partial key:
 
-    .. code-block:: python
+    .. doctest:: key-ctor
 
-      >>> Key('Parent', 'foo', 'Child')
-      <Key[{'kind': 'Parent', 'name': 'foo'}, {'kind': 'Child'}]>
+       >>> client.key('Parent', 'foo', 'Child')
+       <Key('Parent', 'foo', 'Child'), project=...>
 
     :type path_args: tuple of string and integer
     :param path_args: May represent a partial (odd length) or full (even

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -57,6 +57,7 @@ class Config(object):
     global state.
     """
     CLIENT = None
+    TO_DELETE = []
 
 
 def clone_client(client):
@@ -81,6 +82,12 @@ def setUpModule():
                                          namespace=test_namespace,
                                          credentials=credentials,
                                          http=http)
+
+
+def tearDownModule():
+    keys = [entity.key for entity in Config.TO_DELETE]
+    with Config.CLIENT.transaction():
+        Config.CLIENT.delete_multi(keys)
 
 
 class TestDatastore(unittest.TestCase):


### PR DESCRIPTION
It's worth noting that I delegated clean-up to `system_tests/datastore.py::tearDownModule`. This is because (in my experimenting) I discovered that the `sphinx.ext.doctest` directive `testcleanup` doesn't run when the thing being tested fails. (FWIW, I think it'd be fairly easy for one of us to send a PR to the Sphinx project and fix that behavior, but that was outside the scope of this PR.)

----

To make dev a little faster I did the following:

```
$ tox -e system-tests --recreate --notest
$ source .tox/system-tests/bin/activate
$ GOOGLE_CLOUD_DISABLE_GRPC=true \
> .tox/system-tests/bin/py.test system_tests/datastore.py \
> -k TestDoctest -s -vv
```

and every time I made a change I just re-installed into the env

```
$ .tox/system-tests/bin/pip install --upgrade datastore/
```

Might be worth turning this into a script someday? But I don't want to design it before we know how we'll use it. Just putting it here for posterity.

----

There is a ``code-block`` snippet in `datastore._http` but that module is non-public so I left it alone.

----

This package could use some more snippets, but for now at least they are all covered.