### PR TITLE
Adding helpers to push to PyPI on tags.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,3 +21,11 @@ general:
   branches:
     ignore:
       - gh-pages
+
+deployment:
+  release:
+    tag: /(([a-z]+)-)?([0-9]+)\.([0-9]+)\.([0-9]+)/
+    owner: GoogleCloudPlatform
+    commands:
+      - pip install --upgrade twine
+      - ./scripts/circleci_twine_upload.sh

--- a/scripts/circleci_tagged_pkg.py
+++ b/scripts/circleci_tagged_pkg.py
@@ -1,0 +1,60 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper to determine package from tag.
+
+Get the current package directory corresponding to the Circle Tag.
+"""
+
+from __future__ import print_function
+
+import os
+import re
+import sys
+
+
+RE_TXT = r'^((?P<pkg>[a-z]+)-)?([0-9]+)\.([0-9]+)\.([0-9]+)$'
+TAG_RE = re.compile(RE_TXT)
+TAG_ENV = 'CIRCLE_TAG'
+ERROR_MSG = '%s env. var. not set' % (TAG_ENV,)
+BAD_TAG_MSG = 'Invalid tag name: %s. Expected ' + RE_TXT
+_SCRIPTS_DIR = os.path.dirname(__file__)
+ROOT_DIR = os.path.abspath(os.path.join(_SCRIPTS_DIR, '..'))
+
+
+def main():
+    """Get the current package directory.
+
+    Prints the package directory out so callers can consume it.
+    """
+    if TAG_ENV not in os.environ:
+        print(ERROR_MSG, file=sys.stderr)
+        sys.exit(1)
+
+    tag_name = os.environ[TAG_ENV]
+    match = TAG_RE.match(tag_name)
+    if match is None:
+        print(BAD_TAG_MSG % (tag_name,), file=sys.stderr)
+        sys.exit(1)
+
+    pkg_name = match.group('pkg')
+    if pkg_name is None:
+        print(ROOT_DIR)
+    else:
+        pkg_dir = pkg_name.replace('-', '_')
+        print(os.path.join(ROOT_DIR, pkg_dir))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/circleci_twine_upload.sh
+++ b/scripts/circleci_twine_upload.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ev
+
+# H/T: http://stackoverflow.com/a/246128/1068170
+SCRIPT="$(dirname "${BASH_SOURCE[0]}")/circleci_tagged_pkg.py"
+# Determine the package directory being deploying on this tag.
+PKG_DIR="$(python ${SCRIPT})"
+
+# Move into the package, build the distribution and upload.
+cd ${PKG_DIR}
+python setup.py sdist bdist_wheel
+twine upload dist/*


### PR DESCRIPTION
See #2810 for discussion of which tags are used.

`twine upload` will "just work" since we have set the ``TWINE_USERNAME`` and ``TWINE_PASSWORD`` env. vars on CircleCI.