### PR TITLE
Separate HTTP client.

### DIFF
--- a/vision/google/cloud/vision/_http.py
+++ b/vision/google/cloud/vision/_http.py
@@ -1,0 +1,78 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HTTP Client for interacting with the Google Cloud Vision API."""
+
+from google.cloud.vision.feature import Feature
+
+
+class _HTTPVisionAPI(object):
+    """Vision API for interacting with the JSON/HTTP version of Vision
+
+    :type client: :class:`~google.cloud.core.client.Client`
+    :param client: Instance of ``Client`` object.
+    """
+
+    def __init__(self, client):
+        self._client = client
+        self._connection = client._connection
+
+    def annotate(self, image, features):
+        """Annotate an image to discover it's attributes.
+
+        :type image: :class:`~google.cloud.vision.image.Image`
+        :param image: A instance of ``Image``.
+
+        :type features:  list of :class:`~google.cloud.vision.feature.Feature`
+        :param features: The type of detection that the Vision API should
+                         use to determine image attributes. Pricing is
+                         based on the number of Feature Types.
+
+                         See: https://cloud.google.com/vision/docs/pricing
+        :rtype: dict
+        :returns: List of annotations.
+        """
+        request = _make_request(image, features)
+
+        data = {'requests': [request]}
+        api_response = self._connection.api_request(
+            method='POST', path='/images:annotate', data=data)
+        responses = api_response.get('responses')
+        return responses[0]
+
+
+def _make_request(image, features):
+    """Prepare request object to send to Vision API.
+
+    :type image: :class:`~google.cloud.vision.image.Image`
+    :param image: Instance of ``Image``.
+
+    :type features: list of :class:`~google.cloud.vision.feature.Feature`
+    :param features: Either a list of ``Feature`` instances or a single
+                     instance of ``Feature``.
+
+    :rtype: dict
+    :returns: Dictionary prepared to send to the Vision API.
+    """
+    if isinstance(features, Feature):
+        features = [features]
+
+    feature_check = (isinstance(feature, Feature) for feature in features)
+    if not any(feature_check):
+        raise TypeError('Feature or list of Feature classes are required.')
+
+    return {
+        'image': image.as_dict(),
+        'features': [feature.as_dict() for feature in features],
+    }

--- a/vision/google/cloud/vision/image.py
+++ b/vision/google/cloud/vision/image.py
@@ -109,7 +109,7 @@ class Image(object):
                   :class:`~google.cloud.vision.color.ImagePropertiesAnnotation`,
                   :class:`~google.cloud.vision.sage.SafeSearchAnnotation`,
         """
-        results = self.client.annotate(self, features)
+        results = self.client._vision_api.annotate(self, features)
         return Annotations.from_api_repr(results)
 
     def detect(self, features):

--- a/vision/unit_tests/test__http.py
+++ b/vision/unit_tests/test__http.py
@@ -1,0 +1,65 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import unittest
+
+
+IMAGE_CONTENT = b'/9j/4QNURXhpZgAASUkq'
+PROJECT = 'PROJECT'
+B64_IMAGE_CONTENT = base64.b64encode(IMAGE_CONTENT).decode('ascii')
+
+
+class TestVisionRequest(unittest.TestCase):
+    @staticmethod
+    def _get_target_function():
+        from google.cloud.vision._http import _make_request
+        return _make_request
+
+    def _call_fut(self, *args, **kw):
+        return self._get_target_function()(*args, **kw)
+
+    def test_call_vision_request(self):
+        from google.cloud.vision.feature import Feature
+        from google.cloud.vision.feature import FeatureTypes
+        from google.cloud.vision.image import Image
+
+        client = object()
+        image = Image(client, content=IMAGE_CONTENT)
+        feature = Feature(feature_type=FeatureTypes.FACE_DETECTION,
+                          max_results=3)
+        request = self._call_fut(image, feature)
+        self.assertEqual(request['image'].get('content'), B64_IMAGE_CONTENT)
+        features = request['features']
+        self.assertEqual(len(features), 1)
+        feature = features[0]
+        print(feature)
+        self.assertEqual(feature['type'], FeatureTypes.FACE_DETECTION)
+        self.assertEqual(feature['maxResults'], 3)
+
+    def test_call_vision_request_with_not_feature(self):
+        from google.cloud.vision.image import Image
+
+        client = object()
+        image = Image(client, content=IMAGE_CONTENT)
+        with self.assertRaises(TypeError):
+            self._call_fut(image, 'nonsensefeature')
+
+    def test_call_vision_request_with_list_bad_features(self):
+        from google.cloud.vision.image import Image
+
+        client = object()
+        image = Image(client, content=IMAGE_CONTENT)
+        with self.assertRaises(TypeError):
+            self._call_fut(image, ['nonsensefeature'])


### PR DESCRIPTION
Towards #2753 for adding GAPIC support.

Separates out the REST client in preparation to add the GAPIC client alongside.