### PR TITLE
Make logging unit test file a temp file

### DIFF
--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -553,6 +553,7 @@ class TestClient(unittest.TestCase):
 
     def test_get_default_handler_app_engine(self):
         import os
+        import tempfile
         from google.cloud._testing import _Monkey
         from google.cloud.logging.client import _APPENGINE_FLEXIBLE_ENV_VM
         from google.cloud.logging.handlers import app_engine as _MUT
@@ -562,7 +563,8 @@ class TestClient(unittest.TestCase):
                                 credentials=_make_credentials(),
                                 use_gax=False)
 
-        with _Monkey(_MUT, _LOG_PATH_TEMPLATE='{pid}'):
+        temp_log_path = os.path.join(tempfile.mkdtemp(), '{pid}')
+        with _Monkey(_MUT, _LOG_PATH_TEMPLATE=temp_log_path):
             with _Monkey(os, environ={_APPENGINE_FLEXIBLE_ENV_VM: 'True'}):
                 handler = client.get_default_handler()
 


### PR DESCRIPTION
Fixes #2843. This doesn't clean up the file after but it does make it a temp file, @dhermes let me know if you think this is sufficient which I think it is. 