### PR TITLE
Make sample.content handle bytes and files.

### DIFF
--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -182,9 +182,7 @@ class GAPICSpeechAPI(object):
                        .cloud_speech_pb2.StreamingRecognizeResponse`
         :returns: ``StreamingRecognizeResponse`` instances.
         """
-        if getattr(sample.content, 'closed', None) is None:
-            raise ValueError('Please use file-like object for data stream.')
-        if sample.content.closed:
+        if sample.stream.closed:
             raise ValueError('Stream is closed.')
 
         requests = _stream_requests(sample, language_code=language_code,
@@ -252,7 +250,6 @@ class GAPICSpeechAPI(object):
             language_code=language_code, max_alternatives=max_alternatives,
             profanity_filter=profanity_filter,
             speech_context=SpeechContext(phrases=speech_context))
-
         audio = RecognitionAudio(content=sample.content,
                                  uri=sample.source_uri)
         api = self._gapic_api
@@ -337,7 +334,7 @@ def _stream_requests(sample, language_code=None, max_alternatives=None,
     yield config_request
 
     while True:
-        data = sample.content.read(sample.chunk_size)
+        data = sample.stream.read(sample.chunk_size)
         if not data:
             break
         yield StreamingRecognizeRequest(audio_content=data)

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -66,12 +66,12 @@ class Client(BaseClient):
         else:
             self._use_gax = use_gax
 
-    def sample(self, content=None, source_uri=None, encoding=None,
+    def sample(self, content=None, source_uri=None, stream=None, encoding=None,
                sample_rate=None):
         """Factory: construct Sample to use when making recognize requests.
 
         :type content: bytes
-        :param content: (Optional) Byte stream of audio.
+        :param content: (Optional) Bytes containing audio data.
 
         :type source_uri: str
         :param source_uri: (Optional) URI that points to a file that contains
@@ -79,6 +79,9 @@ class Client(BaseClient):
                            Currently, only Google Cloud Storage URIs are
                            supported, which must be specified in the following
                            format: ``gs://bucket_name/object_name``.
+
+        :type stream: file
+        :param stream: (Optional) File like object to stream.
 
         :type encoding: str
         :param encoding: encoding of audio data sent in all RecognitionAudio
@@ -97,7 +100,7 @@ class Client(BaseClient):
         :rtype: :class:`~google.cloud.speech.sample.Sample`
         :returns: Instance of ``Sample``.
         """
-        return Sample(content=content, source_uri=source_uri,
+        return Sample(content=content, source_uri=source_uri, stream=stream,
                       encoding=encoding, sample_rate=sample_rate, client=self)
 
     @property

--- a/speech/google/cloud/speech/sample.py
+++ b/speech/google/cloud/speech/sample.py
@@ -14,6 +14,7 @@
 
 """Sample class to handle content for Google Cloud Speech API."""
 
+
 from google.cloud.speech.encoding import Encoding
 from google.cloud.speech.result import StreamingSpeechResult
 
@@ -22,7 +23,7 @@ class Sample(object):
     """Representation of an audio sample to be used with Google Speech API.
 
     :type content: bytes
-    :param content: (Optional) Byte stream of audio.
+    :param content: (Optional) Bytes containing audio data.
 
     :type source_uri: str
     :param source_uri: (Optional) URI that points to a file that contains
@@ -30,6 +31,9 @@ class Sample(object):
                        Currently, only Google Cloud Storage URIs are
                        supported, which must be specified in the following
                        format: ``gs://bucket_name/object_name``.
+
+    :type stream: file
+    :param stream: (Optional) File like object to stream.
 
     :type encoding: str
     :param encoding: encoding of audio data sent in all RecognitionAudio
@@ -51,17 +55,19 @@ class Sample(object):
     default_encoding = Encoding.FLAC
     default_sample_rate = 16000
 
-    def __init__(self, content=None, source_uri=None,
+    def __init__(self, content=None, source_uri=None, stream=None,
                  encoding=None, sample_rate=None, client=None):
         self._client = client
 
-        no_source = content is None and source_uri is None
-        both_source = content is not None and source_uri is not None
-        if no_source or both_source:
-            raise ValueError('Supply one of \'content\' or \'source_uri\'')
+        sources = [content is not None, source_uri is not None,
+                   stream is not None]
+        if sources.count(True) != 1:
+            raise ValueError('Supply exactly one of '
+                             '\'content\',  \'source_uri\', \'stream\'')
 
         self._content = content
         self._source_uri = source_uri
+        self._stream = stream
 
         if sample_rate is not None and not 8000 <= sample_rate <= 48000:
             raise ValueError('The value of sample_rate must be between 8000'
@@ -108,6 +114,15 @@ class Sample(object):
         :returns: Integer between 8000 and 48,000.
         """
         return self._sample_rate
+
+    @property
+    def stream(self):
+        """Stream the content when it is a file-like object.
+
+        :rtype: file
+        :returns: File like object to stream.
+        """
+        return self._stream
 
     @property
     def encoding(self):

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -72,7 +72,7 @@ class TestClient(unittest.TestCase):
     SAMPLE_RATE = 16000
     HINTS = ['hi']
     AUDIO_SOURCE_URI = 'gs://sample-bucket/sample-recording.flac'
-    AUDIO_CONTENT = '/9j/4QNURXhpZgAASUkq'
+    AUDIO_CONTENT = b'testing 1 2 3'
 
     @staticmethod
     def _get_target_class():
@@ -125,14 +125,12 @@ class TestClient(unittest.TestCase):
         from base64 import b64encode
 
         from google.cloud._helpers import _bytes_to_unicode
-        from google.cloud._helpers import _to_bytes
 
         from google.cloud import speech
         from google.cloud.speech.alternative import Alternative
         from unit_tests._fixtures import SYNC_RECOGNIZE_RESPONSE
 
-        _AUDIO_CONTENT = _to_bytes(self.AUDIO_CONTENT)
-        _B64_AUDIO_CONTENT = _bytes_to_unicode(b64encode(_AUDIO_CONTENT))
+        _B64_AUDIO_CONTENT = _bytes_to_unicode(b64encode(self.AUDIO_CONTENT))
         RETURNED = SYNC_RECOGNIZE_RESPONSE
         REQUEST = {
             'config': {
@@ -325,8 +323,7 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(low_level, _MockGAPICSpeechAPI)
         self.assertIs(low_level._channel, channel_obj)
         self.assertEqual(
-            channel_args,
-            [(creds, _gax.DEFAULT_USER_AGENT, host)])
+            channel_args, [(creds, _gax.DEFAULT_USER_AGENT, host)])
 
         results = sample.sync_recognize()
 
@@ -462,8 +459,9 @@ class TestClient(unittest.TestCase):
         speech_api.SERVICE_ADDRESS = host
 
         stream.close()
+        self.assertTrue(stream.closed)
 
-        sample = client.sample(content=stream,
+        sample = client.sample(stream=stream,
                                encoding=Encoding.LINEAR16,
                                sample_rate=self.SAMPLE_RATE)
 
@@ -523,7 +521,7 @@ class TestClient(unittest.TestCase):
                      make_secure_channel=make_channel):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 
-        sample = client.sample(content=stream,
+        sample = client.sample(stream=stream,
                                encoding=Encoding.LINEAR16,
                                sample_rate=self.SAMPLE_RATE)
 
@@ -596,7 +594,7 @@ class TestClient(unittest.TestCase):
                      make_secure_channel=make_channel):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 
-        sample = client.sample(content=stream,
+        sample = client.sample(stream=stream,
                                encoding=Encoding.LINEAR16,
                                sample_rate=self.SAMPLE_RATE)
 
@@ -640,7 +638,7 @@ class TestClient(unittest.TestCase):
                      make_secure_channel=make_channel):
             client._speech_api = _gax.GAPICSpeechAPI(client)
 
-        sample = client.sample(content=stream,
+        sample = client.sample(stream=stream,
                                encoding=Encoding.LINEAR16,
                                sample_rate=self.SAMPLE_RATE)
 

--- a/speech/unit_tests/test_sample.py
+++ b/speech/unit_tests/test_sample.py
@@ -38,9 +38,43 @@ class TestSample(unittest.TestCase):
         self.assertEqual(sample.sample_rate, self.SAMPLE_RATE)
 
     def test_content_and_source_uri(self):
+        from io import BytesIO
+
         with self.assertRaises(ValueError):
             self._make_one(content='awefawagaeragere',
                            source_uri=self.AUDIO_SOURCE_URI)
+
+        with self.assertRaises(ValueError):
+            self._make_one(stream=BytesIO(b'awefawagaeragere'),
+                           source_uri=self.AUDIO_SOURCE_URI)
+
+        with self.assertRaises(ValueError):
+            self._make_one(content='awefawagaeragere',
+                           stream=BytesIO(b'awefawagaeragere'),
+                           source_uri=self.AUDIO_SOURCE_URI)
+
+    def test_stream_property(self):
+        from io import BytesIO
+        from google.cloud.speech.encoding import Encoding
+
+        data = b'abc 1 2 3 4'
+        stream = BytesIO(data)
+        sample = self._make_one(stream=stream, encoding=Encoding.FLAC,
+                                sample_rate=self.SAMPLE_RATE)
+        self.assertEqual(sample.stream, stream)
+        self.assertEqual(sample.stream.read(), data)
+
+    def test_bytes_converts_to_file_like_object(self):
+        from google.cloud import speech
+        from google.cloud.speech.sample import Sample
+
+        test_bytes = b'testing 1 2 3'
+
+        sample = Sample(content=test_bytes, encoding=speech.Encoding.FLAC,
+                        sample_rate=self.SAMPLE_RATE)
+        self.assertEqual(sample.content, test_bytes)
+        self.assertEqual(sample.encoding, speech.Encoding.FLAC)
+        self.assertEqual(sample.sample_rate, self.SAMPLE_RATE)
 
     def test_sample_rates(self):
         from google.cloud.speech.encoding import Encoding

--- a/system_tests/speech.py
+++ b/system_tests/speech.py
@@ -118,7 +118,7 @@ class TestSpeechClient(unittest.TestCase):
     def _make_streaming_request(self, file_obj, single_utterance=True,
                                 interim_results=False):
         client = Config.CLIENT
-        sample = client.sample(content=file_obj,
+        sample = client.sample(stream=file_obj,
                                encoding=speech.Encoding.LINEAR16,
                                sample_rate=16000)
         return sample.streaming_recognize(single_utterance=single_utterance,


### PR DESCRIPTION
Towards: #2842

See: https://github.com/GoogleCloudPlatform/google-cloud-python/pull/2680#discussion_r86612107

This PR attempts to handle both bytes and file objects passed to `Sample.content`.

I added `Sample.stream` to distinguish between raw bytes and a file like object.
`Sample.stream` cannot be set, and is derived from `Sample._content`, which can be either bytes or a file.

I'm sure you guys will have some great feedback for this. I'm totally open to suggestions.