### PR TITLE
Force close logging handler.

### DIFF
--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -568,6 +568,7 @@ class TestClient(unittest.TestCase):
             with _Monkey(_MUT, _LOG_PATH_TEMPLATE=temp_log_path):
                 with _Monkey(os, environ={_APPENGINE_FLEXIBLE_ENV_VM: 'True'}):
                     handler = client.get_default_handler()
+                    handler.close()  # allow tempdir cleanup on Windows
 
         self.assertIsInstance(handler, AppEngineHandler)
 


### PR DESCRIPTION
Allow tempdir cleanup to work as expected on Windows.