### PR TITLE
Add a timestamp parameter to the logger.

### DIFF
--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -17,6 +17,7 @@
 import json
 
 from google.protobuf.json_format import MessageToJson
+from google.cloud._helpers import _datetime_to_rfc3339
 
 
 class Logger(object):
@@ -120,7 +121,8 @@ class Logger(object):
         :type http_request: dict
         :param http_request: (optional) info about HTTP request associated with
                              the entry
-        :type timestamp: str
+
+        :type timestamp: :class:`datetime.datetime`
         :param timestamp: (optional) timestamp of event being logged.
 
         :rtype: dict
@@ -158,7 +160,7 @@ class Logger(object):
             resource['httpRequest'] = http_request
 
         if timestamp is not None:
-            resource['timestamp'] = timestamp
+            resource['timestamp'] = _datetime_to_rfc3339(timestamp)
 
         return resource
 
@@ -190,7 +192,7 @@ class Logger(object):
         :param http_request: (optional) info about HTTP request associated with
                              the entry
 
-        :type timestamp: str
+        :type timestamp: :class:`datetime.datetime`
         :param timestamp: (optional) timestamp of event being logged.
         """
         client = self._require_client(client)
@@ -227,7 +229,7 @@ class Logger(object):
         :param http_request: (optional) info about HTTP request associated with
                              the entry.
 
-        :type timestamp: str
+        :type timestamp: :class:`datetime.datetime`
         :param timestamp: (optional) timestamp of event being logged.
         """
         client = self._require_client(client)
@@ -264,7 +266,7 @@ class Logger(object):
         :param http_request: (optional) info about HTTP request associated with
                              the entry.
 
-        :type timestamp: str
+        :type timestamp: :class:`datetime.datetime`
         :param timestamp: (optional) timestamp of event being logged.
         """
         client = self._require_client(client)
@@ -373,7 +375,7 @@ class Batch(object):
         :param http_request: (optional) info about HTTP request associated with
                              the entry.
 
-        :type timestamp: str
+        :type timestamp: :class:`datetime.datetime`
         :param timestamp: (optional) timestamp of event being logged.
         """
         self.entries.append(
@@ -399,7 +401,7 @@ class Batch(object):
         :param http_request: (optional) info about HTTP request associated with
                              the entry.
 
-        :type timestamp: str
+        :type timestamp: :class:`datetime.datetime`
         :param timestamp: (optional) timestamp of event being logged.
         """
         self.entries.append(
@@ -425,7 +427,7 @@ class Batch(object):
         :param http_request: (optional) info about HTTP request associated with
                              the entry.
 
-        :type timestamp: str
+        :type timestamp: :class:`datetime.datetime`
         :param timestamp: (optional) timestamp of event being logged.
         """
         self.entries.append(

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -455,8 +455,8 @@ class Batch(object):
             kwargs['labels'] = self.logger.labels
 
         entries = []
-        for entry_type, entry, labels, iid, severity, http_req, timestamp in \
-                self.entries:
+        for (entry_type, entry, labels, iid, severity, http_req,
+             timestamp) in self.entries:
             if entry_type == 'text':
                 info = {'textPayload': entry}
             elif entry_type == 'struct':

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -379,7 +379,8 @@ class Batch(object):
         :param timestamp: (optional) timestamp of event being logged.
         """
         self.entries.append(
-            ('text', text, labels, insert_id, severity, http_request, timestamp))
+            ('text', text, labels, insert_id, severity, http_request,
+             timestamp))
 
     def log_struct(self, info, labels=None, insert_id=None, severity=None,
                    http_request=None, timestamp=None):
@@ -405,7 +406,8 @@ class Batch(object):
         :param timestamp: (optional) timestamp of event being logged.
         """
         self.entries.append(
-            ('struct', info, labels, insert_id, severity, http_request, timestamp))
+            ('struct', info, labels, insert_id, severity, http_request,
+             timestamp))
 
     def log_proto(self, message, labels=None, insert_id=None, severity=None,
                   http_request=None, timestamp=None):
@@ -431,7 +433,8 @@ class Batch(object):
         :param timestamp: (optional) timestamp of event being logged.
         """
         self.entries.append(
-            ('proto', message, labels, insert_id, severity, http_request, timestamp))
+            ('proto', message, labels, insert_id, severity, http_request,
+             timestamp))
 
     def commit(self, client=None):
         """Send saved log entries as a single API call.
@@ -452,7 +455,8 @@ class Batch(object):
             kwargs['labels'] = self.logger.labels
 
         entries = []
-        for entry_type, entry, labels, iid, severity, http_req, timestamp in self.entries:
+        for entry_type, entry, labels, iid, severity, http_req, timestamp in \
+                self.entries:
             if entry_type == 'text':
                 info = {'textPayload': entry}
             elif entry_type == 'struct':

--- a/logging/unit_tests/test_logger.py
+++ b/logging/unit_tests/test_logger.py
@@ -454,7 +454,7 @@ class TestBatch(unittest.TestCase):
         batch = self._make_one(logger, client=client)
         batch.log_text(TEXT)
         self.assertEqual(batch.entries,
-                         [('text', TEXT, None, None, None, None)])
+                         [('text', TEXT, None, None, None, None, None)])
 
     def test_log_text_explicit(self):
         TEXT = 'This is the entry text'
@@ -469,13 +469,14 @@ class TestBatch(unittest.TestCase):
             'requestUrl': URI,
             'status': STATUS,
         }
+        TIMESTAMP = '2016-10-12T15:01:23.045123456Z'
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
         batch.log_text(TEXT, labels=LABELS, insert_id=IID, severity=SEVERITY,
-                       http_request=REQUEST)
+                       http_request=REQUEST, timestamp=TIMESTAMP)
         self.assertEqual(batch.entries,
-                         [('text', TEXT, LABELS, IID, SEVERITY, REQUEST)])
+                         [('text', TEXT, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP)])
 
     def test_log_struct_defaults(self):
         STRUCT = {'message': 'Message text', 'weather': 'partly cloudy'}
@@ -484,7 +485,7 @@ class TestBatch(unittest.TestCase):
         batch = self._make_one(logger, client=client)
         batch.log_struct(STRUCT)
         self.assertEqual(batch.entries,
-                         [('struct', STRUCT, None, None, None, None)])
+                         [('struct', STRUCT, None, None, None, None, None)])
 
     def test_log_struct_explicit(self):
         STRUCT = {'message': 'Message text', 'weather': 'partly cloudy'}
@@ -499,13 +500,14 @@ class TestBatch(unittest.TestCase):
             'requestUrl': URI,
             'status': STATUS,
         }
+        TIMESTAMP = '2016-10-12T15:01:23.045123456Z'
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
         batch.log_struct(STRUCT, labels=LABELS, insert_id=IID,
-                         severity=SEVERITY, http_request=REQUEST)
+                         severity=SEVERITY, http_request=REQUEST, timestamp=TIMESTAMP)
         self.assertEqual(batch.entries,
-                         [('struct', STRUCT, LABELS, IID, SEVERITY, REQUEST)])
+                         [('struct', STRUCT, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP)])
 
     def test_log_proto_defaults(self):
         from google.protobuf.struct_pb2 import Struct, Value
@@ -515,7 +517,7 @@ class TestBatch(unittest.TestCase):
         batch = self._make_one(logger, client=client)
         batch.log_proto(message)
         self.assertEqual(batch.entries,
-                         [('proto', message, None, None, None, None)])
+                         [('proto', message, None, None, None, None, None)])
 
     def test_log_proto_explicit(self):
         from google.protobuf.struct_pb2 import Struct, Value
@@ -531,13 +533,14 @@ class TestBatch(unittest.TestCase):
             'requestUrl': URI,
             'status': STATUS,
         }
+        TIMESTAMP = '2016-10-12T15:01:23.045123456Z'
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
         batch.log_proto(message, labels=LABELS, insert_id=IID,
-                        severity=SEVERITY, http_request=REQUEST)
+                        severity=SEVERITY, http_request=REQUEST, timestamp=TIMESTAMP)
         self.assertEqual(batch.entries,
-                         [('proto', message, LABELS, IID, SEVERITY, REQUEST)])
+                         [('proto', message, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP)])
 
     def test_commit_w_invalid_entry_type(self):
         logger = _Logger()
@@ -681,20 +684,21 @@ class TestBatch(unittest.TestCase):
             'requestUrl': URI,
             'status': STATUS,
         }
+        TIMESTAMP = '2016-10-12T15:01:23.045123456Z'
         message = Struct(fields={'foo': Value(bool_value=True)})
         client = _Client(project=self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
         logger = _Logger()
         UNSENT = [
-            ('text', TEXT, None, IID, None, None),
-            ('struct', STRUCT, None, None, SEVERITY, None),
-            ('proto', message, LABELS, None, None, REQUEST),
+            ('text', TEXT, None, IID, None, None, TIMESTAMP),
+            ('struct', STRUCT, None, None, SEVERITY, None, None),
+            ('proto', message, LABELS, None, None, REQUEST, None),
         ]
         batch = self._make_one(logger, client=client)
 
         try:
             with batch as other:
-                other.log_text(TEXT, insert_id=IID)
+                other.log_text(TEXT, insert_id=IID, timestamp=TIMESTAMP)
                 other.log_struct(STRUCT, severity=SEVERITY)
                 other.log_proto(message, labels=LABELS, http_request=REQUEST)
                 raise _Bugout()


### PR DESCRIPTION
The timestamp parameter is useful when one sends batches of log records. In this case, every log record in a batch will have the same timestamp. The timestamp equals the date of insertion in the google cloud logging API. 

If one uses the `asctime` attribute from the [LogRecord](https://docs.python.org/2/library/logging.html#logging.LogRecord) instances as timestamp value, a log record would have a propre date.  