### PR TITLE
Cut version 0.22.1 of translation API.

### DIFF
--- a/translate/setup.py
+++ b/translate/setup.py
@@ -55,7 +55,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-translate',
-    version='0.22.0',
+    version='0.22.1',
     description='Python Client for Google Cloud Translation API',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
This releases the branding update for Google Cloud Translation from #2863.

```
git log translate-0.22.0..HEAD translate
```
produced

```
2f75184 Update Translation API branding.
```