### PR TITLE
Remove connection from base Client class

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -58,20 +58,25 @@ class Client(JSONClient):
                     passed when creating a dataset / job.  If not passed,
                     falls back to the default inferred from the environment.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
     """
 
-    _connection_class = Connection
+    def __init__(self, project=None, credentials=None, http=None):
+        super(Client, self).__init__(
+            project=project, credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
 
     def list_projects(self, max_results=None, page_token=None):
         """List projects for the project associated with this client.

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -19,7 +19,6 @@ from google.oauth2 import service_account
 import six
 
 from google.cloud._helpers import _determine_default_project
-from google.cloud._http import Connection
 from google.cloud.credentials import get_credentials
 
 
@@ -72,23 +71,22 @@ class _ClientFactoryMixin(object):
 class Client(_ClientFactoryMixin):
     """Client to bundle configuration needed for API requests.
 
-    Assumes that the associated ``_connection_class`` only accepts
-    ``http`` and ``credentials`` in its constructor.
+    Stores ``credentials`` and ``http`` object so that subclasses
+    can pass them along to a connection class.
 
-    :type credentials: :class:`google.auth.credentials.Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
     """
-
-    _connection_class = Connection
 
     def __init__(self, credentials=None, http=None):
         if (credentials is not None and
@@ -97,8 +95,8 @@ class Client(_ClientFactoryMixin):
             raise ValueError(_GOOGLE_AUTH_CREDENTIALS_HELP)
         if credentials is None and http is None:
             credentials = get_credentials()
-        self._connection = self._connection_class(
-            credentials=credentials, http=http)
+        self._credentials = credentials
+        self._http = http
 
 
 class _ClientProjectMixin(object):
@@ -142,15 +140,16 @@ class JSONClient(Client, _ClientProjectMixin):
                     passed falls back to the default inferred from the
                     environment.
 
-    :type credentials: :class:`google.auth.credentials.Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
 

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -82,8 +82,8 @@ class Client(_ClientFactoryMixin):
 
     :type http: :class:`~httplib2.Http`
     :param http: (Optional) HTTP object to make requests. Can be any object
-                  that defines ``request()`` with the same interface as
-                  :meth:`~httplib2.Http.request`. If not passed, an
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
     """
@@ -148,8 +148,8 @@ class JSONClient(Client, _ClientProjectMixin):
 
     :type http: :class:`~httplib2.Http`
     :param http: (Optional) HTTP object to make requests. Can be any object
-                  that defines ``request()`` with the same interface as
-                  :meth:`~httplib2.Http.request`. If not passed, an
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
 

--- a/core/tox.ini
+++ b/core/tox.ini
@@ -4,7 +4,7 @@ envlist =
 
 [testing]
 deps =
-    grpcio >= 1.0.2rc0
+    grpcio >= 1.0.2
     mock
     pytest
 covercmd =

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -157,26 +157,29 @@ class Client(_BaseClient, _ClientProjectMixin):
     :type namespace: str
     :param namespace: (optional) namespace to pass to proxied API methods.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
     """
-    _connection_class = Connection
 
     def __init__(self, project=None, namespace=None,
                  credentials=None, http=None):
         _ClientProjectMixin.__init__(self, project=project)
+        _BaseClient.__init__(self, credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
+
         self.namespace = namespace
         self._batch_stack = _LocalStack()
-        super(Client, self).__init__(credentials, http)
 
     @staticmethod
     def _determine_default(project):

--- a/datastore/unit_tests/test_client.py
+++ b/datastore/unit_tests/test_client.py
@@ -118,13 +118,15 @@ class TestClient(unittest.TestCase):
     PROJECT = 'PROJECT'
 
     def setUp(self):
-        KLASS = self._get_target_class()
-        self.original_cnxn_class = KLASS._connection_class
-        KLASS._connection_class = _MockConnection
+        from google.cloud.datastore import client as MUT
+
+        self.original_cnxn_class = MUT.Connection
+        MUT.Connection = _MockConnection
 
     def tearDown(self):
-        KLASS = self._get_target_class()
-        KLASS._connection_class = self.original_cnxn_class
+        from google.cloud.datastore import client as MUT
+
+        MUT.Connection = self.original_cnxn_class
 
     @staticmethod
     def _get_target_class():

--- a/dns/google/cloud/dns/client.py
+++ b/dns/google/cloud/dns/client.py
@@ -29,20 +29,25 @@ class Client(JSONClient):
                     passed when creating a zone.  If not passed,
                     falls back to the default inferred from the environment.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
     """
 
-    _connection_class = Connection
+    def __init__(self, project=None, credentials=None, http=None):
+        super(Client, self).__init__(
+            project=project, credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
 
     def quotas(self):
         """Return DNS quotas for the project associated with this client.

--- a/language/google/cloud/language/client.py
+++ b/language/google/cloud/language/client.py
@@ -23,19 +23,25 @@ from google.cloud.language.document import Document
 class Client(client_module.Client):
     """Client to bundle configuration needed for API requests.
 
-    :type credentials: :class:`~oauth2client.client.OAuth2Credentials`
-    :param credentials: (Optional) The OAuth2 Credentials to use for the
-                        connection owned by this client. If not passed (and
-                        if no ``http`` object is passed), falls back to the
-                        default inferred from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
     """
 
-    _connection_class = Connection
+    def __init__(self, credentials=None, http=None):
+        super(Client, self).__init__(
+            credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
 
     def document_from_text(self, content, **kwargs):
         """Create a plain text document bound to this client.

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -67,15 +67,16 @@ class Client(JSONClient):
                     If not passed, falls back to the default inferred
                     from the environment.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
 
@@ -86,12 +87,16 @@ class Client(JSONClient):
                     variable
     """
 
-    _connection_class = Connection
-    _logging_api = _sinks_api = _metrics_api = None
+    _logging_api = None
+    _sinks_api = None
+    _metrics_api = None
 
     def __init__(self, project=None, credentials=None,
                  http=None, use_gax=None):
-        super(Client, self).__init__(project, credentials, http)
+        super(Client, self).__init__(
+            project=project, credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
         if use_gax is None:
             self._use_gax = _USE_GAX
         else:

--- a/monitoring/google/cloud/monitoring/client.py
+++ b/monitoring/google/cloud/monitoring/client.py
@@ -54,20 +54,25 @@ class Client(JSONClient):
     :param project: The target project. If not passed, falls back to the
                     default inferred from the environment.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
     """
 
-    _connection_class = Connection
+    def __init__(self, project=None, credentials=None, http=None):
+        super(Client, self).__init__(
+            project=project, credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
 
     def query(self,
               metric_type=Query.DEFAULT_METRIC_TYPE,

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -51,15 +51,16 @@ class Client(JSONClient):
                     passed when creating a topic.  If not passed,
                     falls back to the default inferred from the environment.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
 
@@ -69,16 +70,21 @@ class Client(JSONClient):
                     falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
                     variable
     """
+
+    _publisher_api = None
+    _subscriber_api = None
+    _iam_policy_api = None
+
     def __init__(self, project=None, credentials=None,
                  http=None, use_gax=None):
-        super(Client, self).__init__(project, credentials, http)
+        super(Client, self).__init__(
+            project=project, credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
         if use_gax is None:
             self._use_gax = _USE_GAX
         else:
             self._use_gax = use_gax
-
-    _connection_class = Connection
-    _publisher_api = _subscriber_api = _iam_policy_api = None
 
     @property
     def publisher_api(self):

--- a/resource_manager/google/cloud/resource_manager/client.py
+++ b/resource_manager/google/cloud/resource_manager/client.py
@@ -33,20 +33,25 @@ class Client(BaseClient):
         >>> from google.cloud import resource_manager
         >>> client = resource_manager.Client()
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
     """
 
-    _connection_class = Connection
+    def __init__(self, credentials=None, http=None):
+        super(Client, self).__init__(
+            credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
 
     def new_project(self, project_id, name=None, labels=None):
         """Create a project bound to the current client.

--- a/runtimeconfig/google/cloud/runtimeconfig/client.py
+++ b/runtimeconfig/google/cloud/runtimeconfig/client.py
@@ -28,20 +28,25 @@ class Client(JSONClient):
         (Optional) The project which the client acts on behalf of.  If not
         passed, falls back to the default inferred from the environment.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
-    :param credentials:
-        (Optional) The OAuth2 Credentials to use for the connection owned by
-        this client. If not passed (and if no ``http`` object is passed), falls
-        back to the default inferred from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http:
-        (Optional) An HTTP object to make requests. If not passed, an ``http``
-        object is created that is bound to the ``credentials`` for the current
-        object.
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
+                 ``http`` object is created that is bound to the
+                 ``credentials`` for the current object.
     """
 
-    _connection_class = Connection
+    def __init__(self, project=None, credentials=None, http=None):
+        super(Client, self).__init__(
+            project=project, credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
 
     def config(self, config_name):
         """Factory constructor for config object.

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -35,15 +35,16 @@ _USE_GAX = not os.getenv(DISABLE_GRPC, False)
 class Client(BaseClient):
     """Client to bundle configuration needed for API requests.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
 
@@ -53,15 +54,17 @@ class Client(BaseClient):
                     falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
                     variable
     """
+
+    _speech_api = None
+
     def __init__(self, credentials=None, http=None, use_gax=None):
         super(Client, self).__init__(credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
         if use_gax is None:
             self._use_gax = _USE_GAX
         else:
             self._use_gax = use_gax
-
-    _connection_class = Connection
-    _speech_api = None
 
     def sample(self, content=None, source_uri=None, encoding=None,
                sample_rate=None):

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -32,25 +32,26 @@ class Client(JSONClient):
                     passed when creating a topic.  If not passed,
                     falls back to the default inferred from the environment.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
     """
-
-    _connection_class = Connection
 
     def __init__(self, project=None, credentials=None, http=None):
         self._base_connection = None
         super(Client, self).__init__(project=project, credentials=credentials,
                                      http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
         self._batch_stack = _LocalStack()
 
     @property

--- a/translate/google/cloud/translate/client.py
+++ b/translate/google/cloud/translate/client.py
@@ -40,23 +40,26 @@ class Client(BaseClient):
                             translations and language names. (Defaults to
                             :data:`ENGLISH_ISO_639`.)
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
-    :param credentials: (Optional) The OAuth2 Credentials to use for the
-                        connection owned by this client. If not passed (and
-                        if no ``http`` object is passed), falls back to the
-                        default inferred from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: (Optional) HTTP object to make requests. If not
-                 passed, an :class:`httplib.Http` object is created.
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
+                 ``http`` object is created that is bound to the
+                 ``credentials`` for the current object.
     """
-
-    _connection_class = Connection
 
     def __init__(self, target_language=ENGLISH_ISO_639,
                  credentials=None, http=None):
         self.target_language = target_language
         super(Client, self).__init__(credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
 
     def get_languages(self, target_language=None):
         """Get list of supported languages for translation.

--- a/vision/google/cloud/vision/client.py
+++ b/vision/google/cloud/vision/client.py
@@ -67,20 +67,25 @@ class Client(JSONClient):
                     If not passed, falls back to the default inferred
                     from the environment.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
-                       :class:`NoneType`
-    :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
-                        object is passed), falls back to the default inferred
-                        from the environment.
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed (and if no ``http`` object is
+                        passed), falls back to the default inferred from the
+                        environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
+    :type http: :class:`~httplib2.Http`
+    :param http: (Optional) HTTP object to make requests. Can be any object
+                 that defines ``request()`` with the same interface as
+                 :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
     """
 
-    _connection_class = Connection
+    def __init__(self, project=None, credentials=None, http=None):
+        super(Client, self).__init__(
+            project=project, credentials=credentials, http=http)
+        self._connection = Connection(
+            credentials=self._credentials, http=self._http)
 
     def annotate(self, image, features):
         """Annotate an image to discover it's attributes.


### PR DESCRIPTION
This is part of #2606. The idea behind this PR: we can drop support for `Connection` classes on a package-by-package basis rather than all at once.

/cc @tseaver and @mckoss this will have teeny implications on downstream clients