### PR TITLE
Prep gcloud-0.18.4 release.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,12 @@
 Google Cloud Python Client
 ==========================
 
-    Python idiomatic client for `Google Cloud Platform`_ services.
+.. warning::
+
+   This library has been renamed ``google-cloud``.  Please update
+   to use the new version.  https://pypi.python.org/pypi/google-cloud
+
+Python idiomatic client for `Google Cloud Platform`_ services.
 
 .. _Google Cloud Platform: https://cloud.google.com/
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,8 @@
+.. warning::
+
+   This library has been renamed ``google-cloud``.  Please update
+   to use the new version.  https://pypi.python.org/pypi/google-cloud
+
 .. toctree::
   :maxdepth: 0
   :hidden:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if sys.version_info[:2] == (2, 7) and 'READTHEDOCS' not in os.environ:
 
 setup(
     name='gcloud',
-    version='0.18.3',
+    version='0.18.4',
     description='API Client library for Google Cloud',
     author='Google Cloud Platform',
     author_email='jjg+gcloud-python@google.com',


### PR DESCRIPTION
Identical to 0.18.3, except adding warnings to the PyPI page and the docs that the package has been renamed.

Closes: #2748, #2885.