### PR TITLE
Feature/range bytes

### DIFF
--- a/core/google/cloud/streaming/transfer.py
+++ b/core/google/cloud/streaming/transfer.py
@@ -371,11 +371,11 @@ class Download(_Transfer):
         :type http: :class:`httplib2.Http` (or workalike)
         :param http: Http instance for this request.
 
+        For more info on Range Bytes:
+        https://cloud.google.com/storage/docs/xml-api/reference-headers#range
         :type range_bytes: tuple
         :param range_bytes: (Optional). Range of bytes to download.
 
-        For more info on Range Bytes:
-        https://cloud.google.com/storage/docs/xml-api/reference-headers#range
         """
         self._ensure_uninitialized()
         url = http_request.url
@@ -396,7 +396,7 @@ class Download(_Transfer):
             # otherwise we get the total of the file and the entire contents
             # are downloaded
             if range_bytes:
-                self._total_size = abs(end_byte - start_byte)
+                self._total_size = abs(end_byte - start_byte + 1)
             url = response.info.get('content-location', response.request_url)
         self._initialize(http, url)
         # Unless the user has requested otherwise, we want to just

--- a/core/google/cloud/streaming/transfer.py
+++ b/core/google/cloud/streaming/transfer.py
@@ -380,10 +380,8 @@ class Download(_Transfer):
         self._ensure_uninitialized()
         url = http_request.url
         if self.auto_transfer:
-            if range_bytes:
+            if range_bytes is not None:
                 start_byte, end_byte = range_bytes
-                start_byte = int(start_byte)
-                end_byte = int(end_byte)
             else:
                 start_byte = 0
                 end_byte = self._compute_end_byte(0)
@@ -397,7 +395,8 @@ class Download(_Transfer):
             # when using `range_bytes` we need to reset total_size,
             # otherwise we get the total of the file and the entire contents
             # are downloaded
-            if range_bytes: self._total_size = abs(end_byte - start_byte)
+            if range_bytes:
+                self._total_size = abs(end_byte - start_byte)
             url = response.info.get('content-location', response.request_url)
         self._initialize(http, url)
         # Unless the user has requested otherwise, we want to just

--- a/core/google/cloud/streaming/transfer.py
+++ b/core/google/cloud/streaming/transfer.py
@@ -359,7 +359,7 @@ class Download(_Transfer):
         if self.total_size is None:
             self._total_size = 0
 
-    def initialize_download(self, http_request, http):
+    def initialize_download(self, http_request, http, range_bytes):
         """Initialize this download.
 
         If the instance has :attr:`auto_transfer` enabled, begins the
@@ -370,18 +370,30 @@ class Download(_Transfer):
 
         :type http: :class:`httplib2.Http` (or workalike)
         :param http: Http instance for this request.
+
+        :type range_bytes: tuple
+        :param range_bytes: Optional. Range of bytes to download.
         """
         self._ensure_uninitialized()
         url = http_request.url
         if self.auto_transfer:
-            end_byte = self._compute_end_byte(0)
-            self._set_range_header(http_request, 0, end_byte)
+            if range_bytes:
+                start_byte, end_byte = range_bytes
+                end_byte = end_byte - 1
+            else:
+                start_byte = 0
+                end_byte = self._compute_end_byte(0)
+            self._set_range_header(http_request, start_byte, end_byte)
             response = make_api_request(
                 self.bytes_http or http, http_request)
             if response.status_code not in self._ACCEPTABLE_STATUSES:
                 raise HttpError.from_response(response)
             self._initial_response = response
             self._set_total(response.info)
+            # when using `range_bytes` we need to reset total_size
+            # otherwise we get the total of the file and the entire contents
+            # are downloaded
+            if range_bytes: self._total_size = abs(end_byte - start_byte + 1)
             url = response.info.get('content-location', response.request_url)
         self._initialize(http, url)
         # Unless the user has requested otherwise, we want to just

--- a/core/unit_tests/streaming/test_transfer.py
+++ b/core/unit_tests/streaming/test_transfer.py
@@ -291,6 +291,23 @@ class Test_Download(unittest.TestCase):
         self.assertIs(download.http, http)
         self.assertEqual(download.url, request.url)
 
+    def test_initialize_w_range_bytes(self):
+        from six.moves import http_client
+        from google.cloud._testing import _Monkey
+        from google.cloud.streaming import transfer as MUT
+        request = _Request()
+        http = object()
+        download = self._make_one(_Stream(), auto_transfer=True)
+
+        response = _makeResponse(http_client.OK)
+        requester = _MakeRequest(response)
+
+        with _Monkey(MUT, make_api_request=requester):
+            download.initialize_download(request, http, range_bytes=(1, 100))
+
+        self.assertEqual(download.total_size, 100)
+        self.assertEqual(request.headers['range'], 'bytes=1-100')
+
     def test_initialize_download_w_autotransfer_failing(self):
         from six.moves import http_client
         from google.cloud._testing import _Monkey

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -320,7 +320,7 @@ class Blob(_PropertyMixin):
                        to the ``client`` stored on the blob's bucket.
 
         :type range_bytes: tuple
-        :param range_bytes: Optional. Range of bytes to download.
+        :param range_bytes: (Optional). Range of bytes to download.
 
         :raises: :class:`google.cloud.exceptions.NotFound`
         """
@@ -361,7 +361,7 @@ class Blob(_PropertyMixin):
                        to the ``client`` stored on the blob's bucket.
 
         :type range_bytes: tuple
-        :param range_bytes: Optional. Range of bytes to download.
+        :param range_bytes: (Optional). Range of bytes to download.
 
 
         :raises: :class:`google.cloud.exceptions.NotFound`
@@ -382,7 +382,7 @@ class Blob(_PropertyMixin):
                        to the ``client`` stored on the blob's bucket.
 
         :type range_bytes: tuple
-        :param range_bytes: Optional. Range of bytes to download.
+        :param range_bytes: (Optional). Range of bytes to download.
 
         :rtype: bytes
         :returns: The data stored in this blob.

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -290,7 +290,7 @@ class Blob(_PropertyMixin):
         """
         return self.bucket.delete_blob(self.name, client=client)
 
-    def download_to_file(self, file_obj, client=None):
+    def download_to_file(self, file_obj, client=None, range_bytes=None):
         """Download the contents of this blob into a file-like object.
 
         .. note::
@@ -319,6 +319,9 @@ class Blob(_PropertyMixin):
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the blob's bucket.
 
+        :type range_bytes: tuple
+        :param range_bytes: Optional. Range of bytes to download.
+
         :raises: :class:`google.cloud.exceptions.NotFound`
         """
         client = self._require_client(client)
@@ -343,9 +346,10 @@ class Blob(_PropertyMixin):
         # build_api_url) are also defined on the Batch class, but we just
         # use the wrapped connection since it has all three (http,
         # API_BASE_URL and build_api_url).
-        download.initialize_download(request, client._base_connection.http)
+        download.initialize_download(request, client._base_connection.http,
+                                     range_bytes=range_bytes)
 
-    def download_to_filename(self, filename, client=None):
+    def download_to_filename(self, filename, client=None, range_bytes=None):
         """Download the contents of this blob into a named file.
 
         :type filename: str
@@ -356,15 +360,20 @@ class Blob(_PropertyMixin):
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the blob's bucket.
 
+        :type range_bytes: tuple
+        :param range_bytes: Optional. Range of bytes to download.
+
+
         :raises: :class:`google.cloud.exceptions.NotFound`
         """
         with open(filename, 'wb') as file_obj:
-            self.download_to_file(file_obj, client=client)
+            self.download_to_file(file_obj, client=client,
+                                  range_bytes=range_bytes)
 
         mtime = time.mktime(self.updated.timetuple())
         os.utime(file_obj.name, (mtime, mtime))
 
-    def download_as_string(self, client=None):
+    def download_as_string(self, client=None, range_bytes=None):
         """Download the contents of this blob as a string.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -372,12 +381,16 @@ class Blob(_PropertyMixin):
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the blob's bucket.
 
+        :type range_bytes: tuple
+        :param range_bytes: Optional. Range of bytes to download.
+
         :rtype: bytes
         :returns: The data stored in this blob.
         :raises: :class:`google.cloud.exceptions.NotFound`
         """
         string_buffer = BytesIO()
-        self.download_to_file(string_buffer, client=client)
+        self.download_to_file(string_buffer, client=client,
+                              range_bytes=range_bytes)
         return string_buffer.getvalue()
 
     @staticmethod

--- a/storage/unit_tests/test_blob.py
+++ b/storage/unit_tests/test_blob.py
@@ -478,7 +478,7 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 3
-        fetched = blob.download_as_string(range_bytes=(0, 3))
+        fetched = blob.download_as_string(range_bytes=(0, 2))
         self.assertEqual(fetched, b'abc')
 
     def test_upload_from_file_size_failure(self):

--- a/storage/unit_tests/test_blob.py
+++ b/storage/unit_tests/test_blob.py
@@ -478,7 +478,7 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         blob._CHUNK_SIZE_MULTIPLE = 1
         blob.chunk_size = 3
-        fetched = blob.download_as_string(range_bytes=(0,3))
+        fetched = blob.download_as_string(range_bytes=(0, 3))
         self.assertEqual(fetched, b'abc')
 
     def test_upload_from_file_size_failure(self):

--- a/storage/unit_tests/test_blob.py
+++ b/storage/unit_tests/test_blob.py
@@ -459,6 +459,28 @@ class Test_Blob(unittest.TestCase):
         fetched = blob.download_as_string()
         self.assertEqual(fetched, b'abcdef')
 
+    def test_download_range_bytes(self):
+        from six.moves.http_client import OK
+        from six.moves.http_client import PARTIAL_CONTENT
+        BLOB_NAME = 'blob-name'
+        chunk1_response = {'status': PARTIAL_CONTENT,
+                           'content-range': 'bytes 0-2/6'}
+        chunk2_response = {'status': OK,
+                           'content-range': 'bytes 3-5/6'}
+        connection = _Connection(
+            (chunk1_response, b'abc'),
+            (chunk2_response, b'def'),
+        )
+        client = _Client(connection)
+        bucket = _Bucket(client)
+        MEDIA_LINK = 'http://example.com/media/'
+        properties = {'mediaLink': MEDIA_LINK}
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
+        blob._CHUNK_SIZE_MULTIPLE = 1
+        blob.chunk_size = 3
+        fetched = blob.download_as_string(range_bytes=(0,3))
+        self.assertEqual(fetched, b'abc')
+
     def test_upload_from_file_size_failure(self):
         BLOB_NAME = 'blob-name'
         connection = _Connection()


### PR DESCRIPTION
PR attempts to resolve https://github.com/GoogleCloudPlatform/google-cloud-python/issues/2888.   Users should be able to easily download a range of bytes when working with storage blobs.  This PR tries to minimally inject a new kwarg: `range_bytes` in `download_as_string` and related downloading functions:

```python
# download the first 100 bytes
blob.download_as_string(range_bytes=(0,100))

# download the second 100 bytes
blob.download_as_string(range_bytes=(99,200))
```

cc @daspecster