### PR TITLE
Conform to expected wire format for struct query parameters.

### DIFF
--- a/bigquery/unit_tests/test__helpers.py
+++ b/bigquery/unit_tests/test__helpers.py
@@ -1174,7 +1174,7 @@ class Test_StructQueryParameter(unittest.TestCase):
         RESOURCE = {
             'name': 'foo',
             'parameterType': {
-                'type': 'STRUTCT',
+                'type': 'STRUCT',
                 'structTypes': [
                     {'name': 'bar', 'type': {'type': 'INT64'}},
                     {'name': 'baz', 'type': {'type': 'STRING'}},
@@ -1196,7 +1196,7 @@ class Test_StructQueryParameter(unittest.TestCase):
     def test_from_api_repr_wo_name(self):
         RESOURCE = {
             'parameterType': {
-                'type': 'STRUTCT',
+                'type': 'STRUCT',
                 'structTypes': [
                     {'name': 'bar', 'type': {'type': 'INT64'}},
                     {'name': 'baz', 'type': {'type': 'STRING'}},

--- a/bigquery/unit_tests/test__helpers.py
+++ b/bigquery/unit_tests/test__helpers.py
@@ -1082,6 +1082,7 @@ class Test_ArrayQueryParameter(unittest.TestCase):
     def test_from_api_repr_wo_name(self):
         RESOURCE = {
             'parameterType': {
+                'type': 'ARRAY',
                 'arrayType': 'INT64',
             },
             'parameterValue': {
@@ -1098,6 +1099,7 @@ class Test_ArrayQueryParameter(unittest.TestCase):
         EXPECTED = {
             'name': 'foo',
             'parameterType': {
+                'type': 'ARRAY',
                 'arrayType': 'INT64',
             },
             'parameterValue': {
@@ -1110,6 +1112,7 @@ class Test_ArrayQueryParameter(unittest.TestCase):
     def test_to_api_repr_wo_name(self):
         EXPECTED = {
             'parameterType': {
+                'type': 'ARRAY',
                 'arrayType': 'INT64',
             },
             'parameterValue': {
@@ -1123,6 +1126,7 @@ class Test_ArrayQueryParameter(unittest.TestCase):
     def test_to_api_repr_w_unknown_type(self):
         EXPECTED = {
             'parameterType': {
+                'type': 'ARRAY',
                 'arrayType': 'UNKNOWN',
             },
             'parameterValue': {
@@ -1170,13 +1174,17 @@ class Test_StructQueryParameter(unittest.TestCase):
         RESOURCE = {
             'name': 'foo',
             'parameterType': {
+                'type': 'STRUTCT',
                 'structTypes': [
-                    {'name': 'bar', 'type': 'INT64'},
-                    {'name': 'baz', 'type': 'STRING'},
+                    {'name': 'bar', 'type': {'type': 'INT64'}},
+                    {'name': 'baz', 'type': {'type': 'STRING'}},
                 ],
             },
             'parameterValue': {
-                'structValues': {'bar': 123, 'baz': 'abc'},
+                'structValues': {
+                    'bar': {'value': 123},
+                    'baz': {'value': 'abc'},
+                },
             },
         }
         klass = self._get_target_class()
@@ -1188,13 +1196,17 @@ class Test_StructQueryParameter(unittest.TestCase):
     def test_from_api_repr_wo_name(self):
         RESOURCE = {
             'parameterType': {
+                'type': 'STRUTCT',
                 'structTypes': [
-                    {'name': 'bar', 'type': 'INT64'},
-                    {'name': 'baz', 'type': 'STRING'},
+                    {'name': 'bar', 'type': {'type': 'INT64'}},
+                    {'name': 'baz', 'type': {'type': 'STRING'}},
                 ],
             },
             'parameterValue': {
-                'structValues': {'bar': 123, 'baz': 'abc'},
+                'structValues': {
+                    'bar': {'value': 123},
+                    'baz': {'value': 'abc'},
+                },
             },
         }
         klass = self._get_target_class()
@@ -1207,13 +1219,17 @@ class Test_StructQueryParameter(unittest.TestCase):
         EXPECTED = {
             'name': 'foo',
             'parameterType': {
+                'type': 'STRUCT',
                 'structTypes': [
-                    {'name': 'bar', 'type': 'INT64'},
-                    {'name': 'baz', 'type': 'STRING'},
+                    {'name': 'bar', 'type': {'type': 'INT64'}},
+                    {'name': 'baz', 'type': {'type': 'STRING'}},
                 ],
             },
             'parameterValue': {
-                'structValues': {'bar': '123', 'baz': 'abc'},
+                'structValues': {
+                    'bar': {'value': '123'},
+                    'baz': {'value': 'abc'},
+                },
             },
         }
         sub_1 = self._make_subparam('bar', 'INT64', 123)
@@ -1224,13 +1240,17 @@ class Test_StructQueryParameter(unittest.TestCase):
     def test_to_api_repr_wo_name(self):
         EXPECTED = {
             'parameterType': {
+                'type': 'STRUCT',
                 'structTypes': [
-                    {'name': 'bar', 'type': 'INT64'},
-                    {'name': 'baz', 'type': 'STRING'},
+                    {'name': 'bar', 'type': {'type': 'INT64'}},
+                    {'name': 'baz', 'type': {'type': 'STRING'}},
                 ],
             },
             'parameterValue': {
-                'structValues': {'bar': '123', 'baz': 'abc'},
+                'structValues': {
+                    'bar': {'value': '123'},
+                    'baz': {'value': 'abc'},
+                },
             },
         }
         sub_1 = self._make_subparam('bar', 'INT64', 123)

--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -483,11 +483,20 @@ class TestBigQuery(unittest.TestCase):
         import datetime
         from google.cloud._helpers import UTC
         from google.cloud.bigquery._helpers import ScalarQueryParameter
+        from google.cloud.bigquery._helpers import StructQueryParameter
         naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
         stamp = "%s %s" % (naive.date().isoformat(), naive.time().isoformat())
         zoned = naive.replace(tzinfo=UTC)
         zoned_param = ScalarQueryParameter(
             name='zoned', type_='TIMESTAMP', value=zoned)
+        question = 'What is the answer to life, the universe, and everything?'
+        question_param = ScalarQueryParameter(
+            name='question', type_='STRING', value=question)
+        answer = 42
+        answer_param = ScalarQueryParameter(
+            name='answer', type_='INT64', value=answer)
+        struct_param = StructQueryParameter(
+            'hitchhiker', question_param, answer_param)
         EXAMPLES = [
             {
                 'sql': 'SELECT 1',
@@ -560,6 +569,11 @@ class TestBigQuery(unittest.TestCase):
                 'sql': 'SELECT @zoned',
                 'expected': zoned,
                 'query_parameters': [zoned_param],
+            },
+            {
+                'sql': 'SELECT (@hitchhiker.question, @hitchhiker.answer)',
+                'expected': ({'_field_1': question, '_field_2': answer}),
+                'query_parameters': [struct_param],
             },
         ]
         for example in EXAMPLES:


### PR DESCRIPTION
Closes: #2887.

/cc @tswast 