### PR TITLE
Add a starter class for _gax.

### DIFF
--- a/vision/google/cloud/vision/_gax.py
+++ b/vision/google/cloud/vision/_gax.py
@@ -1,0 +1,25 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GAX Client for interacting with the Google Cloud Vision API."""
+
+
+class _GAPICVisionAPI(object):
+    """Vision API for interacting with the gRPC version of Vision.
+
+    :type client: :class:`~google.cloud.core.client.Client`
+    :param client: Instance of ``Client`` object.
+    """
+    def __init__(self, client=None):
+        raise NotImplementedError

--- a/vision/unit_tests/test__gax.py
+++ b/vision/unit_tests/test__gax.py
@@ -1,0 +1,29 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+
+class TestGAXClient(unittest.TestCase):
+    def _get_target_class(self):
+        from google.cloud.vision._gax import _GAPICVisionAPI
+        return _GAPICVisionAPI
+
+    def _make_one(self, *args, **kwargs):
+        return self._get_target_class()(*args, **kwargs)
+
+    def test_gax_not_implemented(self):
+        client = object()
+        with self.assertRaises(NotImplementedError):
+            self._make_one(client=client)

--- a/vision/unit_tests/test_client.py
+++ b/vision/unit_tests/test_client.py
@@ -55,6 +55,15 @@ class TestClient(unittest.TestCase):
         client._vision_api.annotate()
         api.annotate.assert_called_once_with()
 
+    def test_gax_not_implemented_from_client(self):
+        credentials = _make_credentials()
+        client = self._make_one(project=PROJECT, credentials=credentials,
+                                use_gax=None)
+        client._connection = _Connection()
+
+        with self.assertRaises(NotImplementedError):
+            client._vision_api()
+
     def test_face_annotation(self):
         from google.cloud.vision.feature import Feature, FeatureTypes
         from unit_tests._fixtures import FACE_DETECTION_RESPONSE


### PR DESCRIPTION
Towards #2753

TL;DR This PR just adds the beginning of the `_GAPICVisionAPI` class and `Client` branching.

I started just doing the straight up conversion but it got huge.
Then I tried just converting face annotations and that got huge.

So this is part 1 of many, hopefully small PRs to add this in.

There are a lot of classes that will need the `from_pb` added to them and also test splitting to support both since the JSON responses vary in the value names a lot from the proto responses.

So for starters this was the smallest chunk I could come up with. Next up I will be adding the `annotate` method which requires some interesting helpers to translate `Feature` and `Image`s.