### PR TITLE
Add Vision Image and Feature gRPC conversion helper functions.

### DIFF
--- a/vision/google/cloud/vision/_gax.py
+++ b/vision/google/cloud/vision/_gax.py
@@ -14,12 +14,55 @@
 
 """GAX Client for interacting with the Google Cloud Vision API."""
 
+from google.cloud.gapic.vision.v1 import image_annotator_client
+from google.cloud.grpc.vision.v1 import image_annotator_pb2
+
+from google.cloud._helpers import _to_bytes
+
 
 class _GAPICVisionAPI(object):
     """Vision API for interacting with the gRPC version of Vision.
 
-    :type client: :class:`~google.cloud.core.client.Client`
+    :type client: :class:`~google.cloud.vision.client.Client`
     :param client: Instance of ``Client`` object.
     """
     def __init__(self, client=None):
-        raise NotImplementedError
+        self._client = client
+        self._api = image_annotator_client.ImageAnnotatorClient()
+
+
+def _to_gapic_feature(feature):
+    """Helper function to convert a ``Feature`` to a gRPC ``Feature``.
+
+    :type feature: :class:`~google.cloud.vision.feature.Feature`
+    :param feature: Local ``Feature`` class to be converted to gRPC ``Feature``
+                    instance.
+
+    :rtype: :class:`~google.cloud.grpc.vision.v1.image_annotator_pb2.Feature`
+    :returns: gRPC ``Feature`` converted from
+              :class:`~google.cloud.vision.feature.Feature`.
+    """
+    return image_annotator_pb2.Feature(
+        type=getattr(image_annotator_pb2.Feature, feature.feature_type),
+        max_results=feature.max_results)
+
+
+def _to_gapic_image(image):
+    """Helper function to convert an ``Image`` to a gRPC ``Image``.
+
+    :type image: :class:`~google.cloud.vision.image.Image`
+    :param image: Local ``Image`` class to be converted to gRPC ``Image``.
+
+    :rtype: :class:`~google.cloud.grpc.vision.v1.image_annotator_pb2.Image`
+    :returns: gRPC ``Image`` converted from
+              :class:`~google.cloud.vision.image.Image`.
+    """
+    if image.content is not None:
+        return image_annotator_pb2.Image(content=_to_bytes(image.content))
+    if image.source is not None:
+        return image_annotator_pb2.Image(
+            source=image_annotator_pb2.ImageSource(
+                gcs_image_uri=image.source
+            ),
+        )
+    raise ValueError('No image content or source found.')

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -52,6 +52,7 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'enum34',
     'google-cloud-core >= 0.22.1, < 0.23dev',
+    'gapic-google-cloud-vision-v1 >= 0.14.0, < 0.15dev',
 ]
 
 setup(

--- a/vision/unit_tests/test_client.py
+++ b/vision/unit_tests/test_client.py
@@ -55,14 +55,25 @@ class TestClient(unittest.TestCase):
         client._vision_api.annotate()
         api.annotate.assert_called_once_with()
 
-    def test_gax_not_implemented_from_client(self):
+    def test_make_gax_client(self):
+        from google.cloud.vision._gax import _GAPICVisionAPI
+
         credentials = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=credentials,
                                 use_gax=None)
         client._connection = _Connection()
+        with mock.patch('google.cloud.vision.client._GAPICVisionAPI',
+                        spec=True):
+            self.assertIsInstance(client._vision_api, _GAPICVisionAPI)
 
-        with self.assertRaises(NotImplementedError):
-            client._vision_api()
+    def test_make_http_client(self):
+        from google.cloud.vision._http import _HTTPVisionAPI
+
+        credentials = _make_credentials()
+        client = self._make_one(project=PROJECT, credentials=credentials,
+                                use_gax=False)
+        client._connection = _Connection()
+        self.assertIsInstance(client._vision_api, _HTTPVisionAPI)
 
     def test_face_annotation(self):
         from google.cloud.vision.feature import Feature, FeatureTypes


### PR DESCRIPTION
Towards #2753 

This adds two helper functions to convert internal `Image` and `Feature` classes to gRPC versions of those classes to use when making GAPIC requests.