### PR TITLE
Only running 3.4 tests on PR builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 script:
   - python2.7 scripts/run_unit_tests.py
-  - python3.4 scripts/run_unit_tests.py
+  - if [[ "${TRAVIS_EVENT_TYPE}" != "pull_request" ]]; then python3.4 scripts/run_unit_tests.py; fi
   - python3.5 scripts/run_unit_tests.py
   - python scripts/run_unit_tests.py --tox-env cover
   - tox -e lint


### PR DESCRIPTION
It's worth noting that we are "one foot out the door" with Travis, so this change is just a temporary kludge to keep push builds from erroring out (due to timeout).

The "correct" long-term solution is:

-   run a nightly cron job which runs everything
-   run **everything** on "tag" builds
-   on all other non-PR builds, run a restricted set of tests based on the new changes added since the last build. It's worth noting that CircleCI makes these commits easy to access in the UI (unclear if easy in the VMs):

    ![screenshot from 2017-01-04 11-27-01](https://cloud.githubusercontent.com/assets/520669/21655935/d446f082-d270-11e6-91fe-779bc47e7fc0.png)
