### PR TITLE
Implementation of DB-API for BigQuery.

### DIFF
--- a/bigquery/google/cloud/bigquery/dbapi/__init__.py
+++ b/bigquery/google/cloud/bigquery/dbapi/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,12 +53,12 @@ from google.cloud.bigquery.dbapi.types import ROWID
 from google.cloud.bigquery.dbapi.types import STRING
 
 
-apilevel = "2.0"
+apilevel = '2.0'
 
 # Threads may share the module, but not connections.
 threadsafety = 1
 
-paramstyle = "pyformat"
+paramstyle = 'pyformat'
 
 __all__ = [
     'apilevel', 'threadsafety', 'paramstyle', 'connect', 'Connection',

--- a/bigquery/google/cloud/bigquery/dbapi/__init__.py
+++ b/bigquery/google/cloud/bigquery/dbapi/__init__.py
@@ -26,31 +26,31 @@ for Google BigQuery.
    or deprecation policy.
 """
 
-from google.cloud.bigquery.dbapi.connection import connect  # noqa
-from google.cloud.bigquery.dbapi.connection import Connection  # noqa
-from google.cloud.bigquery.dbapi.cursor import Cursor  # noqa
-from google.cloud.bigquery.dbapi.exceptions import Warning  # noqa
-from google.cloud.bigquery.dbapi.exceptions import Error  # noqa
-from google.cloud.bigquery.dbapi.exceptions import InterfaceError  # noqa
-from google.cloud.bigquery.dbapi.exceptions import DatabaseError  # noqa
-from google.cloud.bigquery.dbapi.exceptions import DataError  # noqa
-from google.cloud.bigquery.dbapi.exceptions import OperationalError  # noqa
-from google.cloud.bigquery.dbapi.exceptions import IntegrityError  # noqa
-from google.cloud.bigquery.dbapi.exceptions import InternalError  # noqa
-from google.cloud.bigquery.dbapi.exceptions import ProgrammingError  # noqa
-from google.cloud.bigquery.dbapi.exceptions import NotSupportedError  # noqa
-from google.cloud.bigquery.dbapi.types import Binary  # noqa
-from google.cloud.bigquery.dbapi.types import Date  # noqa
-from google.cloud.bigquery.dbapi.types import DateFromTicks  # noqa
-from google.cloud.bigquery.dbapi.types import Time  # noqa
-from google.cloud.bigquery.dbapi.types import TimeFromTicks  # noqa
-from google.cloud.bigquery.dbapi.types import Timestamp  # noqa
-from google.cloud.bigquery.dbapi.types import TimestampFromTicks  # noqa
-from google.cloud.bigquery.dbapi.types import BINARY  # noqa
-from google.cloud.bigquery.dbapi.types import DATETIME  # noqa
-from google.cloud.bigquery.dbapi.types import NUMBER  # noqa
-from google.cloud.bigquery.dbapi.types import ROWID  # noqa
-from google.cloud.bigquery.dbapi.types import STRING  # noqa
+from google.cloud.bigquery.dbapi.connection import connect
+from google.cloud.bigquery.dbapi.connection import Connection
+from google.cloud.bigquery.dbapi.cursor import Cursor
+from google.cloud.bigquery.dbapi.exceptions import Warning
+from google.cloud.bigquery.dbapi.exceptions import Error
+from google.cloud.bigquery.dbapi.exceptions import InterfaceError
+from google.cloud.bigquery.dbapi.exceptions import DatabaseError
+from google.cloud.bigquery.dbapi.exceptions import DataError
+from google.cloud.bigquery.dbapi.exceptions import OperationalError
+from google.cloud.bigquery.dbapi.exceptions import IntegrityError
+from google.cloud.bigquery.dbapi.exceptions import InternalError
+from google.cloud.bigquery.dbapi.exceptions import ProgrammingError
+from google.cloud.bigquery.dbapi.exceptions import NotSupportedError
+from google.cloud.bigquery.dbapi.types import Binary
+from google.cloud.bigquery.dbapi.types import Date
+from google.cloud.bigquery.dbapi.types import DateFromTicks
+from google.cloud.bigquery.dbapi.types import Time
+from google.cloud.bigquery.dbapi.types import TimeFromTicks
+from google.cloud.bigquery.dbapi.types import Timestamp
+from google.cloud.bigquery.dbapi.types import TimestampFromTicks
+from google.cloud.bigquery.dbapi.types import BINARY
+from google.cloud.bigquery.dbapi.types import DATETIME
+from google.cloud.bigquery.dbapi.types import NUMBER
+from google.cloud.bigquery.dbapi.types import ROWID
+from google.cloud.bigquery.dbapi.types import STRING
 
 
 apilevel = "2.0"
@@ -59,3 +59,12 @@ apilevel = "2.0"
 threadsafety = 1
 
 paramstyle = "pyformat"
+
+__all__ = [
+    'apilevel', 'threadsafety', 'paramstyle', 'connect', 'Connection',
+    'Cursor', 'Warning', 'Error', 'InterfaceError', 'DatabaseError',
+    'DataError', 'OperationalError', 'IntegrityError', 'InternalError',
+    'ProgrammingError', 'NotSupportedError', 'Binary', 'Date', 'DateFromTicks',
+    'Time', 'TimeFromTicks', 'Timestamp', 'TimestampFromTicks', 'BINARY',
+    'DATETIME', 'NUMBER', 'ROWID', 'STRING',
+]

--- a/bigquery/google/cloud/bigquery/dbapi/__init__.py
+++ b/bigquery/google/cloud/bigquery/dbapi/__init__.py
@@ -1,0 +1,61 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Google BigQuery implementation of the Database API Specification v2.0.
+
+This module implements the `Python Database API Specification v2.0 (DB-API)`_
+for Google BigQuery.
+
+.. _Python Database API Specification v2.0 (DB-API):
+   https://www.python.org/dev/peps/pep-0249/
+
+.. warning::
+   The ``dbapi`` module is **alpha**. The implementation is not complete. It
+   might be changed in backward-incompatible ways and is not subject to any SLA
+   or deprecation policy.
+"""
+
+from google.cloud.bigquery.dbapi.connection import connect  # noqa
+from google.cloud.bigquery.dbapi.connection import Connection  # noqa
+from google.cloud.bigquery.dbapi.cursor import Cursor  # noqa
+from google.cloud.bigquery.dbapi.exceptions import Warning  # noqa
+from google.cloud.bigquery.dbapi.exceptions import Error  # noqa
+from google.cloud.bigquery.dbapi.exceptions import InterfaceError  # noqa
+from google.cloud.bigquery.dbapi.exceptions import DatabaseError  # noqa
+from google.cloud.bigquery.dbapi.exceptions import DataError  # noqa
+from google.cloud.bigquery.dbapi.exceptions import OperationalError  # noqa
+from google.cloud.bigquery.dbapi.exceptions import IntegrityError  # noqa
+from google.cloud.bigquery.dbapi.exceptions import InternalError  # noqa
+from google.cloud.bigquery.dbapi.exceptions import ProgrammingError  # noqa
+from google.cloud.bigquery.dbapi.exceptions import NotSupportedError  # noqa
+from google.cloud.bigquery.dbapi.types import Binary  # noqa
+from google.cloud.bigquery.dbapi.types import Date  # noqa
+from google.cloud.bigquery.dbapi.types import DateFromTicks  # noqa
+from google.cloud.bigquery.dbapi.types import Time  # noqa
+from google.cloud.bigquery.dbapi.types import TimeFromTicks  # noqa
+from google.cloud.bigquery.dbapi.types import Timestamp  # noqa
+from google.cloud.bigquery.dbapi.types import TimestampFromTicks  # noqa
+from google.cloud.bigquery.dbapi.types import BINARY  # noqa
+from google.cloud.bigquery.dbapi.types import DATETIME  # noqa
+from google.cloud.bigquery.dbapi.types import NUMBER  # noqa
+from google.cloud.bigquery.dbapi.types import ROWID  # noqa
+from google.cloud.bigquery.dbapi.types import STRING  # noqa
+
+
+apilevel = "2.0"
+
+# Threads may share the module, but not connections.
+threadsafety = 1
+
+paramstyle = "pyformat"

--- a/bigquery/google/cloud/bigquery/dbapi/_helpers.py
+++ b/bigquery/google/cloud/bigquery/dbapi/_helpers.py
@@ -1,0 +1,138 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import collections
+import datetime
+import numbers
+import six
+import time
+
+from google.cloud import bigquery
+from google.cloud.bigquery.dbapi import exceptions
+
+
+def wait_for_job(job):
+    """Waits for a job to complete by polling until the state is `DONE`.
+
+    Raises a DatabaseError if the job fails.
+
+    :type: :class:`~google.cloud.bigquery.job._AsyncJob`
+    :param job: Wait for this job to finish.
+    """
+    while True:
+        job.reload()
+        if job.state == 'DONE':
+            if job.error_result:
+                # TODO: raise a more specific exception, based on the error.
+                # See: https://cloud.google.com/bigquery/troubleshooting-errors
+                raise exceptions.DatabaseError(job.errors)
+            return
+        time.sleep(1)
+
+
+def scalar_to_query_parameter(name=None, value=None):
+    """Convert a scalar value into a query parameter.
+
+    Note: the bytes type cannot be distinguished from a string in Python 2.
+
+    Raises a :class:`~ google.cloud.bigquery.dbapi.exceptions.ProgrammingError`
+    if the type cannot be determined.
+
+    For more information about BigQuery data types, see:
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
+
+    :type: str
+    :param name: Optional name of the query parameter.
+
+    :type: any
+    :param value: A scalar value to convert into a query parameter.
+
+    :rtype: :class:`~google.cloud.bigquery.ScalarQueryParameter`
+    """
+    parameter_type = None
+
+    if isinstance(value, bool):
+        parameter_type = 'BOOL'
+    elif isinstance(value, numbers.Integral):
+        parameter_type = 'INT64'
+    elif isinstance(value, numbers.Real):
+        parameter_type = 'FLOAT64'
+    elif isinstance(value, six.string_types):
+        parameter_type = 'STRING'
+    elif isinstance(value, bytes):
+        parameter_type = 'BYTES'
+    elif isinstance(value, datetime.datetime):
+        parameter_type = 'TIMESTAMP' if value.tzinfo else 'DATETIME'
+    elif isinstance(value, datetime.date):
+        parameter_type = 'DATE'
+    elif isinstance(value, datetime.time):
+        parameter_type = 'TIME'
+    else:
+        raise exceptions.ProgrammingError(
+            'encountered parameter {} with value {} of unexpected type'.format(
+                name, value))
+    return bigquery.ScalarQueryParameter(name, parameter_type, value)
+
+
+def to_query_parameters_list(parameters):
+    """Converts a list of parameter values into query parameters.
+
+    :type: list
+    :param parameters: List of query parameter values.
+
+    :rtype:
+        list of :class:`~google.cloud.bigquery._helpers.AbstractQueryParameter`
+    """
+    query_parameters = []
+
+    for value in parameters:
+        query_parameters.append(scalar_to_query_parameter(value=value))
+
+    return query_parameters
+
+
+def to_query_parameters_dict(parameters):
+    """Converts a dictionary of parameter values into query parameters.
+
+    :type: dict
+    :param parameters: Dictionary of query parameter values.
+
+    :rtype:
+        list of :class:`~google.cloud.bigquery._helpers.AbstractQueryParameter`
+    """
+    query_parameters = []
+
+    for name in parameters:
+        value = parameters[name]
+        query_parameters.append(scalar_to_query_parameter(name, value))
+
+    return query_parameters
+
+
+def to_query_parameters(parameters):
+    """Converts DB-API parameter values into query parameters.
+
+    :type: dict or list
+    :param parameters: Optional dictionary or list of query parameter values.
+
+    :rtype:
+        list of :class:`~google.cloud.bigquery._helpers.AbstractQueryParameter`
+    """
+    if parameters is None:
+        return []
+
+    if isinstance(parameters, collections.Mapping):
+        return to_query_parameters_dict(parameters)
+
+    return to_query_parameters_list(parameters)

--- a/bigquery/google/cloud/bigquery/dbapi/connection.py
+++ b/bigquery/google/cloud/bigquery/dbapi/connection.py
@@ -1,0 +1,56 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Connection for the Google BigQuery DB-API."""
+
+from google.cloud import bigquery
+from google.cloud.bigquery.dbapi import cursor
+
+
+class Connection(object):
+    """DB-API Connection to Google BigQuery.
+
+    :type: :class:`~google.cloud.bigquery.Client`
+    :param client: A client used to connect to BigQuery.
+    """
+    def __init__(self, client):
+        self._client = client
+
+    def close(self):
+        """No-op."""
+
+    def commit(self):
+        """No-op."""
+
+    def cursor(self):
+        """Return a new cursor object.
+
+        :rtype: :class:`~google.cloud.bigquery.dbapi.Cursor`
+        """
+        return cursor.Cursor(self)
+
+
+def connect(client=None):
+    """Construct a DB-API connection to Google BigQuery.
+
+    :type: :class:`~google.cloud.bigquery.Client`
+    :param client:
+        (Optional) A client used to connect to BigQuery. If not passed, a
+        client is created using default options inferred from the environment.
+
+    :rtype: :class:`~google.cloud.bigquery.dbapi.Connection`
+    """
+    if client is None:
+        client = bigquery.Client()
+    return Connection(client)

--- a/bigquery/google/cloud/bigquery/dbapi/connection.py
+++ b/bigquery/google/cloud/bigquery/dbapi/connection.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ from google.cloud.bigquery.dbapi import cursor
 class Connection(object):
     """DB-API Connection to Google BigQuery.
 
-    :type: :class:`~google.cloud.bigquery.Client`
+    :type client: :class:`~google.cloud.bigquery.Client`
     :param client: A client used to connect to BigQuery.
     """
     def __init__(self, client):
@@ -37,6 +37,7 @@ class Connection(object):
         """Return a new cursor object.
 
         :rtype: :class:`~google.cloud.bigquery.dbapi.Cursor`
+        :returns: A DB-API cursor that uses this connection.
         """
         return cursor.Cursor(self)
 
@@ -44,12 +45,13 @@ class Connection(object):
 def connect(client=None):
     """Construct a DB-API connection to Google BigQuery.
 
-    :type: :class:`~google.cloud.bigquery.Client`
+    :type client: :class:`~google.cloud.bigquery.Client`
     :param client:
         (Optional) A client used to connect to BigQuery. If not passed, a
         client is created using default options inferred from the environment.
 
     :rtype: :class:`~google.cloud.bigquery.dbapi.Connection`
+    :returns: A new DB-API connection to BigQuery.
     """
     if client is None:
         client = bigquery.Client()

--- a/bigquery/google/cloud/bigquery/dbapi/cursor.py
+++ b/bigquery/google/cloud/bigquery/dbapi/cursor.py
@@ -1,0 +1,261 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Cursor for the Google BigQuery DB-API."""
+
+import collections
+import uuid
+
+import six
+
+from google.cloud.bigquery.dbapi import _helpers
+from google.cloud.bigquery.dbapi import exceptions
+
+
+_ARRAYSIZE_DEFAULT = 20
+
+
+class Cursor(object):
+    """DB-API Cursor to Google BigQuery.
+
+    :type: :class:`~google.cloud.bigquery.dbapi.Connection`
+    :param connection: A DB-API connection to Google BigQuery.
+    """
+    def __init__(self, connection):
+        self.connection = connection
+        self.description = None
+        self.rowcount = -1
+        self.arraysize = None
+        self._query_data = None
+        self._page_token = None
+        self._has_fetched_all_rows = True
+
+    def close(self):
+        """No-op."""
+
+    def _set_description(self, schema):
+        """Set description from schema.
+
+        :type: list of :class:`~google.cloud.bigquery.schema.SchemaField`
+        """
+        if schema is None:
+            self.description = None
+            return
+
+        desc = []
+        for field in schema:
+            desc.append(tuple([
+                field.name,
+                field.field_type,
+                None,
+                None,
+                None,
+                None,
+                field.mode == 'NULLABLE']))
+        self.description = tuple(desc)
+
+    def _set_rowcount(self, query_results):
+        """Set the rowcount from query results.
+
+        Normally, this sets rowcount to the number of rows returned by the
+        query, but if it was a DML statement, it sets rowcount to the number
+        of modified rows.
+
+        :type: :class:`~google.cloud.bigquery.query.QueryResults`
+        :param query_results: results of a query
+        """
+        total_rows = 0
+        num_dml_affected_rows = query_results.num_dml_affected_rows
+
+        if (query_results.total_rows is not None
+                and query_results.total_rows > 0):
+            total_rows = query_results.total_rows
+        if num_dml_affected_rows is not None and num_dml_affected_rows > 0:
+            total_rows = num_dml_affected_rows
+        self.rowcount = total_rows
+
+    def _format_operation_list(self, operation, parameters):
+        """Formats parameters in operation in way BigQuery expects.
+
+        :type: str
+        :param operation: A Google BigQuery query string.
+
+        :type: list
+        :param parameters: List parameter values.
+        """
+        formatted_params = ['?' for _ in parameters]
+
+        try:
+            return operation % tuple(formatted_params)
+        except TypeError as ex:
+            raise exceptions.ProgrammingError(ex)
+
+    def _format_operation_dict(self, operation, parameters):
+        """Formats parameters in operation in way BigQuery expects.
+
+        :type: str
+        :param operation: A Google BigQuery query string.
+
+        :type: dict
+        :param parameters: Dictionary of parameter values.
+        """
+        formatted_params = {}
+        for name in parameters:
+            formatted_params[name] = '@{}'.format(name)
+
+        try:
+            return operation % formatted_params
+        except KeyError as ex:
+            raise exceptions.ProgrammingError(ex)
+
+    def _format_operation(self, operation, parameters=None):
+        """Formats parameters in operation in way BigQuery expects.
+
+        Raises a ProgrammingError if a parameter used in the operation is not
+        found in the parameters dictionary.
+
+        :type: str
+        :param operation: A Google BigQuery query string.
+
+        :type: dict or list
+        :param parameters: Optional parameter values.
+        """
+        if parameters is None:
+            return operation
+
+        if isinstance(parameters, collections.Mapping):
+            return self._format_operation_dict(operation, parameters)
+
+        return self._format_operation_list(operation, parameters)
+
+    def execute(self, operation, parameters=None):
+        """Prepare and execute a database operation.
+
+        :type: str
+        :param operation: A Google BigQuery query string.
+
+        :type: dict or list
+        :param parameters: Optional dictionary or sequence of parameter values.
+        """
+        self._query_results = None
+        self._page_token = None
+        self._has_fetched_all_rows = False
+        client = self.connection._client
+        job_id = str(uuid.uuid4())
+
+        # The DB-API uses the pyformat formatting, since the way BigQuery does
+        # query parameters was not one of the standard options. Convert both
+        # the query and the parameters to the format expected by the client
+        # libraries.
+        formatted_operation = self._format_operation(
+            operation, parameters=parameters)
+        query_parameters = _helpers.to_query_parameters(parameters)
+
+        query_job = client.run_async_query(
+            job_id,
+            formatted_operation,
+            query_parameters=query_parameters)
+        query_job.use_legacy_sql = False
+        query_job.begin()
+        _helpers.wait_for_job(query_job)
+        query_results = query_job.results()
+
+        # Force the iterator to run because the query_results doesn't
+        # have the total_rows populated. See:
+        # https://github.com/GoogleCloudPlatform/google-cloud-python/issues/3506
+        query_iterator = query_results.fetch_data()
+        try:
+            six.next(iter(query_iterator))
+        except StopIteration:
+            pass
+
+        self._query_data = iter(
+            query_results.fetch_data(max_results=self.arraysize))
+        self._set_rowcount(query_results)
+        self._set_description(query_results.schema)
+
+    def executemany(self, operation, seq_of_parameters):
+        """Prepare and execute a database operation multiple times.
+
+        :type: str
+        :param operation: A Google BigQuery query string.
+
+        :type: list
+        :param parameters: Sequence of many sets of parameter values.
+        """
+        for parameters in seq_of_parameters:
+            self.execute(operation, parameters)
+
+    def fetchone(self):
+        """Fetch a single row from the results of the last ``execute*()`` call.
+
+        :rtype: tuple
+        :returns:
+            A tuple representing a row or ``None`` if no more data is
+            available.
+        """
+        if self._query_data is None:
+            raise exceptions.InterfaceError(
+                'No query results: execute() must be called before fetch.')
+
+        try:
+            return six.next(self._query_data)
+        except StopIteration:
+            return None
+
+    def fetchmany(self, size=None):
+        """Fetch multiple results from the last ``execute*()`` call.
+
+        Note that the size parameter is not used for the request/response size.
+        Use ``arraysize()`` before calling ``execute()`` to set the batch size.
+
+        :type: int
+        :param size:
+            Optional maximum number of rows to return. Defaults to the
+            arraysize attribute.
+
+        :rtype: tuple
+        :returns: A list of rows.
+        """
+        if self._query_data is None:
+            raise exceptions.InterfaceError(
+                'No query results: execute() must be called before fetch.')
+        if size is None:
+            size = self.arraysize
+        if size is None:
+            size = _ARRAYSIZE_DEFAULT
+
+        rows = []
+        for row in self._query_data:
+            rows.append(row)
+            if len(rows) >= size:
+                break
+        return rows
+
+    def fetchall(self):
+        """Fetch all remaining results from the last ``execute*()`` call.
+
+        :rtype: list of tuples
+        :returns: A list of all the rows in the results.
+        """
+        if self._query_data is None:
+            raise exceptions.InterfaceError(
+                'No query results: execute() must be called before fetch.')
+        return [row for row in self._query_data]
+
+    def setinputsizes(self, sizes):
+        """No-op."""
+
+    def setoutputsize(self, size, column=None):
+        """No-op."""

--- a/bigquery/google/cloud/bigquery/dbapi/cursor.py
+++ b/bigquery/google/cloud/bigquery/dbapi/cursor.py
@@ -70,13 +70,13 @@ class Cursor(object):
 
         self.description = tuple([
             Column(
-                field.name,
-                field.field_type,
-                None,
-                None,
-                None,
-                None,
-                field.mode == 'NULLABLE')
+                name=field.name,
+                type_code=field.field_type,
+                display_size=None,
+                internal_size=None,
+                precision=None,
+                scale=None,
+                null_ok=field.mode == 'NULLABLE')
             for field in schema])
 
     def _set_rowcount(self, query_results):

--- a/bigquery/google/cloud/bigquery/dbapi/exceptions.py
+++ b/bigquery/google/cloud/bigquery/dbapi/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bigquery/google/cloud/bigquery/dbapi/exceptions.py
+++ b/bigquery/google/cloud/bigquery/dbapi/exceptions.py
@@ -1,0 +1,58 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Exceptions used in the Google BigQuery DB-API."""
+
+
+class Warning(Exception):
+    """Exception raised for important DB-API warnings."""
+
+
+class Error(Exception):
+    """Exception representing all non-warning DB-API errors."""
+
+
+class InterfaceError(Error):
+    """DB-API error related to the database interface."""
+
+
+class DatabaseError(Error):
+    """DB-API error related to the database."""
+
+
+class DataError(DatabaseError):
+    """DB-API error due to problems with the processed data."""
+
+
+class OperationalError(DatabaseError):
+    """DB-API error related to the database operation.
+
+    These errors are not necessarily under the control of the programmer.
+    """
+
+
+class IntegrityError(DatabaseError):
+    """DB-API error when integrity of the database is affected."""
+
+
+class InternalError(DatabaseError):
+    """DB-API error when the database encounters an internal error."""
+
+
+class ProgrammingError(DatabaseError):
+    """DB-API exception raised for programming errors."""
+
+
+class NotSupportedError(DatabaseError):
+    """DB-API error for operations not supported by the database or API."""

--- a/bigquery/google/cloud/bigquery/dbapi/types.py
+++ b/bigquery/google/cloud/bigquery/dbapi/types.py
@@ -14,15 +14,13 @@
 
 """Types used in the Google BigQuery DB-API.
 
-See `PEP 249`_ for details.
+See `PEP-249`_ for details.
 
-.. _`PEP 249`:
+.. _PEP-249:
     https://www.python.org/dev/peps/pep-0249/#type-objects-and-constructors
 """
 
 import datetime
-
-import six
 
 
 Date = datetime.date
@@ -30,7 +28,18 @@ Time = datetime.time
 Timestamp = datetime.datetime
 DateFromTicks = datetime.date.fromtimestamp
 TimestampFromTicks = datetime.datetime.fromtimestamp
-Binary = six.binary_type
+
+
+def Binary(string):
+    """Contruct a DB-API binary value.
+
+    :type string: str
+    :param string: A string to encode as a binary value.
+
+    :rtype: bytes
+    :returns: The UTF-8 encoded bytes representing the string.
+    """
+    return string.encode('utf-8')
 
 
 def TimeFromTicks(ticks, tz=None):
@@ -54,9 +63,9 @@ def TimeFromTicks(ticks, tz=None):
 class _DBAPITypeObject(object):
     """DB-API type object which compares equal to many different strings.
 
-    See `PEP 249`_ for details.
+    See `PEP-249`_ for details.
 
-    .. _`PEP 249`:
+    .. _PEP-249:
         https://www.python.org/dev/peps/pep-0249/#implementation-hints-for-module-authors
     """
 
@@ -64,9 +73,7 @@ class _DBAPITypeObject(object):
         self.values = values
 
     def __eq__(self, other):
-        if other in self.values:
-            return True
-        return False
+        return other in self.values
 
 
 STRING = 'STRING'

--- a/bigquery/google/cloud/bigquery/dbapi/types.py
+++ b/bigquery/google/cloud/bigquery/dbapi/types.py
@@ -1,0 +1,75 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Types used in the Google BigQuery DB-API.
+
+See `PEP 249`_ for details.
+
+.. _`PEP 249`:
+    https://www.python.org/dev/peps/pep-0249/#type-objects-and-constructors
+"""
+
+import datetime
+
+
+Date = datetime.date
+Time = datetime.time
+Timestamp = datetime.datetime
+DateFromTicks = datetime.date.fromtimestamp
+TimestampFromTicks = datetime.datetime.fromtimestamp
+Binary = bytes
+
+
+def TimeFromTicks(ticks, tz=None):
+    """Construct a DB-API time value from the given ticks value.
+
+    :type ticks: float
+    :param ticks:
+        a number of seconds since the epoch; see the documentation of the
+        standard Python time module for details.
+
+    :type tz: :class:`datetime.tzinfo`
+    :param tz: (Optional) time zone to use for conversion
+
+    :rtype: :class:`datetime.time`
+    :returns: time represented by ticks.
+    """
+    dt = datetime.datetime.fromtimestamp(ticks, tz=tz)
+    return dt.timetz()
+
+
+class _DBAPITypeObject(object):
+    """DB-API type object which compares equal to many different strings.
+
+    See `PEP 249`_ for details.
+
+    .. _`PEP 249`:
+        https://www.python.org/dev/peps/pep-0249/#implementation-hints-for-module-authors
+    """
+
+    def __init__(self, *values):
+        self.values = values
+
+    def __eq__(self, other):
+        if other in self.values:
+            return True
+        return False
+
+
+STRING = 'STRING'
+BINARY = _DBAPITypeObject('BYTES', 'RECORD', 'STRUCT')
+NUMBER = _DBAPITypeObject(
+    'INTEGER', 'INT64', 'FLOAT', 'FLOAT64', 'BOOLEAN', 'BOOL')
+DATETIME = _DBAPITypeObject('TIMESTAMP', 'DATE', 'TIME', 'DATETIME')
+ROWID = 'ROWID'

--- a/bigquery/google/cloud/bigquery/dbapi/types.py
+++ b/bigquery/google/cloud/bigquery/dbapi/types.py
@@ -22,13 +22,15 @@ See `PEP 249`_ for details.
 
 import datetime
 
+import six
+
 
 Date = datetime.date
 Time = datetime.time
 Timestamp = datetime.datetime
 DateFromTicks = datetime.date.fromtimestamp
 TimestampFromTicks = datetime.datetime.fromtimestamp
-Binary = bytes
+Binary = six.binary_type
 
 
 def TimeFromTicks(ticks, tz=None):

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -547,7 +547,7 @@ class TestBigQuery(unittest.TestCase):
         naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
         stamp = '%s %s' % (naive.date().isoformat(), naive.time().isoformat())
         zoned = naive.replace(tzinfo=UTC)
-        EXAMPLES = [
+        examples = [
             {
                 'sql': 'SELECT 1',
                 'expected': 1,
@@ -573,7 +573,7 @@ class TestBigQuery(unittest.TestCase):
                 'expected': zoned,
             },
         ]
-        for example in EXAMPLES:
+        for example in examples:
             query = Config.CLIENT.run_sync_query(example['sql'])
             query.use_legacy_sql = True
             query.run()
@@ -664,8 +664,8 @@ class TestBigQuery(unittest.TestCase):
         ]
 
     def test_sync_query_w_standard_sql_types(self):
-        EXAMPLES = self._generate_standard_sql_types_examples()
-        for example in EXAMPLES:
+        examples = self._generate_standard_sql_types_examples()
+        for example in examples:
             query = Config.CLIENT.run_sync_query(example['sql'])
             query.use_legacy_sql = False
             query.run()
@@ -674,8 +674,8 @@ class TestBigQuery(unittest.TestCase):
             self.assertEqual(query.rows[0][0], example['expected'])
 
     def test_dbapi_w_standard_sql_types(self):
-        EXAMPLES = self._generate_standard_sql_types_examples()
-        for example in EXAMPLES:
+        examples = self._generate_standard_sql_types_examples()
+        for example in examples:
             Config.CURSOR.execute(example['sql'])
             self.assertEqual(Config.CURSOR.rowcount, 1)
             row = Config.CURSOR.fetchone()
@@ -724,7 +724,7 @@ class TestBigQuery(unittest.TestCase):
     def test_sync_query_w_dml(self):
         dataset_name = _make_dataset_name('dml_tests')
         table_name = 'test_table'
-        self._load_table_for_dml([('Hello World',),], dataset_name, table_name)
+        self._load_table_for_dml([('Hello World',)], dataset_name, table_name)
 
         query = Config.CLIENT.run_sync_query(
             'UPDATE {}.{} '
@@ -739,7 +739,7 @@ class TestBigQuery(unittest.TestCase):
     def test_dbapi_w_dml(self):
         dataset_name = _make_dataset_name('dml_tests')
         table_name = 'test_table'
-        self._load_table_for_dml([('Hello World',),], dataset_name, table_name)
+        self._load_table_for_dml([('Hello World',)], dataset_name, table_name)
 
         Config.CURSOR.execute(
             'UPDATE {}.{} '
@@ -811,7 +811,7 @@ class TestBigQuery(unittest.TestCase):
             name='friends', array_type='STRING',
             values=[phred_name, bharney_name])
         with_friends_param = StructQueryParameter(None, friends_param)
-        EXAMPLES = [
+        examples = [
             {
                 'sql': 'SELECT @question',
                 'expected': question,
@@ -891,7 +891,7 @@ class TestBigQuery(unittest.TestCase):
                 'query_parameters': [with_friends_param],
             },
         ]
-        for example in EXAMPLES:
+        for example in examples:
             query = Config.CLIENT.run_sync_query(
                 example['sql'],
                 query_parameters=example['query_parameters'])
@@ -902,7 +902,7 @@ class TestBigQuery(unittest.TestCase):
             self.assertEqual(query.rows[0][0], example['expected'])
 
     def test_dbapi_w_query_parameters(self):
-        EXAMPLES = [
+        examples = [
             {
                 'sql': 'SELECT %(boolval)s',
                 'expected': True,
@@ -967,17 +967,19 @@ class TestBigQuery(unittest.TestCase):
             {
                 'sql': 'SELECT TIMESTAMP_TRUNC(%(zoned)s, MINUTE)',
                 'query_parameters': {
-                    'zoned': datetime.datetime(2012, 3, 4, 5, 6, 7, tzinfo=UTC),
+                    'zoned': datetime.datetime(
+                        2012, 3, 4, 5, 6, 7, tzinfo=UTC),
                 },
                 'expected': datetime.datetime(2012, 3, 4, 5, 6, 0, tzinfo=UTC),
             },
         ]
-        for example in EXAMPLES:
+        for example in examples:
             msg = 'sql: {} query_parameters: {}'.format(
                 example['sql'], example['query_parameters'])
 
             try:
-                Config.CURSOR.execute(example['sql'], example['query_parameters'])
+                Config.CURSOR.execute(
+                    example['sql'], example['query_parameters'])
             except dbapi.DatabaseError as ex:
                 raise dbapi.DatabaseError('{} {}'.format(ex, msg))
 

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -22,6 +22,7 @@ import unittest
 
 from google.cloud import bigquery
 from google.cloud._helpers import UTC
+from google.cloud.bigquery import dbapi
 from google.cloud.exceptions import Forbidden
 
 from test_utils.retry import RetryErrors
@@ -70,10 +71,12 @@ class Config(object):
     global state.
     """
     CLIENT = None
+    CURSOR = None
 
 
 def setUpModule():
     Config.CLIENT = bigquery.Client()
+    Config.CURSOR = dbapi.connect().cursor()
 
 
 class TestBigQuery(unittest.TestCase):
@@ -578,11 +581,11 @@ class TestBigQuery(unittest.TestCase):
             self.assertEqual(len(query.rows[0]), 1)
             self.assertEqual(query.rows[0][0], example['expected'])
 
-    def test_sync_query_w_standard_sql_types(self):
+    def _generate_standard_sql_types_examples(self):
         naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
         stamp = '%s %s' % (naive.date().isoformat(), naive.time().isoformat())
         zoned = naive.replace(tzinfo=UTC)
-        EXAMPLES = [
+        return [
             {
                 'sql': 'SELECT 1',
                 'expected': 1,
@@ -659,6 +662,9 @@ class TestBigQuery(unittest.TestCase):
                 'expected': [{u'_field_1': [1, 2]}],
             },
         ]
+
+    def test_sync_query_w_standard_sql_types(self):
+        EXAMPLES = self._generate_standard_sql_types_examples()
         for example in EXAMPLES:
             query = Config.CLIENT.run_sync_query(example['sql'])
             query.use_legacy_sql = False
@@ -666,6 +672,82 @@ class TestBigQuery(unittest.TestCase):
             self.assertEqual(len(query.rows), 1)
             self.assertEqual(len(query.rows[0]), 1)
             self.assertEqual(query.rows[0][0], example['expected'])
+
+    def test_dbapi_w_standard_sql_types(self):
+        EXAMPLES = self._generate_standard_sql_types_examples()
+        for example in EXAMPLES:
+            Config.CURSOR.execute(example['sql'])
+            self.assertEqual(Config.CURSOR.rowcount, 1)
+            row = Config.CURSOR.fetchone()
+            self.assertEqual(len(row), 1)
+            self.assertEqual(row[0], example['expected'])
+            row = Config.CURSOR.fetchone()
+            self.assertIsNone(row)
+
+    def _load_table_for_dml(self, rows, dataset_name, table_name):
+        import csv
+        from google.cloud._testing import _NamedTemporaryFile
+
+        dataset = Config.CLIENT.dataset(dataset_name)
+        retry_403(dataset.create)()
+        self.to_delete.append(dataset)
+
+        greeting = bigquery.SchemaField(
+            'greeting', 'STRING', mode='NULLABLE')
+        table = dataset.table(table_name, schema=[greeting])
+        table.create()
+        self.to_delete.insert(0, table)
+
+        with _NamedTemporaryFile() as temp:
+            with open(temp.name, 'w') as csv_write:
+                writer = csv.writer(csv_write)
+                writer.writerow(('Greeting'))
+                writer.writerows(rows)
+
+            with open(temp.name, 'rb') as csv_read:
+                job = table.upload_from_file(
+                    csv_read,
+                    source_format='CSV',
+                    skip_leading_rows=1,
+                    create_disposition='CREATE_NEVER',
+                    write_disposition='WRITE_EMPTY',
+                )
+
+        def _job_done(instance):
+            return instance.state.lower() == 'done'
+
+        # Retry until done.
+        retry = RetryInstanceState(_job_done, max_tries=8)
+        retry(job.reload)()
+        self._fetch_single_page(table)
+
+    def test_sync_query_w_dml(self):
+        dataset_name = _make_dataset_name('dml_tests')
+        table_name = 'test_table'
+        self._load_table_for_dml([('Hello World',),], dataset_name, table_name)
+
+        query = Config.CLIENT.run_sync_query(
+            'UPDATE {}.{} '
+            'SET greeting = \'Guten Tag\' '
+            'WHERE greeting = \'Hello World\''.format(
+                dataset_name, table_name))
+        query.use_legacy_sql = False
+        query.run()
+
+        self.assertEqual(query.num_dml_affected_rows, 1)
+
+    def test_dbapi_w_dml(self):
+        dataset_name = _make_dataset_name('dml_tests')
+        table_name = 'test_table'
+        self._load_table_for_dml([('Hello World',),], dataset_name, table_name)
+
+        Config.CURSOR.execute(
+            'UPDATE {}.{} '
+            'SET greeting = \'Guten Tag\' '
+            'WHERE greeting = \'Hello World\''.format(
+                dataset_name, table_name))
+        self.assertEqual(Config.CURSOR.rowcount, 1)
+        self.assertIsNone(Config.CURSOR.fetchone())
 
     def test_sync_query_w_query_params(self):
         from google.cloud.bigquery._helpers import ArrayQueryParameter
@@ -818,6 +900,93 @@ class TestBigQuery(unittest.TestCase):
             self.assertEqual(len(query.rows), 1)
             self.assertEqual(len(query.rows[0]), 1)
             self.assertEqual(query.rows[0][0], example['expected'])
+
+    def test_dbapi_w_query_parameters(self):
+        EXAMPLES = [
+            {
+                'sql': 'SELECT %(boolval)s',
+                'expected': True,
+                'query_parameters': {
+                    'boolval': True,
+                },
+            },
+            {
+                'sql': 'SELECT %s',
+                'expected': False,
+                'query_parameters': [False],
+            },
+            {
+                'sql': 'SELECT %(intval)s',
+                'expected': 123,
+                'query_parameters': {
+                    'intval': 123,
+                },
+            },
+            {
+                'sql': 'SELECT %s',
+                'expected': -123456789,
+                'query_parameters': [-123456789],
+            },
+            {
+                'sql': 'SELECT %(floatval)s',
+                'expected': 1.25,
+                'query_parameters': {
+                    'floatval': 1.25,
+                },
+            },
+            {
+                'sql': 'SELECT LOWER(%(strval)s)',
+                'query_parameters': {
+                    'strval': 'I Am A String',
+                },
+                'expected': 'i am a string',
+            },
+            {
+                'sql': 'SELECT DATE_SUB(%(dateval)s, INTERVAL 1 DAY)',
+                'query_parameters': {
+                    'dateval': datetime.date(2017, 4, 2),
+                },
+                'expected': datetime.date(2017, 4, 1),
+            },
+            {
+                'sql': 'SELECT TIME_ADD(%(timeval)s, INTERVAL 4 SECOND)',
+                'query_parameters': {
+                    'timeval': datetime.time(12, 34, 56),
+                },
+                'expected': datetime.time(12, 35, 0),
+            },
+            {
+                'sql': (
+                    'SELECT DATETIME_ADD(%(datetimeval)s, INTERVAL 53 SECOND)'
+                ),
+                'query_parameters': {
+                    'datetimeval': datetime.datetime(2012, 3, 4, 5, 6, 7),
+                },
+                'expected': datetime.datetime(2012, 3, 4, 5, 7, 0),
+            },
+            {
+                'sql': 'SELECT TIMESTAMP_TRUNC(%(zoned)s, MINUTE)',
+                'query_parameters': {
+                    'zoned': datetime.datetime(2012, 3, 4, 5, 6, 7, tzinfo=UTC),
+                },
+                'expected': datetime.datetime(2012, 3, 4, 5, 6, 0, tzinfo=UTC),
+            },
+        ]
+        for example in EXAMPLES:
+            msg = 'sql: {} query_parameters: {}'.format(
+                example['sql'], example['query_parameters'])
+
+            try:
+                Config.CURSOR.execute(example['sql'], example['query_parameters'])
+            except dbapi.DatabaseError as ex:
+                raise dbapi.DatabaseError('{} {}'.format(ex, msg))
+
+            self.assertEqual(Config.CURSOR.rowcount, 1, msg=msg)
+            row = Config.CURSOR.fetchone()
+            self.assertEqual(len(row), 1, msg=msg)
+            self.assertEqual(row[0], example['expected'], msg=msg)
+            row = Config.CURSOR.fetchone()
+            self.assertIsNone(row, msg=msg)
 
     def test_dump_table_w_public_data(self):
         PUBLIC = 'bigquery-public-data'

--- a/bigquery/tests/unit/test_dbapi__helpers.py
+++ b/bigquery/tests/unit/test_dbapi__helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bigquery/tests/unit/test_dbapi__helpers.py
+++ b/bigquery/tests/unit/test_dbapi__helpers.py
@@ -1,0 +1,146 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import datetime
+import math
+import unittest
+
+import mock
+import six
+
+import google.cloud._helpers
+from google.cloud.bigquery.dbapi import _helpers
+from google.cloud.bigquery.dbapi import exceptions
+
+
+class Test_wait_for_job(unittest.TestCase):
+
+    def _mock_job(self):
+        from google.cloud.bigquery import job
+        mock_job = mock.create_autospec(job.QueryJob)
+        mock_job.state = 'RUNNING'
+        mock_job._mocked_iterations = 0
+
+        def mock_reload():
+            mock_job._mocked_iterations += 1
+            if mock_job._mocked_iterations >= 2:
+                mock_job.state = 'DONE'
+
+        mock_job.reload.side_effect = mock_reload
+        return mock_job
+
+    def _call_fut(self, job):
+        from google.cloud.bigquery.dbapi._helpers import wait_for_job
+        wait_for_job(job)
+
+    def test_wo_error(self):
+        mock_job = self._mock_job()
+        mock_job.error_result = None
+        self._call_fut(mock_job)
+        self.assertEqual('DONE', mock_job.state)
+
+    def test_w_error(self):
+        from google.cloud.bigquery.dbapi import exceptions
+        mock_job = self._mock_job()
+        mock_job.error_result ={'reason': 'invalidQuery'}
+        self.assertRaises(exceptions.DatabaseError, self._call_fut, mock_job)
+        self.assertEqual('DONE', mock_job.state)
+
+
+class TestHelpers(unittest.TestCase):
+
+    def test_scalar_to_query_parameter(self):
+        expected_types = [
+            (True, 'BOOL'),
+            (False, 'BOOL'),
+            (123, 'INT64'),
+            (-123456789, 'INT64'),
+            (1.25, 'FLOAT64'),
+            ('I am a plain old string', 'STRING'),
+            (u'I am a unicode string', 'STRING'),
+            (datetime.date(2017, 4, 1), 'DATE'),
+            (datetime.time(12, 34, 56), 'TIME'),
+            (datetime.datetime(2012, 3, 4, 5, 6, 7), 'DATETIME'),
+            (
+                datetime.datetime(
+                    2012, 3, 4, 5, 6, 7, tzinfo=google.cloud._helpers.UTC),
+                'TIMESTAMP',
+            ),
+        ]
+        for value, expected_type in expected_types:
+            msg = 'value: {} expected_type: {}'.format(value, expected_type)
+            parameter = _helpers.scalar_to_query_parameter(None, value)
+            self.assertIsNone(parameter.name, msg=msg)
+            self.assertEqual(parameter.type_, expected_type, msg=msg)
+            self.assertEqual(parameter.value, value, msg=msg)
+            named_parameter = _helpers.scalar_to_query_parameter('myvar', value)
+            self.assertEqual(named_parameter.name, 'myvar', msg=msg)
+            self.assertEqual(named_parameter.type_, expected_type, msg=msg)
+            self.assertEqual(named_parameter.value, value, msg=msg)
+
+    @unittest.skipIf(six.PY2, 'Bytes cannot be distinguished from string.')
+    def test_scalar_to_query_parameter_w_bytes(self):
+        parameter = _helpers.scalar_to_query_parameter(
+            None, b'some-bytes-literal')
+        self.assertIsNone(parameter.name)
+        self.assertEqual(parameter.type_, 'BYTES')
+        self.assertEqual(parameter.value, b'some-bytes-literal')
+        named_parameter = _helpers.scalar_to_query_parameter(
+            'myvar', b'some-bytes-literal')
+        self.assertEqual(named_parameter.name, 'myvar')
+        self.assertEqual(named_parameter.type_, 'BYTES')
+        self.assertEqual(named_parameter.value, b'some-bytes-literal')
+
+    def test_scalar_to_query_parameter_w_unexpected_type(self):
+        with self.assertRaises(exceptions.ProgrammingError):
+            _helpers.scalar_to_query_parameter(value={'a': 'dictionary'})
+
+    def test_scalar_to_query_parameter_w_special_floats(self):
+        nan_parameter = _helpers.scalar_to_query_parameter(None, float('nan'))
+        self.assertTrue(math.isnan(nan_parameter.value))
+        self.assertEqual(nan_parameter.type_, 'FLOAT64')
+        inf_parameter = _helpers.scalar_to_query_parameter(None, float('inf'))
+        self.assertTrue(math.isinf(inf_parameter.value))
+        self.assertEqual(inf_parameter.type_, 'FLOAT64')
+
+    def test_to_query_parameters_w_dict(self):
+        parameters = {
+            'somebool': True,
+            'somestring': 'a-string-value',
+        }
+        query_parameters = _helpers.to_query_parameters(parameters)
+        query_parameter_tuples = []
+        for param in query_parameters:
+            query_parameter_tuples.append(
+                (param.name, param.type_, param.value))
+        self.assertSequenceEqual(
+            sorted(query_parameter_tuples),
+            sorted([
+                ('somebool', 'BOOL', True),
+                ('somestring', 'STRING', 'a-string-value'),
+            ]))
+
+    def test_to_query_parameters_w_list(self):
+        parameters = [True, 'a-string-value']
+        query_parameters = _helpers.to_query_parameters(parameters)
+        query_parameter_tuples = []
+        for param in query_parameters:
+            query_parameter_tuples.append(
+                (param.name, param.type_, param.value))
+        self.assertSequenceEqual(
+            sorted(query_parameter_tuples),
+            sorted([
+                (None, 'BOOL', True),
+                (None, 'STRING', 'a-string-value'),
+            ]))

--- a/bigquery/tests/unit/test_dbapi_connection.py
+++ b/bigquery/tests/unit/test_dbapi_connection.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bigquery/tests/unit/test_dbapi_connection.py
+++ b/bigquery/tests/unit/test_dbapi_connection.py
@@ -1,0 +1,73 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import unittest
+
+import mock
+
+
+class TestConnection(unittest.TestCase):
+
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.bigquery.dbapi import Connection
+        return Connection
+
+    def _make_one(self, *args, **kw):
+        return self._get_target_class()(*args, **kw)
+
+    def _mock_client(self, rows=None, schema=None):
+        from google.cloud.bigquery import client
+        mock_client = mock.create_autospec(client.Client)
+        return mock_client
+
+    def test_ctor(self):
+        from google.cloud.bigquery.dbapi import Connection
+        mock_client = self._mock_client()
+        connection = self._make_one(client=mock_client)
+        self.assertIsInstance(connection, Connection)
+        self.assertIs(connection._client, mock_client)
+
+    @mock.patch('google.cloud.bigquery.Client', autospec=True)
+    def test_connect_wo_client(self, mock_client):
+        from google.cloud.bigquery.dbapi import connect
+        from google.cloud.bigquery.dbapi import Connection
+        connection = connect()
+        self.assertIsInstance(connection, Connection)
+        self.assertIsNotNone(connection._client)
+
+    def test_connect_w_client(self):
+        from google.cloud.bigquery.dbapi import connect
+        from google.cloud.bigquery.dbapi import Connection
+        mock_client = self._mock_client()
+        connection = connect(client=mock_client)
+        self.assertIsInstance(connection, Connection)
+        self.assertIs(connection._client, mock_client)
+
+    def test_close(self):
+        connection = self._make_one(client=self._mock_client())
+        # close() is a no-op, there is nothing to test.
+        connection.close()
+
+    def test_commit(self):
+        connection = self._make_one(client=self._mock_client())
+        # commit() is a no-op, there is nothing to test.
+        connection.commit()
+
+    def test_cursor(self):
+        from google.cloud.bigquery.dbapi import Cursor
+        connection = self._make_one(client=self._mock_client())
+        cursor = connection.cursor()
+        self.assertIsInstance(cursor, Cursor)
+        self.assertIs(cursor.connection, connection)

--- a/bigquery/tests/unit/test_dbapi_cursor.py
+++ b/bigquery/tests/unit/test_dbapi_cursor.py
@@ -1,0 +1,278 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import unittest
+
+import mock
+
+
+class TestCursor(unittest.TestCase):
+
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.bigquery.dbapi import Cursor
+        return Cursor
+
+    def _make_one(self, *args, **kw):
+        return self._get_target_class()(*args, **kw)
+
+    def _mock_client(
+        self, rows=None, schema=None, num_dml_affected_rows=None):
+        from google.cloud.bigquery import client
+        mock_client = mock.create_autospec(client.Client)
+        mock_client.run_async_query.return_value = self._mock_job(
+            rows=rows, schema=schema,
+            num_dml_affected_rows=num_dml_affected_rows)
+        return mock_client
+
+    def _mock_job(
+        self, rows=None, schema=None, num_dml_affected_rows=None):
+        from google.cloud.bigquery import job
+        mock_job = mock.create_autospec(job.QueryJob)
+        mock_job.error_result = None
+        mock_job.state = 'DONE'
+        mock_job.results.return_value = self._mock_results(
+            rows=rows, schema=schema,
+            num_dml_affected_rows=num_dml_affected_rows)
+        return mock_job
+
+    def _mock_results(
+        self, rows=None, schema=None, num_dml_affected_rows=None):
+        from google.cloud.bigquery import query
+        mock_results = mock.create_autospec(query.QueryResults)
+        mock_results.schema = schema
+        mock_results.num_dml_affected_rows = num_dml_affected_rows
+
+        if rows is None:
+            mock_results.total_rows = 0
+        else:
+            mock_results.total_rows = len(rows)
+
+        mock_results.fetch_data.return_value = rows
+        return mock_results
+
+    def test_ctor(self):
+        from google.cloud.bigquery.dbapi import connect
+        from google.cloud.bigquery.dbapi import Cursor
+        connection = connect(self._mock_client())
+        cursor = self._make_one(connection)
+        self.assertIsInstance(cursor, Cursor)
+        self.assertIs(cursor.connection, connection)
+
+    def test_close(self):
+        from google.cloud.bigquery.dbapi import connect
+        from google.cloud.bigquery.dbapi import Cursor
+        connection = connect(self._mock_client())
+        cursor = connection.cursor()
+        # close() is a no-op, there is nothing to test.
+        cursor.close()
+
+    def test_fetchone_wo_execute_raises_error(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(self._mock_client())
+        cursor = connection.cursor()
+        self.assertRaises(dbapi.Error, cursor.fetchone)
+
+    def test_fetchone_w_row(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(
+            self._mock_client(rows=[(1,)]))
+        cursor = connection.cursor()
+        cursor.execute('SELECT 1;')
+        row = cursor.fetchone()
+        self.assertEquals(row, (1,))
+        self.assertIsNone(cursor.fetchone())
+
+    def test_fetchmany_wo_execute_raises_error(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(self._mock_client())
+        cursor = connection.cursor()
+        self.assertRaises(dbapi.Error, cursor.fetchmany)
+
+    def test_fetchmany_w_row(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(
+            self._mock_client(rows=[(1,)]))
+        cursor = connection.cursor()
+        cursor.execute('SELECT 1;')
+        rows = cursor.fetchmany()
+        self.assertEquals(len(rows), 1)
+        self.assertEquals(rows[0], (1,))
+
+    def test_fetchmany_w_size(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(
+            self._mock_client(
+                rows=[
+                    (1, 2, 3),
+                    (4, 5, 6),
+                    (7, 8, 9),
+                ]))
+        cursor = connection.cursor()
+        cursor.execute('SELECT a, b, c;')
+        rows = cursor.fetchmany(size=2)
+        self.assertEquals(len(rows), 2)
+        self.assertEquals(rows[0], (1, 2, 3))
+        self.assertEquals(rows[1], (4, 5, 6))
+        second_page = cursor.fetchmany(size=2)
+        self.assertEquals(len(second_page), 1)
+        self.assertEquals(second_page[0], (7, 8, 9))
+        third_page = cursor.fetchmany(size=2)
+        self.assertEquals(third_page, [])
+
+    def test_fetchmany_w_arraysize(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(
+            self._mock_client(
+                rows=[
+                    (1, 2, 3),
+                    (4, 5, 6),
+                    (7, 8, 9),
+                ]))
+        cursor = connection.cursor()
+        cursor.arraysize = 2
+        cursor.execute('SELECT a, b, c;')
+        rows = cursor.fetchmany()
+        self.assertEquals(len(rows), 2)
+        self.assertEquals(rows[0], (1, 2, 3))
+        self.assertEquals(rows[1], (4, 5, 6))
+        second_page = cursor.fetchmany()
+        self.assertEquals(len(second_page), 1)
+        self.assertEquals(second_page[0], (7, 8, 9))
+        third_page = cursor.fetchmany()
+        self.assertEquals(third_page, [])
+
+    def test_fetchall_wo_execute_raises_error(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(self._mock_client())
+        cursor = connection.cursor()
+        self.assertRaises(dbapi.Error, cursor.fetchall)
+
+    def test_fetchall_w_row(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(
+            self._mock_client(rows=[(1,)]))
+        cursor = connection.cursor()
+        cursor.execute('SELECT 1;')
+        self.assertIsNone(cursor.description)
+        self.assertEquals(cursor.rowcount, 1)
+        rows = cursor.fetchall()
+        self.assertEquals(len(rows), 1)
+        self.assertEquals(rows[0], (1,))
+
+    def test_execute_w_dml(self):
+        from google.cloud.bigquery.dbapi import connect
+        from google.cloud.bigquery.dbapi import Cursor
+        connection = connect(
+            self._mock_client(rows=[], num_dml_affected_rows=12))
+        cursor = connection.cursor()
+        cursor.execute('DELETE FROM UserSessions WHERE user_id = \'test\';')
+        self.assertIsNone(cursor.description)
+        self.assertEquals(cursor.rowcount, 12)
+
+    def test_execute_w_query(self):
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery import dbapi
+
+        connection = dbapi.connect(self._mock_client(
+            rows=[('hello', 'world', 1), ('howdy', 'y\'all', 2)],
+            schema=[
+                SchemaField('a', 'STRING', mode='NULLABLE'),
+                SchemaField('b', 'STRING', mode='REQUIRED'),
+                SchemaField('c', 'INTEGER', mode='NULLABLE')]))
+        cursor = connection.cursor()
+        cursor.execute('SELECT a, b, c FROM hello_world WHERE d > 3;')
+
+        # Verify the description.
+        self.assertEquals(len(cursor.description), 3)
+        a_name, a_type, _, _, _, _, a_null_ok = cursor.description[0]
+        self.assertEquals(a_name, 'a')
+        self.assertEquals(a_type, 'STRING')
+        self.assertEquals(a_type, dbapi.STRING)
+        self.assertTrue(a_null_ok)
+        b_name, b_type, _, _, _, _, b_null_ok = cursor.description[1]
+        self.assertEquals(b_name, 'b')
+        self.assertEquals(b_type, 'STRING')
+        self.assertEquals(b_type, dbapi.STRING)
+        self.assertFalse(b_null_ok)
+        c_name, c_type, _, _, _, _, c_null_ok = cursor.description[2]
+        self.assertEquals(c_name, 'c')
+        self.assertEquals(c_type, 'INTEGER')
+        self.assertEquals(c_type, dbapi.NUMBER)
+        self.assertTrue(c_null_ok)
+
+        # Verify the results.
+        self.assertEquals(cursor.rowcount, 2)
+        row = cursor.fetchone()
+        self.assertEquals(row, ('hello', 'world', 1))
+        row = cursor.fetchone()
+        self.assertEquals(row, ('howdy', 'y\'all', 2))
+        row = cursor.fetchone()
+        self.assertIsNone(row)
+
+    def test_executemany_w_dml(self):
+        from google.cloud.bigquery.dbapi import connect
+        from google.cloud.bigquery.dbapi import Cursor
+        connection = connect(
+            self._mock_client(rows=[], num_dml_affected_rows=12))
+        cursor = connection.cursor()
+        cursor.executemany(
+            'DELETE FROM UserSessions WHERE user_id = %s;',
+            (('test',), ('anothertest',)))
+        self.assertIsNone(cursor.description)
+        self.assertEquals(cursor.rowcount, 12)
+
+    def test__format_operation_w_dict(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(self._mock_client())
+        cursor = connection.cursor()
+        formatted_operation = cursor._format_operation(
+            'SELECT %(somevalue)s, %(othervalue)s;',
+            {
+                'somevalue': 'hi',
+                'othervalue': 'world',
+            })
+        self.assertEquals(
+            formatted_operation, 'SELECT @somevalue, @othervalue;')
+
+    def test__format_operation_w_wrong_dict(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(self._mock_client())
+        cursor = connection.cursor()
+        self.assertRaises(
+            dbapi.ProgrammingError,
+            cursor._format_operation,
+            'SELECT %(somevalue)s, %(othervalue)s;',
+            {
+                'somevalue-not-here': 'hi',
+                'othervalue': 'world',
+            })
+
+    def test__format_operation_w_sequence(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(self._mock_client())
+        cursor = connection.cursor()
+        formatted_operation = cursor._format_operation(
+            'SELECT %s, %s;', ('hello', 'world'))
+        self.assertEquals(formatted_operation, 'SELECT ?, ?;')
+
+    def test__format_operation_w_too_short_sequence(self):
+        from google.cloud.bigquery import dbapi
+        connection = dbapi.connect(self._mock_client())
+        cursor = connection.cursor()
+        self.assertRaises(
+            dbapi.ProgrammingError,
+            cursor._format_operation,
+            'SELECT %s, %s;',
+            ('hello',))

--- a/bigquery/tests/unit/test_dbapi_cursor.py
+++ b/bigquery/tests/unit/test_dbapi_cursor.py
@@ -28,7 +28,7 @@ class TestCursor(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def _mock_client(
-        self, rows=None, schema=None, num_dml_affected_rows=None):
+            self, rows=None, schema=None, num_dml_affected_rows=None):
         from google.cloud.bigquery import client
         mock_client = mock.create_autospec(client.Client)
         mock_client.run_async_query.return_value = self._mock_job(
@@ -37,7 +37,7 @@ class TestCursor(unittest.TestCase):
         return mock_client
 
     def _mock_job(
-        self, rows=None, schema=None, num_dml_affected_rows=None):
+            self, rows=None, schema=None, num_dml_affected_rows=None):
         from google.cloud.bigquery import job
         mock_job = mock.create_autospec(job.QueryJob)
         mock_job.error_result = None
@@ -48,7 +48,7 @@ class TestCursor(unittest.TestCase):
         return mock_job
 
     def _mock_results(
-        self, rows=None, schema=None, num_dml_affected_rows=None):
+            self, rows=None, schema=None, num_dml_affected_rows=None):
         from google.cloud.bigquery import query
         mock_results = mock.create_autospec(query.QueryResults)
         mock_results.schema = schema
@@ -72,7 +72,6 @@ class TestCursor(unittest.TestCase):
 
     def test_close(self):
         from google.cloud.bigquery.dbapi import connect
-        from google.cloud.bigquery.dbapi import Cursor
         connection = connect(self._mock_client())
         cursor = connection.cursor()
         # close() is a no-op, there is nothing to test.
@@ -173,7 +172,6 @@ class TestCursor(unittest.TestCase):
 
     def test_execute_w_dml(self):
         from google.cloud.bigquery.dbapi import connect
-        from google.cloud.bigquery.dbapi import Cursor
         connection = connect(
             self._mock_client(rows=[], num_dml_affected_rows=12))
         cursor = connection.cursor()
@@ -223,7 +221,6 @@ class TestCursor(unittest.TestCase):
 
     def test_executemany_w_dml(self):
         from google.cloud.bigquery.dbapi import connect
-        from google.cloud.bigquery.dbapi import Cursor
         connection = connect(
             self._mock_client(rows=[], num_dml_affected_rows=12))
         cursor = connection.cursor()

--- a/bigquery/tests/unit/test_dbapi_cursor.py
+++ b/bigquery/tests/unit/test_dbapi_cursor.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -231,22 +231,19 @@ class TestCursor(unittest.TestCase):
         self.assertEquals(cursor.rowcount, 12)
 
     def test__format_operation_w_dict(self):
-        from google.cloud.bigquery import dbapi
-        connection = dbapi.connect(self._mock_client())
-        cursor = connection.cursor()
+        from google.cloud.bigquery.dbapi import cursor
         formatted_operation = cursor._format_operation(
-            'SELECT %(somevalue)s, %(othervalue)s;',
+            'SELECT %(somevalue)s, %(a `weird` one)s;',
             {
                 'somevalue': 'hi',
-                'othervalue': 'world',
+                'a `weird` one': 'world',
             })
         self.assertEquals(
-            formatted_operation, 'SELECT @somevalue, @othervalue;')
+            formatted_operation, 'SELECT @`somevalue`, @`a \\`weird\\` one`;')
 
     def test__format_operation_w_wrong_dict(self):
         from google.cloud.bigquery import dbapi
-        connection = dbapi.connect(self._mock_client())
-        cursor = connection.cursor()
+        from google.cloud.bigquery.dbapi import cursor
         self.assertRaises(
             dbapi.ProgrammingError,
             cursor._format_operation,
@@ -257,17 +254,14 @@ class TestCursor(unittest.TestCase):
             })
 
     def test__format_operation_w_sequence(self):
-        from google.cloud.bigquery import dbapi
-        connection = dbapi.connect(self._mock_client())
-        cursor = connection.cursor()
+        from google.cloud.bigquery.dbapi import cursor
         formatted_operation = cursor._format_operation(
             'SELECT %s, %s;', ('hello', 'world'))
         self.assertEquals(formatted_operation, 'SELECT ?, ?;')
 
     def test__format_operation_w_too_short_sequence(self):
         from google.cloud.bigquery import dbapi
-        connection = dbapi.connect(self._mock_client())
-        cursor = connection.cursor()
+        from google.cloud.bigquery.dbapi import cursor
         self.assertRaises(
             dbapi.ProgrammingError,
             cursor._format_operation,

--- a/bigquery/tests/unit/test_dbapi_types.py
+++ b/bigquery/tests/unit/test_dbapi_types.py
@@ -1,0 +1,36 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import datetime
+import unittest
+
+import google.cloud._helpers
+from google.cloud.bigquery.dbapi import types
+
+
+class TestTypes(unittest.TestCase):
+    def test_binary_type(self):
+        self.assertEqual('BYTES', types.BINARY)
+        self.assertEqual('RECORD', types.BINARY)
+        self.assertEqual('STRUCT', types.BINARY)
+        self.assertNotEqual('STRING', types.BINARY)
+
+    def test_timefromticks(self):
+        somedatetime = datetime.datetime(
+            2017, 2, 18, 12, 47, 26, tzinfo=google.cloud._helpers.UTC)
+        epoch = datetime.datetime(1970, 1, 1, tzinfo=google.cloud._helpers.UTC)
+        ticks = (somedatetime - epoch).total_seconds()
+        self.assertEqual(
+            types.TimeFromTicks(ticks, google.cloud._helpers.UTC),
+            datetime.time(12, 47, 26, tzinfo=google.cloud._helpers.UTC))

--- a/bigquery/tests/unit/test_dbapi_types.py
+++ b/bigquery/tests/unit/test_dbapi_types.py
@@ -26,6 +26,10 @@ class TestTypes(unittest.TestCase):
         self.assertEqual('STRUCT', types.BINARY)
         self.assertNotEqual('STRING', types.BINARY)
 
+    def test_binary_constructor(self):
+        self.assertEqual(types.Binary(u'hello'), b'hello')
+        self.assertEqual(types.Binary(u'\u1f60'), u'\u1f60'.encode('utf-8'))
+
     def test_timefromticks(self):
         somedatetime = datetime.datetime(
             2017, 2, 18, 12, 47, 26, tzinfo=google.cloud._helpers.UTC)


### PR DESCRIPTION
Implements `Cursor.execute()` and `Cursor.fetchone()` without support
for query parameters.

Tested manually with a Jupyter notebook
```
# In[1]:
from google.cloud import bigquery
from google.cloud.bigquery import bqdb
connection = bqdb.connect()
cursor = connection.cursor()

# In[2]:
cursor.execute("SELECT (1 + 2) AS s;")

# In[3]:
cursor.fetchone()

# In[4]:
cursor.fetchone()

# In[5]:
cursor.description

# In[6]:
cursor.rowcount

# In[7]:
cursor.execute("DELETE FROM `swast-scratch.hello_world.hello` WHERE id = 1;")

# In[8]:
cursor.rowcount
```

Makes progress on https://github.com/GoogleCloudPlatform/google-cloud-python/issues/2434