### PR TITLE
Add storage.blob property time_created (timeCreated)

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -933,6 +933,21 @@ class Blob(_PropertyMixin):
             return _rfc3339_to_datetime(value)
 
     @property
+    def time_created(self):
+        """Retrieve the timestamp at which the object was created.
+
+        See: https://cloud.google.com/storage/docs/json_api/v1/objects
+
+        :rtype: :class:`datetime.datetime` or ``NoneType``
+        :returns: Datetime object parsed from RFC3339 valid timestamp, or
+                  ``None`` if the property is not set locally.
+        """
+        value = self._properties.get('timeCreated')
+        if value is not None:
+            return _rfc3339_to_datetime(value)
+
+
+    @property
     def updated(self):
         """Retrieve the timestamp at which the object was updated.
 

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -946,7 +946,6 @@ class Blob(_PropertyMixin):
         if value is not None:
             return _rfc3339_to_datetime(value)
 
-
     @property
     def updated(self):
         """Retrieve the timestamp at which the object was updated.

--- a/storage/unit_tests/test_blob.py
+++ b/storage/unit_tests/test_blob.py
@@ -1639,6 +1639,11 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.time_deleted, TIMESTAMP)
 
+    def test_time_deleted_unset(self):
+        BUCKET = object()
+        blob = self._make_one('blob-name', bucket=BUCKET)
+        self.assertIsNone(blob.time_deleted)
+
     def test_time_created(self):
         import datetime
         from google.cloud._helpers import _RFC3339_MICROS
@@ -1651,10 +1656,10 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.time_created, TIMESTAMP)
 
-    def test_time_deleted_unset(self):
+    def test_time_created_unset(self):
         BUCKET = object()
         blob = self._make_one('blob-name', bucket=BUCKET)
-        self.assertIsNone(blob.time_deleted)
+        self.assertIsNone(blob.time_created)
 
     def test_updated(self):
         import datetime

--- a/storage/unit_tests/test_blob.py
+++ b/storage/unit_tests/test_blob.py
@@ -1639,6 +1639,18 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.time_deleted, TIMESTAMP)
 
+    def test_time_created(self):
+        import datetime
+        from google.cloud._helpers import _RFC3339_MICROS
+        from google.cloud._helpers import UTC
+        BLOB_NAME = 'blob-name'
+        bucket = _Bucket()
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
+        TIME_CREATED = TIMESTAMP.strftime(_RFC3339_MICROS)
+        properties = {'timeCreated': TIME_CREATED}
+        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
+        self.assertEqual(blob.time_created, TIMESTAMP)
+
     def test_time_deleted_unset(self):
         BUCKET = object()
         blob = self._make_one('blob-name', bucket=BUCKET)


### PR DESCRIPTION
This is a super small PR which adds storage.blob property time_created (timeCreated) which I found myself needing recently. It's basically a copy paste of time_deleted. Unit test added.