### PR TITLE
Create exceptions (and bases) for RPC-only errors in core

### DIFF
--- a/core/google/cloud/exceptions.py
+++ b/core/google/cloud/exceptions.py
@@ -15,6 +15,7 @@
 """Custom exceptions for :mod:`google.cloud` package.
 
 See: https://cloud.google.com/storage/docs/json_api/v1/status-codes
+See: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 """
 
 # Avoid the grpc and google.cloud.grpc collision.
@@ -70,6 +71,11 @@ class GoogleCloudError(Exception):
         :returns: a list of mappings describing each error.
         """
         return [copy.deepcopy(error) for error in self._errors]
+
+
+class GoogleCloudRPCError(GoogleCloudError):
+    """Base error class for RPC errors that do not map directly to HTTP errors.
+    """
 
 
 class Redirection(GoogleCloudError):
@@ -181,8 +187,21 @@ class ServiceUnavailable(ServerError):
 
 
 class GatewayTimeout(ServerError):
-    """Excepption mapping a `504 Gateway Timeout'` response."""
+    """Exception mapping a '504 Gateway Timeout' response."""
     code = 504
+
+
+class RPCServerError(GoogleCloudRPCError):
+    """Base for 5xx-like RPC errors:  (abstract)"""
+
+
+class Unknown(RPCServerError):
+    """Exception mapping a '2 UNKNOWN' RPC error."""
+    code = 2
+
+
+class DataLoss(RPCServerError):
+    """Exception mapping a '15 DATA LOSS' RPC error."""
 
 
 def make_exception(response, content, error_info=None, use_json=True):
@@ -245,8 +264,11 @@ def _walk_subclasses(klass):
             yield subsub
 
 
-# Build the code->exception class mapping.
+# Build the HTTP code->exception class mapping, excluding RPC-only exceptions.
 for _eklass in _walk_subclasses(GoogleCloudError):
+    if issubclass(_eklass, GoogleCloudRPCError):
+        continue
+
     code = getattr(_eklass, 'code', None)
     if code is not None:
         _HTTP_CODE_TO_EXCEPTION[code] = _eklass

--- a/core/google/cloud/exceptions.py
+++ b/core/google/cloud/exceptions.py
@@ -202,6 +202,7 @@ class Unknown(RPCServerError):
 
 class DataLoss(RPCServerError):
     """Exception mapping a '15 DATA LOSS' RPC error."""
+    code = 15
 
 
 def make_exception(response, content, error_info=None, use_json=True):

--- a/core/unit_tests/test_exceptions.py
+++ b/core/unit_tests/test_exceptions.py
@@ -46,6 +46,13 @@ class Test_GoogleCloudError(unittest.TestCase):
         self.assertEqual(e.message, 'Testing')
         self.assertEqual(list(e.errors), [ERROR])
 
+    def test_rpc_only_errors_not_exported(self):
+        from google.cloud.exceptions import GoogleCloudRPCError
+        from google.cloud.exceptions import _HTTP_CODE_TO_EXCEPTION
+        http_exceptions = _HTTP_CODE_TO_EXCEPTION.values()
+        self.assertFalse(
+            any([issubclass(e, GoogleCloudRPCError) for e in http_exceptions]))
+
 
 class Test_make_exception(unittest.TestCase):
 

--- a/core/unit_tests/test_exceptions.py
+++ b/core/unit_tests/test_exceptions.py
@@ -49,6 +49,7 @@ class Test_GoogleCloudError(unittest.TestCase):
     def test_rpc_only_errors_not_exported(self):
         from google.cloud.exceptions import GoogleCloudRPCError
         from google.cloud.exceptions import _HTTP_CODE_TO_EXCEPTION
+
         http_exceptions = _HTTP_CODE_TO_EXCEPTION.values()
         self.assertFalse(
             any([issubclass(e, GoogleCloudRPCError) for e in http_exceptions]))


### PR DESCRIPTION
Several RPC exceptions that can be raised from a protobuf response map to the same HTTP status code, which creates some semantic overlap, as the [current strategy](https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/datastore/google/cloud/datastore/_http.py#L39) is to always map to an HTTP status code. An example of this is `DATA_LOSS` and `INTERNAL`, which are two different conditions as reported by the backend but are mapped to HTTP 500 (as per the [comments in the proto definition](https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto#L178)), but may have different operational semantics.

My intent in doing this is to address the issue in #2583 which is thus far unresolved and seems to be dead in the water. After establishing these new exception classes, it's a simple matter to [raise them when relevant](https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/datastore/google/cloud/datastore/_http.py#L39) rather than mashing multiple backend error codes onto a single exception as is currently implemented. As noted in #2583 this prevents the library user from appropriately handling some error conditions with retry logic.

Pending this, I'll follow up with a simple PR that raises the RPC-specific exceptions.

Note: I hemmed and hawed about re-using the `code` class attribute on these exceptions, because it is a reach IMO to extend the semantics of that from "HTTP status code" to "some protocol that has numeric status codes" but I decided it's alright in this case primarily because it keeps it simple and there's little danger of an additional 84 proto error codes being gobbled up (at which point you'd lose the invariant that `status code < 100 => RPC status code, not HTTP`).