### PR TITLE
Update import spacing in tests.

### DIFF
--- a/monitoring/unit_tests/test__dataframe.py
+++ b/monitoring/unit_tests/test__dataframe.py
@@ -55,6 +55,7 @@ ARRAY = [VALUES] * DIMENSIONS[0]
 def parse_timestamps():  # pragma: NO COVER
     import datetime
     from google.cloud._helpers import _RFC3339_MICROS
+
     return [datetime.datetime.strptime(t, _RFC3339_MICROS)
             for t in TIMESTAMPS]
 
@@ -88,6 +89,7 @@ class Test__build_dataframe(unittest.TestCase):  # pragma: NO COVER
 
     def _call_fut(self, *args, **kwargs):
         from google.cloud.monitoring._dataframe import _build_dataframe
+
         return _build_dataframe(*args, **kwargs)
 
     def test_both_label_and_labels_illegal(self):
@@ -209,6 +211,7 @@ class Test__sorted_resource_labels(unittest.TestCase):
 
     def _call_fut(self, labels):
         from google.cloud.monitoring._dataframe import _sorted_resource_labels
+
         return _sorted_resource_labels(labels)
 
     def test_empty(self):
@@ -216,11 +219,13 @@ class Test__sorted_resource_labels(unittest.TestCase):
 
     def test_sorted(self):
         from google.cloud.monitoring._dataframe import TOP_RESOURCE_LABELS
+
         EXPECTED = TOP_RESOURCE_LABELS + ('other-1', 'other-2')
         self.assertSequenceEqual(self._call_fut(EXPECTED), EXPECTED)
 
     def test_reversed(self):
         from google.cloud.monitoring._dataframe import TOP_RESOURCE_LABELS
+
         EXPECTED = TOP_RESOURCE_LABELS + ('other-1', 'other-2')
         INPUT = list(reversed(EXPECTED))
         self.assertSequenceEqual(self._call_fut(INPUT), EXPECTED)

--- a/monitoring/unit_tests/test_client.py
+++ b/monitoring/unit_tests/test_client.py
@@ -22,6 +22,7 @@ PROJECT = 'my-project'
 
 def _make_credentials():
     import google.auth.credentials
+
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 
@@ -30,6 +31,7 @@ class TestClient(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.client import Client
+
         return Client
 
     def _make_one(self, *args, **kwargs):
@@ -198,6 +200,7 @@ class TestClient(unittest.TestCase):
     def test_timeseries_factory_gauge(self):
         import datetime
         from google.cloud._helpers import _datetime_to_rfc3339
+
         METRIC_TYPE = 'custom.googleapis.com/my_metric'
         METRIC_LABELS = {
             'status': 'successful'
@@ -243,6 +246,7 @@ class TestClient(unittest.TestCase):
     def test_timeseries_factory_cumulative(self):
         import datetime
         from google.cloud._helpers import _datetime_to_rfc3339
+
         MY_CUMULATIVE_METRIC = 'custom.googleapis.com/my_cumulative_metric'
         METRIC_LABELS = {
             'status': 'successful'
@@ -615,6 +619,7 @@ class TestClient(unittest.TestCase):
 
     def test_write_point(self):
         import datetime
+
         PATH = '/projects/{project}/timeSeries/'.format(project=PROJECT)
         client = self._make_one(
             project=PROJECT, credentials=_make_credentials())
@@ -654,6 +659,7 @@ class _Connection(object):
 
     def api_request(self, **kwargs):
         from google.cloud.exceptions import NotFound
+
         self._requested.append(kwargs)
         try:
             return self._responses.pop(0)

--- a/monitoring/unit_tests/test_connection.py
+++ b/monitoring/unit_tests/test_connection.py
@@ -20,6 +20,7 @@ class TestConnection(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.connection import Connection
+
         return Connection
 
     def _make_one(self, *args, **kwargs):

--- a/monitoring/unit_tests/test_group.py
+++ b/monitoring/unit_tests/test_group.py
@@ -19,6 +19,7 @@ class Test_group_id_from_name(unittest.TestCase):
 
     def _call_fut(self, path, project):
         from google.cloud.monitoring.group import _group_id_from_name
+
         return _group_id_from_name(path, project)
 
     def test_w_empty_name(self):
@@ -87,6 +88,7 @@ class TestGroup(unittest.TestCase):
 
     def _setUpResources(self):
         from google.cloud.monitoring.resource import Resource
+
         info1 = {
             'type': 'gce_instance',
             'labels': {
@@ -110,6 +112,7 @@ class TestGroup(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.group import Group
+
         return Group
 
     def _make_one(self, *args, **kwargs):
@@ -534,6 +537,7 @@ class _Connection(object):
 
     def api_request(self, **kwargs):
         from google.cloud.exceptions import NotFound
+
         self._requested.append(kwargs)
         try:
             return self._responses.pop(0)

--- a/monitoring/unit_tests/test_label.py
+++ b/monitoring/unit_tests/test_label.py
@@ -20,6 +20,7 @@ class TestLabelValueType(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.label import LabelValueType
+
         return LabelValueType
 
     def test_one(self):
@@ -36,6 +37,7 @@ class TestLabelDescriptor(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.label import LabelDescriptor
+
         return LabelDescriptor
 
     def _make_one(self, *args, **kwargs):

--- a/monitoring/unit_tests/test_metric.py
+++ b/monitoring/unit_tests/test_metric.py
@@ -20,6 +20,7 @@ class TestMetricKind(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.metric import MetricKind
+
         return MetricKind
 
     def test_one(self):
@@ -36,6 +37,7 @@ class TestValueType(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.metric import ValueType
+
         return ValueType
 
     def test_one(self):
@@ -52,6 +54,7 @@ class TestMetricDescriptor(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.metric import MetricDescriptor
+
         return MetricDescriptor
 
     def _make_one(self, *args, **kwargs):
@@ -500,6 +503,7 @@ class TestMetric(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.metric import Metric
+
         return Metric
 
     def _make_one(self, *args, **kwargs):
@@ -555,6 +559,7 @@ class _Connection(object):
 
     def api_request(self, **kwargs):
         from google.cloud.exceptions import NotFound
+
         self._requested.append(kwargs)
         try:
             return self._responses.pop(0)

--- a/monitoring/unit_tests/test_query.py
+++ b/monitoring/unit_tests/test_query.py
@@ -46,6 +46,7 @@ class TestAligner(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.query import Aligner
+
         return Aligner
 
     def test_one(self):
@@ -62,6 +63,7 @@ class TestReducer(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.query import Reducer
+
         return Reducer
 
     def test_one(self):
@@ -79,6 +81,7 @@ class TestQuery(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.query import Query
+
         return Query
 
     def _make_one(self, *args, **kwargs):
@@ -87,6 +90,7 @@ class TestQuery(unittest.TestCase):
     @staticmethod
     def _make_timestamp(value):
         from google.cloud._helpers import _datetime_to_rfc3339
+
         return _datetime_to_rfc3339(value)
 
     def test_constructor_minimal(self):
@@ -149,6 +153,7 @@ class TestQuery(unittest.TestCase):
 
     def test_constructor_nonzero_duration_illegal(self):
         import datetime
+
         T1 = datetime.datetime(2016, 4, 7, 2, 30, 30)
         client = _Client(project=PROJECT, connection=_Connection())
         with self.assertRaises(ValueError):
@@ -506,6 +511,7 @@ class Test_Filter(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.query import _Filter
+
         return _Filter
 
     def _make_one(self, metric_type):
@@ -540,6 +546,7 @@ class Test__build_label_filter(unittest.TestCase):
 
     def _call_fut(self, *args, **kwargs):
         from google.cloud.monitoring.query import _build_label_filter
+
         return _build_label_filter(*args, **kwargs)
 
     def test_no_labels(self):
@@ -636,6 +643,7 @@ class _Connection(object):
 
     def api_request(self, **kwargs):
         from google.cloud.exceptions import NotFound
+
         self._requested.append(kwargs)
         try:
             return self._responses.pop(0)

--- a/monitoring/unit_tests/test_resource.py
+++ b/monitoring/unit_tests/test_resource.py
@@ -20,6 +20,7 @@ class TestResourceDescriptor(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.resource import ResourceDescriptor
+
         return ResourceDescriptor
 
     def _make_one(self, *args, **kwargs):
@@ -280,6 +281,7 @@ class TestResource(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.resource import Resource
+
         return Resource
 
     def _make_one(self, *args, **kwargs):
@@ -340,6 +342,7 @@ class _Connection(object):
 
     def api_request(self, **kwargs):
         from google.cloud.exceptions import NotFound
+
         self._requested.append(kwargs)
         try:
             return self._responses.pop(0)

--- a/monitoring/unit_tests/test_timeseries.py
+++ b/monitoring/unit_tests/test_timeseries.py
@@ -36,6 +36,7 @@ class TestTimeSeries(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.timeseries import TimeSeries
+
         return TimeSeries
 
     def _make_one(self, *args, **kwargs):
@@ -184,6 +185,7 @@ class TestPoint(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.monitoring.timeseries import Point
+
         return Point
 
     def _make_one(self, *args, **kwargs):
@@ -232,6 +234,7 @@ class TestPoint(unittest.TestCase):
     def test_to_dict_int64(self):
         import datetime
         from google.cloud._helpers import _datetime_to_rfc3339
+
         VALUE = 42
         end_time = datetime.datetime.now()
         end_time_str = _datetime_to_rfc3339(end_time, ignore_zone=False)
@@ -248,6 +251,7 @@ class TestPoint(unittest.TestCase):
     def test_to_dict_float_with_start_time(self):
         import datetime
         from google.cloud._helpers import _datetime_to_rfc3339
+
         VALUE = 1.6180339
         start_time = datetime.datetime.now()
         start_time_str = _datetime_to_rfc3339(start_time, ignore_zone=False)

--- a/pubsub/unit_tests/test__gax.py
+++ b/pubsub/unit_tests/test__gax.py
@@ -32,6 +32,7 @@ def _make_credentials():
     # pylint: disable=redefined-outer-name
     import google.auth.credentials
     # pylint: enable=redefined-outer-name
+
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 
@@ -55,6 +56,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub._gax import _PublisherAPI
+
         return _PublisherAPI
 
     def test_ctor(self):
@@ -137,6 +139,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
     def test_topic_create_already_exists(self):
         from google.cloud.exceptions import Conflict
+
         gax_api = _GAXPublisherAPI(_create_topic_conflict=True)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -150,6 +153,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
     def test_topic_create_error(self):
         from google.gax.errors import GaxError
+
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -176,6 +180,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
     def test_topic_get_miss(self):
         from google.cloud.exceptions import NotFound
+
         gax_api = _GAXPublisherAPI()
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -189,6 +194,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
     def test_topic_get_error(self):
         from google.gax.errors import GaxError
+
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -213,6 +219,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
     def test_topic_delete_miss(self):
         from google.cloud.exceptions import NotFound
+
         gax_api = _GAXPublisherAPI(_delete_topic_ok=False)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -226,6 +233,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
     def test_topic_delete_error(self):
         from google.gax.errors import GaxError
+
         gax_api = _GAXPublisherAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -239,6 +247,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
 
     def test_topic_publish_hit(self):
         import base64
+
         PAYLOAD = b'This is the message text'
         B64 = base64.b64encode(PAYLOAD).decode('ascii')
         MSGID = 'DEADBEEF'
@@ -261,6 +270,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_publish_miss_w_attrs_w_bytes_payload(self):
         import base64
         from google.cloud.exceptions import NotFound
+
         PAYLOAD = b'This is the message text'
         B64 = base64.b64encode(PAYLOAD)
         MESSAGE = {'data': B64, 'attributes': {'foo': 'bar'}}
@@ -281,6 +291,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
     def test_topic_publish_error(self):
         import base64
         from google.gax.errors import GaxError
+
         PAYLOAD = b'This is the message text'
         B64 = base64.b64encode(PAYLOAD).decode('ascii')
         MESSAGE = {'data': B64, 'attributes': {}}
@@ -539,6 +550,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_create_already_exists(self):
         from google.cloud.exceptions import Conflict
+
         DEADLINE = 600
         gax_api = _GAXSubscriberAPI(_create_subscription_conflict=True)
         client = _Client(self.PROJECT)
@@ -558,6 +570,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_create_error(self):
         from google.gax.errors import GaxError
+
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -600,6 +613,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_get_miss(self):
         from google.cloud.exceptions import NotFound
+
         gax_api = _GAXSubscriberAPI()
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -613,6 +627,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_get_error(self):
         from google.gax.errors import GaxError
+
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -637,6 +652,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_delete_miss(self):
         from google.cloud.exceptions import NotFound
+
         gax_api = _GAXSubscriberAPI(_delete_subscription_ok=False)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -650,6 +666,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_delete_error(self):
         from google.gax.errors import GaxError
+
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -675,6 +692,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_modify_push_config_miss(self):
         from google.cloud.exceptions import NotFound
+
         gax_api = _GAXSubscriberAPI()
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -690,6 +708,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_modify_push_config_error(self):
         from google.gax.errors import GaxError
+
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -744,6 +763,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_pull_defaults_miss(self):
         from google.cloud.exceptions import NotFound
+
         gax_api = _GAXSubscriberAPI()
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -760,6 +780,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_pull_defaults_error(self):
         from google.gax.errors import GaxError
+
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
         client = _Client(self.PROJECT)
         api = self._make_one(gax_api, client)
@@ -808,6 +829,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_acknowledge_miss(self):
         from google.cloud.exceptions import NotFound
+
         ACK_ID1 = 'DEADBEEF'
         ACK_ID2 = 'BEADCAFE'
         gax_api = _GAXSubscriberAPI()
@@ -824,6 +846,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_acknowledge_error(self):
         from google.gax.errors import GaxError
+
         ACK_ID1 = 'DEADBEEF'
         ACK_ID2 = 'BEADCAFE'
         gax_api = _GAXSubscriberAPI(_random_gax_error=True)
@@ -858,6 +881,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_modify_ack_deadline_miss(self):
         from google.cloud.exceptions import NotFound
+
         ACK_ID1 = 'DEADBEEF'
         ACK_ID2 = 'BEADCAFE'
         NEW_DEADLINE = 90
@@ -878,6 +902,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     def test_subscription_modify_ack_deadline_error(self):
         from google.gax.errors import GaxError
+
         ACK_ID1 = 'DEADBEEF'
         ACK_ID2 = 'BEADCAFE'
         NEW_DEADLINE = 90
@@ -902,6 +927,7 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
 
     def _call_fut(self, *args, **kwargs):
         from google.cloud.pubsub._gax import make_gax_publisher_api
+
         return make_gax_publisher_api(*args, **kwargs)
 
     def test_live_api(self):
@@ -968,6 +994,7 @@ class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
 
     def _call_fut(self, *args, **kwargs):
         from google.cloud.pubsub._gax import make_gax_subscriber_api
+
         return make_gax_subscriber_api(*args, **kwargs)
 
     def test_live_api(self):
@@ -1039,6 +1066,7 @@ class _GAXPublisherAPI(_GAXBaseAPI):
 
     def create_topic(self, name, options=None):
         from google.gax.errors import GaxError
+
         self._create_topic_called_with = name, options
         if self._random_gax_error:
             raise GaxError('error')
@@ -1048,6 +1076,7 @@ class _GAXPublisherAPI(_GAXBaseAPI):
 
     def get_topic(self, name, options=None):
         from google.gax.errors import GaxError
+
         self._get_topic_called_with = name, options
         if self._random_gax_error:
             raise GaxError('error')
@@ -1058,6 +1087,7 @@ class _GAXPublisherAPI(_GAXBaseAPI):
 
     def delete_topic(self, name, options=None):
         from google.gax.errors import GaxError
+
         self._delete_topic_called_with = name, options
         if self._random_gax_error:
             raise GaxError('error')
@@ -1066,6 +1096,7 @@ class _GAXPublisherAPI(_GAXBaseAPI):
 
     def publish(self, topic, messages, options=None):
         from google.gax.errors import GaxError
+
         self._publish_called_with = topic, messages, options
         if self._random_gax_error:
             raise GaxError('error')
@@ -1076,6 +1107,7 @@ class _GAXPublisherAPI(_GAXBaseAPI):
 
     def list_topic_subscriptions(self, topic, page_size, options=None):
         from google.gax.errors import GaxError
+
         self._list_topic_subscriptions_called_with = topic, page_size, options
         if self._random_gax_error:
             raise GaxError('error')
@@ -1101,6 +1133,7 @@ class _GAXSubscriberAPI(_GAXBaseAPI):
                             push_config, ack_deadline_seconds,
                             options=None):
         from google.gax.errors import GaxError
+
         self._create_subscription_called_with = (
             name, topic, push_config, ack_deadline_seconds, options)
         if self._random_gax_error:
@@ -1111,6 +1144,7 @@ class _GAXSubscriberAPI(_GAXBaseAPI):
 
     def get_subscription(self, name, options=None):
         from google.gax.errors import GaxError
+
         self._get_subscription_called_with = name, options
         if self._random_gax_error:
             raise GaxError('error')
@@ -1121,6 +1155,7 @@ class _GAXSubscriberAPI(_GAXBaseAPI):
 
     def delete_subscription(self, name, options=None):
         from google.gax.errors import GaxError
+
         self._delete_subscription_called_with = name, options
         if self._random_gax_error:
             raise GaxError('error')
@@ -1129,6 +1164,7 @@ class _GAXSubscriberAPI(_GAXBaseAPI):
 
     def modify_push_config(self, name, push_config, options=None):
         from google.gax.errors import GaxError
+
         self._modify_push_config_called_with = name, push_config, options
         if self._random_gax_error:
             raise GaxError('error')
@@ -1137,6 +1173,7 @@ class _GAXSubscriberAPI(_GAXBaseAPI):
 
     def pull(self, name, max_messages, return_immediately, options=None):
         from google.gax.errors import GaxError
+
         self._pull_called_with = (
             name, max_messages, return_immediately, options)
         if self._random_gax_error:
@@ -1151,6 +1188,7 @@ class _GAXSubscriberAPI(_GAXBaseAPI):
 
     def acknowledge(self, name, ack_ids, options=None):
         from google.gax.errors import GaxError
+
         self._acknowledge_called_with = name, ack_ids, options
         if self._random_gax_error:
             raise GaxError('error')
@@ -1159,6 +1197,7 @@ class _GAXSubscriberAPI(_GAXBaseAPI):
 
     def modify_ack_deadline(self, name, ack_ids, deadline, options=None):
         from google.gax.errors import GaxError
+
         self._modify_ack_deadline_called_with = (
             name, ack_ids, deadline, options)
         if self._random_gax_error:

--- a/pubsub/unit_tests/test__helpers.py
+++ b/pubsub/unit_tests/test__helpers.py
@@ -19,6 +19,7 @@ class Test_topic_name_from_path(unittest.TestCase):
 
     def _call_fut(self, path, project):
         from google.cloud.pubsub._helpers import topic_name_from_path
+
         return topic_name_from_path(path, project)
 
     def test_w_simple_name(self):
@@ -40,6 +41,7 @@ class Test_subscription_name_from_path(unittest.TestCase):
 
     def _call_fut(self, path, project):
         from google.cloud.pubsub._helpers import subscription_name_from_path
+
         return subscription_name_from_path(path, project)
 
     def test_w_simple_name(self):

--- a/pubsub/unit_tests/test__http.py
+++ b/pubsub/unit_tests/test__http.py
@@ -19,6 +19,7 @@ import mock
 
 def _make_credentials():
     import google.auth.credentials
+
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 
@@ -41,6 +42,7 @@ class TestConnection(_Base):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub._http import Connection
+
         return Connection
 
     def test_default_url(self):
@@ -73,6 +75,7 @@ class TestConnection(_Base):
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
+
         conn = self._make_one()
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
@@ -101,6 +104,7 @@ class Test_PublisherAPI(_Base):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub._http import _PublisherAPI
+
         return _PublisherAPI
 
     def _make_one(self, *args, **kw):
@@ -204,6 +208,7 @@ class Test_PublisherAPI(_Base):
 
     def test_topic_create_already_exists(self):
         from google.cloud.exceptions import Conflict
+
         connection = _Connection()
         connection._no_response_error = Conflict
         client = _Client(connection, self.PROJECT)
@@ -231,6 +236,7 @@ class Test_PublisherAPI(_Base):
 
     def test_topic_get_miss(self):
         from google.cloud.exceptions import NotFound
+
         connection = _Connection()
         client = _Client(connection, self.PROJECT)
         api = self._make_one(client)
@@ -256,6 +262,7 @@ class Test_PublisherAPI(_Base):
 
     def test_topic_delete_miss(self):
         from google.cloud.exceptions import NotFound
+
         connection = _Connection()
         client = _Client(connection, self.PROJECT)
         api = self._make_one(client)
@@ -269,6 +276,7 @@ class Test_PublisherAPI(_Base):
 
     def test_topic_publish_hit(self):
         import base64
+
         PAYLOAD = b'This is the message text'
         B64_PAYLOAD = base64.b64encode(PAYLOAD).decode('ascii')
         MSGID = 'DEADBEEF'
@@ -440,6 +448,7 @@ class Test_SubscriberAPI(_Base):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub._http import _SubscriberAPI
+
         return _SubscriberAPI
 
     def _make_one(self, *args, **kw):
@@ -645,6 +654,7 @@ class Test_SubscriberAPI(_Base):
 
     def test_subscription_pull_defaults(self):
         import base64
+
         PAYLOAD = b'This is the message text'
         B64 = base64.b64encode(PAYLOAD).decode('ascii')
         ACK_ID = 'DEADBEEF'
@@ -672,6 +682,7 @@ class Test_SubscriberAPI(_Base):
 
     def test_subscription_pull_explicit(self):
         import base64
+
         PAYLOAD = b'This is the message text'
         B64 = base64.b64encode(PAYLOAD).decode('ascii')
         ACK_ID = 'DEADBEEF'
@@ -743,6 +754,7 @@ class Test_IAMPolicyAPI(_Base):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub._http import _IAMPolicyAPI
+
         return _IAMPolicyAPI
 
     def test_ctor(self):
@@ -861,22 +873,26 @@ class Test_IAMPolicyAPI(_Base):
 class Test__transform_messages_base64_empty(unittest.TestCase):
     def _call_fut(self, messages, transform, key=None):
         from google.cloud.pubsub._http import _transform_messages_base64
+
         return _transform_messages_base64(messages, transform, key)
 
     def test__transform_messages_base64_empty_message(self):
         from base64 import b64decode
+
         DATA = [{'message': {}}]
         self._call_fut(DATA, b64decode, 'message')
         self.assertEqual(DATA, [{'message': {}}])
 
     def test__transform_messages_base64_empty_data(self):
         from base64 import b64decode
+
         DATA = [{'message': {'data': b''}}]
         self._call_fut(DATA, b64decode, 'message')
         self.assertEqual(DATA, [{'message': {'data': b''}}])
 
     def test__transform_messages_base64_pull(self):
         from base64 import b64encode
+
         DATA = [{'message': {'data': b'testing 1 2 3'}}]
         self._call_fut(DATA, b64encode, 'message')
         self.assertEqual(DATA[0]['message']['data'],
@@ -884,6 +900,7 @@ class Test__transform_messages_base64_empty(unittest.TestCase):
 
     def test__transform_messages_base64_publish(self):
         from base64 import b64encode
+
         DATA = [{'data': b'testing 1 2 3'}]
         self._call_fut(DATA, b64encode)
         self.assertEqual(DATA[0]['data'], b64encode(b'testing 1 2 3'))
@@ -899,6 +916,7 @@ class _Connection(object):
 
     def api_request(self, **kw):
         from google.cloud.exceptions import NotFound
+
         self._called_with = kw
         try:
             response, self._responses = self._responses[0], self._responses[1:]

--- a/pubsub/unit_tests/test_client.py
+++ b/pubsub/unit_tests/test_client.py
@@ -19,6 +19,7 @@ import mock
 
 def _make_credentials():
     import google.auth.credentials
+
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 
@@ -32,6 +33,7 @@ class TestClient(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub.client import Client
+
         return Client
 
     def _make_one(self, *args, **kw):
@@ -181,6 +183,7 @@ class TestClient(unittest.TestCase):
 
     def test_iam_policy_api(self):
         from google.cloud.pubsub._http import _IAMPolicyAPI
+
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds)
         conn = client._connection = _Connection()

--- a/pubsub/unit_tests/test_iam.py
+++ b/pubsub/unit_tests/test_iam.py
@@ -20,6 +20,7 @@ class TestPolicy(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub.iam import Policy
+
         return Policy
 
     def _make_one(self, *args, **kw):
@@ -99,6 +100,7 @@ class TestPolicy(unittest.TestCase):
             PUBSUB_PUBLISHER_ROLE,
             PUBSUB_SUBSCRIBER_ROLE,
         )
+
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         EDITOR1 = 'domain:google.com'
@@ -158,6 +160,7 @@ class TestPolicy(unittest.TestCase):
             PUBSUB_PUBLISHER_ROLE,
             PUBSUB_SUBSCRIBER_ROLE,
         )
+
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
         EDITOR1 = 'domain:google.com'

--- a/pubsub/unit_tests/test_message.py
+++ b/pubsub/unit_tests/test_message.py
@@ -20,6 +20,7 @@ class TestMessage(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub.message import Message
+
         return Message
 
     def _make_one(self, *args, **kw):
@@ -71,6 +72,7 @@ class TestMessage(unittest.TestCase):
         from datetime import datetime
         from google.cloud._helpers import _RFC3339_MICROS
         from google.cloud._helpers import UTC
+
         DATA = b'DEADBEEF'
         MESSAGE_ID = b'12345'
         TIMESTAMP = '2015-04-10T18:42:27.131956Z'

--- a/pubsub/unit_tests/test_subscription.py
+++ b/pubsub/unit_tests/test_subscription.py
@@ -29,6 +29,7 @@ class TestSubscription(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub.subscription import Subscription
+
         return Subscription
 
     def _make_one(self, *args, **kw):
@@ -72,6 +73,7 @@ class TestSubscription(unittest.TestCase):
 
     def test_from_api_repr_no_topics(self):
         from google.cloud.pubsub.topic import Topic
+
         resource = {'topic': self.TOPIC_PATH,
                     'name': self.SUB_PATH,
                     'ackDeadlineSeconds': self.DEADLINE,
@@ -103,6 +105,7 @@ class TestSubscription(unittest.TestCase):
 
     def test_from_api_repr_w_topics_no_topic_match(self):
         from google.cloud.pubsub.topic import Topic
+
         resource = {'topic': self.TOPIC_PATH,
                     'name': self.SUB_PATH,
                     'ackDeadlineSeconds': self.DEADLINE,
@@ -148,6 +151,7 @@ class TestSubscription(unittest.TestCase):
 
     def test_autoack_defaults(self):
         from google.cloud.pubsub.subscription import AutoAck
+
         client = _Client(project=self.PROJECT)
         topic = _Topic(self.TOPIC_NAME, client=client)
         subscription = self._make_one(self.SUB_NAME, topic)
@@ -160,6 +164,7 @@ class TestSubscription(unittest.TestCase):
 
     def test_autoack_explicit(self):
         from google.cloud.pubsub.subscription import AutoAck
+
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
         topic = _Topic(self.TOPIC_NAME, client=client1)
@@ -326,6 +331,7 @@ class TestSubscription(unittest.TestCase):
 
     def test_pull_wo_return_immediately_max_messages_w_bound_client(self):
         from google.cloud.pubsub.message import Message
+
         ACK_ID = 'DEADBEEF'
         MSG_ID = 'BEADCAFE'
         PAYLOAD = b'This is the message text'
@@ -351,6 +357,7 @@ class TestSubscription(unittest.TestCase):
 
     def test_pull_w_return_immediately_w_max_messages_w_alt_client(self):
         from google.cloud.pubsub.message import Message
+
         ACK_ID = 'DEADBEEF'
         MSG_ID = 'BEADCAFE'
         PAYLOAD = b'This is the message text'
@@ -457,6 +464,7 @@ class TestSubscription(unittest.TestCase):
             PUBSUB_PUBLISHER_ROLE,
             PUBSUB_SUBSCRIBER_ROLE,
         )
+
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         EDITOR1 = 'domain:google.com'
@@ -523,6 +531,7 @@ class TestSubscription(unittest.TestCase):
             PUBSUB_PUBLISHER_ROLE,
             PUBSUB_SUBSCRIBER_ROLE,
         )
+
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
         EDITOR1 = 'domain:google.com'
@@ -573,6 +582,7 @@ class TestSubscription(unittest.TestCase):
 
     def test_set_iam_policy_w_alternate_client(self):
         from google.cloud.pubsub.iam import Policy
+
         RESPONSE = {'etag': 'ACAB'}
         client1 = _Client(project=self.PROJECT)
         client2 = _Client(project=self.PROJECT)
@@ -639,6 +649,7 @@ class _FauxSubscribererAPI(object):
 
     def subscription_get(self, subscription_path):
         from google.cloud.exceptions import NotFound
+
         self._subscription_got = subscription_path
         try:
             return self._subscription_get_response
@@ -677,6 +688,7 @@ class TestAutoAck(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub.subscription import AutoAck
+
         return AutoAck
 
     def _make_one(self, *args, **kw):
@@ -792,6 +804,7 @@ class _Client(object):
 
     def topic(self, name, timestamp_messages=False):
         from google.cloud.pubsub.topic import Topic
+
         return Topic(name, client=self, timestamp_messages=timestamp_messages)
 
 

--- a/pubsub/unit_tests/test_topic.py
+++ b/pubsub/unit_tests/test_topic.py
@@ -19,6 +19,7 @@ import mock
 
 def _make_credentials():
     import google.auth.credentials
+
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 
@@ -30,6 +31,7 @@ class TestTopic(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub.topic import Topic
+
         return Topic
 
     def _make_one(self, *args, **kw):
@@ -306,6 +308,7 @@ class TestTopic(unittest.TestCase):
 
     def test_subscription(self):
         from google.cloud.pubsub.subscription import Subscription
+
         client = _Client(project=self.PROJECT)
         topic = self._make_one(self.TOPIC_NAME, client=client)
 
@@ -447,6 +450,7 @@ class TestTopic(unittest.TestCase):
             PUBSUB_PUBLISHER_ROLE,
             PUBSUB_SUBSCRIBER_ROLE,
         )
+
         OWNER1 = 'user:phred@example.com'
         OWNER2 = 'group:cloud-logs@google.com'
         EDITOR1 = 'domain:google.com'
@@ -513,6 +517,7 @@ class TestTopic(unittest.TestCase):
             PUBSUB_PUBLISHER_ROLE,
             PUBSUB_SUBSCRIBER_ROLE,
         )
+
         OWNER1 = 'group:cloud-logs@google.com'
         OWNER2 = 'user:phred@example.com'
         EDITOR1 = 'domain:google.com'
@@ -568,6 +573,7 @@ class TestTopic(unittest.TestCase):
 
     def test_set_iam_policy_w_alternate_client(self):
         from google.cloud.pubsub.iam import Policy
+
         RESPONSE = {'etag': 'ACAB'}
 
         client1 = _Client(project=self.PROJECT)
@@ -629,6 +635,7 @@ class TestBatch(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.pubsub.topic import Batch
+
         return Batch
 
     def _make_one(self, *args, **kwargs):
@@ -782,6 +789,7 @@ class _FauxPublisherAPI(object):
 
     def topic_get(self, topic_path):
         from google.cloud.exceptions import NotFound
+
         self._topic_got = topic_path
         try:
             return self._topic_get_response

--- a/runtimeconfig/unit_tests/test__helpers.py
+++ b/runtimeconfig/unit_tests/test__helpers.py
@@ -20,6 +20,7 @@ class Test_config_name_from_full_name(unittest.TestCase):
     def _call_fut(self, full_name):
         from google.cloud.runtimeconfig._helpers import (
             config_name_from_full_name)
+
         return config_name_from_full_name(full_name)
 
     def test_w_simple_name(self):
@@ -47,6 +48,7 @@ class Test_variable_name_from_full_name(unittest.TestCase):
     def _call_fut(self, full_name):
         from google.cloud.runtimeconfig._helpers import (
             variable_name_from_full_name)
+
         return variable_name_from_full_name(full_name)
 
     def test_w_simple_name(self):

--- a/runtimeconfig/unit_tests/test_client.py
+++ b/runtimeconfig/unit_tests/test_client.py
@@ -19,6 +19,7 @@ import mock
 
 def _make_credentials():
     import google.auth.credentials
+
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 
@@ -27,6 +28,7 @@ class TestClient(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.runtimeconfig.client import Client
+
         return Client
 
     def _make_one(self, *args, **kw):

--- a/runtimeconfig/unit_tests/test_config.py
+++ b/runtimeconfig/unit_tests/test_config.py
@@ -23,6 +23,7 @@ class TestConfig(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.runtimeconfig.config import Config
+
         return Config
 
     def _make_one(self, *args, **kw):
@@ -346,6 +347,7 @@ class _Connection(object):
 
     def api_request(self, **kw):
         from google.cloud.exceptions import NotFound
+
         self._requested.append(kw)
 
         try:

--- a/runtimeconfig/unit_tests/test_connection.py
+++ b/runtimeconfig/unit_tests/test_connection.py
@@ -20,6 +20,7 @@ class TestConnection(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.runtimeconfig.connection import Connection
+
         return Connection
 
     def _make_one(self, *args, **kw):

--- a/runtimeconfig/unit_tests/test_variable.py
+++ b/runtimeconfig/unit_tests/test_variable.py
@@ -25,6 +25,7 @@ class TestVariable(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.runtimeconfig.variable import Variable
+
         return Variable
 
     def _make_one(self, *args, **kw):

--- a/speech/unit_tests/test__gax.py
+++ b/speech/unit_tests/test__gax.py
@@ -24,6 +24,7 @@ class TestSpeechGAXMakeRequests(unittest.TestCase):
                   profanity_filter, speech_context, single_utterance,
                   interim_results):
         from google.cloud.speech._gax import _make_streaming_request
+
         return _make_streaming_request(sample=sample,
                                        language_code=language_code,
                                        max_alternatives=max_alternatives,
@@ -89,6 +90,7 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
                   profanity_filter, speech_context, single_utterance,
                   interim_results):
         from google.cloud.speech._gax import _stream_requests
+
         return _stream_requests(sample=sample,
                                 language_code=language_code,
                                 max_alternatives=max_alternatives,

--- a/speech/unit_tests/test_alternative.py
+++ b/speech/unit_tests/test_alternative.py
@@ -20,6 +20,7 @@ class TestAlternative(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.speech.alternative import Alternative
+
         return Alternative
 
     def _make_one(self, *args, **kwargs):

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -19,6 +19,7 @@ import mock
 
 def _make_credentials():
     import google.auth.credentials
+
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 

--- a/speech/unit_tests/test_connection.py
+++ b/speech/unit_tests/test_connection.py
@@ -20,6 +20,7 @@ class TestConnection(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.speech.connection import Connection
+
         return Connection
 
     def _make_one(self, *args, **kw):

--- a/speech/unit_tests/test_operation.py
+++ b/speech/unit_tests/test_operation.py
@@ -22,6 +22,7 @@ class TestOperation(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.speech.operation import Operation
+
         return Operation
 
     def _make_one(self, *args, **kwargs):

--- a/speech/unit_tests/test_sample.py
+++ b/speech/unit_tests/test_sample.py
@@ -22,6 +22,7 @@ class TestSample(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.speech.sample import Sample
+
         return Sample
 
     def _make_one(self, *args, **kw):

--- a/storage/unit_tests/test__helpers.py
+++ b/storage/unit_tests/test__helpers.py
@@ -20,6 +20,7 @@ class Test_PropertyMixin(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.storage._helpers import _PropertyMixin
+
         return _PropertyMixin
 
     def _make_one(self, *args, **kw):
@@ -99,6 +100,7 @@ class Test__scalar_property(unittest.TestCase):
 
     def _call_fut(self, fieldName):
         from google.cloud.storage._helpers import _scalar_property
+
         return _scalar_property(fieldName)
 
     def test_getter(self):
@@ -127,10 +129,12 @@ class Test__base64_md5hash(unittest.TestCase):
 
     def _call_fut(self, bytes_to_sign):
         from google.cloud.storage._helpers import _base64_md5hash
+
         return _base64_md5hash(bytes_to_sign)
 
     def test_it(self):
         from io import BytesIO
+
         BYTES_TO_SIGN = b'FOO'
         BUFFER = BytesIO()
         BUFFER.write(BYTES_TO_SIGN)

--- a/storage/unit_tests/test__http.py
+++ b/storage/unit_tests/test__http.py
@@ -20,6 +20,7 @@ class TestConnection(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.storage._http import Connection
+
         return Connection
 
     def _make_one(self, *args, **kw):
@@ -38,6 +39,7 @@ class TestConnection(unittest.TestCase):
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
+
         conn = self._make_one()
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)

--- a/storage/unit_tests/test_acl.py
+++ b/storage/unit_tests/test_acl.py
@@ -20,6 +20,7 @@ class Test_ACLEntity(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.storage.acl import _ACLEntity
+
         return _ACLEntity
 
     def _make_one(self, *args, **kw):
@@ -130,6 +131,7 @@ class Test_ACL(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.storage.acl import ACL
+
         return ACL
 
     def _make_one(self, *args, **kw):
@@ -270,6 +272,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_has_entity_miss_entity(self):
         from google.cloud.storage.acl import _ACLEntity
+
         TYPE = 'type'
         ID = 'id'
         entity = _ACLEntity(TYPE, ID)
@@ -310,6 +313,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_get_entity_miss_entity_no_default(self):
         from google.cloud.storage.acl import _ACLEntity
+
         TYPE = 'type'
         ID = 'id'
         entity = _ACLEntity(TYPE, ID)
@@ -325,6 +329,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_get_entity_miss_entity_w_default(self):
         from google.cloud.storage.acl import _ACLEntity
+
         DEFAULT = object()
         TYPE = 'type'
         ID = 'id'
@@ -351,6 +356,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_add_entity_miss_eager(self):
         from google.cloud.storage.acl import _ACLEntity
+
         TYPE = 'type'
         ID = 'id'
         ROLE = 'role'
@@ -366,6 +372,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_add_entity_miss_lazy(self):
         from google.cloud.storage.acl import _ACLEntity
+
         TYPE = 'type'
         ID = 'id'
         ROLE = 'role'
@@ -386,6 +393,7 @@ class Test_ACL(unittest.TestCase):
 
     def test_add_entity_hit(self):
         from google.cloud.storage.acl import _ACLEntity
+
         TYPE = 'type'
         ID = 'id'
         ENTITY_VAL = '%s-%s' % (TYPE, ID)
@@ -715,6 +723,7 @@ class Test_BucketACL(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.storage.acl import BucketACL
+
         return BucketACL
 
     def _make_one(self, *args, **kw):
@@ -736,6 +745,7 @@ class Test_DefaultObjectACL(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.storage.acl import DefaultObjectACL
+
         return DefaultObjectACL
 
     def _make_one(self, *args, **kw):
@@ -757,6 +767,7 @@ class Test_ObjectACL(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.storage.acl import ObjectACL
+
         return ObjectACL
 
     def _make_one(self, *args, **kw):

--- a/storage/unit_tests/test_batch.py
+++ b/storage/unit_tests/test_batch.py
@@ -19,6 +19,7 @@ import mock
 
 def _make_credentials():
     import google.auth.credentials
+
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 
@@ -27,6 +28,7 @@ class TestMIMEApplicationHTTP(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.storage.batch import MIMEApplicationHTTP
+
         return MIMEApplicationHTTP
 
     def _make_one(self, *args, **kw):
@@ -79,6 +81,7 @@ class TestBatch(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.storage.batch import Batch
+
         return Batch
 
     def _make_one(self, *args, **kw):
@@ -95,6 +98,7 @@ class TestBatch(unittest.TestCase):
 
     def test_current(self):
         from google.cloud.storage.client import Client
+
         project = 'PROJECT'
         credentials = _make_credentials()
         client = Client(project=project, credentials=credentials)
@@ -110,6 +114,7 @@ class TestBatch(unittest.TestCase):
 
     def test__make_request_GET_normal(self):
         from google.cloud.storage.batch import _FutureDict
+
         URL = 'http://example.com/api'
         expected = _Response()
         http = _HTTP((expected, ''))
@@ -136,6 +141,7 @@ class TestBatch(unittest.TestCase):
 
     def test__make_request_POST_normal(self):
         from google.cloud.storage.batch import _FutureDict
+
         URL = 'http://example.com/api'
         http = _HTTP()  # no requests expected
         connection = _Connection(http=http)
@@ -161,6 +167,7 @@ class TestBatch(unittest.TestCase):
 
     def test__make_request_PATCH_normal(self):
         from google.cloud.storage.batch import _FutureDict
+
         URL = 'http://example.com/api'
         http = _HTTP()  # no requests expected
         connection = _Connection(http=http)
@@ -186,6 +193,7 @@ class TestBatch(unittest.TestCase):
 
     def test__make_request_DELETE_normal(self):
         from google.cloud.storage.batch import _FutureDict
+
         URL = 'http://example.com/api'
         http = _HTTP()  # no requests expected
         connection = _Connection(http=http)
@@ -241,6 +249,7 @@ class TestBatch(unittest.TestCase):
 
     def _check_subrequest_payload(self, chunk, method, url, payload):
         import json
+
         lines = chunk.splitlines()
         # blank + 2 headers + blank + request + 2 headers + blank + body
         payload_str = json.dumps(payload)
@@ -262,6 +271,7 @@ class TestBatch(unittest.TestCase):
 
     def test_finish_nonempty(self):
         import httplib2
+
         URL = 'http://api.example.com/other_api'
         expected = _Response()
         expected['content-type'] = 'multipart/mixed; boundary="DEADBEEF="'
@@ -325,6 +335,7 @@ class TestBatch(unittest.TestCase):
 
     def test_finish_nonempty_with_status_failure(self):
         from google.cloud.exceptions import NotFound
+
         URL = 'http://api.example.com/other_api'
         expected = _Response()
         expected['content-type'] = 'multipart/mixed; boundary="DEADBEEF="'
@@ -380,6 +391,7 @@ class TestBatch(unittest.TestCase):
 
     def test_as_context_mgr_wo_error(self):
         from google.cloud.storage.client import Client
+
         URL = 'http://example.com/api'
         expected = _Response()
         expected['content-type'] = 'multipart/mixed; boundary="DEADBEEF="'
@@ -417,6 +429,7 @@ class TestBatch(unittest.TestCase):
     def test_as_context_mgr_w_error(self):
         from google.cloud.storage.batch import _FutureDict
         from google.cloud.storage.client import Client
+
         URL = 'http://example.com/api'
         http = _HTTP()
         connection = _Connection(http=http)
@@ -457,10 +470,12 @@ class Test__unpack_batch_response(unittest.TestCase):
 
     def _call_fut(self, response, content):
         from google.cloud.storage.batch import _unpack_batch_response
+
         return _unpack_batch_response(response, content)
 
     def _unpack_helper(self, response, content):
         import httplib2
+
         result = list(self._call_fut(response, content))
         self.assertEqual(len(result), 3)
         response0 = httplib2.Response({
@@ -548,6 +563,7 @@ class Test__FutureDict(unittest.TestCase):
 
     def _make_one(self, *args, **kw):
         from google.cloud.storage.batch import _FutureDict
+
         return _FutureDict(*args, **kw)
 
     def test_get(self):
@@ -580,14 +596,12 @@ class _Connection(object):
 
 
 class _Response(dict):
-
     def __init__(self, status=200, **kw):
         self.status = status
         super(_Response, self).__init__(**kw)
 
 
 class _HTTP(object):
-
     def __init__(self, *responses):
         self._requests = []
         self._responses = list(responses)

--- a/storage/unit_tests/test_blob.py
+++ b/storage/unit_tests/test_blob.py
@@ -14,11 +14,14 @@
 
 import unittest
 
+import mock
+
 
 class Test_Blob(unittest.TestCase):
 
     def _make_one(self, *args, **kw):
         from google.cloud.storage.blob import Blob
+
         properties = kw.pop('properties', None)
         blob = Blob(*args, **kw)
         blob._properties = properties or {}
@@ -45,6 +48,7 @@ class Test_Blob(unittest.TestCase):
 
     def test_chunk_size_ctor(self):
         from google.cloud.storage.blob import Blob
+
         BLOB_NAME = 'blob-name'
         BUCKET = object()
         chunk_size = 10 * Blob._CHUNK_SIZE_MULTIPLE
@@ -80,6 +84,7 @@ class Test_Blob(unittest.TestCase):
 
     def test_acl_property(self):
         from google.cloud.storage.acl import ObjectACL
+
         FAKE_BUCKET = _Bucket()
         blob = self._make_one(None, bucket=FAKE_BUCKET)
         acl = blob.acl
@@ -126,8 +131,6 @@ class Test_Blob(unittest.TestCase):
             'https://storage.googleapis.com/name/parent%2Fchild')
 
     def _basic_generate_signed_url_helper(self, credentials=None):
-        import mock
-
         BLOB_NAME = 'blob-name'
         EXPIRATION = '2014-10-16T20:34:37.000Z'
         connection = _Connection()
@@ -165,8 +168,6 @@ class Test_Blob(unittest.TestCase):
         self._basic_generate_signed_url_helper()
 
     def test_generate_signed_url_w_content_type(self):
-        import mock
-
         BLOB_NAME = 'blob-name'
         EXPIRATION = '2014-10-16T20:34:37.000Z'
         connection = _Connection()
@@ -203,8 +204,6 @@ class Test_Blob(unittest.TestCase):
         self._basic_generate_signed_url_helper(credentials=credentials)
 
     def test_generate_signed_url_w_slash_in_name(self):
-        import mock
-
         BLOB_NAME = 'parent/child'
         EXPIRATION = '2014-10-16T20:34:37.000Z'
         connection = _Connection()
@@ -234,8 +233,6 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(SIGNER._signed, [(EXPECTED_ARGS, EXPECTED_KWARGS)])
 
     def test_generate_signed_url_w_method_arg(self):
-        import mock
-
         BLOB_NAME = 'blob-name'
         EXPIRATION = '2014-10-16T20:34:37.000Z'
         connection = _Connection()
@@ -267,6 +264,7 @@ class Test_Blob(unittest.TestCase):
 
     def test_exists_miss(self):
         from six.moves.http_client import NOT_FOUND
+
         NONESUCH = 'nonesuch'
         not_found_response = ({'status': NOT_FOUND}, b'')
         connection = _Connection(not_found_response)
@@ -277,6 +275,7 @@ class Test_Blob(unittest.TestCase):
 
     def test_exists_hit(self):
         from six.moves.http_client import OK
+
         BLOB_NAME = 'blob-name'
         found_response = ({'status': OK}, b'')
         connection = _Connection(found_response)
@@ -300,9 +299,10 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(bucket._deleted, [(BLOB_NAME, None)])
 
     def test_download_to_file_wo_media_link(self):
+        from io import BytesIO
         from six.moves.http_client import OK
         from six.moves.http_client import PARTIAL_CONTENT
-        from io import BytesIO
+
         BLOB_NAME = 'blob-name'
         MEDIA_LINK = 'http://example.com/media/'
         chunk1_response = {'status': PARTIAL_CONTENT,
@@ -326,9 +326,10 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(blob.media_link, MEDIA_LINK)
 
     def _download_to_file_helper(self, chunk_size=None):
+        from io import BytesIO
         from six.moves.http_client import OK
         from six.moves.http_client import PARTIAL_CONTENT
-        from io import BytesIO
+
         BLOB_NAME = 'blob-name'
         chunk1_response = {'status': PARTIAL_CONTENT,
                            'content-range': 'bytes 0-2/6'}
@@ -440,6 +441,7 @@ class Test_Blob(unittest.TestCase):
     def test_download_as_string(self):
         from six.moves.http_client import OK
         from six.moves.http_client import PARTIAL_CONTENT
+
         BLOB_NAME = 'blob-name'
         chunk1_response = {'status': PARTIAL_CONTENT,
                            'content-range': 'bytes 0-2/6'}
@@ -618,6 +620,7 @@ class Test_Blob(unittest.TestCase):
     def test_upload_from_file_simple_not_found(self):
         from six.moves.http_client import NOT_FOUND
         from google.cloud.exceptions import NotFound
+
         with self.assertRaises(NotFound):
             self._upload_from_file_simple_test_helper(status=NOT_FOUND)
 
@@ -647,7 +650,6 @@ class Test_Blob(unittest.TestCase):
             expected_content_type=EXPECTED_CONTENT_TYPE)
 
     def test_upload_from_file_resumable(self):
-        import mock
         from six.moves.http_client import OK
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
@@ -734,7 +736,6 @@ class Test_Blob(unittest.TestCase):
         })
 
     def test_upload_from_file_resumable_w_error(self):
-        import mock
         from six.moves.http_client import NOT_FOUND
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
@@ -974,6 +975,7 @@ class Test_Blob(unittest.TestCase):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
         from google.cloud.streaming import http_wrapper
+
         BLOB_NAME = 'blob-name'
         UPLOAD_URL = 'http://example.com/upload/name/key'
         DATA = b'ABCDEF'
@@ -1013,6 +1015,7 @@ class Test_Blob(unittest.TestCase):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
         from google.cloud.streaming import http_wrapper
+
         BLOB_NAME = 'blob-name'
         UPLOAD_URL = 'http://example.com/upload/name/key'
         DATA = u'ABCDEF\u1234'
@@ -1053,6 +1056,7 @@ class Test_Blob(unittest.TestCase):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
         from google.cloud.streaming import http_wrapper
+
         BLOB_NAME = 'blob-name'
         KEY = b'aa426195405adee2c8081bb9e7e74b19'
         HEADER_KEY_VALUE = 'YWE0MjYxOTU0MDVhZGVlMmM4MDgxYmI5ZTdlNzRiMTk='
@@ -1099,6 +1103,7 @@ class Test_Blob(unittest.TestCase):
     def test_make_public(self):
         from six.moves.http_client import OK
         from google.cloud.storage.acl import _ACLEntity
+
         BLOB_NAME = 'blob-name'
         permissive = [{'entity': 'allUsers', 'role': _ACLEntity.READER_ROLE}]
         after = ({'status': OK}, {'acl': permissive})
@@ -1132,6 +1137,7 @@ class Test_Blob(unittest.TestCase):
 
     def test_compose_minimal(self):
         from six.moves.http_client import OK
+
         SOURCE_1 = 'source-1'
         SOURCE_2 = 'source-2'
         DESTINATION = 'destinaton'
@@ -1168,6 +1174,7 @@ class Test_Blob(unittest.TestCase):
 
     def test_compose_w_additional_property_changes(self):
         from six.moves.http_client import OK
+
         SOURCE_1 = 'source-1'
         SOURCE_2 = 'source-2'
         DESTINATION = 'destinaton'
@@ -1210,6 +1217,7 @@ class Test_Blob(unittest.TestCase):
 
     def test_rewrite_other_bucket_other_name_no_encryption_partial(self):
         from six.moves.http_client import OK
+
         SOURCE_BLOB = 'source'
         DEST_BLOB = 'dest'
         DEST_BUCKET = 'other-bucket'
@@ -1258,6 +1266,7 @@ class Test_Blob(unittest.TestCase):
         import base64
         import hashlib
         from six.moves.http_client import OK
+
         KEY = b'01234567890123456789012345678901'  # 32 bytes
         KEY_B64 = base64.b64encode(KEY).rstrip().decode('ascii')
         KEY_HASH = hashlib.sha256(KEY).digest()
@@ -1305,6 +1314,7 @@ class Test_Blob(unittest.TestCase):
         import base64
         import hashlib
         from six.moves.http_client import OK
+
         SOURCE_KEY = b'01234567890123456789012345678901'  # 32 bytes
         SOURCE_KEY_B64 = base64.b64encode(SOURCE_KEY).rstrip().decode('ascii')
         SOURCE_KEY_HASH = hashlib.sha256(SOURCE_KEY).digest()
@@ -1631,6 +1641,7 @@ class Test_Blob(unittest.TestCase):
         import datetime
         from google.cloud._helpers import _RFC3339_MICROS
         from google.cloud._helpers import UTC
+
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
         TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
@@ -1648,6 +1659,7 @@ class Test_Blob(unittest.TestCase):
         import datetime
         from google.cloud._helpers import _RFC3339_MICROS
         from google.cloud._helpers import UTC
+
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
         TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
@@ -1665,6 +1677,7 @@ class Test_Blob(unittest.TestCase):
         import datetime
         from google.cloud._helpers import _RFC3339_MICROS
         from google.cloud._helpers import UTC
+
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
         TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
@@ -1705,6 +1718,7 @@ class _Connection(_Responder):
     def api_request(self, **kw):
         from six.moves.http_client import NOT_FOUND
         from google.cloud.exceptions import NotFound
+
         info, content = self._respond(**kw)
         if info.get('status') == NOT_FOUND:
             raise NotFound(info)
@@ -1715,6 +1729,7 @@ class _Connection(_Responder):
         from six.moves.urllib.parse import urlencode
         from six.moves.urllib.parse import urlsplit
         from six.moves.urllib.parse import urlunsplit
+
         # Mimic the build_api_url interface.
         qs = urlencode(query_params or {})
         scheme, netloc, _, _, _ = urlsplit(api_base_url)
@@ -1776,6 +1791,7 @@ class _Stream(object):
 
     def __init__(self, to_read=b''):
         import io
+
         self._written = []
         self._to_read = io.BytesIO(to_read)
 

--- a/storage/unit_tests/test_bucket.py
+++ b/storage/unit_tests/test_bucket.py
@@ -19,6 +19,7 @@ class Test_Bucket(unittest.TestCase):
 
     def _make_one(self, client=None, name=None, properties=None):
         from google.cloud.storage.bucket import Bucket
+
         if client is None:
             connection = _Connection()
             client = _Client(connection)
@@ -164,6 +165,7 @@ class Test_Bucket(unittest.TestCase):
 
     def test_acl_property(self):
         from google.cloud.storage.acl import BucketACL
+
         bucket = self._make_one()
         acl = bucket.acl
         self.assertIsInstance(acl, BucketACL)
@@ -171,6 +173,7 @@ class Test_Bucket(unittest.TestCase):
 
     def test_default_object_acl_property(self):
         from google.cloud.storage.acl import DefaultObjectACL
+
         bucket = self._make_one()
         acl = bucket.default_object_acl
         self.assertIsInstance(acl, DefaultObjectACL)
@@ -276,6 +279,7 @@ class Test_Bucket(unittest.TestCase):
 
     def test_delete_miss(self):
         from google.cloud.exceptions import NotFound
+
         NAME = 'name'
         connection = _Connection()
         client = _Client(connection)
@@ -369,6 +373,7 @@ class Test_Bucket(unittest.TestCase):
 
     def test_delete_blob_miss(self):
         from google.cloud.exceptions import NotFound
+
         NAME = 'name'
         NONESUCH = 'nonesuch'
         connection = _Connection()
@@ -413,6 +418,7 @@ class Test_Bucket(unittest.TestCase):
 
     def test_delete_blobs_miss_no_on_error(self):
         from google.cloud.exceptions import NotFound
+
         NAME = 'name'
         BLOB_NAME = 'blob-name'
         NONESUCH = 'nonesuch'
@@ -469,6 +475,7 @@ class Test_Bucket(unittest.TestCase):
 
     def test_copy_blobs_preserve_acl(self):
         from google.cloud.storage.acl import ObjectACL
+
         SOURCE = 'source'
         DEST = 'dest'
         BLOB_NAME = 'blob-name'
@@ -778,6 +785,7 @@ class Test_Bucket(unittest.TestCase):
         import datetime
         from google.cloud._helpers import _RFC3339_MICROS
         from google.cloud._helpers import UTC
+
         TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
         TIME_CREATED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {'timeCreated': TIME_CREATED}
@@ -832,6 +840,7 @@ class Test_Bucket(unittest.TestCase):
 
     def test_make_public_defaults(self):
         from google.cloud.storage.acl import _ACLEntity
+
         NAME = 'name'
         permissive = [{'entity': 'allUsers', 'role': _ACLEntity.READER_ROLE}]
         after = {'acl': permissive, 'defaultObjectAcl': []}
@@ -852,6 +861,7 @@ class Test_Bucket(unittest.TestCase):
 
     def _make_public_w_future_helper(self, default_object_acl_loaded=True):
         from google.cloud.storage.acl import _ACLEntity
+
         NAME = 'name'
         permissive = [{'entity': 'allUsers', 'role': _ACLEntity.READER_ROLE}]
         after1 = {'acl': permissive, 'defaultObjectAcl': []}
@@ -1074,6 +1084,7 @@ class _Connection(object):
 
     def api_request(self, **kw):
         from google.cloud.exceptions import NotFound
+
         self._requested.append(kw)
 
         method = kw.get('method')

--- a/storage/unit_tests/test_client.py
+++ b/storage/unit_tests/test_client.py
@@ -19,6 +19,7 @@ import mock
 
 def _make_credentials():
     import google.auth.credentials
+
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
 
@@ -27,6 +28,7 @@ class TestClient(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.storage.client import Client
+
         return Client
 
     def _make_one(self, *args, **kw):
@@ -89,6 +91,7 @@ class TestClient(unittest.TestCase):
 
     def test__connection_getter_with_batch(self):
         from google.cloud.storage.batch import Batch
+
         PROJECT = 'PROJECT'
         CREDENTIALS = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
@@ -303,6 +306,7 @@ class TestClient(unittest.TestCase):
         from six.moves.urllib.parse import parse_qs
         from six.moves.urllib.parse import urlencode
         from six.moves.urllib.parse import urlparse
+
         PROJECT = 'PROJECT'
         CREDENTIALS = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
@@ -419,6 +423,7 @@ class _Http(object):
 
     def __init__(self, headers, content):
         from httplib2 import Response
+
         self._response = Response(headers)
         self._content = content
 

--- a/translate/unit_tests/test_client.py
+++ b/translate/unit_tests/test_client.py
@@ -20,6 +20,7 @@ class TestClient(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.translate.client import Client
+
         return Client
 
     def _make_one(self, *args, **kw):

--- a/translate/unit_tests/test_connection.py
+++ b/translate/unit_tests/test_connection.py
@@ -20,6 +20,7 @@ class TestConnection(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.translate.connection import Connection
+
         return Connection
 
     def _make_one(self, *args, **kw):
@@ -39,6 +40,7 @@ class TestConnection(unittest.TestCase):
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
+
         conn = self._make_one()
         query_params = [('q', 'val1'), ('q', 'val2')]
         uri = conn.build_api_url('/foo', query_params=query_params)


### PR DESCRIPTION
Updating the import spacing to include one newline between imports and code.

This way when contributors look at other tests they aren't confused with the style.

I'll make another PR with the other half of the services after this one.