### PR TITLE
Cloud Speech Veneer does not raise for > 1 result.

### DIFF
--- a/docs/speech-usage.rst
+++ b/docs/speech-usage.rst
@@ -88,14 +88,14 @@ Great Britian.
     >>> sample = client.sample(source_uri='gs://my-bucket/recording.flac',
     ...                        encoding=speech.Encoding.FLAC,
     ...                        sample_rate=44100)
-    >>> alternatives = sample.sync_recognize(
+    >>> results = sample.sync_recognize(
     ...     speech.Encoding.FLAC, 16000,
     ...     source_uri='gs://my-bucket/recording.flac', language_code='en-GB',
     ...     max_alternatives=2)
-    >>> for alternative in alternatives:
+    >>> for result in results:
     ...     print('=' * 20)
-    ...     print('transcript: ' + alternative.transcript)
-    ...     print('confidence: ' + alternative.confidence)
+    ...     print('transcript: ' + result.transcript)
+    ...     print('confidence: ' + result.confidence)
     ====================
     transcript: Hello, this is a test
     confidence: 0.81
@@ -112,12 +112,12 @@ Example of using the profanity filter.
     >>> sample = client.sample(source_uri='gs://my-bucket/recording.flac',
     ...                        encoding=speech.Encoding.FLAC,
     ...                        sample_rate=44100)
-    >>> alternatives = sample.sync_recognize(max_alternatives=1,
-    ...                                      profanity_filter=True)
-    >>> for alternative in alternatives:
+    >>> results = sample.sync_recognize(max_alternatives=1,
+    ...                                 profanity_filter=True)
+    >>> for result in results:
     ...     print('=' * 20)
-    ...     print('transcript: ' + alternative.transcript)
-    ...     print('confidence: ' + alternative.confidence)
+    ...     print('transcript: ' + result.transcript)
+    ...     print('confidence: ' + result.confidence)
     ====================
     transcript: Hello, this is a f****** test
     confidence: 0.81
@@ -134,12 +134,12 @@ words to the vocabulary of the recognizer.
     ...                        encoding=speech.Encoding.FLAC,
     ...                        sample_rate=44100)
     >>> hints = ['hi', 'good afternoon']
-    >>> alternatives = sample.sync_recognize(max_alternatives=2,
-    ...                                      speech_context=hints)
-    >>> for alternative in alternatives:
+    >>> results = sample.sync_recognize(max_alternatives=2,
+    ...                                 speech_context=hints)
+    >>> for result in results:
     ...     print('=' * 20)
-    ...     print('transcript: ' + alternative.transcript)
-    ...     print('confidence: ' + alternative.confidence)
+    ...     print('transcript: ' + result.transcript)
+    ...     print('confidence: ' + result.confidence)
     ====================
     transcript: Hello, this is a test
     confidence: 0.81

--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -16,13 +16,9 @@
 
 
 from google.cloud.gapic.speech.v1beta1.speech_client import SpeechClient
-from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import RecognitionAudio
-from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import RecognitionConfig
-from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import SpeechContext
 from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
-    StreamingRecognitionConfig)
-from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
-    StreamingRecognizeRequest)
+    RecognitionAudio, RecognitionConfig, SpeechContext,
+    StreamingRecognitionConfig, StreamingRecognizeRequest)
 from google.longrunning import operations_grpc
 
 from google.cloud._helpers import make_secure_channel

--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -25,7 +25,6 @@ from google.cloud._helpers import make_secure_channel
 from google.cloud._helpers import make_secure_stub
 from google.cloud._http import DEFAULT_USER_AGENT
 
-from google.cloud.speech.alternative import Alternative
 from google.cloud.speech.operation import Operation
 from google.cloud.speech.result import Result
 

--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -230,7 +230,8 @@ class GAPICSpeechAPI(object):
                                and phrases. This can also be used to add new
                                words to the vocabulary of the recognizer.
 
-        :yields: :class:`google.cloud.speech.result.Result` objects.
+        :rtype: list
+        :returns: List of :class:`google.cloud.speech.result.Result` objects.
 
         :raises: ValueError if there are no results.
         """
@@ -249,8 +250,7 @@ class GAPICSpeechAPI(object):
             raise ValueError('No results returned from the Speech API.')
 
         # Iterate over any results that came back.
-        for result in api_response.results:
-            yield Result.from_pb(result)
+        return [Result.from_pb(i) for i in api_response.results]
 
 
 def _stream_requests(sample, language_code=None, max_alternatives=None,

--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -250,7 +250,7 @@ class GAPICSpeechAPI(object):
             raise ValueError('No results returned from the Speech API.')
 
         # Iterate over any results that came back.
-        return [Result.from_pb(i) for i in api_response.results]
+        return [Result.from_pb(result) for result in api_response.results]
 
 
 def _stream_requests(sample, language_code=None, max_alternatives=None,

--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -16,9 +16,15 @@
 
 
 from google.cloud.gapic.speech.v1beta1.speech_client import SpeechClient
+from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import RecognitionAudio
 from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
-    RecognitionAudio, RecognitionConfig, SpeechContext,
-    StreamingRecognitionConfig, StreamingRecognizeRequest)
+    RecognitionConfig)
+from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+    SpeechContext)
+from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+    StreamingRecognitionConfig)
+from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+    StreamingRecognizeRequest)
 from google.longrunning import operations_grpc
 
 from google.cloud._helpers import make_secure_channel

--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -230,16 +230,9 @@ class GAPICSpeechAPI(object):
                                and phrases. This can also be used to add new
                                words to the vocabulary of the recognizer.
 
-        :rtype: list
-        :returns: A list of dictionaries. One dict for each alternative. Each
-                  dictionary typically contains two keys (though not
-                  all will be present in all cases)
+        :yields: :class:`google.cloud.speech.result.Result` objects.
 
-                  * ``transcript``: The detected text from the audio recording.
-                  * ``confidence``: The confidence in language detection, float
-                    between 0 and 1.
-
-        :raises: ValueError if more than one result is returned or no results.
+        :raises: ValueError if there are no results.
         """
         config = RecognitionConfig(
             encoding=sample.encoding, sample_rate=sample.sample_rate,
@@ -253,7 +246,7 @@ class GAPICSpeechAPI(object):
 
         # Sanity check: If we got no results back, raise an error.
         if len(api_response.results) == 0:
-            raise ValueError('No results returned from the Speecn API.')
+            raise ValueError('No results returned from the Speech API.')
 
         # Iterate over any results that came back.
         for result in api_response.results:

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -60,7 +60,11 @@ class Client(BaseClient):
     def __init__(self, credentials=None, http=None, use_gax=None):
         super(Client, self).__init__(credentials=credentials, http=http)
         self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+            credentials=self._credentials,
+            http=self._http,
+        )
+
+        # Save on the actual client class whether we use GAX or not.
         if use_gax is None:
             self._use_gax = _USE_GAX
         else:

--- a/speech/google/cloud/speech/operation.py
+++ b/speech/google/cloud/speech/operation.py
@@ -66,5 +66,5 @@ class Operation(operation.Operation):
 
         # Save the results to the Operation object.
         self.results = []
-        for r in pb_results:
-            self.results.append(Result.from_pb(r))
+        for pb_result in pb_results:
+            self.results.append(Result.from_pb(pb_result))

--- a/speech/google/cloud/speech/operation.py
+++ b/speech/google/cloud/speech/operation.py
@@ -14,10 +14,10 @@
 
 """Long running operation representation for Google Speech API"""
 
-from google.cloud.grpc.speech.v1beta1 import cloud_speech_pb2
+from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
 
 from google.cloud import operation
-from google.cloud.speech.alternative import Alternative
+from google.cloud.speech.result import Result
 
 
 operation.register_type(cloud_speech_pb2.AsyncRecognizeMetadata)
@@ -58,11 +58,13 @@ class Operation(operation.Operation):
         if result_type != 'response':
             return
 
+        # Retrieve the results.
+        # If there were no results at all, raise an exception.
         pb_results = self.response.results
-        if len(pb_results) != 1:
-            raise ValueError('Expected exactly one result, found:',
-                             pb_results)
+        if len(pb_results) == 0:
+            raise ValueError('Speech API returned no results.')
 
-        result = pb_results[0]
-        self.results = [Alternative.from_pb(alternative)
-                        for alternative in result.alternatives]
+        # Save the results to the Operation object.
+        self.results = []
+        for r in pb_results:
+            self.results.append(Result.from_pb(r))

--- a/speech/google/cloud/speech/result.py
+++ b/speech/google/cloud/speech/result.py
@@ -17,6 +17,53 @@
 from google.cloud.speech.alternative import Alternative
 
 
+class Result(object):
+    """Speech recognition result representation.
+    This is the object that comes back on sync or async requests
+    (but not streaming requests).
+
+    :type alternatives: list
+    :param alternatives: List of
+        :class:`~google.cloud.speech.alternative.Alternative`.
+    """
+    def __init__(self, alternatives):
+        self.alternatives = alternatives
+
+    @classmethod
+    def from_pb(cls, result):
+        """Factory: construct instance of ``SpeechRecognitionResult``.
+
+        :type result: :class:`~google.cloud.grpc.speech.v1beta1\
+                               .cloud_speech_pb2.StreamingRecognizeResult`
+        :param result: Instance of ``StreamingRecognizeResult`` protobuf.
+
+        :rtype: :class:`~google.cloud.speech.result.SpeechRecognitionResult`
+        :returns: Instance of ``SpeechRecognitionResult``.
+        """
+        alternatives = []
+        for alt in result.alternatives:
+            alternatives.append(Alternative.from_pb(alt))
+        return cls(alternatives=alternatives)
+
+    @property
+    def confidence(self):
+        """Return the confidence for the most probable alternative.
+
+        :rtype: float
+        :returns: Confidence value, between 0 and 1.
+        """
+        return self.alternatives[0].confidence
+
+    @property
+    def transcript(self):
+        """Return the transcript for the most probable alternative.
+
+        :rtype: str
+        :returns: Speech transcript.
+        """
+        return self.alternatives[0].transcript
+
+
 class StreamingSpeechResult(object):
     """Streaming speech result representation.
 
@@ -46,9 +93,28 @@ class StreamingSpeechResult(object):
         :rtype: :class:`~google.cloud.speech.result.StreamingSpeechResult`
         :returns: Instance of ``StreamingSpeechResult``.
         """
-        alternatives = [Alternative.from_pb(alternative)
-                        for alternative in response.alternatives]
+        alternatives = []
+        for alt in response.alternatives:
+            alternatives.append(Alternative.from_pb(alt))
         is_final = response.is_final
         stability = response.stability
         return cls(alternatives=alternatives, is_final=is_final,
                    stability=stability)
+
+    @property
+    def confidence(self):
+        """Return the confidence for the most probable alternative.
+
+        :rtype: float
+        :returns: Confidence value, between 0 and 1.
+        """
+        return self.alternatives[0].confidence
+
+    @property
+    def transcript(self):
+        """Return the transcript for the most probable alternative.
+
+        :rtype: str
+        :returns: Speech transcript.
+        """
+        return self.alternatives[0].transcript

--- a/speech/google/cloud/speech/result.py
+++ b/speech/google/cloud/speech/result.py
@@ -41,7 +41,8 @@ class Result(object):
         :rtype: :class:`~google.cloud.speech.result.SpeechRecognitionResult`
         :returns: Instance of ``SpeechRecognitionResult``.
         """
-        alternatives = [Alternative.from_pb(i) for i in result.alternatives]
+        alternatives = [Alternative.from_pb(result) for result
+                        in result.alternatives]
         return cls(alternatives=alternatives)
 
     @property
@@ -92,7 +93,8 @@ class StreamingSpeechResult(object):
         :rtype: :class:`~google.cloud.speech.result.StreamingSpeechResult`
         :returns: Instance of ``StreamingSpeechResult``.
         """
-        alternatives = [Alternative.from_pb(i) for i in response.alternatives]
+        alternatives = [Alternative.from_pb(result) for result
+                        in response.alternatives]
         is_final = response.is_final
         stability = response.stability
         return cls(alternatives=alternatives, is_final=is_final,

--- a/speech/google/cloud/speech/result.py
+++ b/speech/google/cloud/speech/result.py
@@ -41,9 +41,7 @@ class Result(object):
         :rtype: :class:`~google.cloud.speech.result.SpeechRecognitionResult`
         :returns: Instance of ``SpeechRecognitionResult``.
         """
-        alternatives = []
-        for alt in result.alternatives:
-            alternatives.append(Alternative.from_pb(alt))
+        alternatives = [Alternative.from_pb(i) for i in result.alternatives]
         return cls(alternatives=alternatives)
 
     @property
@@ -94,9 +92,7 @@ class StreamingSpeechResult(object):
         :rtype: :class:`~google.cloud.speech.result.StreamingSpeechResult`
         :returns: Instance of ``StreamingSpeechResult``.
         """
-        alternatives = []
-        for alternative in response.alternatives:
-            alternatives.append(Alternative.from_pb(alternative))
+        alternatives = [Alternative.from_pb(i) for i in response.alternatives]
         is_final = response.is_final
         stability = response.stability
         return cls(alternatives=alternatives, is_final=is_final,

--- a/speech/google/cloud/speech/result.py
+++ b/speech/google/cloud/speech/result.py
@@ -19,6 +19,7 @@ from google.cloud.speech.alternative import Alternative
 
 class Result(object):
     """Speech recognition result representation.
+
     This is the object that comes back on sync or async requests
     (but not streaming requests).
 
@@ -94,8 +95,8 @@ class StreamingSpeechResult(object):
         :returns: Instance of ``StreamingSpeechResult``.
         """
         alternatives = []
-        for alt in response.alternatives:
-            alternatives.append(Alternative.from_pb(alt))
+        for alternative in response.alternatives:
+            alternatives.append(Alternative.from_pb(alternative))
         is_final = response.is_final
         stability = response.stability
         return cls(alternatives=alternatives, is_final=is_final,

--- a/speech/setup.py
+++ b/speech/setup.py
@@ -51,7 +51,7 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'google-cloud-core >= 0.22.1, < 0.23dev',
     'grpcio >= 1.0.2, < 2.0dev',
-    'gapic-google-cloud-speech-v1beta1 >= 0.14.0, < 0.15dev',
+    'gapic-google-cloud-speech-v1beta1 >= 0.15.0, < 0.16dev',
 ]
 
 setup(

--- a/speech/unit_tests/test__gax.py
+++ b/speech/unit_tests/test__gax.py
@@ -36,13 +36,8 @@ class TestSpeechGAXMakeRequests(unittest.TestCase):
     def test_ctor(self):
         from google.cloud import speech
         from google.cloud.speech.sample import Sample
-        from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import (
-            SpeechContext)
-        from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import (
-            RecognitionConfig)
-        from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import (
-            StreamingRecognitionConfig)
-        from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import (
+        from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+            RecognitionConfig, SpeechContext, StreamingRecognitionConfig,
             StreamingRecognizeRequest)
 
         sample = Sample(content=self.AUDIO_CONTENT,
@@ -103,10 +98,8 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
         from io import BytesIO
         from google.cloud import speech
         from google.cloud.speech.sample import Sample
-        from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import (
-            StreamingRecognitionConfig)
-        from google.cloud.grpc.speech.v1beta1.cloud_speech_pb2 import (
-            StreamingRecognizeRequest)
+        from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+            StreamingRecognitionConfig, StreamingRecognizeRequest)
 
         sample = Sample(stream=BytesIO(self.AUDIO_CONTENT),
                         encoding=speech.Encoding.FLAC,

--- a/speech/unit_tests/test_alternative.py
+++ b/speech/unit_tests/test_alternative.py
@@ -54,7 +54,7 @@ class TestAlternative(unittest.TestCase):
         self.assertIsNone(alternative.confidence)
 
     def test_from_pb_with_no_confidence(self):
-        from google.cloud.grpc.speech.v1beta1 import cloud_speech_pb2
+        from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
 
         text = 'the double trouble'
         pb_value = cloud_speech_pb2.SpeechRecognitionAlternative(

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -231,7 +231,7 @@ class TestClient(unittest.TestCase):
                                sample_rate=self.SAMPLE_RATE)
 
         with self.assertRaises(ValueError):
-            [i for i in sample.sync_recognize()]
+            next(sample.sync_recognize())
 
     def test_sync_recognize_with_empty_results_gax(self):
         from google.cloud._testing import _Monkey
@@ -274,7 +274,7 @@ class TestClient(unittest.TestCase):
                                sample_rate=self.SAMPLE_RATE)
 
         with self.assertRaises(ValueError):
-            [i for i in sample.sync_recognize()]
+            next(sample.sync_recognize())
 
     def test_sync_recognize_with_gax(self):
         from google.cloud._testing import _Monkey

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -24,7 +24,7 @@ def _make_credentials():
 
 
 def _make_result(alternatives=()):
-    from google.cloud.grpc.speech.v1beta1 import cloud_speech_pb2
+    from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
 
     return cloud_speech_pb2.SpeechRecognitionResult(
         alternatives=[
@@ -37,7 +37,7 @@ def _make_result(alternatives=()):
 
 
 def _make_streaming_result(alternatives=(), is_final=True, stability=1.0):
-    from google.cloud.grpc.speech.v1beta1 import cloud_speech_pb2
+    from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
 
     return cloud_speech_pb2.StreamingRecognitionResult(
         alternatives=[
@@ -52,7 +52,7 @@ def _make_streaming_result(alternatives=(), is_final=True, stability=1.0):
 
 
 def _make_streaming_response(*results):
-    from google.cloud.grpc.speech.v1beta1 import cloud_speech_pb2
+    from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
 
     response = cloud_speech_pb2.StreamingRecognizeResponse(
         results=results,
@@ -61,7 +61,7 @@ def _make_streaming_response(*results):
 
 
 def _make_sync_response(*results):
-    from google.cloud.grpc.speech.v1beta1 import cloud_speech_pb2
+    from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
 
     response = cloud_speech_pb2.SyncRecognizeResponse(
         results=results,
@@ -202,7 +202,7 @@ class TestClient(unittest.TestCase):
         sample = client.sample(source_uri=self.AUDIO_SOURCE_URI,
                                encoding=encoding, sample_rate=self.SAMPLE_RATE)
 
-        response = sample.sync_recognize()
+        response = [i for i in sample.sync_recognize()]
 
         self.assertEqual(len(client._connection._requested), 1)
         req = client._connection._requested[0]
@@ -231,7 +231,7 @@ class TestClient(unittest.TestCase):
                                sample_rate=self.SAMPLE_RATE)
 
         with self.assertRaises(ValueError):
-            sample.sync_recognize()
+            [i for i in sample.sync_recognize()]
 
     def test_sync_recognize_with_empty_results_gax(self):
         from google.cloud._testing import _Monkey
@@ -274,7 +274,7 @@ class TestClient(unittest.TestCase):
                                sample_rate=self.SAMPLE_RATE)
 
         with self.assertRaises(ValueError):
-            sample.sync_recognize()
+            [i for i in sample.sync_recognize()]
 
     def test_sync_recognize_with_gax(self):
         from google.cloud._testing import _Monkey
@@ -326,16 +326,19 @@ class TestClient(unittest.TestCase):
         self.assertEqual(
             channel_args, [(creds, _gax.DEFAULT_USER_AGENT, host)])
 
-        results = sample.sync_recognize()
+        results = [i for i in sample.sync_recognize()]
 
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results[0].alternatives), 2)
         self.assertEqual(results[0].transcript,
+                         results[0].alternatives[0].transcript,
                          alternatives[0]['transcript'])
         self.assertEqual(results[0].confidence,
+                         results[0].alternatives[0].confidence,
                          alternatives[0]['confidence'])
-        self.assertEqual(results[1].transcript,
+        self.assertEqual(results[0].alternatives[1].transcript,
                          alternatives[1]['transcript'])
-        self.assertEqual(results[1].confidence,
+        self.assertEqual(results[0].alternatives[1].confidence,
                          alternatives[1]['confidence'])
 
     def test_async_supported_encodings(self):
@@ -535,9 +538,11 @@ class TestClient(unittest.TestCase):
         self.assertEqual(results[0].stability, 0.122435)
         self.assertEqual(results[1].stability, 0.1432343)
         self.assertFalse(results[1].is_final)
-        self.assertEqual(results[1].alternatives[0].transcript,
+        self.assertEqual(results[1].transcript,
+                         results[1].alternatives[0].transcript,
                          alternatives[0]['transcript'])
-        self.assertEqual(results[1].alternatives[0].confidence,
+        self.assertEqual(results[1].confidence,
+                         results[1].alternatives[0].confidence,
                          alternatives[0]['confidence'])
         self.assertEqual(results[1].alternatives[1].transcript,
                          alternatives[1]['transcript'])
@@ -545,9 +550,11 @@ class TestClient(unittest.TestCase):
                          alternatives[1]['confidence'])
         self.assertTrue(results[2].is_final)
         self.assertEqual(results[2].stability, 0.9834534)
-        self.assertEqual(results[2].alternatives[0].transcript,
+        self.assertEqual(results[2].transcript,
+                         results[2].alternatives[0].transcript,
                          alternatives[0]['transcript'])
-        self.assertEqual(results[2].alternatives[0].confidence,
+        self.assertEqual(results[2].confidence,
+                         results[2].alternatives[0].confidence,
                          alternatives[0]['confidence'])
 
     def test_stream_recognize(self):


### PR DESCRIPTION
This commit also:

  * adds `transcript` and `confidence` convenience methods
    on result objects
  * updates unit tests appropriately
  * moves from google.cloud.grpc.* to google.cloud.proto.*
  * updates dependencies accordingly

Fixes #2947.