### PR TITLE
Pubsub batch autocommitting.

### DIFF
--- a/pubsub/google/cloud/pubsub/topic.py
+++ b/pubsub/google/cloud/pubsub/topic.py
@@ -427,10 +427,10 @@ class Batch(object):
                          (off).
     :type max_messages: float
     """
-    INFINITY = float('inf')
+    _INFINITY = float('inf')
 
-    def __init__(self, topic, client, max_interval=INFINITY,
-                 max_messages=INFINITY):
+    def __init__(self, topic, client, max_interval=_INFINITY,
+                 max_messages=_INFINITY):
         self.topic = topic
         self.messages = []
         self.message_ids = []

--- a/pubsub/google/cloud/pubsub/topic.py
+++ b/pubsub/google/cloud/pubsub/topic.py
@@ -470,12 +470,11 @@ class Batch(object):
 
         # If too much time has elapsed since the first message
         # was added, autocommit.
-        if self._max_interval < self.INFINITY:
-            now = time.time()
-            if now - self._start_timestamp > self._max_interval:
-                self.commit()
-                self._start_timestamp = now
-                return
+        now = time.time()
+        if now - self._start_timestamp > self._max_interval:
+            self.commit()
+            self._start_timestamp = now
+            return
 
         # If the number of messages on the list is greater than the
         # maximum allowed, autocommit (with the batch's client).

--- a/pubsub/google/cloud/pubsub/topic.py
+++ b/pubsub/google/cloud/pubsub/topic.py
@@ -442,7 +442,7 @@ class Batch(object):
         self._max_messages = max_messages
 
         # Set the initial starting timestamp (used against the interval).
-        self._start_timestamp = float(time.time())
+        self._start_timestamp = time.time()
 
     def __enter__(self):
         return self
@@ -462,9 +462,6 @@ class Batch(object):
 
         :type attrs: dict (string -> string)
         :param attrs: key-value pairs to send as message attributes
-
-        :rtype: None
-        :returns: None
         """
         self.topic._timestamp_message(attrs)
         self.messages.append(
@@ -474,14 +471,17 @@ class Batch(object):
         # If too much time has elapsed since the first message
         # was added, autocommit.
         if self._max_interval < self.INFINITY:
-            if float(time.time()) - self._start_timestamp > self._max_interval:
-                self._start_timestamp = float(time.time())
-                return self.commit()
+            now = time.time()
+            if now - self._start_timestamp > self._max_interval:
+                self.commit()
+                self._start_timestamp = now
+                return
 
         # If the number of messages on the list is greater than the
         # maximum allowed, autocommit (with the batch's client).
         if len(self.messages) >= self._max_messages:
-            return self.commit()
+            self.commit()
+            return
 
     def commit(self, client=None):
         """Send saved messages as a single API call.

--- a/pubsub/unit_tests/test_topic.py
+++ b/pubsub/unit_tests/test_topic.py
@@ -779,6 +779,77 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(list(batch.messages), [MESSAGE1, MESSAGE2])
         self.assertEqual(getattr(api, '_topic_published', self), self)
 
+    def test_message_count_autocommit(self):
+        """Establish that if the batch is assigned to take a maximum
+        number of messages, that it commits when it reaches that maximum.
+        """
+        client = _Client(project='PROJECT')
+        topic = _Topic(name='TOPIC')
+
+        # Track commits, but do not perform them.
+        Batch = self._get_target_class()
+        with mock.patch.object(Batch, 'commit') as commit:
+            with self._make_one(topic, client=client, max_messages=5) as batch:
+                self.assertIsInstance(batch, self._get_target_class())
+
+                # Publish four messages and establish that the batch does
+                # not commit.
+                for i in range(0, 4):
+                    batch.publish({
+                        'attributes': {},
+                        'data': 'Batch message %d.' % i,
+                    })
+                    commit.assert_not_called()
+
+                # Publish a fifth message and observe the commit.
+                batch.publish({
+                    'attributes': {},
+                    'data': 'The final call to trigger a commit!',
+                })
+                commit.assert_called_once_with()
+
+            # There should be a second commit after the context manager
+            # exits.
+            self.assertEqual(commit.call_count, 2)
+
+    @mock.patch('time.time')
+    def test_message_time_autocommit(self, mock_time):
+        """Establish that if the batch is sufficiently old, that it commits
+        the next time it receives a publish.
+        """
+        client = _Client(project='PROJECT')
+        topic = _Topic(name='TOPIC')
+
+        # Track commits, but do not perform them.
+        Batch = self._get_target_class()
+        with mock.patch.object(Batch, 'commit') as commit:
+            mock_time.return_value = 0.0
+            with self._make_one(topic, client=client, max_interval=5) as batch:
+                self.assertIsInstance(batch, self._get_target_class())
+
+                # Publish some messages and establish that the batch does
+                # not commit.
+                for i in range(0, 10):
+                    batch.publish({
+                        'attributes': {},
+                        'data': 'Batch message %d.' % i,
+                    })
+                    commit.assert_not_called()
+
+                # Move time ahead so that this batch is too old.
+                mock_time.return_value = 10.0
+
+                # Publish another message and observe the commit.
+                batch.publish({
+                    'attributes': {},
+                    'data': 'The final call to trigger a commit!',
+                })
+                commit.assert_called_once_with()
+
+            # There should be a second commit after the context manager
+            # exits.
+            self.assertEqual(commit.call_count, 2)
+
 
 class _FauxPublisherAPI(object):
     _api_called = 0

--- a/pubsub/unit_tests/test_topic.py
+++ b/pubsub/unit_tests/test_topic.py
@@ -790,14 +790,14 @@ class TestBatch(unittest.TestCase):
         Batch = self._get_target_class()
         with mock.patch.object(Batch, 'commit') as commit:
             with self._make_one(topic, client=client, max_messages=5) as batch:
-                self.assertIsInstance(batch, self._get_target_class())
+                self.assertIsInstance(batch, Batch)
 
                 # Publish four messages and establish that the batch does
                 # not commit.
                 for i in range(0, 4):
                     batch.publish({
                         'attributes': {},
-                        'data': 'Batch message %d.' % i,
+                        'data': 'Batch message %d.' % (i,),
                     })
                     commit.assert_not_called()
 
@@ -825,14 +825,14 @@ class TestBatch(unittest.TestCase):
         with mock.patch.object(Batch, 'commit') as commit:
             mock_time.return_value = 0.0
             with self._make_one(topic, client=client, max_interval=5) as batch:
-                self.assertIsInstance(batch, self._get_target_class())
+                self.assertIsInstance(batch, Batch)
 
                 # Publish some messages and establish that the batch does
                 # not commit.
                 for i in range(0, 10):
                     batch.publish({
                         'attributes': {},
-                        'data': 'Batch message %d.' % i,
+                        'data': 'Batch message %d.' % (i,),
                     })
                     commit.assert_not_called()
 


### PR DESCRIPTION
This PR adds some functionality to the Batch object:

  * The ability to specify `max_messages` and have the batch
    automatically call `commit` when the number of messages
    gets that high.
  * The ability to specify `max_interval` and have the batch
    automatically commit when a publish occurs and the batch
    is at least as old as the specified interval.

This is one of two changes requested by the PubSub team.