### PR TITLE
Making Connection()-s act as proxies for data stored in Client()-s

### DIFF
--- a/bigquery/google/cloud/bigquery/_http.py
+++ b/bigquery/google/cloud/bigquery/_http.py
@@ -18,7 +18,11 @@ from google.cloud import _http
 
 
 class Connection(_http.JSONConnection):
-    """A connection to Google BigQuery via the JSON REST API."""
+    """A connection to Google BigQuery via the JSON REST API.
+
+    :type client: :class:`~google.cloud.bigquery.client.Client`
+    :param client: The client that owns the current connection.
+    """
 
     API_BASE_URL = 'https://www.googleapis.com'
     """The base of the API call URL."""

--- a/bigquery/google/cloud/bigquery/_http.py
+++ b/bigquery/google/cloud/bigquery/_http.py
@@ -28,7 +28,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/bigquery/{api_version}{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/bigquery',
-             'https://www.googleapis.com/auth/cloud-platform')
-    """The scopes required for authenticating as a BigQuery consumer."""

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -72,11 +72,14 @@ class Client(ClientWithProject):
                  ``credentials`` for the current object.
     """
 
+    SCOPE = ('https://www.googleapis.com/auth/bigquery',
+             'https://www.googleapis.com/auth/cloud-platform')
+    """The scopes required for authenticating as a BigQuery consumer."""
+
     def __init__(self, project=None, credentials=None, http=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
 
     def list_projects(self, max_results=None, page_token=None):
         """List projects for the project associated with this client.

--- a/bigquery/unit_tests/test__http.py
+++ b/bigquery/unit_tests/test__http.py
@@ -27,7 +27,7 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._make_one()
+        conn = self._make_one(object())
         URI = '/'.join([
             conn.API_BASE_URL,
             'bigquery',
@@ -40,7 +40,7 @@ class TestConnection(unittest.TestCase):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
 
-        conn = self._make_one()
+        conn = self._make_one(object())
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -36,7 +36,7 @@ class Connection(object):
     """A generic connection to Google Cloud Platform.
 
     :type client: :class:`~google.cloud.client.Client`
-    :param client: The client that owns the credentials.
+    :param client: The client that owns the current connection.
     """
 
     USER_AGENT = DEFAULT_USER_AGENT

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -20,8 +20,6 @@ import six
 from six.moves.urllib.parse import urlencode
 
 import google.auth.credentials
-import google_auth_httplib2
-import httplib2
 
 from google.cloud.exceptions import make_exception
 
@@ -37,50 +35,14 @@ DEFAULT_USER_AGENT = 'gcloud-python/{0}'.format(
 class Connection(object):
     """A generic connection to Google Cloud Platform.
 
-    Subclasses should understand only the basic types in method arguments,
-    however they should be capable of returning advanced types.
-
-    If no value is passed in for ``http``, a :class:`httplib2.Http` object
-    will be created and authorized with the ``credentials``. If not, the
-    ``credentials`` and ``http`` need not be related.
-
-    Subclasses may seek to use the private key from ``credentials`` to sign
-    data.
-
-    A custom (non-``httplib2``) HTTP object must have a ``request`` method
-    which accepts the following arguments:
-
-    * ``uri``
-    * ``method``
-    * ``body``
-    * ``headers``
-
-    In addition, ``redirections`` and ``connection_type`` may be used.
-
-    Without the use of ``credentials.authorize(http)``, a custom ``http``
-    object will also need to be able to add a bearer token to API
-    requests and handle token refresh on 401 errors.
-
-    :type credentials: :class:`google.auth.credentials.Credentials` or
-                       :class:`NoneType`
-    :param credentials: The credentials to use for this connection.
-
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests.
+    :type client: :class:`~google.cloud.client.Client`
+    :param client: The client that owns the credentials.
     """
 
     USER_AGENT = DEFAULT_USER_AGENT
 
-    SCOPE = None
-    """The scopes required for authenticating with a service.
-
-    Needs to be set by subclasses.
-    """
-
-    def __init__(self, credentials=None, http=None):
-        self._http = http
-        self._credentials = google.auth.credentials.with_scopes_if_required(
-            credentials, self.SCOPE)
+    def __init__(self, client):
+        self._client = client
 
     @property
     def credentials(self):
@@ -90,7 +52,7 @@ class Connection(object):
                 :class:`NoneType`
         :returns: The credentials object associated with this connection.
         """
-        return self._credentials
+        return self._client._credentials
 
     @property
     def http(self):
@@ -99,13 +61,7 @@ class Connection(object):
         :rtype: :class:`httplib2.Http`
         :returns: A Http object used to transport data.
         """
-        if self._http is None:
-            if self._credentials:
-                self._http = google_auth_httplib2.AuthorizedHttp(
-                    self._credentials)
-            else:
-                self._http = httplib2.Http()
-        return self._http
+        return self._client._http
 
 
 class JSONConnection(Connection):

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -19,8 +19,6 @@ from pkg_resources import get_distribution
 import six
 from six.moves.urllib.parse import urlencode
 
-import google.auth.credentials
-
 from google.cloud.exceptions import make_exception
 
 

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -109,7 +109,7 @@ class Client(_ClientFactoryMixin):
                  ``credentials`` for the current object.
     """
 
-    _SCOPE = None
+    SCOPE = None
     """The scopes required for authenticating with a service.
 
     Needs to be set by subclasses.
@@ -123,7 +123,7 @@ class Client(_ClientFactoryMixin):
         if credentials is None and http is None:
             credentials = get_credentials()
         self._credentials = google.auth.credentials.with_scopes_if_required(
-            credentials, self._SCOPE)
+            credentials, self.SCOPE)
         self._http_internal = http
 
     @property

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -16,6 +16,7 @@
 
 import google.auth.credentials
 from google.oauth2 import service_account
+import google_auth_httplib2
 import six
 
 from google.cloud._helpers import _determine_default_project
@@ -74,6 +75,26 @@ class Client(_ClientFactoryMixin):
     Stores ``credentials`` and ``http`` object so that subclasses
     can pass them along to a connection class.
 
+    If no value is passed in for ``http``, a :class:`httplib2.Http` object
+    will be created and authorized with the ``credentials``. If not, the
+    ``credentials`` and ``http`` need not be related.
+
+    Callers and subclasses may seek to use the private key from
+    ``credentials`` to sign data.
+
+    A custom (non-``httplib2``) HTTP object must have a ``request`` method
+    which accepts the following arguments:
+
+    * ``uri``
+    * ``method``
+    * ``body``
+    * ``headers``
+
+    In addition, ``redirections`` and ``connection_type`` may be used.
+
+    A custom ``http`` object will also need to be able to add a bearer token
+    to API requests and handle token refresh on 401 errors.
+
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
                         client. If not passed (and if no ``http`` object is
@@ -88,6 +109,12 @@ class Client(_ClientFactoryMixin):
                  ``credentials`` for the current object.
     """
 
+    _SCOPE = None
+    """The scopes required for authenticating with a service.
+
+    Needs to be set by subclasses.
+    """
+
     def __init__(self, credentials=None, http=None):
         if (credentials is not None and
                 not isinstance(
@@ -95,8 +122,21 @@ class Client(_ClientFactoryMixin):
             raise ValueError(_GOOGLE_AUTH_CREDENTIALS_HELP)
         if credentials is None and http is None:
             credentials = get_credentials()
-        self._credentials = credentials
-        self._http = http
+        self._credentials = google.auth.credentials.with_scopes_if_required(
+            credentials, self._SCOPE)
+        self._http_internal = http
+
+    @property
+    def _http(self):
+        """Getter for object used for HTTP transport.
+
+        :rtype: :class:`~httplib2.Http`
+        :returns: An HTTP object.
+        """
+        if self._http_internal is None:
+            self._http_internal = google_auth_httplib2.AuthorizedHttp(
+                self._credentials)
+        return self._http_internal
 
 
 class _ClientProjectMixin(object):

--- a/core/unit_tests/test__http.py
+++ b/core/unit_tests/test__http.py
@@ -28,61 +28,27 @@ class TestConnection(unittest.TestCase):
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
-    def test_ctor_defaults(self):
-        conn = self._make_one()
-        self.assertIsNone(conn.credentials)
+    def test_constructor(self):
+        client = object()
+        conn = self._make_one(client)
+        self.assertIs(conn._client, client)
 
-    def test_ctor_explicit(self):
-        import google.auth.credentials
+    def test_credentials_property(self):
+        client = mock.Mock(spec=['_credentials'])
+        conn = self._make_one(client)
+        self.assertIs(conn.credentials, client._credentials)
 
-        credentials = mock.Mock(spec=google.auth.credentials.Scoped)
-
-        conn = self._make_one(credentials)
-
-        credentials.with_scopes.assert_called_once_with(conn.SCOPE)
-        self.assertIs(conn.credentials, credentials.with_scopes.return_value)
-        self.assertIsNone(conn._http)
-
-    def test_ctor_explicit_http(self):
-        http = object()
-        conn = self._make_one(http=http)
-        self.assertIsNone(conn.credentials)
-        self.assertIs(conn.http, http)
-
-    def test_ctor_credentials_wo_create_scoped(self):
-        credentials = object()
-        conn = self._make_one(credentials)
-        self.assertIs(conn.credentials, credentials)
-        self.assertIsNone(conn._http)
-
-    def test_http_w_existing(self):
-        conn = self._make_one()
-        conn._http = http = object()
-        self.assertIs(conn.http, http)
-
-    def test_http_wo_creds(self):
-        import httplib2
-
-        conn = self._make_one()
-        self.assertIsInstance(conn.http, httplib2.Http)
-
-    def test_http_w_creds(self):
-        import google.auth.credentials
-        import google_auth_httplib2
-
-        credentials = mock.Mock(spec=google.auth.credentials.Credentials)
-
-        conn = self._make_one(credentials)
-
-        self.assertIsInstance(conn.http, google_auth_httplib2.AuthorizedHttp)
-        self.assertIs(conn.http.credentials, credentials)
+    def test_http_property(self):
+        client = mock.Mock(spec=['_http'])
+        conn = self._make_one(client)
+        self.assertIs(conn.http, client._http)
 
     def test_user_agent_format(self):
         from pkg_resources import get_distribution
 
         expected_ua = 'gcloud-python/{0}'.format(
             get_distribution('google-cloud-core').version)
-        conn = self._make_one()
+        conn = self._make_one(object())
         self.assertEqual(conn.USER_AGENT, expected_ua)
 
 
@@ -97,7 +63,7 @@ class TestJSONConnection(unittest.TestCase):
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
-    def _makeMockOne(self, *args, **kw):
+    def _make_mock_one(self, *args, **kw):
         class MockConnection(self._get_target_class()):
             API_URL_TEMPLATE = '{api_base_url}/mock/{api_version}{path}'
             API_BASE_URL = 'http://mock'
@@ -110,38 +76,14 @@ class TestJSONConnection(unittest.TestCase):
         self.assertIsNone(klass.API_BASE_URL)
         self.assertIsNone(klass.API_VERSION)
 
-    def test_ctor_defaults(self):
-        conn = self._make_one()
-        self.assertIsNone(conn.credentials)
-
-    def test_ctor_explicit(self):
-        conn = self._make_one(mock.sentinel.credentials)
-        self.assertIs(conn.credentials, mock.sentinel.credentials)
-
-    def test_http_w_existing(self):
-        conn = self._make_one()
-        conn._http = http = object()
-        self.assertIs(conn.http, http)
-
-    def test_http_wo_creds(self):
-        import httplib2
-
-        conn = self._make_one()
-        self.assertIsInstance(conn.http, httplib2.Http)
-
-    def test_http_w_creds(self):
-        import google.auth.credentials
-        import google_auth_httplib2
-
-        credentials = mock.Mock(spec=google.auth.credentials.Credentials)
-
-        conn = self._make_one(credentials)
-
-        self.assertIsInstance(conn.http, google_auth_httplib2.AuthorizedHttp)
-        self.assertIs(conn.http.credentials, credentials)
+    def test_constructor(self):
+        client = object()
+        conn = self._make_one(client)
+        self.assertIs(conn._client, client)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._makeMockOne()
+        client = object()
+        conn = self._make_mock_one(client)
         # Intended to emulate self.mock_template
         URI = '/'.join([
             conn.API_BASE_URL,
@@ -155,7 +97,8 @@ class TestJSONConnection(unittest.TestCase):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
 
-        conn = self._makeMockOne()
+        client = object()
+        conn = self._make_mock_one(client)
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
 
         scheme, netloc, path, qs, _ = urlsplit(uri)
@@ -172,12 +115,13 @@ class TestJSONConnection(unittest.TestCase):
         self.assertEqual(parms['bar'], 'baz')
 
     def test__make_request_no_data_no_content_type_no_headers(self):
-        conn = self._make_one()
-        URI = 'http://example.com/test'
-        http = conn._http = _Http(
+        http = _Http(
             {'status': '200', 'content-type': 'text/plain'},
             b'',
         )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_one(client)
+        URI = 'http://example.com/test'
         headers, content = conn._make_request('GET', URI)
         self.assertEqual(headers['status'], '200')
         self.assertEqual(headers['content-type'], 'text/plain')
@@ -193,12 +137,13 @@ class TestJSONConnection(unittest.TestCase):
         self.assertEqual(http._called_with['headers'], expected_headers)
 
     def test__make_request_w_data_no_extra_headers(self):
-        conn = self._make_one()
-        URI = 'http://example.com/test'
-        http = conn._http = _Http(
+        http = _Http(
             {'status': '200', 'content-type': 'text/plain'},
             b'',
         )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_one(client)
+        URI = 'http://example.com/test'
         conn._make_request('GET', URI, {}, 'application/json')
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
@@ -212,12 +157,13 @@ class TestJSONConnection(unittest.TestCase):
         self.assertEqual(http._called_with['headers'], expected_headers)
 
     def test__make_request_w_extra_headers(self):
-        conn = self._make_one()
-        URI = 'http://example.com/test'
-        http = conn._http = _Http(
+        http = _Http(
             {'status': '200', 'content-type': 'text/plain'},
             b'',
         )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_one(client)
+        URI = 'http://example.com/test'
         conn._make_request('GET', URI, headers={'X-Foo': 'foo'})
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
@@ -231,18 +177,19 @@ class TestJSONConnection(unittest.TestCase):
         self.assertEqual(http._called_with['headers'], expected_headers)
 
     def test_api_request_defaults(self):
+        http = _Http(
+            {'status': '200', 'content-type': 'application/json'},
+            b'{}',
+        )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_mock_one(client)
         PATH = '/path/required'
-        conn = self._makeMockOne()
         # Intended to emulate self.mock_template
         URI = '/'.join([
             conn.API_BASE_URL,
             'mock',
             '%s%s' % (conn.API_VERSION, PATH),
         ])
-        http = conn._http = _Http(
-            {'status': '200', 'content-type': 'application/json'},
-            b'{}',
-        )
         self.assertEqual(conn.api_request('GET', PATH), {})
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
@@ -255,20 +202,22 @@ class TestJSONConnection(unittest.TestCase):
         self.assertEqual(http._called_with['headers'], expected_headers)
 
     def test_api_request_w_non_json_response(self):
-        conn = self._makeMockOne()
-        conn._http = _Http(
+        http = _Http(
             {'status': '200', 'content-type': 'text/plain'},
             b'CONTENT',
         )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_mock_one(client)
 
         self.assertRaises(TypeError, conn.api_request, 'GET', '/')
 
     def test_api_request_wo_json_expected(self):
-        conn = self._makeMockOne()
-        conn._http = _Http(
+        http = _Http(
             {'status': '200', 'content-type': 'text/plain'},
             b'CONTENT',
         )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_mock_one(client)
         self.assertEqual(conn.api_request('GET', '/', expect_json=False),
                          b'CONTENT')
 
@@ -276,11 +225,12 @@ class TestJSONConnection(unittest.TestCase):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
 
-        conn = self._makeMockOne()
-        http = conn._http = _Http(
+        http = _Http(
             {'status': '200', 'content-type': 'application/json'},
             b'{}',
         )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_mock_one(client)
         self.assertEqual(conn.api_request('GET', '/', {'foo': 'bar'}), {})
         self.assertEqual(http._called_with['method'], 'GET')
         uri = http._called_with['uri']
@@ -307,11 +257,12 @@ class TestJSONConnection(unittest.TestCase):
     def test_api_request_w_headers(self):
         from six.moves.urllib.parse import urlsplit
 
-        conn = self._makeMockOne()
-        http = conn._http = _Http(
+        http = _Http(
             {'status': '200', 'content-type': 'application/json'},
             b'{}',
         )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_mock_one(client)
         self.assertEqual(
             conn.api_request('GET', '/', headers={'X-Foo': 'bar'}), {})
         self.assertEqual(http._called_with['method'], 'GET')
@@ -341,7 +292,12 @@ class TestJSONConnection(unittest.TestCase):
 
         DATA = {'foo': 'bar'}
         DATAJ = json.dumps(DATA)
-        conn = self._makeMockOne()
+        http = _Http(
+            {'status': '200', 'content-type': 'application/json'},
+            b'{}',
+        )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_mock_one(client)
         # Intended to emulate self.mock_template
         URI = '/'.join([
             conn.API_BASE_URL,
@@ -349,10 +305,6 @@ class TestJSONConnection(unittest.TestCase):
             conn.API_VERSION,
             '',
         ])
-        http = conn._http = _Http(
-            {'status': '200', 'content-type': 'application/json'},
-            b'{}',
-        )
         self.assertEqual(conn.api_request('POST', '/', data=DATA), {})
         self.assertEqual(http._called_with['method'], 'POST')
         self.assertEqual(http._called_with['uri'], URI)
@@ -368,29 +320,33 @@ class TestJSONConnection(unittest.TestCase):
     def test_api_request_w_404(self):
         from google.cloud.exceptions import NotFound
 
-        conn = self._makeMockOne()
-        conn._http = _Http(
+        http = _Http(
             {'status': '404', 'content-type': 'text/plain'},
             b'{}'
         )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_mock_one(client)
         self.assertRaises(NotFound, conn.api_request, 'GET', '/')
 
     def test_api_request_w_500(self):
         from google.cloud.exceptions import InternalServerError
 
-        conn = self._makeMockOne()
-        conn._http = _Http(
+        http = _Http(
             {'status': '500', 'content-type': 'text/plain'},
             b'{}',
         )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_mock_one(client)
         self.assertRaises(InternalServerError, conn.api_request, 'GET', '/')
 
     def test_api_request_non_binary_response(self):
-        conn = self._makeMockOne()
-        http = conn._http = _Http(
+        http = _Http(
             {'status': '200', 'content-type': 'application/json'},
             u'{}',
         )
+        client = mock.Mock(_http=http, spec=['_http'])
+        conn = self._make_mock_one(client)
+
         result = conn.api_request('GET', '/')
         # Intended to emulate self.mock_template
         URI = '/'.join([

--- a/datastore/google/cloud/datastore/_http.py
+++ b/datastore/google/cloud/datastore/_http.py
@@ -397,11 +397,8 @@ class Connection(connection_module.Connection):
     in method arguments, however it should be capable of returning advanced
     types.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
-    :param credentials: The OAuth2 Credentials to use for this connection.
-
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests.
+    :type client: :class:`~google.cloud.datastore.client.Client`
+    :param client: The client that owns the current connection.
     """
 
     API_BASE_URL = 'https://' + DATASTORE_API_HOST
@@ -414,11 +411,8 @@ class Connection(connection_module.Connection):
                         '/{project}:{method}')
     """A template for the URL of a particular API call."""
 
-    SCOPE = ('https://www.googleapis.com/auth/datastore',)
-    """The scopes required for authenticating as a Cloud Datastore consumer."""
-
-    def __init__(self, credentials=None, http=None):
-        super(Connection, self).__init__(credentials=credentials, http=http)
+    def __init__(self, client):
+        super(Connection, self).__init__(client)
         try:
             self.host = os.environ[GCD_HOST]
             self.api_base_url = 'http://' + self.host

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -18,8 +18,7 @@ import os
 from google.cloud._helpers import _LocalStack
 from google.cloud._helpers import (
     _determine_default_project as _base_default_project)
-from google.cloud.client import _ClientProjectMixin
-from google.cloud.client import Client as _BaseClient
+from google.cloud.client import ClientWithProject
 from google.cloud.datastore._http import Connection
 from google.cloud.datastore import helpers
 from google.cloud.datastore.batch import Batch
@@ -143,7 +142,7 @@ def _extended_lookup(connection, project, key_pbs,
     return results
 
 
-class Client(_BaseClient, _ClientProjectMixin):
+class Client(ClientWithProject):
     """Convenience wrapper for invoking APIs/factories w/ a project.
 
     .. doctest::
@@ -171,13 +170,14 @@ class Client(_BaseClient, _ClientProjectMixin):
                  ``credentials`` for the current object.
     """
 
+    SCOPE = ('https://www.googleapis.com/auth/datastore',)
+    """The scopes required for authenticating as a Cloud Datastore consumer."""
+
     def __init__(self, project=None, namespace=None,
                  credentials=None, http=None):
-        _ClientProjectMixin.__init__(self, project=project)
-        _BaseClient.__init__(self, credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
-
+        super(Client, self).__init__(
+            project=project, credentials=credentials, http=http)
+        self._connection = Connection(self)
         self.namespace = namespace
         self._batch_stack = _LocalStack()
 

--- a/datastore/unit_tests/test_client.py
+++ b/datastore/unit_tests/test_client.py
@@ -168,16 +168,17 @@ class TestClient(unittest.TestCase):
             new=fallback_mock)
         patch2 = mock.patch(
             'google.cloud.client.get_credentials',
-            new=lambda: creds)
+            return_value=creds)
 
         with patch1:
             with patch2:
                 client = klass()
+
         self.assertEqual(client.project, OTHER)
         self.assertIsNone(client.namespace)
         self.assertIsInstance(client._connection, _MockConnection)
-        self.assertIs(client._connection.credentials, creds)
-        self.assertIsNone(client._connection.http)
+        self.assertIs(client._credentials, creds)
+        self.assertIsNone(client._http_internal)
         self.assertIsNone(client.current_batch)
         self.assertIsNone(client.current_transaction)
         self.assertEqual(default_called, [None])
@@ -194,8 +195,8 @@ class TestClient(unittest.TestCase):
         self.assertEqual(client.project, OTHER)
         self.assertEqual(client.namespace, NAMESPACE)
         self.assertIsInstance(client._connection, _MockConnection)
-        self.assertIs(client._connection.credentials, creds)
-        self.assertIs(client._connection.http, http)
+        self.assertIs(client._credentials, creds)
+        self.assertIs(client._http_internal, http)
         self.assertIsNone(client.current_batch)
         self.assertEqual(list(client._batch_stack), [])
 

--- a/dns/google/cloud/dns/__init__.py
+++ b/dns/google/cloud/dns/__init__.py
@@ -32,4 +32,4 @@ from google.cloud.dns.zone import ManagedZone
 from google.cloud.dns.resource_record_set import ResourceRecordSet
 
 
-SCOPE = Connection.SCOPE
+SCOPE = Client.SCOPE

--- a/dns/google/cloud/dns/client.py
+++ b/dns/google/cloud/dns/client.py
@@ -43,11 +43,13 @@ class Client(ClientWithProject):
                  ``credentials`` for the current object.
     """
 
+    SCOPE = ('https://www.googleapis.com/auth/ndev.clouddns.readwrite',)
+    """The scopes required for authenticating as a Cloud DNS consumer."""
+
     def __init__(self, project=None, credentials=None, http=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
 
     def quotas(self):
         """Return DNS quotas for the project associated with this client.

--- a/dns/google/cloud/dns/connection.py
+++ b/dns/google/cloud/dns/connection.py
@@ -28,6 +28,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/dns/{api_version}{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/ndev.clouddns.readwrite',)
-    """The scopes required for authenticating as a Cloud DNS consumer."""

--- a/dns/google/cloud/dns/connection.py
+++ b/dns/google/cloud/dns/connection.py
@@ -18,7 +18,11 @@ from google.cloud import _http
 
 
 class Connection(_http.JSONConnection):
-    """A connection to Google Cloud DNS via the JSON REST API."""
+    """A connection to Google Cloud DNS via the JSON REST API.
+
+    :type client: :class:`~google.cloud.dns.client.Client`
+    :param client: The client that owns the current connection.
+    """
 
     API_BASE_URL = 'https://www.googleapis.com'
     """The base of the API call URL."""

--- a/dns/unit_tests/test_connection.py
+++ b/dns/unit_tests/test_connection.py
@@ -27,7 +27,7 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._make_one()
+        conn = self._make_one(object())
         URI = '/'.join([
             conn.API_BASE_URL,
             'dns',
@@ -40,7 +40,7 @@ class TestConnection(unittest.TestCase):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
 
-        conn = self._make_one()
+        conn = self._make_one(object())
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)

--- a/language/google/cloud/language/client.py
+++ b/language/google/cloud/language/client.py
@@ -37,11 +37,13 @@ class Client(client_module.Client):
                  ``credentials`` for the current object.
     """
 
+    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
+    """The scopes required for authenticating as an API consumer."""
+
     def __init__(self, credentials=None, http=None):
         super(Client, self).__init__(
             credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
 
     def document_from_text(self, content, **kwargs):
         """Create a plain text document bound to this client.

--- a/language/google/cloud/language/connection.py
+++ b/language/google/cloud/language/connection.py
@@ -28,6 +28,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}/documents:{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
-    """The scopes required for authenticating as an API consumer."""

--- a/language/google/cloud/language/connection.py
+++ b/language/google/cloud/language/connection.py
@@ -18,7 +18,11 @@ from google.cloud import _http
 
 
 class Connection(_http.JSONConnection):
-    """A connection to Google Cloud Natural Language JSON REST API."""
+    """A connection to Google Cloud Natural Language JSON REST API.
+
+    :type client: :class:`~google.cloud.language.client.Client`
+    :param client: The client that owns the current connection.
+    """
 
     API_BASE_URL = 'https://language.googleapis.com'
     """The base of the API call URL."""

--- a/language/unit_tests/test_connection.py
+++ b/language/unit_tests/test_connection.py
@@ -27,7 +27,7 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url(self):
-        conn = self._make_one()
+        conn = self._make_one(object())
         uri = '/'.join([
             conn.API_BASE_URL,
             conn.API_VERSION,

--- a/logging/google/cloud/logging/_http.py
+++ b/logging/google/cloud/logging/_http.py
@@ -26,16 +26,8 @@ from google.cloud.logging.metric import Metric
 class Connection(_http.JSONConnection):
     """A connection to Google Stackdriver Logging via the JSON REST API.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
-    :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        connection.
-
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: (Optional) HTTP object to make requests.
-
-    :type api_base_url: str
-    :param api_base_url: The base of the API call URL. Defaults to the value
-                         :attr:`Connection.API_BASE_URL`.
+    :type client: :class:`~google.cloud.logging.client.Client`
+    :param client: The client that owns the current connection.
     """
 
     API_BASE_URL = 'https://logging.googleapis.com'
@@ -46,12 +38,6 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/logging.read',
-             'https://www.googleapis.com/auth/logging.write',
-             'https://www.googleapis.com/auth/logging.admin',
-             'https://www.googleapis.com/auth/cloud-platform')
-    """The scopes required for authenticating as a Logging consumer."""
 
 
 class _LoggingAPI(object):

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -91,12 +91,17 @@ class Client(ClientWithProject):
     _sinks_api = None
     _metrics_api = None
 
+    SCOPE = ('https://www.googleapis.com/auth/logging.read',
+             'https://www.googleapis.com/auth/logging.write',
+             'https://www.googleapis.com/auth/logging.admin',
+             'https://www.googleapis.com/auth/cloud-platform')
+    """The scopes required for authenticating as a Logging consumer."""
+
     def __init__(self, project=None, credentials=None,
                  http=None, use_gax=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
         if use_gax is None:
             self._use_gax = _USE_GAX
         else:

--- a/logging/unit_tests/test__http.py
+++ b/logging/unit_tests/test__http.py
@@ -38,9 +38,9 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
-        creds = _make_credentials()
-        conn = self._make_one(creds)
-        self.assertEqual(conn.credentials, creds)
+        client = object()
+        conn = self._make_one(client)
+        self.assertIs(conn._client, client)
 
 
 class Test_LoggingAPI(unittest.TestCase):

--- a/monitoring/google/cloud/monitoring/__init__.py
+++ b/monitoring/google/cloud/monitoring/__init__.py
@@ -44,4 +44,4 @@ __all__ = (
 )
 
 
-SCOPE = Connection.SCOPE
+SCOPE = Client.SCOPE

--- a/monitoring/google/cloud/monitoring/client.py
+++ b/monitoring/google/cloud/monitoring/client.py
@@ -68,11 +68,15 @@ class Client(ClientWithProject):
                  ``credentials`` for the current object.
     """
 
+    SCOPE = ('https://www.googleapis.com/auth/monitoring.read',
+             'https://www.googleapis.com/auth/monitoring',
+             'https://www.googleapis.com/auth/cloud-platform')
+    """The scopes required for authenticating as a Monitoring consumer."""
+
     def __init__(self, project=None, credentials=None, http=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
 
     def query(self,
               metric_type=Query.DEFAULT_METRIC_TYPE,

--- a/monitoring/google/cloud/monitoring/connection.py
+++ b/monitoring/google/cloud/monitoring/connection.py
@@ -20,16 +20,8 @@ from google.cloud import _http
 class Connection(_http.JSONConnection):
     """A connection to Google Stackdriver Monitoring via the JSON REST API.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
-    :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        connection.
-
-    :type http: :class:`httplib2.Http` or class that defines ``request()``
-    :param http: (Optional) HTTP object to make requests.
-
-    :type api_base_url: str
-    :param api_base_url: The base of the API call URL. Defaults to the value
-                         :attr:`Connection.API_BASE_URL`.
+    :type client: :class:`~google.cloud.monitoring.client.Client`
+    :param client: The client that owns the current connection.
     """
 
     API_BASE_URL = 'https://monitoring.googleapis.com'

--- a/monitoring/google/cloud/monitoring/connection.py
+++ b/monitoring/google/cloud/monitoring/connection.py
@@ -40,8 +40,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/monitoring.read',
-             'https://www.googleapis.com/auth/monitoring',
-             'https://www.googleapis.com/auth/cloud-platform')
-    """The scopes required for authenticating as a Monitoring consumer."""

--- a/monitoring/unit_tests/test_connection.py
+++ b/monitoring/unit_tests/test_connection.py
@@ -27,6 +27,6 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kwargs)
 
     def test_constructor(self):
-        credentials = object()
-        connection = self._make_one(credentials)
-        self.assertEqual(connection.credentials, credentials)
+        client = object()
+        connection = self._make_one(client)
+        self.assertIs(connection._client, client)

--- a/pubsub/google/cloud/pubsub/_http.py
+++ b/pubsub/google/cloud/pubsub/_http.py
@@ -34,12 +34,8 @@ PUBSUB_API_HOST = 'pubsub.googleapis.com'
 class Connection(_http.JSONConnection):
     """A connection to Google Cloud Pub/Sub via the JSON REST API.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
-    :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        connection.
-
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: (Optional) HTTP object to make requests.
+    :type client: :class:`~google.cloud.pubsub.client.Client`
+    :param client: The client that owns the current connection.
     """
 
     API_BASE_URL = 'https://' + PUBSUB_API_HOST
@@ -51,12 +47,8 @@ class Connection(_http.JSONConnection):
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
 
-    SCOPE = ('https://www.googleapis.com/auth/pubsub',
-             'https://www.googleapis.com/auth/cloud-platform')
-    """The scopes required for authenticating as a Cloud Pub/Sub consumer."""
-
-    def __init__(self, credentials=None, http=None):
-        super(Connection, self).__init__(credentials=credentials, http=http)
+    def __init__(self, client):
+        super(Connection, self).__init__(client)
         emulator_host = os.getenv(PUBSUB_EMULATOR)
         if emulator_host is None:
             self.host = self.__class__.API_BASE_URL

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -75,12 +75,15 @@ class Client(ClientWithProject):
     _subscriber_api = None
     _iam_policy_api = None
 
+    SCOPE = ('https://www.googleapis.com/auth/pubsub',
+             'https://www.googleapis.com/auth/cloud-platform')
+    """The scopes required for authenticating as a Cloud Pub/Sub consumer."""
+
     def __init__(self, project=None, credentials=None,
                  http=None, use_gax=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
         if use_gax is None:
             self._use_gax = _USE_GAX
         else:
@@ -96,7 +99,7 @@ class Client(ClientWithProject):
                         host=self._connection.host)
                 else:
                     generated = make_gax_publisher_api(
-                        credentials=self._connection._credentials)
+                        credentials=self._credentials)
                 self._publisher_api = GAXPublisherAPI(generated, self)
             else:
                 self._publisher_api = JSONPublisherAPI(self)
@@ -112,7 +115,7 @@ class Client(ClientWithProject):
                         host=self._connection.host)
                 else:
                     generated = make_gax_subscriber_api(
-                        credentials=self._connection._credentials)
+                        credentials=self._credentials)
                 self._subscriber_api = GAXSubscriberAPI(generated, self)
             else:
                 self._subscriber_api = JSONSubscriberAPI(self)

--- a/pubsub/unit_tests/test__http.py
+++ b/pubsub/unit_tests/test__http.py
@@ -46,7 +46,7 @@ class TestConnection(_Base):
         return Connection
 
     def test_default_url(self):
-        conn = self._make_one()
+        conn = self._make_one(object())
         klass = self._get_target_class()
         self.assertEqual(conn.api_base_url, klass.API_BASE_URL)
 
@@ -57,14 +57,14 @@ class TestConnection(_Base):
         fake_environ = {PUBSUB_EMULATOR: HOST}
 
         with mock.patch('os.environ', new=fake_environ):
-            conn = self._make_one()
+            conn = self._make_one(object())
 
         klass = self._get_target_class()
         self.assertNotEqual(conn.api_base_url, klass.API_BASE_URL)
         self.assertEqual(conn.api_base_url, 'http://' + HOST)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._make_one()
+        conn = self._make_one(object())
         URI = '/'.join([
             conn.API_BASE_URL,
             conn.API_VERSION,
@@ -76,7 +76,7 @@ class TestConnection(_Base):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
 
-        conn = self._make_one()
+        conn = self._make_one(object())
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)
@@ -88,7 +88,7 @@ class TestConnection(_Base):
     def test_build_api_url_w_base_url_override(self):
         base_url1 = 'api-base-url1'
         base_url2 = 'api-base-url2'
-        conn = self._make_one()
+        conn = self._make_one(object())
         conn.api_base_url = base_url1
         URI = '/'.join([
             base_url2,

--- a/resource_manager/google/cloud/resource_manager/__init__.py
+++ b/resource_manager/google/cloud/resource_manager/__init__.py
@@ -20,4 +20,4 @@ from google.cloud.resource_manager.connection import Connection
 from google.cloud.resource_manager.project import Project
 
 
-SCOPE = Connection.SCOPE
+SCOPE = Client.SCOPE

--- a/resource_manager/google/cloud/resource_manager/client.py
+++ b/resource_manager/google/cloud/resource_manager/client.py
@@ -47,11 +47,13 @@ class Client(BaseClient):
                  ``credentials`` for the current object.
     """
 
+    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
+    """The scopes required for authenticating as a Resouce Manager consumer."""
+
     def __init__(self, credentials=None, http=None):
         super(Client, self).__init__(
             credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
 
     def new_project(self, project_id, name=None, labels=None):
         """Create a project bound to the current client.

--- a/resource_manager/google/cloud/resource_manager/connection.py
+++ b/resource_manager/google/cloud/resource_manager/connection.py
@@ -21,12 +21,8 @@ from google.cloud import _http
 class Connection(_http.JSONConnection):
     """A connection to Google Cloud Resource Manager via the JSON REST API.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
-    :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        connection.
-
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: (Optional) HTTP object to make requests.
+    :type client: :class:`~google.cloud.resource_manager.client.Client`
+    :param client: The client that owns the current connection.
     """
 
     API_BASE_URL = 'https://cloudresourcemanager.googleapis.com'

--- a/resource_manager/google/cloud/resource_manager/connection.py
+++ b/resource_manager/google/cloud/resource_manager/connection.py
@@ -37,6 +37,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
-    """The scopes required for authenticating as a Resouce Manager consumer."""

--- a/resource_manager/unit_tests/test_client.py
+++ b/resource_manager/unit_tests/test_client.py
@@ -41,8 +41,8 @@ class TestClient(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_one(credentials=credentials, http=http)
         self.assertIsInstance(client._connection, Connection)
-        self.assertEqual(client._connection._credentials, credentials)
-        self.assertEqual(client._connection._http, http)
+        self.assertIs(client._credentials, credentials)
+        self.assertIs(client._http_internal, http)
 
     def test_new_project_factory(self):
         from google.cloud.resource_manager.project import Project

--- a/resource_manager/unit_tests/test_connection.py
+++ b/resource_manager/unit_tests/test_connection.py
@@ -27,7 +27,7 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._make_one()
+        conn = self._make_one(object())
         URI = '/'.join([
             conn.API_BASE_URL,
             conn.API_VERSION,
@@ -39,7 +39,7 @@ class TestConnection(unittest.TestCase):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
 
-        conn = self._make_one()
+        conn = self._make_one(object())
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)

--- a/runtimeconfig/google/cloud/runtimeconfig/client.py
+++ b/runtimeconfig/google/cloud/runtimeconfig/client.py
@@ -42,11 +42,13 @@ class Client(ClientWithProject):
                  ``credentials`` for the current object.
     """
 
+    SCOPE = ('https://www.googleapis.com/auth/cloudruntimeconfig',)
+    """The scopes required for authenticating as a RuntimeConfig consumer."""
+
     def __init__(self, project=None, credentials=None, http=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
 
     def config(self, config_name):
         """Factory constructor for config object.

--- a/runtimeconfig/google/cloud/runtimeconfig/connection.py
+++ b/runtimeconfig/google/cloud/runtimeconfig/connection.py
@@ -22,16 +22,8 @@ from google.cloud import _http
 class Connection(_http.JSONConnection):
     """A connection to Google Cloud RuntimeConfig via the JSON REST API.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
-    :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        connection.
-
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: (Optional) HTTP object to make requests.
-
-    :type api_base_url: str
-    :param api_base_url: The base of the API call URL. Defaults to the value
-                         :attr:`Connection.API_BASE_URL`.
+    :type client: :class:`~google.cloud.runtimeconfig.client.Client`
+    :param client: The client that owns the current connection.
     """
 
     API_BASE_URL = 'https://runtimeconfig.googleapis.com'

--- a/runtimeconfig/google/cloud/runtimeconfig/connection.py
+++ b/runtimeconfig/google/cloud/runtimeconfig/connection.py
@@ -42,6 +42,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/cloudruntimeconfig',)
-    """The scopes required for authenticating as a RuntimeConfig consumer."""

--- a/runtimeconfig/unit_tests/test_connection.py
+++ b/runtimeconfig/unit_tests/test_connection.py
@@ -27,6 +27,6 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
-        creds = object()
-        conn = self._make_one(creds)
-        self.assertEqual(conn.credentials, creds)
+        client = object()
+        conn = self._make_one(client)
+        self.assertIs(conn._client, client)

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -55,14 +55,14 @@ class Client(BaseClient):
                     variable
     """
 
+    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
+    """The scopes required for authenticating as an API consumer."""
+
     _speech_api = None
 
     def __init__(self, credentials=None, http=None, use_gax=None):
         super(Client, self).__init__(credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials,
-            http=self._http,
-        )
+        self._connection = Connection(self)
 
         # Save on the actual client class whether we use GAX or not.
         if use_gax is None:

--- a/speech/google/cloud/speech/connection.py
+++ b/speech/google/cloud/speech/connection.py
@@ -18,7 +18,11 @@ from google.cloud import _http
 
 
 class Connection(_http.JSONConnection):
-    """A connection to Google Cloud Speech JSON REST API."""
+    """A connection to Google Cloud Speech JSON REST API.
+
+    :type client: :class:`~google.cloud.speech.client.Client`
+    :param client: The client that owns the current connection.
+    """
 
     API_BASE_URL = 'https://speech.googleapis.com'
     """The base of the API call URL."""

--- a/speech/google/cloud/speech/connection.py
+++ b/speech/google/cloud/speech/connection.py
@@ -28,6 +28,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}/{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
-    """The scopes required for authenticating as an API consumer."""

--- a/speech/unit_tests/test_connection.py
+++ b/speech/unit_tests/test_connection.py
@@ -27,7 +27,7 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url(self):
-        conn = self._make_one()
+        conn = self._make_one(object())
         method = 'speech:syncrecognize'
         uri = '/'.join([
             conn.API_BASE_URL,

--- a/storage/google/cloud/storage/_http.py
+++ b/storage/google/cloud/storage/_http.py
@@ -20,12 +20,8 @@ from google.cloud import _http
 class Connection(_http.JSONConnection):
     """A connection to Google Cloud Storage via the JSON REST API.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
-    :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        connection.
-
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: (Optional) HTTP object to make requests.
+    :type client: :class:`~google.cloud.storage.client.Client`
+    :param client: The client that owns the current connection.
     """
 
     API_BASE_URL = _http.API_BASE_URL
@@ -36,8 +32,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/storage/{api_version}{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/devstorage.full_control',
-             'https://www.googleapis.com/auth/devstorage.read_only',
-             'https://www.googleapis.com/auth/devstorage.read_write')
-    """The scopes required for authenticating as a Cloud Storage consumer."""

--- a/storage/google/cloud/storage/batch.py
+++ b/storage/google/cloud/storage/batch.py
@@ -132,8 +132,7 @@ class Batch(Connection):
     _MAX_BATCH_SIZE = 1000
 
     def __init__(self, client):
-        super(Batch, self).__init__()
-        self._client = client
+        super(Batch, self).__init__(client)
         self._requests = []
         self._target_objects = []
 

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -46,12 +46,16 @@ class Client(ClientWithProject):
                  ``credentials`` for the current object.
     """
 
+    SCOPE = ('https://www.googleapis.com/auth/devstorage.full_control',
+             'https://www.googleapis.com/auth/devstorage.read_only',
+             'https://www.googleapis.com/auth/devstorage.read_write')
+    """The scopes required for authenticating as a Cloud Storage consumer."""
+
     def __init__(self, project=None, credentials=None, http=None):
         self._base_connection = None
         super(Client, self).__init__(project=project, credentials=credentials,
                                      http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
         self._batch_stack = _LocalStack()
 
     @property

--- a/storage/unit_tests/test__http.py
+++ b/storage/unit_tests/test__http.py
@@ -27,7 +27,7 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._make_one()
+        conn = self._make_one(object())
         URI = '/'.join([
             conn.API_BASE_URL,
             'storage',
@@ -40,7 +40,7 @@ class TestConnection(unittest.TestCase):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
 
-        conn = self._make_one()
+        conn = self._make_one(object())
         uri = conn.build_api_url('/foo', {'bar': 'baz'})
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual('%s://%s' % (scheme, netloc), conn.API_BASE_URL)

--- a/storage/unit_tests/test_batch.py
+++ b/storage/unit_tests/test_batch.py
@@ -399,7 +399,7 @@ class TestBatch(unittest.TestCase):
         project = 'PROJECT'
         credentials = _make_credentials()
         client = Client(project=project, credentials=credentials)
-        client._base_connection._http = http
+        client._http_internal = http
 
         self.assertEqual(list(client._batch_stack), [])
 

--- a/storage/unit_tests/test_client.py
+++ b/storage/unit_tests/test_client.py
@@ -140,7 +140,7 @@ class TestClient(unittest.TestCase):
             'b',
             'nonesuch?projection=noAcl',
         ])
-        http = client._connection._http = _Http(
+        http = client._http_internal = _Http(
             {'status': '404', 'content-type': 'application/json'},
             b'{}',
         )
@@ -163,7 +163,7 @@ class TestClient(unittest.TestCase):
             'b',
             '%s?projection=noAcl' % (BLOB_NAME,),
         ])
-        http = client._connection._http = _Http(
+        http = client._http_internal = _Http(
             {'status': '200', 'content-type': 'application/json'},
             '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
@@ -187,7 +187,7 @@ class TestClient(unittest.TestCase):
             'b',
             'nonesuch?projection=noAcl',
         ])
-        http = client._connection._http = _Http(
+        http = client._http_internal = _Http(
             {'status': '404', 'content-type': 'application/json'},
             b'{}',
         )
@@ -211,7 +211,7 @@ class TestClient(unittest.TestCase):
             'b',
             '%s?projection=noAcl' % (BLOB_NAME,),
         ])
-        http = client._connection._http = _Http(
+        http = client._http_internal = _Http(
             {'status': '200', 'content-type': 'application/json'},
             '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
@@ -236,7 +236,7 @@ class TestClient(unittest.TestCase):
             client._connection.API_VERSION,
             'b?project=%s' % (PROJECT,),
         ])
-        http = client._connection._http = _Http(
+        http = client._http_internal = _Http(
             {'status': '409', 'content-type': 'application/json'},
             '{"error": {"message": "Conflict"}}',
         )
@@ -259,7 +259,7 @@ class TestClient(unittest.TestCase):
             client._connection.API_VERSION,
             'b?project=%s' % (PROJECT,),
         ])
-        http = client._connection._http = _Http(
+        http = client._http_internal = _Http(
             {'status': '200', 'content-type': 'application/json'},
             '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
@@ -282,7 +282,7 @@ class TestClient(unittest.TestCase):
             'project': [PROJECT],
             'projection': ['noAcl'],
         }
-        http = client._connection._http = _Http(
+        http = client._http_internal = _Http(
             {'status': '200', 'content-type': 'application/json'},
             b'{}',
         )
@@ -319,7 +319,7 @@ class TestClient(unittest.TestCase):
             client._connection.API_VERSION,
         ])
         URI = '/'.join([BASE_URI, 'b?%s' % (query_params,)])
-        http = client._connection._http = _Http(
+        http = client._http_internal = _Http(
             {'status': '200', 'content-type': 'application/json'},
             '{{"items": [{{"name": "{0}"}}]}}'.format(BUCKET_NAME)
             .encode('utf-8'),
@@ -354,7 +354,7 @@ class TestClient(unittest.TestCase):
             'fields': [FIELDS],
         }
 
-        http = client._connection._http = _Http(
+        http = client._http_internal = _Http(
             {'status': '200', 'content-type': 'application/json'},
             '{"items": []}',
         )

--- a/translate/google/cloud/translate/client.py
+++ b/translate/google/cloud/translate/client.py
@@ -54,12 +54,14 @@ class Client(BaseClient):
                  ``credentials`` for the current object.
     """
 
+    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
+    """The scopes required for authenticating."""
+
     def __init__(self, target_language=ENGLISH_ISO_639,
                  credentials=None, http=None):
         self.target_language = target_language
         super(Client, self).__init__(credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
 
     def get_languages(self, target_language=None):
         """Get list of supported languages for translation.

--- a/translate/google/cloud/translate/connection.py
+++ b/translate/google/cloud/translate/connection.py
@@ -18,7 +18,11 @@ from google.cloud import _http
 
 
 class Connection(_http.JSONConnection):
-    """A connection to Google Cloud Translation API via the JSON REST API."""
+    """A connection to Google Cloud Translation API via the JSON REST API.
+
+    :type client: :class:`~google.cloud.translate.client.Client`
+    :param client: The client that owns the current connection.
+    """
 
     API_BASE_URL = 'https://translation.googleapis.com'
     """The base of the API call URL."""

--- a/translate/google/cloud/translate/connection.py
+++ b/translate/google/cloud/translate/connection.py
@@ -28,6 +28,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/language/translate/{api_version}{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
-    """The scopes required for authenticating."""

--- a/translate/unit_tests/test_connection.py
+++ b/translate/unit_tests/test_connection.py
@@ -27,7 +27,7 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        conn = self._make_one()
+        conn = self._make_one(object())
         URI = '/'.join([
             conn.API_BASE_URL,
             'language',
@@ -41,7 +41,7 @@ class TestConnection(unittest.TestCase):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
 
-        conn = self._make_one()
+        conn = self._make_one(object())
         query_params = [('q', 'val1'), ('q', 'val2')]
         uri = conn.build_api_url('/foo', query_params=query_params)
         scheme, netloc, path, qs, _ = urlsplit(uri)

--- a/vision/google/cloud/vision/client.py
+++ b/vision/google/cloud/vision/client.py
@@ -55,14 +55,17 @@ class Client(ClientWithProject):
                     falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
                     variable
     """
+
+    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
+    """The scopes required for authenticating as a Cloud Vision consumer."""
+
     _vision_api_internal = None
 
     def __init__(self, project=None, credentials=None, http=None,
                  use_gax=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, http=http)
-        self._connection = Connection(
-            credentials=self._credentials, http=self._http)
+        self._connection = Connection(self)
         if use_gax is None:
             self._use_gax = _USE_GAX
         else:

--- a/vision/google/cloud/vision/connection.py
+++ b/vision/google/cloud/vision/connection.py
@@ -22,16 +22,8 @@ from google.cloud import _http
 class Connection(_http.JSONConnection):
     """A connection to Google Cloud Vision via the JSON REST API.
 
-    :type credentials: :class:`oauth2client.client.OAuth2Credentials`
-    :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        connection.
-
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: (Optional) HTTP object to make requests.
-
-    :type api_base_url: str
-    :param api_base_url: The base of the API call URL. Defaults to the value
-                         :attr:`Connection.API_BASE_URL`.
+    :type client: :class:`~google.cloud.vision.client.Client`
+    :param client: The client that owns the current connection.
     """
 
     API_BASE_URL = 'https://vision.googleapis.com'

--- a/vision/google/cloud/vision/connection.py
+++ b/vision/google/cloud/vision/connection.py
@@ -42,6 +42,3 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
-
-    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
-    """The scopes required for authenticating as a Cloud Vision consumer."""

--- a/vision/unit_tests/test_connection.py
+++ b/vision/unit_tests/test_connection.py
@@ -26,6 +26,6 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_default_url(self):
-        creds = object()
-        conn = self._make_one(creds)
-        self.assertEqual(conn.credentials, creds)
+        client = object()
+        conn = self._make_one(client)
+        self.assertEqual(conn._client, client)


### PR DESCRIPTION
This is part of a re-factoring effort to remove / reduce the role of `Connection` classes (since they are outdated): #2606 

I ran the system tests and `speech` is failing but I think it's unrelated to this? Also, the umbrella coverage is failing, so I sent #2969 to fix (also unrelated to this PR).