### PR TITLE
Do not include a default language.

### DIFF
--- a/language/google/cloud/language/document.py
+++ b/language/google/cloud/language/document.py
@@ -25,10 +25,6 @@ from google.cloud.language.syntax import Sentence
 from google.cloud.language.syntax import Token
 
 
-DEFAULT_LANGUAGE = 'en-US'
-"""Default document language, English."""
-
-
 Annotations = collections.namedtuple(
     'Annotations',
     'sentences tokens sentiment entities')
@@ -93,7 +89,7 @@ class Document(object):
 
     :type language: str
     :param language: (Optional) The language of the document text.
-                     Defaults to :data:`DEFAULT_LANGUAGE`.
+                     Defaults to None (auto-detect).
 
     :type encoding: str
     :param encoding: (Optional) The encoding of the document text.
@@ -115,7 +111,7 @@ class Document(object):
     """HTML document type."""
 
     def __init__(self, client, content=None, gcs_url=None, doc_type=PLAIN_TEXT,
-                 language=DEFAULT_LANGUAGE, encoding=Encoding.UTF8):
+                 language=None, encoding=Encoding.UTF8):
         if content is not None and gcs_url is not None:
             raise ValueError('A Document cannot contain both local text and '
                              'a link to text in a Google Cloud Storage object')
@@ -139,8 +135,9 @@ class Document(object):
         """
         info = {
             'type': self.doc_type,
-            'language': self.language,
         }
+        if self.language is not None:
+            info['language'] = self.language
         if self.content is not None:
             info['content'] = self.content
         elif self.gcs_url is not None:

--- a/language/unit_tests/test_document.py
+++ b/language/unit_tests/test_document.py
@@ -147,8 +147,6 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(document.encoding, MUT.Encoding.UTF32)
 
     def test_constructor_explicit_language(self):
-        import google.cloud.language.document as MUT
-
         client = object()
         content = 'abc'
         document = self._make_one(client, content, language='en-US')

--- a/language/unit_tests/test_document.py
+++ b/language/unit_tests/test_document.py
@@ -125,8 +125,8 @@ class TestDocument(unittest.TestCase):
         self.assertIs(document.client, client)
         self.assertEqual(document.content, content)
         self.assertIsNone(document.gcs_url)
+        self.assertIsNone(document.language)
         self.assertEqual(document.doc_type, MUT.Document.PLAIN_TEXT)
-        self.assertEqual(document.language, MUT.DEFAULT_LANGUAGE)
         self.assertEqual(document.encoding, MUT.Encoding.UTF8)
 
     def test_constructor_explicit(self):
@@ -146,6 +146,15 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(document.language, language)
         self.assertEqual(document.encoding, MUT.Encoding.UTF32)
 
+    def test_constructor_explicit_language(self):
+        import google.cloud.language.document as MUT
+
+        client = object()
+        content = 'abc'
+        document = self._make_one(client, content, language='en-US')
+        self.assertEqual(document.language, 'en-US')
+        self.assertEqual(document._to_dict()['language'], 'en-US')
+
     def test_constructor_no_text(self):
         with self.assertRaises(ValueError):
             self._make_one(None, content=None, gcs_url=None)
@@ -162,7 +171,6 @@ class TestDocument(unittest.TestCase):
         info = document._to_dict()
         self.assertEqual(info, {
             'content': content,
-            'language': document.language,
             'type': klass.PLAIN_TEXT,
         })
 
@@ -173,7 +181,6 @@ class TestDocument(unittest.TestCase):
         info = document._to_dict()
         self.assertEqual(info, {
             'gcsContentUri': gcs_url,
-            'language': document.language,
             'type': klass.PLAIN_TEXT,
         })
 
@@ -183,7 +190,6 @@ class TestDocument(unittest.TestCase):
         document.content = None  # Manually unset the content.
         info = document._to_dict()
         self.assertEqual(info, {
-            'language': document.language,
             'type': klass.PLAIN_TEXT,
         })
 
@@ -203,12 +209,10 @@ class TestDocument(unittest.TestCase):
                        extract_sentiment=False,
                        extract_entities=False,
                        extract_syntax=False):
-        from google.cloud.language.document import DEFAULT_LANGUAGE
         from google.cloud.language.document import Document
 
         expected = {
             'document': {
-                'language': DEFAULT_LANGUAGE,
                 'type': Document.PLAIN_TEXT,
                 'content': content,
             },


### PR DESCRIPTION
The language API auto-detects language if not is not provided, so defaulting to English is incorrect.