### PR TITLE
Rename `document_from_url` to `document_from_gcs_url`.

### DIFF
--- a/language/google/cloud/language/client.py
+++ b/language/google/cloud/language/client.py
@@ -14,6 +14,8 @@
 
 """Basic client for Google Cloud Natural Language API."""
 
+import functools
+import warnings
 
 from google.cloud import client as client_module
 from google.cloud.language.connection import Connection
@@ -87,8 +89,8 @@ class Client(client_module.Client):
         return Document(self, content=content,
                         doc_type=Document.HTML, **kwargs)
 
-    def document_from_url(self, gcs_url,
-                          doc_type=Document.PLAIN_TEXT, **kwargs):
+    def document_from_gcs_url(self, gcs_url,
+                              doc_type=Document.PLAIN_TEXT, **kwargs):
         """Create a Cloud Storage document bound to this client.
 
         :type gcs_url: str
@@ -110,3 +112,13 @@ class Client(client_module.Client):
         :returns: A document bound to this client.
         """
         return Document(self, gcs_url=gcs_url, doc_type=doc_type, **kwargs)
+
+    @functools.wraps(document_from_gcs_url)
+    def document_from_url(self, *args, **kwargs):
+        """Deprecated equivalent to document_from_gcs_url.
+        (Deprecated on 2017-02-06.)
+        """
+
+        warnings.warn('The `document_from_url` method is deprecated; use '
+                      '`document_from_gcs_url` instead.', DeprecationWarning)
+        return self.document_from_gcs_url(*args, **kwargs)

--- a/language/google/cloud/language/client.py
+++ b/language/google/cloud/language/client.py
@@ -116,7 +116,7 @@ class Client(client_module.Client):
     @functools.wraps(document_from_gcs_url)
     def document_from_url(self, *args, **kwargs):
         """Deprecated equivalent to document_from_gcs_url.
-        
+
         (Deprecated on 2017-02-06.)
         """
 

--- a/language/google/cloud/language/client.py
+++ b/language/google/cloud/language/client.py
@@ -117,9 +117,8 @@ class Client(client_module.Client):
     def document_from_url(self, *args, **kwargs):
         """Deprecated equivalent to document_from_gcs_url.
 
-        (Deprecated on 2017-02-06.)
+        DEPRECATED: 2017-02-06
         """
-
         warnings.warn('The `document_from_url` method is deprecated; use '
                       '`document_from_gcs_url` instead.', DeprecationWarning)
         return self.document_from_gcs_url(*args, **kwargs)

--- a/language/google/cloud/language/client.py
+++ b/language/google/cloud/language/client.py
@@ -116,6 +116,7 @@ class Client(client_module.Client):
     @functools.wraps(document_from_gcs_url)
     def document_from_url(self, *args, **kwargs):
         """Deprecated equivalent to document_from_gcs_url.
+        
         (Deprecated on 2017-02-06.)
         """
 


### PR DESCRIPTION
This change was requested by the NL team, since we only accept GCS URLs, and `document_from_url` implies anything.

Rather than a flat rename, I am having the original method warn a `DeprecationWarning`. We do not really have a process for deprecating or keeping up with them, so for the time being I am noting the date in the docstring.