### PR TITLE
Fix build failing with float precision mismatch

### DIFF
--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -297,10 +297,10 @@ class TestClient(unittest.TestCase):
 
         alternatives = [{
             'transcript': 'testing 1 2 3',
-            'confidence': 0.125,
+            'confidence': 0.740234375,
         }, {
             'transcript': 'testing 4 5 6',
-            'confidence': 0.125,
+            'confidence': 0.6396484375,
         }]
         result = _make_result(alternatives)
 
@@ -500,16 +500,16 @@ class TestClient(unittest.TestCase):
 
         alternatives = [{
             'transcript': 'testing streaming 1 2 3',
-            'confidence': 0.125,
+            'confidence': 0.5888671875,
         }, {
             'transcript': 'testing streaming 4 5 6',
-            'confidence': 0.125,
+            'confidence': 0.28125,
         }]
         first_response = _make_streaming_response(
-            _make_streaming_result([], is_final=False, stability=0.125))
+            _make_streaming_result([], is_final=False, stability=0.314453125))
         second_response = _make_streaming_response(
             _make_streaming_result(alternatives, is_final=False,
-                                   stability=0.125))
+                                   stability=0.28125))
         last_response = _make_streaming_response(
             _make_streaming_result(alternatives, is_final=True,
                                    stability=0.9834534))
@@ -542,8 +542,8 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(results[0], StreamingSpeechResult)
         self.assertEqual(results[0].alternatives, [])
         self.assertFalse(results[0].is_final)
-        self.assertEqual(results[0].stability, 0.125)
-        self.assertEqual(results[1].stability, 0.125)
+        self.assertEqual(results[0].stability, 0.314453125)
+        self.assertEqual(results[1].stability, 0.28125)
         self.assertFalse(results[1].is_final)
         self.assertEqual(results[1].transcript,
                          results[1].alternatives[0].transcript,
@@ -580,10 +580,10 @@ class TestClient(unittest.TestCase):
 
         alternatives = [{
             'transcript': 'testing streaming 1 2 3',
-            'confidence': 0.125,
+            'confidence': 0.4375,
         }, {
             'transcript': 'testing streaming 4 5 6',
-            'confidence': 0.125,
+            'confidence': 0.84375,
         }]
 
         first_response = _make_streaming_response(

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -297,10 +297,10 @@ class TestClient(unittest.TestCase):
 
         alternatives = [{
             'transcript': 'testing 1 2 3',
-            'confidence': 0.9224355,
+            'confidence': 0.125,
         }, {
             'transcript': 'testing 4 5 6',
-            'confidence': 0.0123456,
+            'confidence': 0.125,
         }]
         result = _make_result(alternatives)
 
@@ -500,13 +500,13 @@ class TestClient(unittest.TestCase):
 
         alternatives = [{
             'transcript': 'testing streaming 1 2 3',
-            'confidence': 0.9224355,
+            'confidence': 0.125,
         }, {
             'transcript': 'testing streaming 4 5 6',
-            'confidence': 0.0123456,
+            'confidence': 0.125,
         }]
         first_response = _make_streaming_response(
-            _make_streaming_result([], is_final=False, stability=0.122435))
+            _make_streaming_result([], is_final=False, stability=0.125))
         second_response = _make_streaming_response(
             _make_streaming_result(alternatives, is_final=False,
                                    stability=0.1432343))
@@ -542,7 +542,7 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(results[0], StreamingSpeechResult)
         self.assertEqual(results[0].alternatives, [])
         self.assertFalse(results[0].is_final)
-        self.assertEqual(results[0].stability, 0.122435)
+        self.assertEqual(results[0].stability, 0.125)
         self.assertEqual(results[1].stability, 0.1432343)
         self.assertFalse(results[1].is_final)
         self.assertEqual(results[1].transcript,
@@ -580,10 +580,10 @@ class TestClient(unittest.TestCase):
 
         alternatives = [{
             'transcript': 'testing streaming 1 2 3',
-            'confidence': 0.9224355,
+            'confidence': 0.125,
         }, {
             'transcript': 'testing streaming 4 5 6',
-            'confidence': 0.0123456,
+            'confidence': 0.125,
         }]
 
         first_response = _make_streaming_response(

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -509,7 +509,7 @@ class TestClient(unittest.TestCase):
             _make_streaming_result([], is_final=False, stability=0.125))
         second_response = _make_streaming_response(
             _make_streaming_result(alternatives, is_final=False,
-                                   stability=0.1432343))
+                                   stability=0.125))
         last_response = _make_streaming_response(
             _make_streaming_result(alternatives, is_final=True,
                                    stability=0.9834534))
@@ -543,7 +543,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(results[0].alternatives, [])
         self.assertFalse(results[0].is_final)
         self.assertEqual(results[0].stability, 0.125)
-        self.assertEqual(results[1].stability, 0.1432343)
+        self.assertEqual(results[1].stability, 0.125)
         self.assertFalse(results[1].is_final)
         self.assertEqual(results[1].transcript,
                          results[1].alternatives[0].transcript,

--- a/speech/unit_tests/test_client.py
+++ b/speech/unit_tests/test_client.py
@@ -512,7 +512,7 @@ class TestClient(unittest.TestCase):
                                    stability=0.28125))
         last_response = _make_streaming_response(
             _make_streaming_result(alternatives, is_final=True,
-                                   stability=0.9834534))
+                                   stability=0.4375))
         responses = [first_response, second_response, last_response]
 
         channel_args = []
@@ -556,7 +556,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(results[1].alternatives[1].confidence,
                          alternatives[1]['confidence'])
         self.assertTrue(results[2].is_final)
-        self.assertEqual(results[2].stability, 0.9834534)
+        self.assertEqual(results[2].stability, 0.4375)
         self.assertEqual(results[2].transcript,
                          results[2].alternatives[0].transcript,
                          alternatives[0]['transcript'])

--- a/vision/unit_tests/test_annotations.py
+++ b/vision/unit_tests/test_annotations.py
@@ -23,7 +23,7 @@ def _make_pb_entity():
     description = 'testing 1 2 3'
     locale = 'US'
     mid = 'm/w/45342234'
-    score = 0.125
+    score = 0.390625
 
     entity_annotation = image_annotator_pb2.EntityAnnotation(
         mid=mid,
@@ -108,7 +108,7 @@ class Test__make_entity_from_pb(unittest.TestCase):
         description = 'testing 1 2 3'
         locale = 'US'
         mid = 'm/w/45342234'
-        score = 0.125
+        score = 0.390625
         entity_annotation = _make_pb_entity()
         entities = self._call_fut([entity_annotation])
         self.assertEqual(len(entities), 1)
@@ -183,7 +183,7 @@ class Test__process_image_annotations(unittest.TestCase):
         description = 'testing 1 2 3'
         locale = 'US'
         mid = 'm/w/45342234'
-        score = 0.125
+        score = 0.390625
         entity_annotation = _make_pb_entity()
 
         image_response = image_annotator_pb2.AnnotateImageResponse(

--- a/vision/unit_tests/test_annotations.py
+++ b/vision/unit_tests/test_annotations.py
@@ -23,7 +23,7 @@ def _make_pb_entity():
     description = 'testing 1 2 3'
     locale = 'US'
     mid = 'm/w/45342234'
-    score = 0.235434231
+    score = 0.125
 
     entity_annotation = image_annotator_pb2.EntityAnnotation(
         mid=mid,
@@ -108,7 +108,7 @@ class Test__make_entity_from_pb(unittest.TestCase):
         description = 'testing 1 2 3'
         locale = 'US'
         mid = 'm/w/45342234'
-        score = 0.235434231
+        score = 0.125
         entity_annotation = _make_pb_entity()
         entities = self._call_fut([entity_annotation])
         self.assertEqual(len(entities), 1)
@@ -183,7 +183,7 @@ class Test__process_image_annotations(unittest.TestCase):
         description = 'testing 1 2 3'
         locale = 'US'
         mid = 'm/w/45342234'
-        score = 0.235434231
+        score = 0.125
         entity_annotation = _make_pb_entity()
 
         image_response = image_annotator_pb2.AnnotateImageResponse(

--- a/vision/unit_tests/test_entity.py
+++ b/vision/unit_tests/test_entity.py
@@ -39,7 +39,7 @@ class TestEntityAnnotation(unittest.TestCase):
         description = 'testing 1 2 3'
         locale = 'US'
         mid = 'm/w/45342234'
-        score = 0.235434231
+        score = 0.125
         entity_annotation = image_annotator_pb2.EntityAnnotation()
         entity_annotation.mid = mid
         entity_annotation.locale = locale

--- a/vision/unit_tests/test_entity.py
+++ b/vision/unit_tests/test_entity.py
@@ -39,7 +39,7 @@ class TestEntityAnnotation(unittest.TestCase):
         description = 'testing 1 2 3'
         locale = 'US'
         mid = 'm/w/45342234'
-        score = 0.125
+        score = 0.875
         entity_annotation = image_annotator_pb2.EntityAnnotation()
         entity_annotation.mid = mid
         entity_annotation.locale = locale


### PR DESCRIPTION
Build is failing due to float precision.
See: https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/876

Clarification: `float` (i.e. single) vs. `double`. Double values are being cast down into `float` (which is correct, but is also a breaking change). For example

```python
>>> (0.9224355).hex()
'0x1.d849774256bcap-1'
>>> from google.cloud.grpc.vision.v1 import image_annotator_pb2
>>> e = image_annotator_pb2.EntityAnnotation(score=0.9224355)
>>> e.score
0.9224355220794678
>>> e.score.hex()
'0x1.d849780000000p-1'
```