### PR TITLE
Check running status via 'job' property.

### DIFF
--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -351,7 +351,7 @@ class QueryResults(object):
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
         """
-        if self._job is not None:
+        if self.job is not None:
             raise ValueError("Query job is already running.")
 
         client = self._require_client(client)

--- a/bigquery/unit_tests/test_query.py
+++ b/bigquery/unit_tests/test_query.py
@@ -274,6 +274,15 @@ class TestQueryResults(unittest.TestCase):
         with self.assertRaises(ValueError):
             query.run()
 
+    def test_run_w_already_has_job_in_properties(self):
+        JOB_ID = 'JOB_ID'
+        conn = _Connection()
+        client = _Client(project=self.PROJECT, connection=conn)
+        query = self._make_one(self.QUERY, client)
+        query._properties['jobReference'] = {'jobId': JOB_ID}
+        with self.assertRaises(ValueError):
+            query.run()
+
     def test_run_w_bound_client(self):
         PATH = 'projects/%s/queries' % self.PROJECT
         RESOURCE = self._makeResource(complete=False)


### PR DESCRIPTION
If the `_job` attribute is not set, but we have a `jobId` in our properties, we still don't want to re-run the query.

Closes #3003.