### PR TITLE
Spanner Docs Consistency

### DIFF
--- a/docs/spanner-client-usage.rst
+++ b/docs/spanner-client-usage.rst
@@ -1,5 +1,5 @@
-Base for Everything
-===================
+Client
+======
 
 To use the API, the :class:`~google.cloud.spanner.client.Client`
 class defines a high-level interface which handles authorization


### PR DESCRIPTION
Use "Client" as the header for the client docs, not "Base for Everything".
This makes it consistent with every other Google API.