### PR TITLE
Adding ability to send version info header on HTTP requests.

### DIFF
--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -15,7 +15,9 @@
 """Shared implementation of connections to API servers."""
 
 import json
+import platform
 from pkg_resources import get_distribution
+
 import six
 from six.moves.urllib.parse import urlencode
 
@@ -29,6 +31,10 @@ DEFAULT_USER_AGENT = 'gcloud-python/{0}'.format(
     get_distribution('google-cloud-core').version)
 """The user agent for google-cloud-python requests."""
 
+CLIENT_INFO_HEADER = 'X-Goog-API-Client'
+CLIENT_INFO_TEMPLATE = (
+    'gl-python/' + platform.python_version() + ' gccl/{}')
+
 
 class Connection(object):
     """A generic connection to Google Cloud Platform.
@@ -38,6 +44,11 @@ class Connection(object):
     """
 
     USER_AGENT = DEFAULT_USER_AGENT
+    _EXTRA_HEADERS = {}
+    """Headers to be sent with every request.
+
+    Intended to be over-ridden by subclasses.
+    """
 
     def __init__(self, client):
         self._client = client
@@ -147,7 +158,9 @@ class JSONConnection(Connection):
         :param content_type: The proper MIME type of the data provided.
 
         :type headers: dict
-        :param headers: A dictionary of HTTP headers to send with the request.
+        :param headers: (Optional) A dictionary of HTTP headers to send with
+                        the request. If passed, will be modified directly
+                        here with added headers.
 
         :type target_object: object
         :param target_object:
@@ -161,6 +174,7 @@ class JSONConnection(Connection):
                   returned by :meth:`_do_request`.
         """
         headers = headers or {}
+        headers.update(self._EXTRA_HEADERS)
         headers['Accept-Encoding'] = 'gzip'
 
         if data:

--- a/datastore/google/cloud/datastore/_http.py
+++ b/datastore/google/cloud/datastore/_http.py
@@ -16,6 +16,7 @@
 
 import contextlib
 import os
+from pkg_resources import get_distribution
 
 from google.rpc import status_pb2
 
@@ -61,6 +62,9 @@ DATASTORE_API_HOST = 'datastore.googleapis.com'
 
 _DISABLE_GRPC = os.getenv(DISABLE_GRPC, False)
 _USE_GRPC = _HAVE_GRPC and not _DISABLE_GRPC
+_DATASTORE_DIST = get_distribution('google-cloud-datastore')
+_CLIENT_INFO = connection_module.CLIENT_INFO_TEMPLATE.format(
+    _DATASTORE_DIST.version)
 
 
 class _DatastoreAPIOverHttp(object):
@@ -102,6 +106,7 @@ class _DatastoreAPIOverHttp(object):
             'Content-Type': 'application/x-protobuf',
             'Content-Length': str(len(data)),
             'User-Agent': self.connection.USER_AGENT,
+            connection_module.CLIENT_INFO_HEADER: _CLIENT_INFO,
         }
         headers, content = self.connection.http.request(
             uri=self.connection.build_api_url(project=project, method=method),

--- a/storage/google/cloud/storage/_http.py
+++ b/storage/google/cloud/storage/_http.py
@@ -14,7 +14,13 @@
 
 """Create / interact with Google Cloud Storage connections."""
 
+from pkg_resources import get_distribution
+
 from google.cloud import _http
+
+
+_STORAGE_DIST = get_distribution('google-cloud-storage')
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(_STORAGE_DIST.version)
 
 
 class Connection(_http.JSONConnection):
@@ -32,3 +38,7 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/storage/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }

--- a/storage/unit_tests/test__http.py
+++ b/storage/unit_tests/test__http.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestConnection(unittest.TestCase):
 
@@ -25,6 +27,36 @@ class TestConnection(unittest.TestCase):
 
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
+
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.storage import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'hey-yoooouuuuu-guuuuuyyssss'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )
 
     def test_build_api_url_no_extra_query_params(self):
         conn = self._make_one(object())


### PR DESCRIPTION
Added an "extra headers" feature to enable this. I am not a fan
of changing `Connection()` so haphazardly, but I hope to
completely re-factor / destory `Connection()` in the near-term
so I am less worried.

This only adds the storage and datastore header info, for the
purposes of a simple review. Once we agree on the approach,
I can add support in the other subpackages.