### PR TITLE
Remove Travis CI badging and update README and CONTRIBUTING.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -404,21 +404,17 @@ may cause problems creating links or rendering the description.
 
 .. _description on PyPI: https://pypi.python.org/pypi/google-cloud
 
-********************************************
-Travis Configuration and Build Optimizations
-********************************************
+**********************************************
+CircleCI Configuration and Build Optimizations
+**********************************************
 
-All build scripts in the ``.travis.yml`` configuration file which have
+All build scripts in the ``circle.yml`` configuration file which have
 Python dependencies are specified in the ``tox.ini`` configuration.
-They are executed in the Travis build via ``tox -e ${ENV}`` where
+They are executed in the CircleCI build via ``tox -e ${ENV}`` where
 ``${ENV}`` is the environment being tested.
 
-If new ``tox`` environments are added to be run in a Travis build, they
+If new ``tox`` environments are added to be run in a CircleCI build, they
 should be listed in ``[tox].envlist`` as a default environment.
-
-We speed up builds by using the Travis `caching feature`_.
-
-.. _caching feature: https://docs.travis-ci.com/user/caching/#pip-cache
 
 We intentionally **do not** cache the ``.tox/`` directory. Instead, we
 allow the ``tox`` environments to be re-built for every build. This
@@ -445,11 +441,10 @@ Supported versions can be found in our ``tox.ini`` `config`_.
 .. _config: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/tox.ini
 
 We explicitly decided not to support `Python 2.5`_ due to `decreased usage`_
-and lack of continuous integration `support`_.
+and lack of continuous integration support.
 
 .. _Python 2.5: https://docs.python.org/2.5/
 .. _decreased usage: https://caremad.io/2013/10/a-look-at-pypi-downloads/
-.. _support: https://blog.travis-ci.com/2013-11-18-upcoming-build-environment-updates/
 
 We have `dropped 2.6`_ as a supported version as well since Python 2.6 is no
 longer supported by the core development team.

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Google Cloud Python Client
 
 .. _Google Cloud Platform: https://cloud.google.com/
 
-|pypi| |circleci| |build| |appveyor| |coverage| |versions|
+|pypi| |circleci| |appveyor| |coverage| |versions|
 
 -  `Homepage`_
 -  `API Documentation`_
@@ -143,8 +143,6 @@ Apache 2.0 - See `LICENSE`_ for more information.
 
 .. _LICENSE: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/LICENSE
 
-.. |build| image:: https://travis-ci.org/GoogleCloudPlatform/google-cloud-python.svg?branch=master
-   :target: https://travis-ci.org/GoogleCloudPlatform/google-cloud-python
 .. |circleci| image:: https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python.svg?style=shield
    :target: https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python
 .. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/googlecloudplatform/google-cloud-python?branch=master&svg=true


### PR DESCRIPTION
We haven't had a green travis build in a very long time.
Also, with the addition of Spanner, the `master` jobs reach the max time limit on Travis and just [timeout](https://travis-ci.org/GoogleCloudPlatform/google-cloud-python/builds/202484426#L2788) anyway.