### PR TITLE
Add gccl metrics header to Spanner.

### DIFF
--- a/spanner/google/cloud/spanner/__init__.py
+++ b/spanner/google/cloud/spanner/__init__.py
@@ -15,6 +15,10 @@
 """Cloud Spanner API package."""
 
 
+import pkg_resources
+__version__ = pkg_resources.get_distribution('google-cloud-spanner').version
+
+
 from google.cloud.spanner.client import Client
 
 from google.cloud.spanner.keyset import KeyRange

--- a/spanner/google/cloud/spanner/client.py
+++ b/spanner/google/cloud/spanner/client.py
@@ -38,6 +38,7 @@ from google.cloud.client import _ClientFactoryMixin
 from google.cloud.client import _ClientProjectMixin
 from google.cloud.credentials import get_credentials
 from google.cloud.iterator import GAXIterator
+from google.cloud.spanner import __version__
 from google.cloud.spanner._helpers import _options_with_prefix
 from google.cloud.spanner.instance import DEFAULT_NODE_COUNT
 from google.cloud.spanner.instance import Instance
@@ -152,14 +153,20 @@ class Client(_ClientFactoryMixin, _ClientProjectMixin):
     def instance_admin_api(self):
         """Helper for session-related API calls."""
         if self._instance_admin_api is None:
-            self._instance_admin_api = InstanceAdminClient()
+            self._instance_admin_api = InstanceAdminClient(
+                lib_name='gccl',
+                lib_version=__version__,
+            )
         return self._instance_admin_api
 
     @property
     def database_admin_api(self):
         """Helper for session-related API calls."""
         if self._database_admin_api is None:
-            self._database_admin_api = DatabaseAdminClient()
+            self._database_admin_api = DatabaseAdminClient(
+                lib_name='gccl',
+                lib_version=__version__,
+            )
         return self._database_admin_api
 
     def copy(self):

--- a/spanner/google/cloud/spanner/database.py
+++ b/spanner/google/cloud/spanner/database.py
@@ -30,6 +30,7 @@ import six
 from google.cloud.exceptions import Conflict
 from google.cloud.exceptions import NotFound
 from google.cloud.operation import register_type
+from google.cloud.spanner import __version__
 from google.cloud.spanner._helpers import _options_with_prefix
 from google.cloud.spanner.batch import Batch
 from google.cloud.spanner.session import Session
@@ -179,7 +180,8 @@ class Database(object):
     def spanner_api(self):
         """Helper for session-related API calls."""
         if self._spanner_api is None:
-            self._spanner_api = SpannerClient()
+            self._spanner_api = SpannerClient(lib_name='gccl',
+                                              lib_version=__version__)
         return self._spanner_api
 
     def __eq__(self, other):

--- a/spanner/google/cloud/spanner/database.py
+++ b/spanner/google/cloud/spanner/database.py
@@ -180,8 +180,8 @@ class Database(object):
     def spanner_api(self):
         """Helper for session-related API calls."""
         if self._spanner_api is None:
-            self._spanner_api = SpannerClient(lib_name='gccl',
-                                              lib_version=__version__)
+            self._spanner_api = SpannerClient(
+                lib_name='gccl', lib_version=__version__)
         return self._spanner_api
 
     def __eq__(self, other):

--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-spanner',
-    version='0.23.1',
+    version='0.23.2',
     description='Python Client for Cloud Spanner',
     long_description=README,
     namespace_packages=[

--- a/spanner/unit_tests/test_client.py
+++ b/spanner/unit_tests/test_client.py
@@ -107,9 +107,6 @@ class TestClient(unittest.TestCase):
         self._constructor_test_helper(expected_scopes, creds)
 
     def test_admin_api_lib_name(self):
-        """Establish that the lib_name and lib_version are passed to
-        the database and instance API objects in the GAPIC.
-        """
         from google.cloud.spanner import __version__
         from google.cloud.gapic.spanner_admin_database import v1 as db
         from google.cloud.gapic.spanner_admin_instance import v1 as inst

--- a/spanner/unit_tests/test_client.py
+++ b/spanner/unit_tests/test_client.py
@@ -111,7 +111,6 @@ class TestClient(unittest.TestCase):
         the database and instance API objects in the GAPIC.
         """
         from google.cloud.spanner import __version__
-        from google.cloud.spanner import client as MUT
         from google.cloud.gapic.spanner_admin_database import v1 as db
         from google.cloud.gapic.spanner_admin_instance import v1 as inst
 
@@ -123,7 +122,10 @@ class TestClient(unittest.TestCase):
         # name and version.
         with mock.patch.object(DatabaseAdminClient, '__init__') as mock_dac:
             mock_dac.return_value = None
-            client = self._make_one()
+            client = self._make_one(
+                credentials=_make_credentials(),
+                project='foo',
+            )
             self.assertIsInstance(client.database_admin_api,
                                   DatabaseAdminClient)
             mock_dac.assert_called_once()
@@ -135,7 +137,10 @@ class TestClient(unittest.TestCase):
         # name and version.
         with mock.patch.object(InstanceAdminClient, '__init__') as mock_iac:
             mock_iac.return_value = None
-            client = self._make_one()
+            client = self._make_one(
+                credentials=_make_credentials(),
+                project='foo',
+            )
             self.assertIsInstance(client.instance_admin_api,
                                   InstanceAdminClient)
             mock_iac.assert_called_once()
@@ -152,7 +157,8 @@ class TestClient(unittest.TestCase):
 
         class _Client(object):
             def __init__(self, *args, **kwargs):
-                pass
+                self.args = args
+                self.kwargs = kwargs
 
         with _Monkey(MUT, InstanceAdminClient=_Client):
             api = client.instance_admin_api
@@ -160,6 +166,7 @@ class TestClient(unittest.TestCase):
         self.assertTrue(isinstance(api, _Client))
         again = client.instance_admin_api
         self.assertTrue(again is api)
+        self.assertEqual(api.kwargs['lib_name'], 'gccl')
 
     def test_database_admin_api(self):
         from google.cloud._testing import _Monkey
@@ -170,7 +177,8 @@ class TestClient(unittest.TestCase):
 
         class _Client(object):
             def __init__(self, *args, **kwargs):
-                pass
+                self.args = args
+                self.kwargs = kwargs
 
         with _Monkey(MUT, DatabaseAdminClient=_Client):
             api = client.database_admin_api
@@ -178,6 +186,7 @@ class TestClient(unittest.TestCase):
         self.assertTrue(isinstance(api, _Client))
         again = client.database_admin_api
         self.assertTrue(again is api)
+        self.assertEqual(api.kwargs['lib_name'], 'gccl')
 
     def test_copy(self):
         credentials = _Credentials('value')

--- a/spanner/unit_tests/test_client.py
+++ b/spanner/unit_tests/test_client.py
@@ -106,6 +106,43 @@ class TestClient(unittest.TestCase):
         expected_scopes = None
         self._constructor_test_helper(expected_scopes, creds)
 
+    def test_admin_api_lib_name(self):
+        """Establish that the lib_name and lib_version are passed to
+        the database and instance API objects in the GAPIC.
+        """
+        from google.cloud.spanner import __version__
+        from google.cloud.spanner import client as MUT
+        from google.cloud.gapic.spanner_admin_database import v1 as db
+        from google.cloud.gapic.spanner_admin_instance import v1 as inst
+
+        # Get the actual admin client classes.
+        DatabaseAdminClient = db.database_admin_client.DatabaseAdminClient
+        InstanceAdminClient = inst.instance_admin_client.InstanceAdminClient
+
+        # Test that the DatabaseAdminClient is called with the gccl library
+        # name and version.
+        with mock.patch.object(DatabaseAdminClient, '__init__') as mock_dac:
+            mock_dac.return_value = None
+            client = self._make_one()
+            self.assertIsInstance(client.database_admin_api,
+                                  DatabaseAdminClient)
+            mock_dac.assert_called_once()
+            self.assertEqual(mock_dac.mock_calls[0][2]['lib_name'], 'gccl')
+            self.assertEqual(mock_dac.mock_calls[0][2]['lib_version'],
+                             __version__)
+
+        # Test that the InstanceAdminClient is called with the gccl library
+        # name and version.
+        with mock.patch.object(InstanceAdminClient, '__init__') as mock_iac:
+            mock_iac.return_value = None
+            client = self._make_one()
+            self.assertIsInstance(client.instance_admin_api,
+                                  InstanceAdminClient)
+            mock_iac.assert_called_once()
+            self.assertEqual(mock_iac.mock_calls[0][2]['lib_name'], 'gccl')
+            self.assertEqual(mock_iac.mock_calls[0][2]['lib_version'],
+                             __version__)
+
     def test_instance_admin_api(self):
         from google.cloud._testing import _Monkey
         from google.cloud.spanner import client as MUT
@@ -114,7 +151,8 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=self.PROJECT, credentials=creds)
 
         class _Client(object):
-            pass
+            def __init__(self, *args, **kwargs):
+                pass
 
         with _Monkey(MUT, InstanceAdminClient=_Client):
             api = client.instance_admin_api
@@ -131,7 +169,8 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=self.PROJECT, credentials=creds)
 
         class _Client(object):
-            pass
+            def __init__(self, *args, **kwargs):
+                pass
 
         with _Monkey(MUT, DatabaseAdminClient=_Client):
             api = client.database_admin_api

--- a/spanner/unit_tests/test_database.py
+++ b/spanner/unit_tests/test_database.py
@@ -191,7 +191,7 @@ class TestDatabase(_BaseTest):
         _clients = [_client]
 
         def _mock_spanner_client(*args, **kwargs):
-            self.assertIsInstance(args, (list, tuple))
+            self.assertIsInstance(args, tuple)
             self.assertEqual(kwargs['lib_name'], 'gccl')
             self.assertEqual(kwargs['lib_version'], __version__)
             return _clients.pop(0)

--- a/spanner/unit_tests/test_database.py
+++ b/spanner/unit_tests/test_database.py
@@ -17,6 +17,8 @@ import unittest
 
 import mock
 
+from google.cloud.spanner import __version__
+
 from google.cloud._testing import _GAXBaseAPI
 
 
@@ -188,7 +190,9 @@ class TestDatabase(_BaseTest):
         _client = object()
         _clients = [_client]
 
-        def _mock_spanner_client():
+        def _mock_spanner_client(*args, **kwargs):
+            self.assertEqual(kwargs['lib_name'], 'gccl')
+            self.assertEqual(kwargs['lib_version'], __version__)
             return _clients.pop(0)
 
         with _Monkey(MUT, SpannerClient=_mock_spanner_client):

--- a/spanner/unit_tests/test_database.py
+++ b/spanner/unit_tests/test_database.py
@@ -191,6 +191,7 @@ class TestDatabase(_BaseTest):
         _clients = [_client]
 
         def _mock_spanner_client(*args, **kwargs):
+            self.assertIsInstance(args, (list, tuple))
             self.assertEqual(kwargs['lib_name'], 'gccl')
             self.assertEqual(kwargs['lib_version'], __version__)
             return _clients.pop(0)


### PR DESCRIPTION
This PR adds the `gccl/x.y.z` portion of the metrics header in the Spanner client library.