### PR TITLE
Adding GCCL header for HTTP APIs.

### DIFF
--- a/bigquery/google/cloud/bigquery/__init__.py
+++ b/bigquery/google/cloud/bigquery/__init__.py
@@ -23,6 +23,9 @@ The main concepts with this API are:
 """
 
 
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-bigquery').version
+
 from google.cloud.bigquery._helpers import ArrayQueryParameter
 from google.cloud.bigquery._helpers import ScalarQueryParameter
 from google.cloud.bigquery._helpers import StructQueryParameter

--- a/bigquery/google/cloud/bigquery/_http.py
+++ b/bigquery/google/cloud/bigquery/_http.py
@@ -16,6 +16,11 @@
 
 from google.cloud import _http
 
+from google.cloud.bigquery import __version__
+
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
+
 
 class Connection(_http.JSONConnection):
     """A connection to Google BigQuery via the JSON REST API.
@@ -32,3 +37,7 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/bigquery/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }

--- a/bigquery/unit_tests/test__http.py
+++ b/bigquery/unit_tests/test__http.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestConnection(unittest.TestCase):
 
@@ -48,3 +50,33 @@ class TestConnection(unittest.TestCase):
                          '/'.join(['', 'bigquery', conn.API_VERSION, 'foo']))
         parms = dict(parse_qsl(qs))
         self.assertEqual(parms['bar'], 'baz')
+
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.bigquery import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'req-data-boring'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )

--- a/datastore/google/cloud/datastore/__init__.py
+++ b/datastore/google/cloud/datastore/__init__.py
@@ -54,6 +54,9 @@ The main concepts with this API are:
 """
 
 
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-datastore').version
+
 from google.cloud.datastore.batch import Batch
 from google.cloud.datastore.client import Client
 from google.cloud.datastore.entity import Entity

--- a/datastore/google/cloud/datastore/_http.py
+++ b/datastore/google/cloud/datastore/_http.py
@@ -15,7 +15,6 @@
 """Connections to Google Cloud Datastore API servers."""
 
 import os
-from pkg_resources import get_distribution
 
 from google.rpc import status_pb2
 
@@ -24,6 +23,8 @@ from google.cloud.environment_vars import DISABLE_GRPC
 from google.cloud.environment_vars import GCD_HOST
 from google.cloud import exceptions
 from google.cloud.grpc.datastore.v1 import datastore_pb2 as _datastore_pb2
+
+from google.cloud.datastore import __version__
 try:
     from google.cloud.datastore._gax import _DatastoreAPIOverGRPC
     _HAVE_GRPC = True
@@ -37,9 +38,7 @@ DATASTORE_API_HOST = 'datastore.googleapis.com'
 
 _DISABLE_GRPC = os.getenv(DISABLE_GRPC, False)
 _USE_GRPC = _HAVE_GRPC and not _DISABLE_GRPC
-_DATASTORE_DIST = get_distribution('google-cloud-datastore')
-_CLIENT_INFO = connection_module.CLIENT_INFO_TEMPLATE.format(
-    _DATASTORE_DIST.version)
+_CLIENT_INFO = connection_module.CLIENT_INFO_TEMPLATE.format(__version__)
 
 
 class _DatastoreAPIOverHttp(object):

--- a/dns/google/cloud/dns/__init__.py
+++ b/dns/google/cloud/dns/__init__.py
@@ -25,6 +25,9 @@ The main concepts with this API are:
 """
 
 
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-dns').version
+
 from google.cloud.dns.zone import Changes
 from google.cloud.dns.client import Client
 from google.cloud.dns.zone import ManagedZone

--- a/dns/google/cloud/dns/_http.py
+++ b/dns/google/cloud/dns/_http.py
@@ -16,6 +16,11 @@
 
 from google.cloud import _http
 
+from google.cloud.dns import __version__
+
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
+
 
 class Connection(_http.JSONConnection):
     """A connection to Google Cloud DNS via the JSON REST API.
@@ -32,3 +37,7 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/dns/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }

--- a/dns/unit_tests/test__http.py
+++ b/dns/unit_tests/test__http.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestConnection(unittest.TestCase):
 
@@ -48,3 +50,33 @@ class TestConnection(unittest.TestCase):
                          '/'.join(['', 'dns', conn.API_VERSION, 'foo']))
         parms = dict(parse_qsl(qs))
         self.assertEqual(parms['bar'], 'baz')
+
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.dns import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'req-data-boring'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )

--- a/error_reporting/google/cloud/error_reporting/__init__.py
+++ b/error_reporting/google/cloud/error_reporting/__init__.py
@@ -15,6 +15,9 @@
 """Client library for Stackdriver Error Reporting"""
 
 
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-error-reporting').version
+
 from google.cloud.error_reporting.client import Client
 from google.cloud.error_reporting.client import HTTPContext
 from google.cloud.error_reporting.util import build_flask_context

--- a/language/google/cloud/language/__init__.py
+++ b/language/google/cloud/language/__init__.py
@@ -15,6 +15,9 @@
 """Client library for Google Cloud Natural Language API."""
 
 
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-language').version
+
 from google.cloud.language.client import Client
 from google.cloud.language.document import Document
 from google.cloud.language.document import Encoding

--- a/language/google/cloud/language/_http.py
+++ b/language/google/cloud/language/_http.py
@@ -16,6 +16,11 @@
 
 from google.cloud import _http
 
+from google.cloud.language import __version__
+
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
+
 
 class Connection(_http.JSONConnection):
     """A connection to Google Cloud Natural Language JSON REST API.
@@ -32,3 +37,7 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}/documents:{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }

--- a/language/unit_tests/test__http.py
+++ b/language/unit_tests/test__http.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestConnection(unittest.TestCase):
 
@@ -36,3 +38,33 @@ class TestConnection(unittest.TestCase):
         method = 'annotateText'
         uri += ':' + method
         self.assertEqual(conn.build_api_url(method), uri)
+
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.language import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'req-data-boring'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )

--- a/logging/google/cloud/logging/__init__.py
+++ b/logging/google/cloud/logging/__init__.py
@@ -15,6 +15,9 @@
 """Google Stackdriver Logging API wrapper."""
 
 
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-logging').version
+
 from google.cloud.logging.client import Client
 
 

--- a/logging/google/cloud/logging/_http.py
+++ b/logging/google/cloud/logging/_http.py
@@ -18,9 +18,14 @@ import functools
 
 from google.cloud import _http
 from google.cloud.iterator import HTTPIterator
+
+from google.cloud.logging import __version__
 from google.cloud.logging._helpers import entry_from_resource
 from google.cloud.logging.sink import Sink
 from google.cloud.logging.metric import Metric
+
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
 
 
 class Connection(_http.JSONConnection):
@@ -38,6 +43,10 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }
 
 
 class _LoggingAPI(object):

--- a/monitoring/google/cloud/monitoring/__init__.py
+++ b/monitoring/google/cloud/monitoring/__init__.py
@@ -14,6 +14,10 @@
 
 """Google Stackdriver Monitoring API wrapper."""
 
+
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-monitoring').version
+
 from google.cloud.monitoring.client import Client
 from google.cloud.monitoring.group import Group
 from google.cloud.monitoring.label import LabelDescriptor

--- a/monitoring/google/cloud/monitoring/_http.py
+++ b/monitoring/google/cloud/monitoring/_http.py
@@ -16,6 +16,11 @@
 
 from google.cloud import _http
 
+from google.cloud.monitoring import __version__
+
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
+
 
 class Connection(_http.JSONConnection):
     """A connection to Google Stackdriver Monitoring via the JSON REST API.
@@ -32,3 +37,7 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }

--- a/monitoring/unit_tests/test__http.py
+++ b/monitoring/unit_tests/test__http.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestConnection(unittest.TestCase):
 
@@ -30,3 +32,33 @@ class TestConnection(unittest.TestCase):
         client = object()
         connection = self._make_one(client)
         self.assertIs(connection._client, client)
+
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.monitoring import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'req-data-boring'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )

--- a/pubsub/google/cloud/pubsub/__init__.py
+++ b/pubsub/google/cloud/pubsub/__init__.py
@@ -24,6 +24,9 @@ The main concepts with this API are:
 """
 
 
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-pubsub').version
+
 from google.cloud.pubsub.client import Client
 from google.cloud.pubsub.subscription import Subscription
 from google.cloud.pubsub.topic import Topic

--- a/pubsub/google/cloud/pubsub/_http.py
+++ b/pubsub/google/cloud/pubsub/_http.py
@@ -22,6 +22,8 @@ import os
 from google.cloud import _http
 from google.cloud.environment_vars import PUBSUB_EMULATOR
 from google.cloud.iterator import HTTPIterator
+
+from google.cloud.pubsub import __version__
 from google.cloud.pubsub._helpers import subscription_name_from_path
 from google.cloud.pubsub.subscription import Subscription
 from google.cloud.pubsub.topic import Topic
@@ -29,6 +31,8 @@ from google.cloud.pubsub.topic import Topic
 
 PUBSUB_API_HOST = 'pubsub.googleapis.com'
 """Pub / Sub API request host."""
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
 
 
 class Connection(_http.JSONConnection):
@@ -46,6 +50,10 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }
 
     def __init__(self, client):
         super(Connection, self).__init__(client)

--- a/pubsub/unit_tests/test__http.py
+++ b/pubsub/unit_tests/test__http.py
@@ -98,6 +98,36 @@ class TestConnection(_Base):
         self.assertEqual(conn.build_api_url('/foo', api_base_url=base_url2),
                          URI)
 
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.pubsub import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'req-data-boring'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )
+
 
 class Test_PublisherAPI(_Base):
 

--- a/resource_manager/google/cloud/resource_manager/__init__.py
+++ b/resource_manager/google/cloud/resource_manager/__init__.py
@@ -15,6 +15,9 @@
 """Google Cloud Resource Manager API wrapper."""
 
 
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-resource-manager').version
+
 from google.cloud.resource_manager.client import Client
 from google.cloud.resource_manager.project import Project
 

--- a/resource_manager/google/cloud/resource_manager/_http.py
+++ b/resource_manager/google/cloud/resource_manager/_http.py
@@ -17,6 +17,11 @@
 
 from google.cloud import _http
 
+from google.cloud.resource_manager import __version__
+
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
+
 
 class Connection(_http.JSONConnection):
     """A connection to Google Cloud Resource Manager via the JSON REST API.
@@ -33,3 +38,7 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }

--- a/resource_manager/unit_tests/test__http.py
+++ b/resource_manager/unit_tests/test__http.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestConnection(unittest.TestCase):
 
@@ -47,3 +49,33 @@ class TestConnection(unittest.TestCase):
                          '/'.join(['', conn.API_VERSION, 'foo']))
         parms = dict(parse_qsl(qs))
         self.assertEqual(parms['bar'], 'baz')
+
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.resource_manager import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'req-data-boring'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )

--- a/runtimeconfig/google/cloud/runtimeconfig/__init__.py
+++ b/runtimeconfig/google/cloud/runtimeconfig/__init__.py
@@ -14,4 +14,8 @@
 
 """Google Cloud Runtime Configurator API package."""
 
+
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-runtimeconfig').version
+
 from google.cloud.runtimeconfig.client import Client

--- a/runtimeconfig/google/cloud/runtimeconfig/_http.py
+++ b/runtimeconfig/google/cloud/runtimeconfig/_http.py
@@ -18,6 +18,11 @@
 
 from google.cloud import _http
 
+from google.cloud.runtimeconfig import __version__
+
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
+
 
 class Connection(_http.JSONConnection):
     """A connection to Google Cloud RuntimeConfig via the JSON REST API.
@@ -34,3 +39,7 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }

--- a/runtimeconfig/unit_tests/test__http.py
+++ b/runtimeconfig/unit_tests/test__http.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestConnection(unittest.TestCase):
 
@@ -30,3 +32,33 @@ class TestConnection(unittest.TestCase):
         client = object()
         conn = self._make_one(client)
         self.assertIs(conn._client, client)
+
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.runtimeconfig import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'req-data-boring'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )

--- a/speech/google/cloud/speech/__init__.py
+++ b/speech/google/cloud/speech/__init__.py
@@ -14,6 +14,10 @@
 
 """Google Cloud Speech API wrapper."""
 
+
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-speech').version
+
 from google.cloud.speech.alternative import Alternative
 from google.cloud.speech.client import Client
 from google.cloud.speech.encoding import Encoding

--- a/speech/google/cloud/speech/_http.py
+++ b/speech/google/cloud/speech/_http.py
@@ -20,8 +20,12 @@ from google.cloud._helpers import _bytes_to_unicode
 from google.cloud._helpers import _to_bytes
 from google.cloud import _http
 
+from google.cloud.speech import __version__
 from google.cloud.speech.result import Result
 from google.cloud.speech.operation import Operation
+
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
 
 
 class Connection(_http.JSONConnection):
@@ -39,6 +43,10 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}/{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }
 
 
 class HTTPSpeechAPI(object):

--- a/speech/unit_tests/test__http.py
+++ b/speech/unit_tests/test__http.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestConnection(unittest.TestCase):
 
@@ -36,3 +38,33 @@ class TestConnection(unittest.TestCase):
         ])
 
         self.assertEqual(conn.build_api_url(method), uri)
+
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.speech import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'req-data-boring'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )

--- a/storage/google/cloud/storage/__init__.py
+++ b/storage/google/cloud/storage/__init__.py
@@ -30,6 +30,10 @@ The main concepts with this API are:
   machine).
 """
 
+
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-storage').version
+
 from google.cloud.storage.batch import Batch
 from google.cloud.storage.blob import Blob
 from google.cloud.storage.bucket import Bucket

--- a/storage/google/cloud/storage/_http.py
+++ b/storage/google/cloud/storage/_http.py
@@ -14,13 +14,12 @@
 
 """Create / interact with Google Cloud Storage connections."""
 
-from pkg_resources import get_distribution
-
 from google.cloud import _http
 
+from google.cloud.storage import __version__
 
-_STORAGE_DIST = get_distribution('google-cloud-storage')
-_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(_STORAGE_DIST.version)
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
 
 
 class Connection(_http.JSONConnection):

--- a/translate/google/cloud/translate/__init__.py
+++ b/translate/google/cloud/translate/__init__.py
@@ -14,6 +14,10 @@
 
 """Google Cloud Translation API wrapper."""
 
+
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-translate').version
+
 from google.cloud.translate.client import BASE
 from google.cloud.translate.client import Client
 from google.cloud.translate.client import NMT

--- a/translate/google/cloud/translate/_http.py
+++ b/translate/google/cloud/translate/_http.py
@@ -16,6 +16,11 @@
 
 from google.cloud import _http
 
+from google.cloud.translate import __version__
+
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
+
 
 class Connection(_http.JSONConnection):
     """A connection to Google Cloud Translation API via the JSON REST API.
@@ -32,3 +37,7 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/language/translate/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }

--- a/translate/unit_tests/test__http.py
+++ b/translate/unit_tests/test__http.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestConnection(unittest.TestCase):
 
@@ -52,3 +54,33 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(path, expected_path)
         params = parse_qsl(qs)
         self.assertEqual(params, query_params)
+
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.translate import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'req-data-boring'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )

--- a/vision/google/cloud/vision/__init__.py
+++ b/vision/google/cloud/vision/__init__.py
@@ -14,4 +14,8 @@
 
 """Google Cloud Vision API package."""
 
+
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-vision').version
+
 from google.cloud.vision.client import Client

--- a/vision/google/cloud/vision/_http.py
+++ b/vision/google/cloud/vision/_http.py
@@ -14,10 +14,15 @@
 
 """HTTP Client for interacting with the Google Cloud Vision API."""
 
+
 from google.cloud import _http
 
+from google.cloud.vision import __version__
 from google.cloud.vision.annotations import Annotations
 from google.cloud.vision.feature import Feature
+
+
+_CLIENT_INFO = _http.CLIENT_INFO_TEMPLATE.format(__version__)
 
 
 class Connection(_http.JSONConnection):
@@ -35,6 +40,10 @@ class Connection(_http.JSONConnection):
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'
     """A template for the URL of a particular API call."""
+
+    _EXTRA_HEADERS = {
+        _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
+    }
 
 
 class _HTTPVisionAPI(object):

--- a/vision/unit_tests/test__http.py
+++ b/vision/unit_tests/test__http.py
@@ -38,6 +38,36 @@ class TestConnection(unittest.TestCase):
         conn = self._make_one(client)
         self.assertEqual(conn._client, client)
 
+    def test_extra_headers(self):
+        from google.cloud import _http as base_http
+        from google.cloud.vision import _http as MUT
+
+        http = mock.Mock(spec=['request'])
+        response = mock.Mock(status=200, spec=['status'])
+        data = b'brent-spiner'
+        http.request.return_value = response, data
+        client = mock.Mock(_http=http, spec=['_http'])
+
+        conn = self._make_one(client)
+        req_data = 'req-data-boring'
+        result = conn.api_request(
+            'GET', '/rainbow', data=req_data, expect_json=False)
+        self.assertEqual(result, data)
+
+        expected_headers = {
+            'Content-Length': str(len(req_data)),
+            'Accept-Encoding': 'gzip',
+            base_http.CLIENT_INFO_HEADER: MUT._CLIENT_INFO,
+            'User-Agent': conn.USER_AGENT,
+        }
+        expected_uri = conn.build_api_url('/rainbow')
+        http.request.assert_called_once_with(
+            body=req_data,
+            headers=expected_headers,
+            method='GET',
+            uri=expected_uri,
+        )
+
 
 class Test_HTTPVisionAPI(unittest.TestCase):
     def _get_target_class(self):


### PR DESCRIPTION
Continuation of #3035. Fixes #3006.

For now just a single commit: "Adding `__version__` in packages that need HTTP." because I need to step AFK for a bit.
