### PR TITLE
GAPIC Header Consistency: Vision

### DIFF
--- a/vision/google/cloud/vision/_gax.py
+++ b/vision/google/cloud/vision/_gax.py
@@ -85,7 +85,7 @@ def _to_gapic_image(image):
     :type image: :class:`~google.cloud.vision.image.Image`
     :param image: Local ``Image`` class to be converted to gRPC ``Image``.
 
-    :rtype: :class:`~google.cloudvision.v1.image_annotator_pb2.Image`
+    :rtype: :class:`~google.cloud.proto.vision.v1.image_annotator_pb2.Image`
     :returns: gRPC ``Image`` converted from
               :class:`~google.cloud.vision.image.Image`.
     """

--- a/vision/google/cloud/vision/_gax.py
+++ b/vision/google/cloud/vision/_gax.py
@@ -17,6 +17,7 @@
 from google.cloud.gapic.vision.v1 import image_annotator_client
 from google.cloud.grpc.vision.v1 import image_annotator_pb2
 
+from google.cloud.vision import __version__
 from google.cloud.vision.annotations import Annotations
 
 
@@ -25,10 +26,14 @@ class _GAPICVisionAPI(object):
 
     :type client: :class:`~google.cloud.vision.client.Client`
     :param client: Instance of ``Client`` object.
+
+    :type kwargs: dict
+    :param kwargs: Additional keyword arguments are sent to the GAPIC client.
     """
-    def __init__(self, client=None):
+    def __init__(self, client=None, credentials=None):
         self._client = client
-        self._annotator_client = image_annotator_client.ImageAnnotatorClient()
+        self._annotator_client = image_annotator_client.ImageAnnotatorClient(
+            credentials=credentials, lib_name='gccl', lib_version=__version__)
 
     def annotate(self, images):
         """Annotate images through GAX.

--- a/vision/google/cloud/vision/_gax.py
+++ b/vision/google/cloud/vision/_gax.py
@@ -30,10 +30,11 @@ class _GAPICVisionAPI(object):
     :type kwargs: dict
     :param kwargs: Additional keyword arguments are sent to the GAPIC client.
     """
-    def __init__(self, client=None, credentials=None):
+    def __init__(self, client=None):
         self._client = client
         self._annotator_client = image_annotator_client.ImageAnnotatorClient(
-            credentials=credentials, lib_name='gccl', lib_version=__version__)
+            credentials=client._credentials, lib_name='gccl',
+            lib_version=__version__)
 
     def annotate(self, images):
         """Annotate images through GAX.

--- a/vision/google/cloud/vision/_gax.py
+++ b/vision/google/cloud/vision/_gax.py
@@ -15,7 +15,7 @@
 """GAX Client for interacting with the Google Cloud Vision API."""
 
 from google.cloud.gapic.vision.v1 import image_annotator_client
-from google.cloud.grpc.vision.v1 import image_annotator_pb2
+from google.cloud.proto.vision.v1 import image_annotator_pb2
 
 from google.cloud.vision import __version__
 from google.cloud.vision.annotations import Annotations
@@ -70,7 +70,7 @@ def _to_gapic_feature(feature):
     :param feature: Local ``Feature`` class to be converted to gRPC ``Feature``
                     instance.
 
-    :rtype: :class:`~google.cloud.grpc.vision.v1.image_annotator_pb2.Feature`
+    :rtype: :class:`~google.cloudvision.v1.image_annotator_pb2.Feature`
     :returns: gRPC ``Feature`` converted from
               :class:`~google.cloud.vision.feature.Feature`.
     """
@@ -85,7 +85,7 @@ def _to_gapic_image(image):
     :type image: :class:`~google.cloud.vision.image.Image`
     :param image: Local ``Image`` class to be converted to gRPC ``Image``.
 
-    :rtype: :class:`~google.cloud.grpc.vision.v1.image_annotator_pb2.Image`
+    :rtype: :class:`~google.cloudvision.v1.image_annotator_pb2.Image`
     :returns: gRPC ``Image`` converted from
               :class:`~google.cloud.vision.image.Image`.
     """

--- a/vision/google/cloud/vision/_gax.py
+++ b/vision/google/cloud/vision/_gax.py
@@ -70,7 +70,7 @@ def _to_gapic_feature(feature):
     :param feature: Local ``Feature`` class to be converted to gRPC ``Feature``
                     instance.
 
-    :rtype: :class:`~google.cloudvision.v1.image_annotator_pb2.Feature`
+    :rtype: :class:`~google.cloud.proto.vision.v1.image_annotator_pb2.Feature`
     :returns: gRPC ``Feature`` converted from
               :class:`~google.cloud.vision.feature.Feature`.
     """

--- a/vision/google/cloud/vision/_gax.py
+++ b/vision/google/cloud/vision/_gax.py
@@ -26,9 +26,6 @@ class _GAPICVisionAPI(object):
 
     :type client: :class:`~google.cloud.vision.client.Client`
     :param client: Instance of ``Client`` object.
-
-    :type kwargs: dict
-    :param kwargs: Additional keyword arguments are sent to the GAPIC client.
     """
     def __init__(self, client=None):
         self._client = client

--- a/vision/google/cloud/vision/annotations.py
+++ b/vision/google/cloud/vision/annotations.py
@@ -99,7 +99,7 @@ class Annotations(object):
     def from_pb(cls, response):
         """Factory: construct an instance of ``Annotations`` from protobuf.
 
-        :type response: :class:`~google.cloud.grpc.vision.v1.\
+        :type response: :class:`~google.cloudvision.v1.\
                         image_annotator_pb2.AnnotateImageResponse`
         :param response: ``AnnotateImageResponse`` from protobuf call.
 
@@ -113,7 +113,7 @@ class Annotations(object):
 def _process_image_annotations(image):
     """Helper for processing annotation types from protobuf.
 
-    :type image: :class:`~google.cloud.grpc.vision.v1.image_annotator_pb2.\
+    :type image: :class:`~google.cloudvision.v1.image_annotator_pb2.\
                  AnnotateImageResponse`
     :param image: ``AnnotateImageResponse`` from protobuf.
 
@@ -137,7 +137,7 @@ def _make_entity_from_pb(annotations):
     """Create an entity from a protobuf response.
 
     :type annotations:
-    :class:`~google.cloud.grpc.vision.v1.image_annotator_pb2.EntityAnnotation`
+    :class:`~google.cloudvision.v1.image_annotator_pb2.EntityAnnotation`
     :param annotations: protobuf instance of ``EntityAnnotation``.
 
     :rtype: list
@@ -150,7 +150,7 @@ def _make_faces_from_pb(faces):
     """Create face objects from a protobuf response.
 
     :type faces:
-    :class:`~google.cloud.grpc.vision.v1.image_annotator_pb2.FaceAnnotation`
+    :class:`~google.cloudvision.v1.image_annotator_pb2.FaceAnnotation`
     :param faces: Protobuf instance of ``FaceAnnotation``.
 
     :rtype: list
@@ -162,7 +162,7 @@ def _make_faces_from_pb(faces):
 def _make_image_properties_from_pb(image_properties):
     """Create ``ImageProperties`` object from a protobuf response.
 
-    :type image_properties: :class:`~google.cloud.grpc.vision.v1.\
+    :type image_properties: :class:`~google.cloudvision.v1.\
                             image_annotator_pb2.ImagePropertiesAnnotation`
     :param image_properties: Protobuf instance of
                              ``ImagePropertiesAnnotation``.
@@ -176,7 +176,7 @@ def _make_image_properties_from_pb(image_properties):
 def _make_safe_search_from_pb(safe_search):
     """Create ``SafeSearchAnnotation`` object from a protobuf response.
 
-    :type safe_search: :class:`~google.cloud.grpc.vision.v1.\
+    :type safe_search: :class:`~google.cloudvision.v1.\
                             image_annotator_pb2.SafeSearchAnnotation`
     :param safe_search: Protobuf instance of ``SafeSearchAnnotation``.
 

--- a/vision/google/cloud/vision/annotations.py
+++ b/vision/google/cloud/vision/annotations.py
@@ -99,7 +99,7 @@ class Annotations(object):
     def from_pb(cls, response):
         """Factory: construct an instance of ``Annotations`` from protobuf.
 
-        :type response: :class:`~google.cloudvision.v1.\
+        :type response: :class:`~google.cloud.proto.vision.v1.\
                         image_annotator_pb2.AnnotateImageResponse`
         :param response: ``AnnotateImageResponse`` from protobuf call.
 
@@ -113,7 +113,7 @@ class Annotations(object):
 def _process_image_annotations(image):
     """Helper for processing annotation types from protobuf.
 
-    :type image: :class:`~google.cloudvision.v1.image_annotator_pb2.\
+    :type image: :class:`~google.cloud.proto.vision.v1.image_annotator_pb2.\
                  AnnotateImageResponse`
     :param image: ``AnnotateImageResponse`` from protobuf.
 
@@ -137,7 +137,7 @@ def _make_entity_from_pb(annotations):
     """Create an entity from a protobuf response.
 
     :type annotations:
-    :class:`~google.cloudvision.v1.image_annotator_pb2.EntityAnnotation`
+    :class:`~google.cloud.proto.vision.v1.image_annotator_pb2.EntityAnnotation`
     :param annotations: protobuf instance of ``EntityAnnotation``.
 
     :rtype: list
@@ -150,7 +150,7 @@ def _make_faces_from_pb(faces):
     """Create face objects from a protobuf response.
 
     :type faces:
-    :class:`~google.cloudvision.v1.image_annotator_pb2.FaceAnnotation`
+    :class:`~google.cloud.proto.vision.v1.image_annotator_pb2.FaceAnnotation`
     :param faces: Protobuf instance of ``FaceAnnotation``.
 
     :rtype: list
@@ -162,7 +162,7 @@ def _make_faces_from_pb(faces):
 def _make_image_properties_from_pb(image_properties):
     """Create ``ImageProperties`` object from a protobuf response.
 
-    :type image_properties: :class:`~google.cloudvision.v1.\
+    :type image_properties: :class:`~google.cloud.proto.vision.v1.\
                             image_annotator_pb2.ImagePropertiesAnnotation`
     :param image_properties: Protobuf instance of
                              ``ImagePropertiesAnnotation``.
@@ -176,7 +176,7 @@ def _make_image_properties_from_pb(image_properties):
 def _make_safe_search_from_pb(safe_search):
     """Create ``SafeSearchAnnotation`` object from a protobuf response.
 
-    :type safe_search: :class:`~google.cloudvision.v1.\
+    :type safe_search: :class:`~google.cloud.proto.vision.v1.\
                             image_annotator_pb2.SafeSearchAnnotation`
     :param safe_search: Protobuf instance of ``SafeSearchAnnotation``.
 

--- a/vision/google/cloud/vision/client.py
+++ b/vision/google/cloud/vision/client.py
@@ -109,8 +109,7 @@ class Client(ClientWithProject):
         """
         if self._vision_api_internal is None:
             if self._use_gax:
-                self._vision_api_internal = _GAPICVisionAPI(
-                    self, credentials=None)
+                self._vision_api_internal = _GAPICVisionAPI(self)
             else:
                 self._vision_api_internal = _HTTPVisionAPI(self)
         return self._vision_api_internal

--- a/vision/google/cloud/vision/client.py
+++ b/vision/google/cloud/vision/client.py
@@ -109,8 +109,8 @@ class Client(ClientWithProject):
         """
         if self._vision_api_internal is None:
             if self._use_gax:
-                self._vision_api_internal = _GAPICVisionAPI(self,
-                    credentials=None)
+                self._vision_api_internal = _GAPICVisionAPI(
+                    self, credentials=None)
             else:
                 self._vision_api_internal = _HTTPVisionAPI(self)
         return self._vision_api_internal

--- a/vision/google/cloud/vision/client.py
+++ b/vision/google/cloud/vision/client.py
@@ -109,7 +109,8 @@ class Client(ClientWithProject):
         """
         if self._vision_api_internal is None:
             if self._use_gax:
-                self._vision_api_internal = _GAPICVisionAPI(self)
+                self._vision_api_internal = _GAPICVisionAPI(self,
+                    credentials=None)
             else:
                 self._vision_api_internal = _HTTPVisionAPI(self)
         return self._vision_api_internal

--- a/vision/google/cloud/vision/color.py
+++ b/vision/google/cloud/vision/color.py
@@ -45,7 +45,7 @@ class ImagePropertiesAnnotation(object):
     def from_pb(cls, image_properties):
         """Factory: construct ``ImagePropertiesAnnotation`` from a response.
 
-        :type image_properties: :class:`~google.cloud.grpc.vision.v1.\
+        :type image_properties: :class:`~google.cloudvision.v1.\
                                 image_annotator_pb2.ImageProperties`
         :param image_properties: Protobuf response from Vision API with image
                                  properties data.
@@ -196,7 +196,7 @@ class ColorInformation(object):
     def from_pb(cls, color_information):
         """Factory: construct ``ColorInformation`` for a color.
 
-        :type color_information: :class:`~google.cloud.grpc.vision.v1.\
+        :type color_information: :class:`~google.cloudvision.v1.\
                                  image_annotator_pb2.ColorInfo`
         :param color_information: Color data with extra meta information.
 

--- a/vision/google/cloud/vision/color.py
+++ b/vision/google/cloud/vision/color.py
@@ -45,7 +45,7 @@ class ImagePropertiesAnnotation(object):
     def from_pb(cls, image_properties):
         """Factory: construct ``ImagePropertiesAnnotation`` from a response.
 
-        :type image_properties: :class:`~google.cloudvision.v1.\
+        :type image_properties: :class:`~google.cloud.proto.vision.v1.\
                                 image_annotator_pb2.ImageProperties`
         :param image_properties: Protobuf response from Vision API with image
                                  properties data.
@@ -196,7 +196,7 @@ class ColorInformation(object):
     def from_pb(cls, color_information):
         """Factory: construct ``ColorInformation`` for a color.
 
-        :type color_information: :class:`~google.cloudvision.v1.\
+        :type color_information: :class:`~google.cloud.proto.vision.v1.\
                                  image_annotator_pb2.ColorInfo`
         :param color_information: Color data with extra meta information.
 

--- a/vision/google/cloud/vision/entity.py
+++ b/vision/google/cloud/vision/entity.py
@@ -74,7 +74,7 @@ class EntityAnnotation(object):
     def from_pb(cls, response):
         """Factory: construct entity from Vision gRPC response.
 
-        :type response: :class:`~google.cloud.grpc.vision.v1.\
+        :type response: :class:`~google.cloudvision.v1.\
                         image_annotator_pb2.AnnotateImageResponse`
         :param response: gRPC response from Vision API with entity data.
 

--- a/vision/google/cloud/vision/entity.py
+++ b/vision/google/cloud/vision/entity.py
@@ -74,7 +74,7 @@ class EntityAnnotation(object):
     def from_pb(cls, response):
         """Factory: construct entity from Vision gRPC response.
 
-        :type response: :class:`~google.cloudvision.v1.\
+        :type response: :class:`~google.cloud.proto.vision.v1.\
                         image_annotator_pb2.AnnotateImageResponse`
         :param response: gRPC response from Vision API with entity data.
 

--- a/vision/google/cloud/vision/face.py
+++ b/vision/google/cloud/vision/face.py
@@ -50,7 +50,7 @@ class Angles(object):
     def from_pb(cls, angle):
         """Factory: convert protobuf Angle object to local Angle object.
 
-        :type angle: :class:`~google.cloudvision.v1.\
+        :type angle: :class:`~google.cloud.proto.vision.v1.\
                      image_annotator_pb2.FaceAnnotation`
         :param angle: Protobuf ``FaceAnnotation`` response with angle data.
 
@@ -126,7 +126,7 @@ class Emotions(object):
     def from_pb(cls, emotions):
         """Factory: construct ``Emotions`` from Vision API response.
 
-        :type emotions: :class:`~google.cloudvision.v1.\
+        :type emotions: :class:`~google.cloud.proto.vision.v1.\
                         image_annotator_pb2.FaceAnnotation`
         :param emotions: Response dictionary representing a face with emotions.
 
@@ -225,7 +225,7 @@ class Face(object):
     def from_pb(cls, face):
         """Factory: construct an instance of a Face from an protobuf response
 
-        :type face: :class:`~google.cloudvision.v1.\
+        :type face: :class:`~google.cloud.proto.vision.v1.\
                        image_annotator_pb2.AnnotateImageResponse`
         :param face: ``AnnotateImageResponse`` from gRPC call.
 
@@ -397,7 +397,7 @@ class FaceImageProperties(object):
     def from_pb(cls, face):
         """Factory: construct image properties from image.
 
-        :type face: :class:`~google.cloudvision.v1.image_annotator_pb2.\
+        :type face: :class:`~google.cloud.proto.vision.v1.image_annotator_pb2.\
                     FaceAnnotation`
         :param face: Protobuf instace of `Face`.
 
@@ -508,7 +508,7 @@ class Landmark(object):
     def from_pb(cls, landmark):
         """Factory: construct an instance of a Landmark from a response.
 
-        :type landmark: :class:`~google.cloudvision.v1.\
+        :type landmark: :class:`~google.cloud.proto.vision.v1.\
                         image_annotator_pb.FaceAnnotation.Landmark`
         :param landmark: Landmark representation from Vision API.
 

--- a/vision/google/cloud/vision/face.py
+++ b/vision/google/cloud/vision/face.py
@@ -50,7 +50,7 @@ class Angles(object):
     def from_pb(cls, angle):
         """Factory: convert protobuf Angle object to local Angle object.
 
-        :type angle: :class:`~google.cloud.grpc.vision.v1.\
+        :type angle: :class:`~google.cloudvision.v1.\
                      image_annotator_pb2.FaceAnnotation`
         :param angle: Protobuf ``FaceAnnotation`` response with angle data.
 
@@ -126,7 +126,7 @@ class Emotions(object):
     def from_pb(cls, emotions):
         """Factory: construct ``Emotions`` from Vision API response.
 
-        :type emotions: :class:`~google.cloud.grpc.vision.v1.\
+        :type emotions: :class:`~google.cloudvision.v1.\
                         image_annotator_pb2.FaceAnnotation`
         :param emotions: Response dictionary representing a face with emotions.
 
@@ -225,7 +225,7 @@ class Face(object):
     def from_pb(cls, face):
         """Factory: construct an instance of a Face from an protobuf response
 
-        :type face: :class:`~google.cloud.grpc.vision.v1.\
+        :type face: :class:`~google.cloudvision.v1.\
                        image_annotator_pb2.AnnotateImageResponse`
         :param face: ``AnnotateImageResponse`` from gRPC call.
 
@@ -397,7 +397,7 @@ class FaceImageProperties(object):
     def from_pb(cls, face):
         """Factory: construct image properties from image.
 
-        :type face: :class:`~google.cloud.grpc.vision.v1.image_annotator_pb2.\
+        :type face: :class:`~google.cloudvision.v1.image_annotator_pb2.\
                     FaceAnnotation`
         :param face: Protobuf instace of `Face`.
 
@@ -508,7 +508,7 @@ class Landmark(object):
     def from_pb(cls, landmark):
         """Factory: construct an instance of a Landmark from a response.
 
-        :type landmark: :class:`~google.cloud.grpc.vision.v1.\
+        :type landmark: :class:`~google.cloudvision.v1.\
                         image_annotator_pb.FaceAnnotation.Landmark`
         :param landmark: Landmark representation from Vision API.
 

--- a/vision/google/cloud/vision/geometry.py
+++ b/vision/google/cloud/vision/geometry.py
@@ -43,7 +43,7 @@ class BoundsBase(object):
     def from_pb(cls, vertices):
         """Factory: construct BoundsBase instance from a protobuf response.
 
-        :type vertices: :class:`~google.cloudvision.v1.\
+        :type vertices: :class:`~google.cloud.proto.vision.v1.\
                                  geometry_pb2.BoundingPoly`
         :param vertices: List of vertices.
 

--- a/vision/google/cloud/vision/geometry.py
+++ b/vision/google/cloud/vision/geometry.py
@@ -43,7 +43,7 @@ class BoundsBase(object):
     def from_pb(cls, vertices):
         """Factory: construct BoundsBase instance from a protobuf response.
 
-        :type vertices: :class:`~google.cloud.grpc.vision.v1.\
+        :type vertices: :class:`~google.cloudvision.v1.\
                                  geometry_pb2.BoundingPoly`
         :param vertices: List of vertices.
 

--- a/vision/google/cloud/vision/likelihood.py
+++ b/vision/google/cloud/vision/likelihood.py
@@ -17,7 +17,7 @@
 
 from enum import Enum
 
-from google.cloudvision.v1 import image_annotator_pb2
+from google.cloud.proto.vision.v1 import image_annotator_pb2
 
 
 def _get_pb_likelihood(likelihood):

--- a/vision/google/cloud/vision/likelihood.py
+++ b/vision/google/cloud/vision/likelihood.py
@@ -17,7 +17,7 @@
 
 from enum import Enum
 
-from google.cloud.grpc.vision.v1 import image_annotator_pb2
+from google.cloudvision.v1 import image_annotator_pb2
 
 
 def _get_pb_likelihood(likelihood):

--- a/vision/google/cloud/vision/safe_search.py
+++ b/vision/google/cloud/vision/safe_search.py
@@ -66,8 +66,8 @@ class SafeSearchAnnotation(object):
     def from_pb(cls, image):
         """Factory: construct SafeSearchAnnotation from Vision API response.
 
-        :type image: :class:`~google.cloud.proto.vision.v1.image_annotator_pb2.\
-                      SafeSearchAnnotation`
+        :type image: :class:`~google.cloud.proto.vision.v1.\
+                      image_annotator_pb2.SafeSearchAnnotation`
         :param image: Protobuf response from Vision API with safe search data.
 
         :rtype: :class:`~google.cloud.vision.safe_search.SafeSearchAnnotation`

--- a/vision/google/cloud/vision/safe_search.py
+++ b/vision/google/cloud/vision/safe_search.py
@@ -66,7 +66,7 @@ class SafeSearchAnnotation(object):
     def from_pb(cls, image):
         """Factory: construct SafeSearchAnnotation from Vision API response.
 
-        :type image: :class:`~google.cloud.grpc.vision.v1.image_annotator_pb2.\
+        :type image: :class:`~google.cloudvision.v1.image_annotator_pb2.\
                       SafeSearchAnnotation`
         :param image: Protobuf response from Vision API with safe search data.
 

--- a/vision/google/cloud/vision/safe_search.py
+++ b/vision/google/cloud/vision/safe_search.py
@@ -66,7 +66,7 @@ class SafeSearchAnnotation(object):
     def from_pb(cls, image):
         """Factory: construct SafeSearchAnnotation from Vision API response.
 
-        :type image: :class:`~google.cloudvision.v1.image_annotator_pb2.\
+        :type image: :class:`~google.cloud.proto.vision.v1.image_annotator_pb2.\
                       SafeSearchAnnotation`
         :param image: Protobuf response from Vision API with safe search data.
 

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -52,12 +52,12 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'enum34',
     'google-cloud-core >= 0.23.0, < 0.24dev',
-    'gapic-google-cloud-vision-v1 >= 0.14.0, < 0.15dev',
+    'gapic-google-cloud-vision-v1 >= 0.15.0, < 0.16dev',
 ]
 
 setup(
     name='google-cloud-vision',
-    version='0.22.0',
+    version='0.23.0',
     description='Python Client for Google Cloud Vision',
     long_description=README,
     namespace_packages=[

--- a/vision/unit_tests/test__gax.py
+++ b/vision/unit_tests/test__gax.py
@@ -17,6 +17,11 @@ import unittest
 import mock
 
 
+def _make_credentials():
+    import google.auth.credentials
+    return mock.Mock(spec=google.auth.credentials.Credentials)
+
+
 class TestGAXClient(unittest.TestCase):
     def _get_target_class(self):
         from google.cloud.vision._gax import _GAPICVisionAPI
@@ -35,8 +40,7 @@ class TestGAXClient(unittest.TestCase):
     def test_gapic_credentials(self):
         from google.cloud.gapic.vision.v1.image_annotator_client import (
             ImageAnnotatorClient)
-
-        from .test_client import _make_credentials
+        from google.cloud.vision import Client
 
         # Mock the GAPIC ImageAnnotatorClient, whose arguments we
         # want to check.
@@ -45,19 +49,20 @@ class TestGAXClient(unittest.TestCase):
 
             # Create the GAX client.
             credentials = _make_credentials()
-            self._make_one(client=object(), credentials=credentials)
+            client = Client(credentials=credentials)
+            self._make_one(client=client)
 
             # Assert that the GAPIC constructor was called once, and
             # that the credentials were sent.
             iac.assert_called_once()
-            self.assertIs(iac.mock_calls[0][2]['credentials'], credentials)
+            _, _, kwargs = iac.mock_calls[0]
+            self.assertIs(kwargs['credentials'], credentials)
 
     def test_kwarg_lib_name(self):
         from google.cloud.gapic.vision.v1.image_annotator_client import (
             ImageAnnotatorClient)
         from google.cloud.vision import __version__
-
-        from .test_client import _make_credentials
+        from google.cloud.vision import Client
 
         # Mock the GAPIC ImageAnnotatorClient, whose arguments we
         # want to check.
@@ -65,20 +70,22 @@ class TestGAXClient(unittest.TestCase):
             iac.return_value = None
 
             # Create the GAX client.
-            self._make_one(client=object(), credentials=_make_credentials())
+            client = Client(credentials=_make_credentials())
+            self._make_one(client=client)
 
             # Assert that the GAPIC constructor was called once, and
             # that lib_name and lib_version were sent.
             iac.assert_called_once()
-            self.assertEqual(iac.mock_calls[0][2]['lib_name'], 'gccl')
-            self.assertEqual(iac.mock_calls[0][2]['lib_version'], __version__)
+            _, _, kwargs = iac.mock_calls[0]
+            self.assertEqual(kwargs['lib_name'], 'gccl')
+            self.assertEqual(kwargs['lib_version'], __version__)
 
     def test_annotation(self):
         from google.cloud.vision.feature import Feature
         from google.cloud.vision.feature import FeatureTypes
         from google.cloud.vision.image import Image
 
-        client = mock.Mock(spec_set=[])
+        client = mock.Mock(spec_set=['_credentials'])
         feature = Feature(FeatureTypes.LABEL_DETECTION, 5)
         image_content = b'abc 1 2 3'
         image = Image(client, content=image_content)
@@ -105,7 +112,7 @@ class TestGAXClient(unittest.TestCase):
         from google.cloud.vision.feature import FeatureTypes
         from google.cloud.vision.image import Image
 
-        client = mock.Mock(spec_set=[])
+        client = mock.Mock(spec_set=['_credentials'])
         feature = Feature(FeatureTypes.LABEL_DETECTION, 5)
         image_content = b'abc 1 2 3'
         image = Image(client, content=image_content)
@@ -134,7 +141,7 @@ class TestGAXClient(unittest.TestCase):
         from google.cloud.vision.feature import FeatureTypes
         from google.cloud.vision.image import Image
 
-        client = mock.Mock(spec_set=[])
+        client = mock.Mock(spec_set=['_credentials'])
         feature = Feature(FeatureTypes.LABEL_DETECTION, 5)
         image_content = b'abc 1 2 3'
         image = Image(client, content=image_content)

--- a/vision/unit_tests/test__gax.py
+++ b/vision/unit_tests/test__gax.py
@@ -49,7 +49,7 @@ class TestGAXClient(unittest.TestCase):
 
             # Create the GAX client.
             credentials = _make_credentials()
-            client = Client(credentials=credentials)
+            client = Client(credentials=credentials, project='foo')
             self._make_one(client=client)
 
             # Assert that the GAPIC constructor was called once, and
@@ -70,7 +70,7 @@ class TestGAXClient(unittest.TestCase):
             iac.return_value = None
 
             # Create the GAX client.
-            client = Client(credentials=_make_credentials())
+            client = Client(credentials=_make_credentials(), project='foo')
             self._make_one(client=client)
 
             # Assert that the GAPIC constructor was called once, and

--- a/vision/unit_tests/test__gax.py
+++ b/vision/unit_tests/test__gax.py
@@ -32,6 +32,28 @@ class TestGAXClient(unittest.TestCase):
             api = self._make_one(client)
         self.assertIs(api._client, client)
 
+    def test_kwarg_lib_name(self):
+        from google.cloud.gapic.vision.v1.image_annotator_client import (
+            ImageAnnotatorClient)
+        from google.cloud.vision import __version__
+
+        from .test_client import _make_credentials
+
+        # Mock the GAPIC ImageAnnotatorClient, whose arguments we
+        # want to check.
+        with mock.patch.object(ImageAnnotatorClient, '__init__') as iac:
+            iac.return_value = None
+
+            # Create the GAX client.
+            client = object()
+            self._make_one(client, credentials=_make_credentials())
+
+            # Assert that the GAPIC constructor was called once, and
+            # that lib_name and lib_version were sent.
+            iac.assert_called_once()
+            self.assertEqual(iac.mock_calls[0][2]['lib_name'], 'gccl')
+            self.assertEqual(iac.mock_calls[0][2]['lib_version'], __version__)
+
     def test_annotation(self):
         from google.cloud.vision.feature import Feature
         from google.cloud.vision.feature import FeatureTypes

--- a/vision/unit_tests/test__gax.py
+++ b/vision/unit_tests/test__gax.py
@@ -32,6 +32,26 @@ class TestGAXClient(unittest.TestCase):
             api = self._make_one(client)
         self.assertIs(api._client, client)
 
+    def test_gapic_credentials(self):
+        from google.cloud.gapic.vision.v1.image_annotator_client import (
+            ImageAnnotatorClient)
+
+        from .test_client import _make_credentials
+
+        # Mock the GAPIC ImageAnnotatorClient, whose arguments we
+        # want to check.
+        with mock.patch.object(ImageAnnotatorClient, '__init__') as iac:
+            iac.return_value = None
+
+            # Create the GAX client.
+            credentials = _make_credentials()
+            self._make_one(client=object(), credentials=credentials)
+
+            # Assert that the GAPIC constructor was called once, and
+            # that the credentials were sent.
+            iac.assert_called_once()
+            self.assertIs(iac.mock_calls[0][2]['credentials'], credentials)
+
     def test_kwarg_lib_name(self):
         from google.cloud.gapic.vision.v1.image_annotator_client import (
             ImageAnnotatorClient)
@@ -45,8 +65,7 @@ class TestGAXClient(unittest.TestCase):
             iac.return_value = None
 
             # Create the GAX client.
-            client = object()
-            self._make_one(client, credentials=_make_credentials())
+            self._make_one(client=object(), credentials=_make_credentials())
 
             # Assert that the GAPIC constructor was called once, and
             # that lib_name and lib_version were sent.

--- a/vision/unit_tests/test__gax.py
+++ b/vision/unit_tests/test__gax.py
@@ -135,7 +135,7 @@ class TestGAXClient(unittest.TestCase):
         gax_api._annotator_client.batch_annotate_images.assert_called()
 
     def test_annotate_multiple_results(self):
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
         from google.cloud.vision.annotations import Annotations
         from google.cloud.vision.feature import Feature
         from google.cloud.vision.feature import FeatureTypes
@@ -176,7 +176,7 @@ class Test__to_gapic_feature(unittest.TestCase):
     def test__to_gapic_feature(self):
         from google.cloud.vision.feature import Feature
         from google.cloud.vision.feature import FeatureTypes
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
 
         feature = Feature(FeatureTypes.LABEL_DETECTION, 5)
         feature_pb = self._call_fut(feature)
@@ -192,7 +192,7 @@ class Test__to_gapic_image(unittest.TestCase):
 
     def test__to_gapic_image_content(self):
         from google.cloud.vision.image import Image
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
 
         image_content = b'abc 1 2 3'
         client = object()
@@ -203,7 +203,7 @@ class Test__to_gapic_image(unittest.TestCase):
 
     def test__to_gapic_image_uri(self):
         from google.cloud.vision.image import Image
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
 
         image_uri = 'gs://1234/34.jpg'
         client = object()

--- a/vision/unit_tests/test__gax.py
+++ b/vision/unit_tests/test__gax.py
@@ -135,7 +135,7 @@ class TestGAXClient(unittest.TestCase):
         gax_api._annotator_client.batch_annotate_images.assert_called()
 
     def test_annotate_multiple_results(self):
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
         from google.cloud.vision.annotations import Annotations
         from google.cloud.vision.feature import Feature
         from google.cloud.vision.feature import FeatureTypes
@@ -176,7 +176,7 @@ class Test__to_gapic_feature(unittest.TestCase):
     def test__to_gapic_feature(self):
         from google.cloud.vision.feature import Feature
         from google.cloud.vision.feature import FeatureTypes
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
 
         feature = Feature(FeatureTypes.LABEL_DETECTION, 5)
         feature_pb = self._call_fut(feature)
@@ -192,7 +192,7 @@ class Test__to_gapic_image(unittest.TestCase):
 
     def test__to_gapic_image_content(self):
         from google.cloud.vision.image import Image
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
 
         image_content = b'abc 1 2 3'
         client = object()
@@ -203,7 +203,7 @@ class Test__to_gapic_image(unittest.TestCase):
 
     def test__to_gapic_image_uri(self):
         from google.cloud.vision.image import Image
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
 
         image_uri = 'gs://1234/34.jpg'
         client = object()

--- a/vision/unit_tests/test_annotations.py
+++ b/vision/unit_tests/test_annotations.py
@@ -16,8 +16,8 @@ import unittest
 
 
 def _make_pb_entity():
-    from google.cloudvision.v1 import geometry_pb2
-    from google.cloudvision.v1 import image_annotator_pb2
+    from google.cloud.proto.vision.v1 import geometry_pb2
+    from google.cloud.proto.vision.v1 import image_annotator_pb2
     from google.type import latlng_pb2
 
     description = 'testing 1 2 3'
@@ -78,7 +78,7 @@ class TestAnnotations(unittest.TestCase):
     def test_from_pb(self):
         from google.cloud.vision.likelihood import Likelihood
         from google.cloud.vision.safe_search import SafeSearchAnnotation
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
 
         image_response = image_annotator_pb2.AnnotateImageResponse()
         annotations = self._make_one().from_pb(image_response)
@@ -131,7 +131,7 @@ class Test__make_faces_from_pb(unittest.TestCase):
         return _make_faces_from_pb(annotations)
 
     def test_it(self):
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
         from google.cloud.vision.face import Face
 
         faces_pb = [image_annotator_pb2.FaceAnnotation()]
@@ -147,7 +147,7 @@ class Test__make_image_properties_from_pb(unittest.TestCase):
         return _make_image_properties_from_pb(annotations)
 
     def test_it(self):
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
         from google.protobuf.wrappers_pb2 import FloatValue
         from google.type.color_pb2 import Color
 
@@ -178,7 +178,7 @@ class Test__process_image_annotations(unittest.TestCase):
         return _process_image_annotations(image)
 
     def test_it(self):
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
 
         description = 'testing 1 2 3'
         locale = 'US'

--- a/vision/unit_tests/test_annotations.py
+++ b/vision/unit_tests/test_annotations.py
@@ -16,8 +16,8 @@ import unittest
 
 
 def _make_pb_entity():
-    from google.cloud.grpc.vision.v1 import geometry_pb2
-    from google.cloud.grpc.vision.v1 import image_annotator_pb2
+    from google.cloudvision.v1 import geometry_pb2
+    from google.cloudvision.v1 import image_annotator_pb2
     from google.type import latlng_pb2
 
     description = 'testing 1 2 3'
@@ -78,7 +78,7 @@ class TestAnnotations(unittest.TestCase):
     def test_from_pb(self):
         from google.cloud.vision.likelihood import Likelihood
         from google.cloud.vision.safe_search import SafeSearchAnnotation
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
 
         image_response = image_annotator_pb2.AnnotateImageResponse()
         annotations = self._make_one().from_pb(image_response)
@@ -131,7 +131,7 @@ class Test__make_faces_from_pb(unittest.TestCase):
         return _make_faces_from_pb(annotations)
 
     def test_it(self):
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
         from google.cloud.vision.face import Face
 
         faces_pb = [image_annotator_pb2.FaceAnnotation()]
@@ -147,7 +147,7 @@ class Test__make_image_properties_from_pb(unittest.TestCase):
         return _make_image_properties_from_pb(annotations)
 
     def test_it(self):
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
         from google.protobuf.wrappers_pb2 import FloatValue
         from google.type.color_pb2 import Color
 
@@ -178,7 +178,7 @@ class Test__process_image_annotations(unittest.TestCase):
         return _process_image_annotations(image)
 
     def test_it(self):
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
 
         description = 'testing 1 2 3'
         locale = 'US'

--- a/vision/unit_tests/test_color.py
+++ b/vision/unit_tests/test_color.py
@@ -95,7 +95,7 @@ class TestImagePropertiesAnnotation(unittest.TestCase):
         return ImagePropertiesAnnotation
 
     def test_image_properties_annotation_from_pb(self):
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
         from google.protobuf.wrappers_pb2 import FloatValue
         from google.type.color_pb2 import Color
 
@@ -121,7 +121,7 @@ class TestImagePropertiesAnnotation(unittest.TestCase):
         self.assertEqual(image_properties.colors[0].color.alpha, 1.0)
 
     def test_empty_image_properties_annotation_from_pb(self):
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
 
         image_properties_pb = image_annotator_pb2.ImageProperties()
 

--- a/vision/unit_tests/test_color.py
+++ b/vision/unit_tests/test_color.py
@@ -95,7 +95,7 @@ class TestImagePropertiesAnnotation(unittest.TestCase):
         return ImagePropertiesAnnotation
 
     def test_image_properties_annotation_from_pb(self):
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
         from google.protobuf.wrappers_pb2 import FloatValue
         from google.type.color_pb2 import Color
 
@@ -121,7 +121,7 @@ class TestImagePropertiesAnnotation(unittest.TestCase):
         self.assertEqual(image_properties.colors[0].color.alpha, 1.0)
 
     def test_empty_image_properties_annotation_from_pb(self):
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
 
         image_properties_pb = image_annotator_pb2.ImageProperties()
 

--- a/vision/unit_tests/test_entity.py
+++ b/vision/unit_tests/test_entity.py
@@ -34,7 +34,7 @@ class TestEntityAnnotation(unittest.TestCase):
         self.assertEqual(162, logo.bounds.vertices[0].y_coordinate)
 
     def test_logo_pb_annotation(self):
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
 
         description = 'testing 1 2 3'
         locale = 'US'

--- a/vision/unit_tests/test_entity.py
+++ b/vision/unit_tests/test_entity.py
@@ -34,7 +34,7 @@ class TestEntityAnnotation(unittest.TestCase):
         self.assertEqual(162, logo.bounds.vertices[0].y_coordinate)
 
     def test_logo_pb_annotation(self):
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
 
         description = 'testing 1 2 3'
         locale = 'US'

--- a/vision/unit_tests/test_face.py
+++ b/vision/unit_tests/test_face.py
@@ -22,7 +22,7 @@ class TestFace(unittest.TestCase):
         return Face
 
     def _make_face_pb(self, *args, **kwargs):
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
 
         return image_annotator_pb2.FaceAnnotation(*args, **kwargs)
 
@@ -34,8 +34,8 @@ class TestFace(unittest.TestCase):
             self.FACE_ANNOTATIONS['faceAnnotations'][0])
 
     def test_face_from_pb(self):
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
-        from google.cloud.grpc.vision.v1 import geometry_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import geometry_pb2
 
         position_pb = geometry_pb2.Position(x=1.0, y=2.0, z=3.0)
         landmark_pb = image_annotator_pb2.FaceAnnotation.Landmark(

--- a/vision/unit_tests/test_face.py
+++ b/vision/unit_tests/test_face.py
@@ -22,7 +22,7 @@ class TestFace(unittest.TestCase):
         return Face
 
     def _make_face_pb(self, *args, **kwargs):
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
 
         return image_annotator_pb2.FaceAnnotation(*args, **kwargs)
 
@@ -34,8 +34,8 @@ class TestFace(unittest.TestCase):
             self.FACE_ANNOTATIONS['faceAnnotations'][0])
 
     def test_face_from_pb(self):
-        from google.cloudvision.v1 import image_annotator_pb2
-        from google.cloudvision.v1 import geometry_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import geometry_pb2
 
         position_pb = geometry_pb2.Position(x=1.0, y=2.0, z=3.0)
         landmark_pb = image_annotator_pb2.FaceAnnotation.Landmark(

--- a/vision/unit_tests/test_safe_search.py
+++ b/vision/unit_tests/test_safe_search.py
@@ -38,9 +38,9 @@ class TestSafeSearchAnnotation(unittest.TestCase):
 
     def test_pb_safe_search_annotation(self):
         from google.cloud.vision.likelihood import Likelihood
-        from google.cloudvision.v1.image_annotator_pb2 import (
+        from google.cloud.proto.vision.v1.image_annotator_pb2 import (
             Likelihood as LikelihoodPB)
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
 
         possible = LikelihoodPB.Value('POSSIBLE')
         possible_name = Likelihood.POSSIBLE
@@ -57,7 +57,7 @@ class TestSafeSearchAnnotation(unittest.TestCase):
 
     def test_empty_pb_safe_search_annotation(self):
         from google.cloud.vision.likelihood import Likelihood
-        from google.cloudvision.v1 import image_annotator_pb2
+        from google.cloud.proto.vision.v1 import image_annotator_pb2
 
         unknown = Likelihood.UNKNOWN
         safe_search_annotation = image_annotator_pb2.SafeSearchAnnotation()

--- a/vision/unit_tests/test_safe_search.py
+++ b/vision/unit_tests/test_safe_search.py
@@ -38,9 +38,9 @@ class TestSafeSearchAnnotation(unittest.TestCase):
 
     def test_pb_safe_search_annotation(self):
         from google.cloud.vision.likelihood import Likelihood
-        from google.cloud.grpc.vision.v1.image_annotator_pb2 import (
+        from google.cloudvision.v1.image_annotator_pb2 import (
             Likelihood as LikelihoodPB)
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
 
         possible = LikelihoodPB.Value('POSSIBLE')
         possible_name = Likelihood.POSSIBLE
@@ -57,7 +57,7 @@ class TestSafeSearchAnnotation(unittest.TestCase):
 
     def test_empty_pb_safe_search_annotation(self):
         from google.cloud.vision.likelihood import Likelihood
-        from google.cloud.grpc.vision.v1 import image_annotator_pb2
+        from google.cloudvision.v1 import image_annotator_pb2
 
         unknown = Likelihood.UNKNOWN
         safe_search_annotation = image_annotator_pb2.SafeSearchAnnotation()


### PR DESCRIPTION
@daspecster Would you please take a longer look at this one? I found the "two clients" thing really confusing and am not sure I did this correctly.

In particular, I am pretty sure the existing code threw away the `credentials` argument when being used with GAX. (Not sure how anyone would successfully set any of the _other_ arguments, either.) I updated this and added a test for it.