### PR TITLE
Drop usage of overly broad mock.Mock() in tests.

### DIFF
--- a/logging/unit_tests/test_client.py
+++ b/logging/unit_tests/test_client.py
@@ -617,7 +617,7 @@ class TestClient(unittest.TestCase):
 
         http_mock = mock.Mock(spec=httplib2.Http)
         deepcopy = mock.Mock(return_value=http_mock)
-        setup_logging = mock.Mock()
+        setup_logging = mock.Mock(spec=[])
 
         credentials = _make_credentials()
 

--- a/vision/unit_tests/test__gax.py
+++ b/vision/unit_tests/test__gax.py
@@ -33,7 +33,10 @@ class TestGAXClient(unittest.TestCase):
         return self._get_target_class()(*args, **kwargs)
 
     def test_ctor(self):
-        client = mock.Mock()
+        client = mock.Mock(
+            _credentials=_make_credentials(),
+            spec=['_credentials'],
+        )
         with mock.patch('google.cloud.vision._gax.image_annotator_client.'
                         'ImageAnnotatorClient'):
             api = self._make_one(client)

--- a/vision/unit_tests/test_batch.py
+++ b/vision/unit_tests/test_batch.py
@@ -40,7 +40,7 @@ class TestBatch(unittest.TestCase):
         from google.cloud.vision.feature import FeatureTypes
         from google.cloud.vision.image import Image
 
-        client = mock.Mock()
+        client = mock.Mock(spec=[])
         image = Image(client, source_uri='gs://images/imageone.jpg')
         face_feature = Feature(FeatureTypes.FACE_DETECTION, 5)
         logo_feature = Feature(FeatureTypes.LOGO_DETECTION, 3)
@@ -66,8 +66,13 @@ class TestBatch(unittest.TestCase):
         image_two = client.image(source_uri='gs://images/imagtwo.jpg')
         face_feature = Feature(FeatureTypes.FACE_DETECTION, 5)
         logo_feature = Feature(FeatureTypes.LOGO_DETECTION, 3)
-        client._vision_api_internal = mock.Mock()
-        client._vision_api_internal.annotate.return_value = True
+
+        # Make mocks.
+        annotate = mock.Mock(return_value=True, spec=[])
+        vision_api = mock.Mock(annotate=annotate, spec=['annotate'])
+        client._vision_api_internal = vision_api
+
+        # Actually  call the partially-mocked method.
         batch = client.batch()
         batch.add_image(image_one, [face_feature])
         batch.add_image(image_two, [logo_feature, face_feature])

--- a/vision/unit_tests/test_client.py
+++ b/vision/unit_tests/test_client.py
@@ -51,12 +51,12 @@ class TestClient(unittest.TestCase):
         vision_api = client._vision_api
         vision_api._connection = _Connection()
 
-        api = mock.Mock()
-        api.annotate.return_value = mock.sentinel.annotated
+        annotate = mock.Mock(return_value=mock.sentinel.annotated, spec=[])
+        api = mock.Mock(annotate=annotate, spec=['annotate'])
 
         client._vision_api_internal = api
         client._vision_api.annotate()
-        api.annotate.assert_called_once_with()
+        annotate.assert_called_once_with()
 
     def test_make_gax_client(self):
         from google.cloud.vision._gax import _GAPICVisionAPI


### PR DESCRIPTION
@lukesneeringer @tseaver any ideas on an easy "lint"-like check that will scream if people create a `Mock()` without a `spec`?

SIDEBAR: The error reporting unit tests are in a **very bad state**. This change opened my eyes to that fact, but I fear there is more hiding under the surface.