### PR TITLE
Making datastore Connection.run_query() return low-level protobuf.

### DIFF
--- a/datastore/google/cloud/datastore/_http.py
+++ b/datastore/google/cloud/datastore/_http.py
@@ -379,10 +379,8 @@ class Connection(connection_module.Connection):
                                the given transaction.  Incompatible with
                                ``eventual==True``.
 
-        :rtype: tuple
-        :returns: Four-tuple containing the entities returned,
-                  the end cursor of the query, a ``more_results``
-                  enum and a count of the number of skipped results.
+        :rtype: :class:`.datastore_pb2.RunQueryResponse`
+        :returns: The protobuf response from a ``runQuery`` request.
         """
         request = _datastore_pb2.RunQueryRequest()
         _set_read_options(request, eventual, transaction_id)
@@ -391,13 +389,7 @@ class Connection(connection_module.Connection):
             request.partition_id.namespace_id = namespace
 
         request.query.CopyFrom(query_pb)
-        response = self._datastore_api.run_query(project, request)
-        return (
-            [e.entity for e in response.batch.entity_results],
-            response.batch.end_cursor,  # Assume response always has cursor.
-            response.batch.more_results,
-            response.batch.skipped_results,
-        )
+        return self._datastore_api.run_query(project, request)
 
     def begin_transaction(self, project):
         """Begin a transaction.

--- a/datastore/unit_tests/test_query.py
+++ b/datastore/unit_tests/test_query.py
@@ -28,13 +28,13 @@ class TestQuery(unittest.TestCase):
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
-    def _makeClient(self, connection=None):
+    def _make_client(self, connection=None):
         if connection is None:
             connection = _Connection()
         return _Client(self._PROJECT, connection)
 
     def test_ctor_defaults(self):
-        client = self._makeClient()
+        client = self._make_client()
         query = self._make_one(client)
         self.assertIs(query._client, client)
         self.assertEqual(query.project, client.project)
@@ -52,7 +52,7 @@ class TestQuery(unittest.TestCase):
         _PROJECT = 'OTHER_PROJECT'
         _KIND = 'KIND'
         _NAMESPACE = 'OTHER_NAMESPACE'
-        client = self._makeClient()
+        client = self._make_client()
         ancestor = Key('ANCESTOR', 123, project=_PROJECT)
         FILTERS = [('foo', '=', 'Qux'), ('bar', '<', 17)]
         PROJECTION = ['foo', 'bar', 'baz']
@@ -81,26 +81,26 @@ class TestQuery(unittest.TestCase):
 
     def test_ctor_bad_projection(self):
         BAD_PROJECTION = object()
-        self.assertRaises(TypeError, self._make_one, self._makeClient(),
+        self.assertRaises(TypeError, self._make_one, self._make_client(),
                           projection=BAD_PROJECTION)
 
     def test_ctor_bad_order(self):
         BAD_ORDER = object()
-        self.assertRaises(TypeError, self._make_one, self._makeClient(),
+        self.assertRaises(TypeError, self._make_one, self._make_client(),
                           order=BAD_ORDER)
 
     def test_ctor_bad_distinct_on(self):
         BAD_DISTINCT_ON = object()
-        self.assertRaises(TypeError, self._make_one, self._makeClient(),
+        self.assertRaises(TypeError, self._make_one, self._make_client(),
                           distinct_on=BAD_DISTINCT_ON)
 
     def test_ctor_bad_filters(self):
         FILTERS_CANT_UNPACK = [('one', 'two')]
-        self.assertRaises(ValueError, self._make_one, self._makeClient(),
+        self.assertRaises(ValueError, self._make_one, self._make_client(),
                           filters=FILTERS_CANT_UNPACK)
 
     def test_namespace_setter_w_non_string(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
 
         def _assign(val):
             query.namespace = val
@@ -109,12 +109,12 @@ class TestQuery(unittest.TestCase):
 
     def test_namespace_setter(self):
         _NAMESPACE = 'OTHER_NAMESPACE'
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.namespace = _NAMESPACE
         self.assertEqual(query.namespace, _NAMESPACE)
 
     def test_kind_setter_w_non_string(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
 
         def _assign(val):
             query.kind = val
@@ -123,21 +123,21 @@ class TestQuery(unittest.TestCase):
 
     def test_kind_setter_wo_existing(self):
         _KIND = 'KIND'
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.kind = _KIND
         self.assertEqual(query.kind, _KIND)
 
     def test_kind_setter_w_existing(self):
         _KIND_BEFORE = 'KIND_BEFORE'
         _KIND_AFTER = 'KIND_AFTER'
-        query = self._make_one(self._makeClient(), kind=_KIND_BEFORE)
+        query = self._make_one(self._make_client(), kind=_KIND_BEFORE)
         self.assertEqual(query.kind, _KIND_BEFORE)
         query.kind = _KIND_AFTER
         self.assertEqual(query.project, self._PROJECT)
         self.assertEqual(query.kind, _KIND_AFTER)
 
     def test_ancestor_setter_w_non_key(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
 
         def _assign(val):
             query.ancestor = val
@@ -150,7 +150,7 @@ class TestQuery(unittest.TestCase):
 
         _NAME = u'NAME'
         key = Key('KIND', 123, project=self._PROJECT)
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.add_filter('name', '=', _NAME)
         query.ancestor = key
         self.assertEqual(query.ancestor.path, key.path)
@@ -159,22 +159,22 @@ class TestQuery(unittest.TestCase):
         from google.cloud.datastore.key import Key
 
         key = Key('KIND', 123, project=self._PROJECT)
-        query = self._make_one(client=self._makeClient(), ancestor=key)
+        query = self._make_one(client=self._make_client(), ancestor=key)
         del query.ancestor
         self.assertIsNone(query.ancestor)
 
     def test_add_filter_setter_w_unknown_operator(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         self.assertRaises(ValueError, query.add_filter,
                           'firstname', '~~', 'John')
 
     def test_add_filter_w_known_operator(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.add_filter('firstname', '=', u'John')
         self.assertEqual(query.filters, [('firstname', '=', u'John')])
 
     def test_add_filter_w_all_operators(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.add_filter('leq_prop', '<=', u'val1')
         query.add_filter('geq_prop', '>=', u'val2')
         query.add_filter('lt_prop', '<', u'val3')
@@ -190,7 +190,7 @@ class TestQuery(unittest.TestCase):
     def test_add_filter_w_known_operator_and_entity(self):
         from google.cloud.datastore.entity import Entity
 
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         other = Entity()
         other['firstname'] = u'John'
         other['lastname'] = u'Smith'
@@ -198,7 +198,7 @@ class TestQuery(unittest.TestCase):
         self.assertEqual(query.filters, [('other', '=', other)])
 
     def test_add_filter_w_whitespace_property_name(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         PROPERTY_NAME = '  property with lots of space '
         query.add_filter(PROPERTY_NAME, '=', u'John')
         self.assertEqual(query.filters, [(PROPERTY_NAME, '=', u'John')])
@@ -206,7 +206,7 @@ class TestQuery(unittest.TestCase):
     def test_add_filter___key__valid_key(self):
         from google.cloud.datastore.key import Key
 
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         key = Key('Foo', project=self._PROJECT)
         query.add_filter('__key__', '=', key)
         self.assertEqual(query.filters, [('__key__', '=', key)])
@@ -215,47 +215,47 @@ class TestQuery(unittest.TestCase):
         from google.cloud.datastore.key import Key
 
         key = Key('Foo', project=self._PROJECT)
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.add_filter('__key__', '<', key)
         self.assertEqual(query.filters, [('__key__', '<', key)])
 
     def test_filter___key__invalid_value(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         self.assertRaises(ValueError, query.add_filter, '__key__', '=', None)
 
     def test_projection_setter_empty(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.projection = []
         self.assertEqual(query.projection, [])
 
     def test_projection_setter_string(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.projection = 'field1'
         self.assertEqual(query.projection, ['field1'])
 
     def test_projection_setter_non_empty(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.projection = ['field1', 'field2']
         self.assertEqual(query.projection, ['field1', 'field2'])
 
     def test_projection_setter_multiple_calls(self):
         _PROJECTION1 = ['field1', 'field2']
         _PROJECTION2 = ['field3']
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.projection = _PROJECTION1
         self.assertEqual(query.projection, _PROJECTION1)
         query.projection = _PROJECTION2
         self.assertEqual(query.projection, _PROJECTION2)
 
     def test_keys_only(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.keys_only()
         self.assertEqual(query.projection, ['__key__'])
 
     def test_key_filter_defaults(self):
         from google.cloud.datastore.key import Key
 
-        client = self._makeClient()
+        client = self._make_client()
         query = self._make_one(client)
         self.assertEqual(query.filters, [])
         key = Key('Kind', 1234, project='project')
@@ -265,7 +265,7 @@ class TestQuery(unittest.TestCase):
     def test_key_filter_explicit(self):
         from google.cloud.datastore.key import Key
 
-        client = self._makeClient()
+        client = self._make_client()
         query = self._make_one(client)
         self.assertEqual(query.filters, [])
         key = Key('Kind', 1234, project='project')
@@ -273,44 +273,44 @@ class TestQuery(unittest.TestCase):
         self.assertEqual(query.filters, [('__key__', '>', key)])
 
     def test_order_setter_empty(self):
-        query = self._make_one(self._makeClient(), order=['foo', '-bar'])
+        query = self._make_one(self._make_client(), order=['foo', '-bar'])
         query.order = []
         self.assertEqual(query.order, [])
 
     def test_order_setter_string(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.order = 'field'
         self.assertEqual(query.order, ['field'])
 
     def test_order_setter_single_item_list_desc(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.order = ['-field']
         self.assertEqual(query.order, ['-field'])
 
     def test_order_setter_multiple(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.order = ['foo', '-bar']
         self.assertEqual(query.order, ['foo', '-bar'])
 
     def test_distinct_on_setter_empty(self):
-        query = self._make_one(self._makeClient(), distinct_on=['foo', 'bar'])
+        query = self._make_one(self._make_client(), distinct_on=['foo', 'bar'])
         query.distinct_on = []
         self.assertEqual(query.distinct_on, [])
 
     def test_distinct_on_setter_string(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.distinct_on = 'field1'
         self.assertEqual(query.distinct_on, ['field1'])
 
     def test_distinct_on_setter_non_empty(self):
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.distinct_on = ['field1', 'field2']
         self.assertEqual(query.distinct_on, ['field1', 'field2'])
 
     def test_distinct_on_multiple_calls(self):
         _DISTINCT_ON1 = ['field1', 'field2']
         _DISTINCT_ON2 = ['field3']
-        query = self._make_one(self._makeClient())
+        query = self._make_one(self._make_client())
         query.distinct_on = _DISTINCT_ON1
         self.assertEqual(query.distinct_on, _DISTINCT_ON1)
         query.distinct_on = _DISTINCT_ON2
@@ -320,7 +320,7 @@ class TestQuery(unittest.TestCase):
         from google.cloud.datastore.query import Iterator
 
         connection = _Connection()
-        client = self._makeClient(connection)
+        client = self._make_client(connection)
         query = self._make_one(client)
         iterator = query.fetch()
 
@@ -334,8 +334,8 @@ class TestQuery(unittest.TestCase):
         from google.cloud.datastore.query import Iterator
 
         connection = _Connection()
-        client = self._makeClient(connection)
-        other_client = self._makeClient(connection)
+        client = self._make_client(connection)
+        other_client = self._make_client(connection)
         query = self._make_one(client)
         iterator = query.fetch(limit=7, offset=8, client=other_client)
         self.assertIsInstance(iterator, Iterator)
@@ -443,15 +443,17 @@ class TestIterator(unittest.TestCase):
                                   end_cursor='abcd')
         self.assertIsNotNone(iterator._end_cursor)
 
-        entity_pbs = object()
+        entity_pbs = [
+            _make_entity('Hello', 9998, 'PRAHJEKT'),
+        ]
         cursor_as_bytes = b'\x9ai\xe7'
         cursor = b'mmnn'
         skipped_results = 4
         more_results_enum = query_pb2.QueryResultBatch.NOT_FINISHED
-        result = iterator._process_query_results(
-            entity_pbs, cursor_as_bytes,
-            more_results_enum, skipped_results)
-        self.assertIs(result, entity_pbs)
+        response_pb = _make_query_response(
+            entity_pbs, cursor_as_bytes, more_results_enum, skipped_results)
+        result = iterator._process_query_results(response_pb)
+        self.assertEqual(result, entity_pbs)
 
         self.assertEqual(iterator._skipped_results, skipped_results)
         self.assertEqual(iterator.next_page_token, cursor)
@@ -464,14 +466,16 @@ class TestIterator(unittest.TestCase):
                                   end_cursor='abcd')
         self.assertIsNotNone(iterator._end_cursor)
 
-        entity_pbs = object()
+        entity_pbs = [
+            _make_entity('World', 1234, 'PROJECT'),
+        ]
         cursor_as_bytes = b''
         skipped_results = 44
         more_results_enum = query_pb2.QueryResultBatch.NO_MORE_RESULTS
-        result = iterator._process_query_results(
-            entity_pbs, cursor_as_bytes,
-            more_results_enum, skipped_results)
-        self.assertIs(result, entity_pbs)
+        response_pb = _make_query_response(
+            entity_pbs, cursor_as_bytes, more_results_enum, skipped_results)
+        result = iterator._process_query_results(response_pb)
+        self.assertEqual(result, entity_pbs)
 
         self.assertEqual(iterator._skipped_results, skipped_results)
         self.assertIsNone(iterator.next_page_token)
@@ -480,9 +484,10 @@ class TestIterator(unittest.TestCase):
     def test__process_query_results_bad_enum(self):
         iterator = self._make_one(None, None)
         more_results_enum = 999
+        response_pb = _make_query_response(
+            [], b'', more_results_enum, 0)
         with self.assertRaises(ValueError):
-            iterator._process_query_results(
-                None, b'', more_results_enum, None)
+            iterator._process_query_results(response_pb)
 
     def test__next_page(self):
         from google.cloud.iterator import Page
@@ -491,7 +496,7 @@ class TestIterator(unittest.TestCase):
 
         connection = _Connection()
         more_enum = query_pb2.QueryResultBatch.NOT_FINISHED
-        result = ([], b'', more_enum, 0)
+        result = _make_query_response([], b'', more_enum, 0)
         connection._results = [result]
         project = 'prujekt'
         client = _Client(project, connection)
@@ -695,3 +700,32 @@ class _Client(object):
     @property
     def current_transaction(self):
         pass
+
+
+def _make_entity(kind, id_, project):
+    from google.cloud.grpc.datastore.v1 import entity_pb2
+
+    key = entity_pb2.Key()
+    key.partition_id.project_id = project
+    elem = key.path.add()
+    elem.kind = kind
+    elem.id = id_
+    return entity_pb2.Entity(key=key)
+
+
+def _make_query_response(
+        entity_pbs, cursor_as_bytes, more_results_enum, skipped_results):
+    from google.cloud.grpc.datastore.v1 import datastore_pb2
+    from google.cloud.grpc.datastore.v1 import query_pb2
+
+    return datastore_pb2.RunQueryResponse(
+        batch=query_pb2.QueryResultBatch(
+            skipped_results=skipped_results,
+            end_cursor=cursor_as_bytes,
+            more_results=more_results_enum,
+            entity_results=[
+                query_pb2.EntityResult(entity=entity)
+                for entity in entity_pbs
+            ],
+        ),
+    )


### PR DESCRIPTION
Towards #2746 (as is #3064). This approach is to slowly transition from our current approach to use the GAPIC generated surface.

These unit tests weren't so bad to update. I did "editorialize" as I went, downgrading constants to just variables, renamining for PEP8, etc.