### PR TITLE
for streaming sample should have "stream=" param

### DIFF
--- a/docs/speech-usage.rst
+++ b/docs/speech-usage.rst
@@ -207,7 +207,7 @@ If ``interim_results`` is set to :data:`True`, interim results
     >>> from google.cloud import speech
     >>> client = speech.Client()
     >>> with open('./hello.wav', 'rb') as stream:
-    ...     sample = client.sample(content=stream,
+    ...     sample = client.sample(stream=stream,
     ...                            encoding=speech.Encoding.LINEAR16,
     ...                            sample_rate=16000)
     ...     for results in sample.streaming_recognize(interim_results=True):


### PR DESCRIPTION
Sample class can take in content, source_uri or stream, should be stream here.
```
    :type content: bytes
    :param content: (Optional) Bytes containing audio data.

    :type stream: file
    :param stream: (Optional) File like object to stream.
```
the type is deduced using:
```sources = [content is not None, source_uri is not None, stream is not None]```