### PR TITLE
Passing along client instead of project when creating error API.

### DIFF
--- a/error_reporting/google/cloud/error_reporting/client.py
+++ b/error_reporting/google/cloud/error_reporting/client.py
@@ -159,7 +159,7 @@ class Client(object):
         """
         if self._report_errors_api is None:
             if self._use_gax:
-                self._report_errors_api = make_report_error_api(self._project)
+                self._report_errors_api = make_report_error_api(self)
             else:
                 self._report_errors_api = _ErrorReportingLoggingAPI(
                     self._project, self._credentials, self._http)


### PR DESCRIPTION
Also changed a lot of the unit tests. Fixes #3071.

----

Between #3063 and this, my confidence in the `error_reporting` package is pretty shaken.

/cc @jonparrott @waprin 