### PR TITLE
Making datastore Connection.begin_transaction() return low-level protobuf.

### DIFF
--- a/datastore/google/cloud/datastore/_http.py
+++ b/datastore/google/cloud/datastore/_http.py
@@ -399,12 +399,11 @@ class Connection(connection_module.Connection):
         :type project: str
         :param project: The project to which the transaction applies.
 
-        :rtype: bytes
+        :rtype: :class:`.datastore_pb2.BeginTransactionResponse`
         :returns: The serialized transaction that was begun.
         """
         request = _datastore_pb2.BeginTransactionRequest()
-        response = self._datastore_api.begin_transaction(project, request)
-        return response.transaction
+        return self._datastore_api.begin_transaction(project, request)
 
     def commit(self, project, request, transaction_id):
         """Commit mutations in context of current transaction (if any).

--- a/datastore/google/cloud/datastore/transaction.py
+++ b/datastore/google/cloud/datastore/transaction.py
@@ -184,8 +184,9 @@ class Transaction(Batch):
         """
         super(Transaction, self).begin()
         try:
-            self._id = self._client._connection.begin_transaction(
+            response_pb = self._client._connection.begin_transaction(
                 self.project)
+            self._id = response_pb.transaction
         except:  # noqa: E722 do not use bare except, specify exception instead
             self._status = self._ABORTED
             raise

--- a/datastore/unit_tests/test_transaction.py
+++ b/datastore/unit_tests/test_transaction.py
@@ -206,9 +206,12 @@ class _Connection(object):
             mutation_results=mutation_results)
 
     def begin_transaction(self, project):
+        import mock
+
         self._begun = project
         if self._side_effect is None:
-            return self._xact_id
+            return mock.Mock(
+                transaction=self._xact_id, spec=['transaction'])
         else:
             raise self._side_effect
 


### PR DESCRIPTION
Towards #2746 (as were #3064 and #3066). This approach is to slowly transition from our current approach to use the GAPIC generated surface.