### PR TITLE
Making datastore Connection.rollback() return low-level protobuf.

### DIFF
--- a/datastore/google/cloud/datastore/_http.py
+++ b/datastore/google/cloud/datastore/_http.py
@@ -448,11 +448,14 @@ class Connection(connection_module.Connection):
         :type transaction_id: str
         :param transaction_id: The transaction ID returned from
                                :meth:`begin_transaction`.
+
+        :rtype: :class:`.datastore_pb2.RollbackResponse`
+        :returns: The returned protobuf response object.
         """
         request = _datastore_pb2.RollbackRequest()
         request.transaction = transaction_id
-        # Nothing to do with this response, so just execute the method.
-        self._datastore_api.rollback(project, request)
+        # Response is empty (i.e. no fields) but we return it anyway.
+        return self._datastore_api.rollback(project, request)
 
     def allocate_ids(self, project, key_pbs):
         """Obtain backend-generated IDs for a set of keys.

--- a/datastore/google/cloud/datastore/transaction.py
+++ b/datastore/google/cloud/datastore/transaction.py
@@ -199,6 +199,7 @@ class Transaction(Batch):
         - Sets the current transaction's ID to None.
         """
         try:
+            # No need to use the response it contains nothing.
             self._client._connection.rollback(self.project, self._id)
         finally:
             super(Transaction, self).rollback()

--- a/datastore/unit_tests/test__http.py
+++ b/datastore/unit_tests/test__http.py
@@ -767,26 +767,31 @@ class TestConnection(unittest.TestCase):
     def test_rollback_ok(self):
         from google.cloud.proto.datastore.v1 import datastore_pb2
 
-        PROJECT = 'PROJECT'
-        TRANSACTION = b'xact'
-
+        project = 'PROJECT'
+        transaction = b'xact'
         rsp_pb = datastore_pb2.RollbackResponse()
+
+        # Create mock HTTP and client with response.
         http = Http({'status': '200'}, rsp_pb.SerializeToString())
         client = mock.Mock(_http=http, spec=['_http'])
+
+        # Make request.
         conn = self._make_one(client)
-        URI = '/'.join([
+        response = conn.rollback(project, transaction)
+
+        # Check the result and verify the callers.
+        self.assertEqual(response, rsp_pb)
+        uri = '/'.join([
             conn.api_base_url,
             conn.API_VERSION,
             'projects',
-            PROJECT + ':rollback',
+            project + ':rollback',
         ])
-        self.assertIsNone(conn.rollback(PROJECT, TRANSACTION))
         cw = http._called_with
-        self._verify_protobuf_call(cw, URI, conn)
-        rq_class = datastore_pb2.RollbackRequest
-        request = rq_class()
+        self._verify_protobuf_call(cw, uri, conn)
+        request = datastore_pb2.RollbackRequest()
         request.ParseFromString(cw['body'])
-        self.assertEqual(request.transaction, TRANSACTION)
+        self.assertEqual(request.transaction, transaction)
 
     def test_allocate_ids_empty(self):
         from google.cloud.proto.datastore.v1 import datastore_pb2


### PR DESCRIPTION
Towards #2746 (as were #3064 and #3066 and #3091). This approach is to slowly transition from our current approach to use the GAPIC generated surface.