### PR TITLE
Cut version 0.23.1 of Bigtable.

### DIFF
--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -56,7 +56,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-bigtable',
-    version='0.23.0',
+    version='0.23.1',
     description='Python Client for Google Cloud Bigtable',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Only commits since the last release came from #3089, so release notes will be easy.

```
$ git log bigtable-0.23.0..cut-bigtable-0.23.1 -- bigtable/
commit f99fb80baf810ca4447c7f1bc6b39a9f430f7072
Author: Danny Hermes <daniel.j.hermes@gmail.com>
Date:   Fri Mar 3 11:18:05 2017 -0800

    Cut version 0.23.1 of Bigtable.

commit 20ffd2be9b31bbff9bca8bd698c941da5a7f1951
Author: Danny Hermes <daniel.j.hermes@gmail.com>
Date:   Thu Mar 2 16:54:21 2017 -0800

    Sending x-goog-api-client header in Bigtable.
    
    We missed this because it does not use GAPIC (the most
    recent generated Bigtable GAPIC surface is 5+ months old).
```