### PR TITLE
Vision Beta

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ Cloud Platform services:
 -  `Google Cloud Datastore`_ (`Datastore README`_)
 -  `Stackdriver Logging`_ (`Logging README`_)
 -  `Google Cloud Storage`_ (`Storage README`_)
+-  `Google Cloud Vision`_ (`Vision README`_)
 
 **Beta** indicates that the client library for a particular service is
 mostly stable and is being prepared for release. Issues and requests
@@ -39,7 +40,6 @@ Cloud Platform services:
 -  `Google Cloud Natural Language`_ (`Natural Language README`_)
 -  `Google Cloud Translation`_ (`Translation README`_)
 -  `Google Cloud Speech`_ (`Speech README`_)
--  `Google Cloud Vision`_ (`Vision README`_)
 -  `Google Cloud Bigtable - HappyBase`_ (`HappyBase README`_)
 -  `Google Cloud Runtime Configuration`_ (`Runtime Config README`_)
 -  `Cloud Spanner`_ (`Cloud Spanner README`_)

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-vision',
-    version='0.90.0',
+    version='0.23.3',
     description='Python Client for Google Cloud Vision',
     long_description=README,
     namespace_packages=[

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -35,7 +35,7 @@ SETUP_BASE = {
     'include_package_data': True,
     'zip_safe': False,
     'classifiers': [
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
@@ -52,12 +52,12 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'enum34',
     'google-cloud-core >= 0.23.1, < 0.24dev',
-    'gapic-google-cloud-vision-v1 >= 0.15.2, < 0.16dev',
+    'gapic-google-cloud-vision-v1 >= 0.90.3, < 0.91dev',
 ]
 
 setup(
     name='google-cloud-vision',
-    version='0.23.2',
+    version='0.90.0',
     description='Python Client for Google Cloud Vision',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
This PR officially makes `google-cloud-vision` a beta library.

@daspecster What else (besides a release, of course) is needed to accomplish this? Do the docs proclaim Vision as alpha right now? If so, we need to update that. (Also, we will need a manual docs trigger once this is pushed out.)