### PR TITLE
Add basic helpers needed for GAPIC client in datastore.

### DIFF
--- a/datastore/google/cloud/datastore/_gax.py
+++ b/datastore/google/cloud/datastore/_gax.py
@@ -17,12 +17,15 @@
 
 import contextlib
 
+from google.cloud.gapic.datastore.v1 import datastore_client
 from google.cloud.proto.datastore.v1 import datastore_pb2_grpc
 from google.gax.utils import metrics
 from grpc import StatusCode
 
 from google.cloud._helpers import make_insecure_stub
+from google.cloud._helpers import make_secure_channel
 from google.cloud._helpers import make_secure_stub
+from google.cloud._http import DEFAULT_USER_AGENT
 from google.cloud import exceptions
 
 from google.cloud.datastore import __version__
@@ -204,3 +207,19 @@ class _DatastoreAPIOverGRPC(object):
         request_pb.project_id = project
         with _grpc_catch_rendezvous():
             return self._stub.AllocateIds(request_pb)
+
+
+def make_datastore_api(client):
+    """Create an instance of the GAPIC Datastore API.
+
+    :type client: :class:`~google.cloud.datastore.client.Client`
+    :param client: The client that holds configuration details.
+
+    :rtype: :class:`.datastore.v1.datastore_client.DatastoreClient`
+    :returns: A datastore API instance with the proper credentials.
+    """
+    channel = make_secure_channel(
+        client._credentials, DEFAULT_USER_AGENT,
+        datastore_client.DatastoreClient.SERVICE_ADDRESS)
+    return datastore_client.DatastoreClient(
+        channel=channel, lib_name='gccl', lib_version=__version__)

--- a/datastore/google/cloud/datastore/_http.py
+++ b/datastore/google/cloud/datastore/_http.py
@@ -467,6 +467,19 @@ class Connection(connection_module.Connection):
         return self._datastore_api.allocate_ids(project, request)
 
 
+class HTTPDatastoreAPI(object):
+    """An API object that sends proto-over-HTTP requests.
+
+    Intended to provide the same methods as the GAPIC ``DatastoreClient``.
+
+    :type client: :class:`~google.cloud.datastore.client.Client`
+    :param client: The client that provides configuration.
+    """
+
+    def __init__(self, client):
+        self.client = client
+
+
 def _set_read_options(request, eventual, transaction_id):
     """Validate rules for read options, and assign to the request.
 

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -19,18 +19,29 @@ from google.cloud._helpers import _LocalStack
 from google.cloud._helpers import (
     _determine_default_project as _base_default_project)
 from google.cloud.client import ClientWithProject
+from google.cloud.environment_vars import DISABLE_GRPC
+from google.cloud.environment_vars import GCD_DATASET
+
 from google.cloud.datastore._http import Connection
+from google.cloud.datastore._http import HTTPDatastoreAPI
 from google.cloud.datastore import helpers
 from google.cloud.datastore.batch import Batch
 from google.cloud.datastore.entity import Entity
 from google.cloud.datastore.key import Key
 from google.cloud.datastore.query import Query
 from google.cloud.datastore.transaction import Transaction
-from google.cloud.environment_vars import GCD_DATASET
+try:
+    from google.cloud.datastore._gax import make_datastore_api
+    _HAVE_GRPC = True
+except ImportError:  # pragma: NO COVER
+    make_datastore_api = None
+    _HAVE_GRPC = False
 
 
 _MAX_LOOPS = 128
 """Maximum number of iterations to wait for deferred keys."""
+
+_USE_GAX = _HAVE_GRPC and not os.getenv(DISABLE_GRPC, False)
 
 
 def _get_gcd_project():
@@ -169,23 +180,44 @@ class Client(ClientWithProject):
                  :meth:`~httplib2.Http.request`. If not passed, an
                  ``http`` object is created that is bound to the
                  ``credentials`` for the current object.
+
+    :type use_gax: bool
+    :param use_gax: (Optional) Explicitly specifies whether
+                    to use the gRPC transport (via GAX) or HTTP. If unset,
+                    falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
+                    variable.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/datastore',)
     """The scopes required for authenticating as a Cloud Datastore consumer."""
 
     def __init__(self, project=None, namespace=None,
-                 credentials=None, http=None):
+                 credentials=None, http=None, use_gax=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, http=http)
         self._connection = Connection(self)
         self.namespace = namespace
         self._batch_stack = _LocalStack()
+        self._datastore_api_internal = None
+        if use_gax is None:
+            self._use_gax = _USE_GAX
+        else:
+            self._use_gax = use_gax
 
     @staticmethod
     def _determine_default(project):
         """Helper:  override default project detection."""
         return _determine_default_project(project)
+
+    @property
+    def _datastore_api(self):
+        """Getter for a wrapped API object."""
+        if self._datastore_api_internal is None:
+            if self._use_gax:
+                self._datastore_api_internal = make_datastore_api(self)
+            else:
+                self._datastore_api_internal = HTTPDatastoreAPI(self)
+        return self._datastore_api_internal
 
     def _push_batch(self, batch):
         """Push a batch/transaction onto our stack.

--- a/datastore/unit_tests/test__http.py
+++ b/datastore/unit_tests/test__http.py
@@ -914,6 +914,23 @@ class TestConnection(unittest.TestCase):
             self.assertEqual(key_before, key_after)
 
 
+class TestHTTPDatastoreAPI(unittest.TestCase):
+
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.datastore._http import HTTPDatastoreAPI
+
+        return HTTPDatastoreAPI
+
+    def _make_one(self, *args, **kwargs):
+        return self._get_target_class()(*args, **kwargs)
+
+    def test_constructor(self):
+        client = object()
+        ds_api = self._make_one(client)
+        self.assertIs(ds_api.client, client)
+
+
 class Http(object):
 
     _called_with = None


### PR DESCRIPTION
Includes

- ``use_gax`` argument in Client constructor
- ``make_datastore_api`` helper to make a gRPC channel with
  the correct credentials
- A basic ``HTTPDatastoreAPI`` class to act as the equivalent
  to the GAPIC ``DatastoreClient``
- A lazy property on ``Client`` that will hold the API
  object.

Towards #2746.