### PR TITLE
Bump language version to 0.23.1

### DIFF
--- a/language/setup.py
+++ b/language/setup.py
@@ -55,7 +55,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-language',
-    version='0.23.0',
+    version='0.23.1',
     description='Python Client for Google Cloud Natural Language',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Based on `git log a3596d6..HEAD language/`...

  * Fixes default encoding to correctly detect based on `sys.maxunicode`. (#3102)