### PR TITLE
Only requiring HTTP object to make datastore RPC-over-HTTP.

### DIFF
--- a/datastore/google/cloud/datastore/_http.py
+++ b/datastore/google/cloud/datastore/_http.py
@@ -48,12 +48,11 @@ _USE_GRPC = _HAVE_GRPC and not _DISABLE_GRPC
 _CLIENT_INFO = connection_module.CLIENT_INFO_TEMPLATE.format(__version__)
 
 
-def _request(connection, project, method, data):
+def _request(http, project, method, data, base_url):
     """Make a request over the Http transport to the Cloud Datastore API.
 
-    :type connection: :class:`Connection`
-    :param connection: A connection object that contains helpful
-                       information for making requests.
+    :type http: :class:`~httplib2.Http`
+    :param http: HTTP object to make requests.
 
     :type project: str
     :param project: The project to make the request for.
@@ -66,6 +65,9 @@ def _request(connection, project, method, data):
     :param data: The data to send with the API call.
                  Typically this is a serialized Protobuf string.
 
+    :type base_url: str
+    :param base_url: The base URL where the API lives.
+
     :rtype: str
     :returns: The string response content from the API call.
     :raises: :class:`google.cloud.exceptions.GoogleCloudError` if the
@@ -77,8 +79,8 @@ def _request(connection, project, method, data):
         'User-Agent': connection_module.DEFAULT_USER_AGENT,
         connection_module.CLIENT_INFO_HEADER: _CLIENT_INFO,
     }
-    api_url = build_api_url(project, method, connection.api_base_url)
-    headers, content = connection.http.request(
+    api_url = build_api_url(project, method, base_url)
+    headers, content = http.request(
         uri=api_url, method='POST', headers=headers, body=data)
 
     status = headers['status']
@@ -90,12 +92,11 @@ def _request(connection, project, method, data):
     return content
 
 
-def _rpc(connection, project, method, request_pb, response_pb_cls):
+def _rpc(http, project, method, base_url, request_pb, response_pb_cls):
     """Make a protobuf RPC request.
 
-    :type connection: :class:`Connection`
-    :param connection: A connection object that contains helpful
-                       information for making requests.
+    :type http: :class:`~httplib2.Http`
+    :param http: HTTP object to make requests.
 
     :type project: str
     :param project: The project to connect to. This is
@@ -103,6 +104,9 @@ def _rpc(connection, project, method, request_pb, response_pb_cls):
 
     :type method: str
     :param method: The name of the method to invoke.
+
+    :type base_url: str
+    :param base_url: The base URL where the API lives.
 
     :type request_pb: :class:`google.protobuf.message.Message` instance
     :param request_pb: the protobuf instance representing the request.
@@ -115,8 +119,9 @@ def _rpc(connection, project, method, request_pb, response_pb_cls):
     :rtype: :class:`google.protobuf.message.Message`
     :returns: The RPC message parsed from the response.
     """
-    response = _request(connection=connection, project=project,
-                        method=method, data=request_pb.SerializeToString())
+    req_data = request_pb.SerializeToString()
+    response = _request(
+        http, project, method, req_data, base_url)
     return response_pb_cls.FromString(response)
 
 
@@ -135,7 +140,6 @@ def build_api_url(project, method, base_url):
 
     :type base_url: str
     :param base_url: The base URL where the API lives.
-                     You shouldn't have to provide this.
 
     :rtype: str
     :returns: The API URL created.
@@ -174,8 +178,9 @@ class _DatastoreAPIOverHttp(object):
         :rtype: :class:`.datastore_pb2.LookupResponse`
         :returns: The returned protobuf response object.
         """
-        return _rpc(self.connection, project, 'lookup', request_pb,
-                    _datastore_pb2.LookupResponse)
+        return _rpc(self.connection.http, project, 'lookup',
+                    self.connection.api_base_url,
+                    request_pb, _datastore_pb2.LookupResponse)
 
     def run_query(self, project, request_pb):
         """Perform a ``runQuery`` request.
@@ -190,8 +195,9 @@ class _DatastoreAPIOverHttp(object):
         :rtype: :class:`.datastore_pb2.RunQueryResponse`
         :returns: The returned protobuf response object.
         """
-        return _rpc(self.connection, project, 'runQuery', request_pb,
-                    _datastore_pb2.RunQueryResponse)
+        return _rpc(self.connection.http, project, 'runQuery',
+                    self.connection.api_base_url,
+                    request_pb, _datastore_pb2.RunQueryResponse)
 
     def begin_transaction(self, project, request_pb):
         """Perform a ``beginTransaction`` request.
@@ -207,8 +213,9 @@ class _DatastoreAPIOverHttp(object):
         :rtype: :class:`.datastore_pb2.BeginTransactionResponse`
         :returns: The returned protobuf response object.
         """
-        return _rpc(self.connection, project, 'beginTransaction', request_pb,
-                    _datastore_pb2.BeginTransactionResponse)
+        return _rpc(self.connection.http, project, 'beginTransaction',
+                    self.connection.api_base_url,
+                    request_pb, _datastore_pb2.BeginTransactionResponse)
 
     def commit(self, project, request_pb):
         """Perform a ``commit`` request.
@@ -223,8 +230,9 @@ class _DatastoreAPIOverHttp(object):
         :rtype: :class:`.datastore_pb2.CommitResponse`
         :returns: The returned protobuf response object.
         """
-        return _rpc(self.connection, project, 'commit', request_pb,
-                    _datastore_pb2.CommitResponse)
+        return _rpc(self.connection.http, project, 'commit',
+                    self.connection.api_base_url,
+                    request_pb, _datastore_pb2.CommitResponse)
 
     def rollback(self, project, request_pb):
         """Perform a ``rollback`` request.
@@ -239,8 +247,9 @@ class _DatastoreAPIOverHttp(object):
         :rtype: :class:`.datastore_pb2.RollbackResponse`
         :returns: The returned protobuf response object.
         """
-        return _rpc(self.connection, project, 'rollback', request_pb,
-                    _datastore_pb2.RollbackResponse)
+        return _rpc(self.connection.http, project, 'rollback',
+                    self.connection.api_base_url,
+                    request_pb, _datastore_pb2.RollbackResponse)
 
     def allocate_ids(self, project, request_pb):
         """Perform an ``allocateIds`` request.
@@ -255,8 +264,9 @@ class _DatastoreAPIOverHttp(object):
         :rtype: :class:`.datastore_pb2.AllocateIdsResponse`
         :returns: The returned protobuf response object.
         """
-        return _rpc(self.connection, project, 'allocateIds', request_pb,
-                    _datastore_pb2.AllocateIdsResponse)
+        return _rpc(self.connection.http, project, 'allocateIds',
+                    self.connection.api_base_url,
+                    request_pb, _datastore_pb2.AllocateIdsResponse)
 
 
 class Connection(connection_module.Connection):


### PR DESCRIPTION
**NOTE**: Has #3108 as diffbase.