### PR TITLE
Moving datastore host configuration into Client.

### DIFF
--- a/datastore/google/cloud/datastore/_gax.py
+++ b/datastore/google/cloud/datastore/_gax.py
@@ -21,6 +21,7 @@ from google.cloud.gapic.datastore.v1 import datastore_client
 from google.cloud.proto.datastore.v1 import datastore_pb2_grpc
 from google.gax.utils import metrics
 from grpc import StatusCode
+import six
 
 from google.cloud._helpers import make_insecure_stub
 from google.cloud._helpers import make_secure_channel
@@ -90,20 +91,20 @@ class _DatastoreAPIOverGRPC(object):
     :type connection: :class:`Connection`
     :param connection: A connection object that contains helpful
                        information for making requests.
-
-    :type secure: bool
-    :param secure: Flag indicating if a secure stub connection is needed.
     """
 
-    def __init__(self, connection, secure):
-        if secure:
+    def __init__(self, connection):
+        parse_result = six.moves.urllib_parse.urlparse(
+            connection.api_base_url)
+        host = parse_result.hostname
+        if parse_result.scheme == 'https':
             self._stub = make_secure_stub(
-                connection.credentials, connection.USER_AGENT,
-                datastore_pb2_grpc.DatastoreStub, connection.host,
+                connection.credentials, DEFAULT_USER_AGENT,
+                datastore_pb2_grpc.DatastoreStub, host,
                 extra_options=_GRPC_EXTRA_OPTIONS)
         else:
-            self._stub = make_insecure_stub(datastore_pb2_grpc.DatastoreStub,
-                                            connection.host)
+            self._stub = make_insecure_stub(
+                datastore_pb2_grpc.DatastoreStub, host)
 
     def lookup(self, project, request_pb):
         """Perform a ``lookup`` request.

--- a/datastore/google/cloud/datastore/_http.py
+++ b/datastore/google/cloud/datastore/_http.py
@@ -20,7 +20,6 @@ from google.rpc import status_pb2
 
 from google.cloud import _http as connection_module
 from google.cloud.environment_vars import DISABLE_GRPC
-from google.cloud.environment_vars import GCD_HOST
 from google.cloud import exceptions
 from google.cloud.proto.datastore.v1 import datastore_pb2 as _datastore_pb2
 
@@ -282,16 +281,9 @@ class Connection(connection_module.Connection):
 
     def __init__(self, client):
         super(Connection, self).__init__(client)
-        try:
-            self.host = os.environ[GCD_HOST]
-            self.api_base_url = 'http://' + self.host
-            secure = False
-        except KeyError:
-            self.host = DATASTORE_API_HOST
-            self.api_base_url = API_BASE_URL
-            secure = True
+        self.api_base_url = client._base_url
         if _USE_GRPC:
-            self._datastore_api = _DatastoreAPIOverGRPC(self, secure=secure)
+            self._datastore_api = _DatastoreAPIOverGRPC(self)
         else:
             self._datastore_api = _DatastoreAPIOverHttp(self)
 

--- a/datastore/unit_tests/test__gax.py
+++ b/datastore/unit_tests/test__gax.py
@@ -19,9 +19,6 @@ import mock
 from google.cloud.datastore._http import _HAVE_GRPC
 
 
-USER_AGENT = 'you-sir-age-int'
-
-
 @unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
 class Test__grpc_catch_rendezvous(unittest.TestCase):
 
@@ -98,35 +95,37 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
         return _DatastoreAPIOverGRPC
 
     def _make_one(self, stub, connection=None, secure=True):
-        if connection is None:
-            connection = mock.Mock(
-                credentials=object(),
-                host='CURR_HOST',
-                USER_AGENT=USER_AGENT,
-                spec=['credentials', 'host', 'USER_AGENT'],
-            )
-
         if secure:
             patch = mock.patch(
                 'google.cloud.datastore._gax.make_secure_stub',
                 return_value=stub)
+            base_url = 'https://test.invalid'
         else:
             patch = mock.patch(
                 'google.cloud.datastore._gax.make_insecure_stub',
                 return_value=stub)
+            base_url = 'http://test.invalid'
+
+        if connection is None:
+            connection = mock.Mock(
+                credentials=object(),
+                api_base_url=base_url,
+                spec=['credentials', 'api_base_url'],
+            )
 
         with patch as make_stub_mock:
-            api_obj = self._get_target_class()(connection, secure)
+            api_obj = self._get_target_class()(connection)
             return api_obj, make_stub_mock
 
     def test_constructor(self):
+        from google.cloud._http import DEFAULT_USER_AGENT
         import google.cloud.datastore._gax as MUT
 
+        host = 'test.invalid'
         conn = mock.Mock(
             credentials=object(),
-            host='CURR_HOST',
-            USER_AGENT=USER_AGENT,
-            spec=['credentials', 'host', 'USER_AGENT'],
+            api_base_url='https://' + host,
+            spec=['credentials', 'api_base_url'],
         )
 
         stub = _GRPCStub()
@@ -136,19 +135,20 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
         self.assertIs(datastore_api._stub, stub)
         make_stub_mock.assert_called_once_with(
             conn.credentials,
-            conn.USER_AGENT,
+            DEFAULT_USER_AGENT,
             MUT.datastore_pb2_grpc.DatastoreStub,
-            conn.host,
+            host,
             extra_options=MUT._GRPC_EXTRA_OPTIONS,
         )
 
     def test_constructor_insecure(self):
         from google.cloud.proto.datastore.v1 import datastore_pb2_grpc
 
+        host = 'test.invalid'
         conn = mock.Mock(
             credentials=object(),
-            host='CURR_HOST:1234',
-            spec=['credentials', 'host'],
+            api_base_url='http://' + host,
+            spec=['credentials', 'api_base_url'],
         )
 
         stub = _GRPCStub()
@@ -158,7 +158,7 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
         self.assertIs(datastore_api._stub, stub)
         make_stub_mock.assert_called_once_with(
             datastore_pb2_grpc.DatastoreStub,
-            conn.host,
+            host,
         )
 
     def test_lookup(self):


### PR DESCRIPTION
This is progress towards #2746 and makes Connection() act as a proxy for the contents of Client (as intended).