### PR TITLE
Release Error Reporting 0.23.1.

### DIFF
--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-error-reporting',
-    version='0.23.0',
+    version='0.23.1',
     description='Python Client for Stackdriver Error Reporting',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Patch release for Error Reporting. 
See: #3071.


# google-cloud-error-reporting 0.23.1

- Bugfix: Passing along client instead of project when creating error API. (#3075)

PyPI: https://pypi.python.org/pypi/google-cloud-error-reporting/0.23.1