### PR TITLE
'gcloud preview' command no longer supported.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -265,7 +265,7 @@ Running System Tests
    > --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 
    # Create the indexes
-   $ gcloud preview datastore create-indexes system_tests/data/index.yaml
+   $ gcloud datastore create-indexes system_tests/data/index.yaml
 
 - For datastore query tests, you'll need stored data in your dataset.
   To populate this data, run::


### PR DESCRIPTION
>141.0.0 (2017-01-25) (Google Cloud SDK) The deprecated gcloud preview app and gcloud preview datastore have been removed. Commands are available under the GA release track.

See: https://cloud.google.com/sdk/docs/release-notes