### PR TITLE
Using GAPIC datastore object (and an HTTP equivalent) for commit.

### DIFF
--- a/datastore/google/cloud/datastore/_gax.py
+++ b/datastore/google/cloud/datastore/_gax.py
@@ -16,6 +16,7 @@
 
 
 import contextlib
+import sys
 
 from google.cloud.gapic.datastore.v1 import datastore_client
 from google.cloud.proto.datastore.v1 import datastore_pb2_grpc
@@ -79,14 +80,16 @@ def _grpc_catch_rendezvous():
         if error_class is None:
             raise
         else:
-            raise error_class(exc.cause.details())
+            new_exc = error_class(exc.cause.details())
+            six.reraise(error_class, new_exc, sys.exc_info()[2])
     except exceptions.GrpcRendezvous as exc:
         error_code = exc.code()
         error_class = _GRPC_ERROR_MAPPING.get(error_code)
         if error_class is None:
             raise
         else:
-            raise error_class(exc.details())
+            new_exc = error_class(exc.details())
+            six.reraise(error_class, new_exc, sys.exc_info()[2])
 
 
 class _DatastoreAPIOverGRPC(object):

--- a/datastore/google/cloud/datastore/_gax.py
+++ b/datastore/google/cloud/datastore/_gax.py
@@ -19,6 +19,8 @@ import contextlib
 
 from google.cloud.gapic.datastore.v1 import datastore_client
 from google.cloud.proto.datastore.v1 import datastore_pb2_grpc
+from google.gax.errors import GaxError
+from google.gax.grpc import exc_to_code
 from google.gax.utils import metrics
 from grpc import StatusCode
 import six
@@ -71,6 +73,13 @@ def _grpc_catch_rendezvous():
     """
     try:
         yield
+    except GaxError as exc:
+        error_code = exc_to_code(exc.cause)
+        error_class = _GRPC_ERROR_MAPPING.get(error_code)
+        if error_class is None:
+            raise
+        else:
+            raise error_class(exc.cause.details())
     except exceptions.GrpcRendezvous as exc:
         error_code = exc.code()
         error_class = _GRPC_ERROR_MAPPING.get(error_code)
@@ -158,56 +167,38 @@ class _DatastoreAPIOverGRPC(object):
         with _grpc_catch_rendezvous():
             return self._stub.BeginTransaction(request_pb)
 
-    def commit(self, project, request_pb):
+
+class GAPICDatastoreAPI(datastore_client.DatastoreClient):
+    """An API object that sends proto-over-gRPC requests.
+
+    A light wrapper around the parent class, with exception re-mapping
+    provided (from GaxError to our native errors).
+
+    :type args: tuple
+    :param args: Positional arguments to pass to constructor.
+
+    :type kwargs: dict
+    :param kwargs: Keyword arguments to pass to constructor.
+    """
+
+    def commit(self, *args, **kwargs):
         """Perform a ``commit`` request.
 
-        :type project: str
-        :param project: The project to connect to. This is
-                        usually your project name in the cloud console.
+        A light wrapper around the the base method from the parent class.
+        Intended to provide exception re-mapping (from GaxError to our
+        native errors).
 
-        :type request_pb: :class:`.datastore_pb2.CommitRequest`
-        :param request_pb: The request protobuf object.
+        :type args: tuple
+        :param args: Positional arguments to pass to base method.
+
+        :type kwargs: dict
+        :param kwargs: Keyword arguments to pass to base method.
 
         :rtype: :class:`.datastore_pb2.CommitResponse`
         :returns: The returned protobuf response object.
         """
-        request_pb.project_id = project
         with _grpc_catch_rendezvous():
-            return self._stub.Commit(request_pb)
-
-    def rollback(self, project, request_pb):
-        """Perform a ``rollback`` request.
-
-        :type project: str
-        :param project: The project to connect to. This is
-                        usually your project name in the cloud console.
-
-        :type request_pb: :class:`.datastore_pb2.RollbackRequest`
-        :param request_pb: The request protobuf object.
-
-        :rtype: :class:`.datastore_pb2.RollbackResponse`
-        :returns: The returned protobuf response object.
-        """
-        request_pb.project_id = project
-        with _grpc_catch_rendezvous():
-            return self._stub.Rollback(request_pb)
-
-    def allocate_ids(self, project, request_pb):
-        """Perform an ``allocateIds`` request.
-
-        :type project: str
-        :param project: The project to connect to. This is
-                        usually your project name in the cloud console.
-
-        :type request_pb: :class:`.datastore_pb2.AllocateIdsRequest`
-        :param request_pb: The request protobuf object.
-
-        :rtype: :class:`.datastore_pb2.AllocateIdsResponse`
-        :returns: The returned protobuf response object.
-        """
-        request_pb.project_id = project
-        with _grpc_catch_rendezvous():
-            return self._stub.AllocateIds(request_pb)
+            return super(GAPICDatastoreAPI, self).commit(*args, **kwargs)
 
 
 def make_datastore_api(client):
@@ -222,5 +213,5 @@ def make_datastore_api(client):
     channel = make_secure_channel(
         client._credentials, DEFAULT_USER_AGENT,
         datastore_client.DatastoreClient.SERVICE_ADDRESS)
-    return datastore_client.DatastoreClient(
+    return GAPICDatastoreAPI(
         channel=channel, lib_name='gccl', lib_version=__version__)

--- a/datastore/google/cloud/datastore/_http.py
+++ b/datastore/google/cloud/datastore/_http.py
@@ -216,23 +216,6 @@ class _DatastoreAPIOverHttp(object):
                     self.connection.api_base_url,
                     request_pb, _datastore_pb2.BeginTransactionResponse)
 
-    def commit(self, project, request_pb):
-        """Perform a ``commit`` request.
-
-        :type project: str
-        :param project: The project to connect to. This is
-                        usually your project name in the cloud console.
-
-        :type request_pb: :class:`.datastore_pb2.CommitRequest`
-        :param request_pb: The request protobuf object.
-
-        :rtype: :class:`.datastore_pb2.CommitResponse`
-        :returns: The returned protobuf response object.
-        """
-        return _rpc(self.connection.http, project, 'commit',
-                    self.connection.api_base_url,
-                    request_pb, _datastore_pb2.CommitResponse)
-
 
 class Connection(connection_module.Connection):
     """A connection to the Google Cloud Datastore via the Protobuf API.
@@ -366,37 +349,6 @@ class Connection(connection_module.Connection):
         request = _datastore_pb2.BeginTransactionRequest()
         return self._datastore_api.begin_transaction(project, request)
 
-    def commit(self, project, request, transaction_id):
-        """Commit mutations in context of current transaction (if any).
-
-        Maps the ``DatastoreService.Commit`` protobuf RPC.
-
-        :type project: str
-        :param project: The project to which the transaction applies.
-
-        :type request: :class:`.datastore_pb2.CommitRequest`
-        :param request: The protobuf with the mutations being committed.
-
-        :type transaction_id: str
-        :param transaction_id: (Optional) The transaction ID returned from
-                               :meth:`begin_transaction`.  Non-transactional
-                               batches must pass ``None``.
-
-        .. note::
-
-            This method will mutate ``request`` before using it.
-
-        :rtype: :class:`.datastore_pb2.CommitResponse`
-        :returns: The protobuf response from a commit request.
-        """
-        if transaction_id:
-            request.mode = _datastore_pb2.CommitRequest.TRANSACTIONAL
-            request.transaction = transaction_id
-        else:
-            request.mode = _datastore_pb2.CommitRequest.NON_TRANSACTIONAL
-
-        return self._datastore_api.commit(project, request)
-
 
 class HTTPDatastoreAPI(object):
     """An API object that sends proto-over-HTTP requests.
@@ -409,6 +361,39 @@ class HTTPDatastoreAPI(object):
 
     def __init__(self, client):
         self.client = client
+
+    def commit(self, project, mode, mutations, transaction=None):
+        """Perform a ``commit`` request.
+
+        :type project: str
+        :param project: The project to connect to. This is
+                        usually your project name in the cloud console.
+
+        :type mode: :class:`.gapic.datastore.v1.enums.CommitRequest.Mode`
+        :param mode: The type of commit to perform. Expected to be one of
+                     ``TRANSACTIONAL`` or ``NON_TRANSACTIONAL``.
+
+        :type mutations: list
+        :param mutations: List of :class:`.datastore_pb2.Mutation`, the
+                          mutations to perform.
+
+        :type transaction: bytes
+        :param transaction: (Optional) The transaction ID returned from
+                            :meth:`begin_transaction`.  Non-transactional
+                            commits must pass :data:`None`.
+
+        :rtype: :class:`.datastore_pb2.CommitResponse`
+        :returns: The returned protobuf response object.
+        """
+        request_pb = _datastore_pb2.CommitRequest(
+            project_id=project,
+            mode=mode,
+            transaction=transaction,
+            mutations=mutations,
+        )
+        return _rpc(self.client._http, project, 'commit',
+                    self.client._base_url,
+                    request_pb, _datastore_pb2.CommitResponse)
 
     def rollback(self, project, transaction_id):
         """Perform a ``rollback`` request.

--- a/datastore/unit_tests/test__gax.py
+++ b/datastore/unit_tests/test__gax.py
@@ -34,6 +34,14 @@ class Test__grpc_catch_rendezvous(unittest.TestCase):
         else:
             raise exc
 
+    @staticmethod
+    def _make_rendezvous(status_code, details):
+        from grpc._channel import _RPCState
+        from google.cloud.exceptions import GrpcRendezvous
+
+        exc_state = _RPCState((), None, None, status_code, details)
+        return GrpcRendezvous(exc_state, None, None, None)
+
     def test_success(self):
         expected = object()
         with self._call_fut():
@@ -42,39 +50,30 @@ class Test__grpc_catch_rendezvous(unittest.TestCase):
 
     def test_failure_aborted(self):
         from grpc import StatusCode
-        from grpc._channel import _RPCState
         from google.cloud.exceptions import Conflict
-        from google.cloud.exceptions import GrpcRendezvous
 
         details = 'Bad things.'
-        exc_state = _RPCState((), None, None, StatusCode.ABORTED, details)
-        exc = GrpcRendezvous(exc_state, None, None, None)
+        exc = self._make_rendezvous(StatusCode.ABORTED, details)
         with self.assertRaises(Conflict):
             with self._call_fut():
                 self._fake_method(exc)
 
     def test_failure_invalid_argument(self):
         from grpc import StatusCode
-        from grpc._channel import _RPCState
         from google.cloud.exceptions import BadRequest
-        from google.cloud.exceptions import GrpcRendezvous
 
         details = ('Cannot have inequality filters on multiple '
                    'properties: [created, priority]')
-        exc_state = _RPCState((), None, None,
-                              StatusCode.INVALID_ARGUMENT, details)
-        exc = GrpcRendezvous(exc_state, None, None, None)
+        exc = self._make_rendezvous(StatusCode.INVALID_ARGUMENT, details)
         with self.assertRaises(BadRequest):
             with self._call_fut():
                 self._fake_method(exc)
 
     def test_failure_cancelled(self):
-        from grpc import StatusCode
-        from grpc._channel import _RPCState
         from google.cloud.exceptions import GrpcRendezvous
+        from grpc import StatusCode
 
-        exc_state = _RPCState((), None, None, StatusCode.CANCELLED, None)
-        exc = GrpcRendezvous(exc_state, None, None, None)
+        exc = self._make_rendezvous(StatusCode.CANCELLED, None)
         with self.assertRaises(GrpcRendezvous):
             with self._call_fut():
                 self._fake_method(exc)
@@ -82,6 +81,33 @@ class Test__grpc_catch_rendezvous(unittest.TestCase):
     def test_commit_failure_non_grpc_err(self):
         exc = RuntimeError('Not a gRPC error')
         with self.assertRaises(RuntimeError):
+            with self._call_fut():
+                self._fake_method(exc)
+
+    def test_gax_error(self):
+        from google.gax.errors import GaxError
+        from grpc import StatusCode
+        from google.cloud.exceptions import Forbidden
+
+        # First, create low-level GrpcRendezvous exception.
+        details = 'Some error details.'
+        cause = self._make_rendezvous(StatusCode.PERMISSION_DENIED, details)
+        # Then put it into a high-level GaxError.
+        msg = 'GAX Error content.'
+        exc = GaxError(msg, cause=cause)
+
+        with self.assertRaises(Forbidden):
+            with self._call_fut():
+                self._fake_method(exc)
+
+    def test_gax_error_not_mapped(self):
+        from google.gax.errors import GaxError
+        from grpc import StatusCode
+
+        cause = self._make_rendezvous(StatusCode.CANCELLED, None)
+        exc = GaxError(None, cause=cause)
+
+        with self.assertRaises(GaxError):
             with self._call_fut():
                 self._fake_method(exc)
 
@@ -228,45 +254,38 @@ class Test_DatastoreAPIOverGRPC(unittest.TestCase):
             stub.method_calls,
             [(request_pb, 'BeginTransaction')])
 
-    def test_commit_success(self):
-        return_val = object()
-        stub = _GRPCStub(return_val)
-        datastore_api, _ = self._make_one(stub=stub)
 
-        request_pb = mock.Mock(project_id=None, spec=['project_id'])
-        project = 'PROJECT'
-        result = datastore_api.commit(project, request_pb)
-        self.assertIs(result, return_val)
-        self.assertEqual(request_pb.project_id, project)
-        self.assertEqual(stub.method_calls,
-                         [(request_pb, 'Commit')])
+@unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
+class TestGAPICDatastoreAPI(unittest.TestCase):
 
-    def test_rollback(self):
-        return_val = object()
-        stub = _GRPCStub(return_val)
-        datastore_api, _ = self._make_one(stub=stub)
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.datastore._gax import GAPICDatastoreAPI
 
-        request_pb = mock.Mock(project_id=None, spec=['project_id'])
-        project = 'PROJECT'
-        result = datastore_api.rollback(project, request_pb)
-        self.assertIs(result, return_val)
-        self.assertEqual(request_pb.project_id, project)
-        self.assertEqual(stub.method_calls,
-                         [(request_pb, 'Rollback')])
+        return GAPICDatastoreAPI
 
-    def test_allocate_ids(self):
-        return_val = object()
-        stub = _GRPCStub(return_val)
-        datastore_api, _ = self._make_one(stub=stub)
+    def _make_one(self, *args, **kwargs):
+        return self._get_target_class()(*args, **kwargs)
 
-        request_pb = mock.Mock(project_id=None, spec=['project_id'])
-        project = 'PROJECT'
-        result = datastore_api.allocate_ids(project, request_pb)
-        self.assertIs(result, return_val)
-        self.assertEqual(request_pb.project_id, project)
-        self.assertEqual(
-            stub.method_calls,
-            [(request_pb, 'AllocateIds')])
+    def test_commit(self):
+        from google.cloud.gapic.datastore.v1 import datastore_client
+
+        patch1 = mock.patch.object(
+            datastore_client.DatastoreClient, '__init__',
+            return_value=None)
+        patch2 = mock.patch.object(datastore_client.DatastoreClient, 'commit')
+        patch3 = mock.patch(
+            'google.cloud.datastore._gax._grpc_catch_rendezvous')
+
+        with patch1 as mock_constructor:
+            ds_api = self._make_one()
+            mock_constructor.assert_called_once_with()
+            with patch2 as mock_commit:
+                with patch3 as mock_catch_rendezvous:
+                    mock_catch_rendezvous.assert_not_called()
+                    ds_api.commit(1, 2, a=3)
+                    mock_commit.assert_called_once_with(1, 2, a=3)
+                    mock_catch_rendezvous.assert_called_once_with()
 
 
 @unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
@@ -278,12 +297,12 @@ class Test_make_datastore_api(unittest.TestCase):
         return make_datastore_api(client)
 
     @mock.patch(
-        'google.cloud.gapic.datastore.v1.datastore_client.DatastoreClient',
-        SERVICE_ADDRESS='datastore.mock.mock',
+        'google.cloud.datastore._gax.GAPICDatastoreAPI',
         return_value=mock.sentinel.ds_client)
     @mock.patch('google.cloud.datastore._gax.make_secure_channel',
                 return_value=mock.sentinel.channel)
     def test_it(self, make_chan, mock_klass):
+        from google.cloud.gapic.datastore.v1 import datastore_client
         from google.cloud._http import DEFAULT_USER_AGENT
         from google.cloud.datastore import __version__
 
@@ -294,7 +313,7 @@ class Test_make_datastore_api(unittest.TestCase):
 
         make_chan.assert_called_once_with(
             mock.sentinel.credentials, DEFAULT_USER_AGENT,
-            mock_klass.SERVICE_ADDRESS)
+            datastore_client.DatastoreClient.SERVICE_ADDRESS)
         mock_klass.assert_called_once_with(
             channel=mock.sentinel.channel, lib_name='gccl',
             lib_version=__version__)
@@ -322,12 +341,3 @@ class _GRPCStub(object):
 
     def BeginTransaction(self, request_pb):
         return self._method(request_pb, 'BeginTransaction')
-
-    def Commit(self, request_pb):
-        return self._method(request_pb, 'Commit')
-
-    def Rollback(self, request_pb):
-        return self._method(request_pb, 'Rollback')
-
-    def AllocateIds(self, request_pb):
-        return self._method(request_pb, 'AllocateIds')

--- a/system_tests/datastore.py
+++ b/system_tests/datastore.py
@@ -61,12 +61,10 @@ class Config(object):
 
 
 def clone_client(client):
-    # Fool the Client constructor to avoid creating a new connection.
-    cloned_client = datastore.Client(project=client.project,
-                                     namespace=client.namespace,
-                                     http=object())
-    cloned_client._connection = client._connection
-    return cloned_client
+    return datastore.Client(project=client.project,
+                            namespace=client.namespace,
+                            credentials=client._credentials,
+                            http=client._http)
 
 
 def setUpModule():


### PR DESCRIPTION
This is a bit more involved since

- The signature requires the **caller** to determine the mode
- The signature receives a list of mutations, so we no longer collect mutations within a `CommitRequest` object
- The exception re-mapping must be done, so we can't use the base `datastore_client.DatastoreClient` GAPIC object

----

~~**NOTE**: I have yet to write unit tests, but have the system tests passing and wanted to get some eyeballs on this before I dive into unit test hell.~~