### PR TITLE
Fix double conversion of datetime for log entries.

### DIFF
--- a/logging/google/cloud/logging/_gax.py
+++ b/logging/google/cloud/logging/_gax.py
@@ -33,7 +33,6 @@ from google.protobuf.json_format import MessageToDict
 from google.protobuf.json_format import ParseDict
 from grpc import StatusCode
 
-from google.cloud._helpers import _datetime_to_rfc3339
 from google.cloud._helpers import make_secure_channel
 from google.cloud._http import DEFAULT_USER_AGENT
 from google.cloud.exceptions import Conflict
@@ -452,8 +451,6 @@ def _log_entry_mapping_to_pb(mapping):
     the keys expected in the JSON API.
     """
     entry_pb = LogEntry()
-    if 'timestamp' in mapping:
-        mapping['timestamp'] = _datetime_to_rfc3339(mapping['timestamp'])
     ParseDict(mapping, entry_pb)
     return entry_pb
 

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -476,7 +476,7 @@ class Batch(object):
             if http_req is not None:
                 info['httpRequest'] = http_req
             if timestamp is not None:
-                info['timestamp'] = timestamp
+                info['timestamp'] = _datetime_to_rfc3339(timestamp)
             entries.append(info)
 
         client.logging_api.write_entries(entries, **kwargs)

--- a/logging/unit_tests/test__gax.py
+++ b/logging/unit_tests/test__gax.py
@@ -369,6 +369,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         from datetime import datetime
         from google.logging.type.log_severity_pb2 import WARNING
         from google.cloud.proto.logging.v2.log_entry_pb2 import LogEntry
+        from google.cloud._helpers import _datetime_to_rfc3339
         from google.cloud._helpers import UTC, _pb_timestamp_to_datetime
 
         NOW = datetime.utcnow().replace(tzinfo=UTC)
@@ -412,7 +413,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
             'severity': SEVERITY,
             'labels': LABELS,
             'insertId': IID,
-            'timestamp': NOW.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            'timestamp': _datetime_to_rfc3339(NOW),
             'httpRequest': REQUEST,
             'operation': OPERATION,
         }

--- a/logging/unit_tests/test__gax.py
+++ b/logging/unit_tests/test__gax.py
@@ -412,7 +412,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
             'severity': SEVERITY,
             'labels': LABELS,
             'insertId': IID,
-            'timestamp': NOW,
+            'timestamp': NOW.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             'httpRequest': REQUEST,
             'operation': OPERATION,
         }

--- a/logging/unit_tests/test_logger.py
+++ b/logging/unit_tests/test_logger.py
@@ -667,10 +667,13 @@ class TestBatch(unittest.TestCase):
             'type': 'global',
         }
         ENTRIES = [
-            {'textPayload': TEXT, 'insertId': IID1, 'timestamp': TIMESTAMP1},
-            {'jsonPayload': STRUCT, 'insertId': IID2, 'timestamp': TIMESTAMP2},
+            {'textPayload': TEXT, 'insertId': IID1,
+             'timestamp': TIMESTAMP1.strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
+            {'jsonPayload': STRUCT, 'insertId': IID2,
+             'timestamp': TIMESTAMP2.strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
             {'protoPayload': json.loads(MessageToJson(message)),
-             'insertId': IID3, 'timestamp': TIMESTAMP3},
+             'insertId': IID3,
+             'timestamp': TIMESTAMP3.strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
         ]
         client = _Client(project=self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()

--- a/logging/unit_tests/test_logger.py
+++ b/logging/unit_tests/test_logger.py
@@ -653,6 +653,7 @@ class TestBatch(unittest.TestCase):
         from google.protobuf.json_format import MessageToJson
         from google.protobuf.struct_pb2 import Struct
         from google.protobuf.struct_pb2 import Value
+        from google.cloud._helpers import _datetime_to_rfc3339
 
         TEXT = 'This is the entry text'
         STRUCT = {'message': TEXT, 'weather': 'partly cloudy'}
@@ -668,12 +669,12 @@ class TestBatch(unittest.TestCase):
         }
         ENTRIES = [
             {'textPayload': TEXT, 'insertId': IID1,
-             'timestamp': TIMESTAMP1.strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
+             'timestamp': _datetime_to_rfc3339(TIMESTAMP1)},
             {'jsonPayload': STRUCT, 'insertId': IID2,
-             'timestamp': TIMESTAMP2.strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
+             'timestamp': _datetime_to_rfc3339(TIMESTAMP2)},
             {'protoPayload': json.loads(MessageToJson(message)),
              'insertId': IID3,
-             'timestamp': TIMESTAMP3.strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
+             'timestamp': _datetime_to_rfc3339(TIMESTAMP3)},
         ]
         client = _Client(project=self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()

--- a/system_tests/logging_.py
+++ b/system_tests/logging_.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import logging
 import unittest
 
@@ -19,6 +20,7 @@ from google.gax.errors import GaxError
 from google.gax.grpc import exc_to_code
 from grpc import StatusCode
 
+from google.cloud._helpers import UTC
 from google.cloud.exceptions import Conflict
 from google.cloud.exceptions import NotFound
 from google.cloud.exceptions import TooManyRequests
@@ -131,8 +133,6 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(entries[0].payload, TEXT_PAYLOAD)
 
     def test_log_text_with_timestamp(self):
-        import datetime
-
         text_payload = 'System test: test_log_text_with_timestamp'
         logger = Config.CLIENT.logger(self._logger_name())
         now = datetime.datetime.utcnow()
@@ -143,7 +143,7 @@ class TestLogging(unittest.TestCase):
         entries = _list_entries(logger)
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].payload, text_payload)
-        # self.assertEqual(entries[0].timestamp, now)
+        self.assertEqual(entries[0].timestamp, now.replace(tzinfo=UTC))
 
     def test_log_text_w_metadata(self):
         TEXT_PAYLOAD = 'System test: test_log_text'

--- a/system_tests/logging_.py
+++ b/system_tests/logging_.py
@@ -130,6 +130,21 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].payload, TEXT_PAYLOAD)
 
+    def test_log_text_with_timestamp(self):
+        import datetime
+
+        text_payload = 'System test: test_log_text_with_timestamp'
+        logger = Config.CLIENT.logger(self._logger_name())
+        now = datetime.datetime.utcnow()
+
+        self.to_delete.append(logger)
+
+        logger.log_text(text_payload, timestamp=now)
+        entries = _list_entries(logger)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].payload, text_payload)
+        # self.assertEqual(entries[0].timestamp, now)
+
     def test_log_text_w_metadata(self):
         TEXT_PAYLOAD = 'System test: test_log_text'
         INSERT_ID = 'INSERTID'


### PR DESCRIPTION
Fixes: #3129

This should fix the double conversion issue.

/cc @waprin 