### PR TITLE
Adding (back) support for datastore emulator.

### DIFF
--- a/datastore/google/cloud/datastore/_gax.py
+++ b/datastore/google/cloud/datastore/_gax.py
@@ -22,6 +22,7 @@ from google.cloud.gapic.datastore.v1 import datastore_client
 from google.gax.errors import GaxError
 from google.gax.grpc import exc_to_code
 from google.gax.utils import metrics
+from grpc import insecure_channel
 from grpc import StatusCode
 import six
 
@@ -131,8 +132,14 @@ def make_datastore_api(client):
     :rtype: :class:`.datastore.v1.datastore_client.DatastoreClient`
     :returns: A datastore API instance with the proper credentials.
     """
-    channel = make_secure_channel(
-        client._credentials, DEFAULT_USER_AGENT,
-        datastore_client.DatastoreClient.SERVICE_ADDRESS)
+    parse_result = six.moves.urllib_parse.urlparse(
+        client._base_url)
+    host = parse_result.netloc
+    if parse_result.scheme == 'https':
+        channel = make_secure_channel(
+            client._credentials, DEFAULT_USER_AGENT, host)
+    else:
+        channel = insecure_channel(host)
+
     return GAPICDatastoreAPI(
         channel=channel, lib_name='gccl', lib_version=__version__)

--- a/system_tests/system_test_utils.py
+++ b/system_tests/system_test_utils.py
@@ -17,6 +17,7 @@ import os
 import sys
 import time
 
+import google.auth.credentials
 from google.auth.environment_vars import CREDENTIALS as TEST_CREDENTIALS
 
 
@@ -29,16 +30,28 @@ Please check the CONTRIBUTING guide for instructions.
 """
 
 
-class EmulatorCreds(object):
+class EmulatorCreds(google.auth.credentials.Credentials):
     """A mock credential object.
 
     Used to avoid unnecessary token refreshing or reliance on the network
     while an emulator is running.
     """
 
-    @staticmethod
-    def create_scoped_required():
-        return False
+    def __init__(self):  # pylint: disable=super-init-not-called
+        self.token = b'seekrit'
+        self.expiry = None
+
+    @property
+    def valid(self):
+        """Would-be validity check of the credentials.
+
+        Always is :data:`True`.
+        """
+        return True
+
+    def refresh(self, unused_request):  # pylint: disable=unused-argument
+        """Off-limits implementation for abstract method."""
+        raise RuntimeError('Should never be refreshed.')
 
 
 def check_environ():

--- a/tox.ini
+++ b/tox.ini
@@ -300,7 +300,9 @@ commands =
     {[emulator]emulatorcmd} --package=datastore
 setenv = {[emulator]setenv}
 passenv = {[testing]passenv}
-deps = {[emulator]deps}
+deps =
+    {[emulator]deps}
+    Sphinx
 
 [testenv:pubsub-emulator]
 commands =


### PR DESCRIPTION
Sorry for the delay. I made a few wrong turns (e.g. using `hostname` instead of `netloc`) and debugging with gRPC is **not** fun.