### PR TITLE
Fix make_report_error_api usage of Client._project.

### DIFF
--- a/error_reporting/google/cloud/error_reporting/_gax.py
+++ b/error_reporting/google/cloud/error_reporting/_gax.py
@@ -41,7 +41,7 @@ def make_report_error_api(client):
         report_errors_service_client.ReportErrorsServiceClient.SERVICE_ADDRESS)
     gax_client = report_errors_service_client.ReportErrorsServiceClient(
         channel=channel, lib_name='gccl', lib_version=__version__)
-    return _ErrorReportingGaxApi(gax_client, client.project)
+    return _ErrorReportingGaxApi(gax_client, client._project)
 
 
 class _ErrorReportingGaxApi(object):

--- a/error_reporting/unit_tests/test__gax.py
+++ b/error_reporting/unit_tests/test__gax.py
@@ -30,8 +30,8 @@ class Test_make_report_error_api(unittest.TestCase):
 
         client = mock.Mock(
             _credentials=mock.sentinel.credentials,
-            project='prahj-ekt',
-            spec=['project', '_credentials'],
+            _project='prahj-ekt',
+            spec=['_project', '_credentials'],
         )
 
         # Mock out the constructor for the GAPIC client.
@@ -52,7 +52,7 @@ class Test_make_report_error_api(unittest.TestCase):
 
         # Assert that the final error client has the project in
         # the expected location.
-        self.assertIs(report_error_client._project, client.project)
+        self.assertIs(report_error_client._project, client._project)
 
 
 class Test_ErrorReportingGaxApi(unittest.TestCase):


### PR DESCRIPTION
Fixes #3158

I'm not sure if `Client._project` should be a public property in this case but if so I can change it. This PR just correctly access the desired data.