### PR TITLE
Removing unused code-path for remapping raw gRPC exceptions in datastore.

### DIFF
--- a/datastore/google/cloud/datastore/_gax.py
+++ b/datastore/google/cloud/datastore/_gax.py
@@ -60,8 +60,8 @@ _GRPC_ERROR_MAPPING = {
 
 
 @contextlib.contextmanager
-def _grpc_catch_rendezvous():
-    """Remap gRPC exceptions that happen in context.
+def _catch_remap_gax_error():
+    """Remap GAX exceptions that happen in context.
 
     .. _code.proto: https://github.com/googleapis/googleapis/blob/\
                     master/google/rpc/code.proto
@@ -79,14 +79,6 @@ def _grpc_catch_rendezvous():
             raise
         else:
             new_exc = error_class(exc.cause.details())
-            six.reraise(error_class, new_exc, sys.exc_info()[2])
-    except exceptions.GrpcRendezvous as exc:
-        error_code = exc.code()
-        error_class = _GRPC_ERROR_MAPPING.get(error_code)
-        if error_class is None:
-            raise
-        else:
-            new_exc = error_class(exc.details())
             six.reraise(error_class, new_exc, sys.exc_info()[2])
 
 
@@ -119,7 +111,7 @@ class GAPICDatastoreAPI(datastore_client.DatastoreClient):
         :rtype: :class:`.datastore_pb2.LookupResponse`
         :returns: The returned protobuf response object.
         """
-        with _grpc_catch_rendezvous():
+        with _catch_remap_gax_error():
             return super(GAPICDatastoreAPI, self).lookup(*args, **kwargs)
 
     def run_query(self, *args, **kwargs):
@@ -138,7 +130,7 @@ class GAPICDatastoreAPI(datastore_client.DatastoreClient):
         :rtype: :class:`.datastore_pb2.RunQueryResponse`
         :returns: The returned protobuf response object.
         """
-        with _grpc_catch_rendezvous():
+        with _catch_remap_gax_error():
             return super(GAPICDatastoreAPI, self).run_query(*args, **kwargs)
 
     def begin_transaction(self, *args, **kwargs):
@@ -157,7 +149,7 @@ class GAPICDatastoreAPI(datastore_client.DatastoreClient):
         :rtype: :class:`.datastore_pb2.BeginTransactionResponse`
         :returns: The returned protobuf response object.
         """
-        with _grpc_catch_rendezvous():
+        with _catch_remap_gax_error():
             return super(GAPICDatastoreAPI, self).begin_transaction(
                 *args, **kwargs)
 
@@ -177,7 +169,7 @@ class GAPICDatastoreAPI(datastore_client.DatastoreClient):
         :rtype: :class:`.datastore_pb2.CommitResponse`
         :returns: The returned protobuf response object.
         """
-        with _grpc_catch_rendezvous():
+        with _catch_remap_gax_error():
             return super(GAPICDatastoreAPI, self).commit(*args, **kwargs)
 
     def rollback(self, *args, **kwargs):
@@ -196,7 +188,7 @@ class GAPICDatastoreAPI(datastore_client.DatastoreClient):
         :rtype: :class:`.datastore_pb2.RollbackResponse`
         :returns: The returned protobuf response object.
         """
-        with _grpc_catch_rendezvous():
+        with _catch_remap_gax_error():
             return super(GAPICDatastoreAPI, self).rollback(*args, **kwargs)
 
     def allocate_ids(self, *args, **kwargs):
@@ -215,7 +207,7 @@ class GAPICDatastoreAPI(datastore_client.DatastoreClient):
         :rtype: :class:`.datastore_pb2.AllocateIdsResponse`
         :returns: The returned protobuf response object.
         """
-        with _grpc_catch_rendezvous():
+        with _catch_remap_gax_error():
             return super(GAPICDatastoreAPI, self).allocate_ids(
                 *args, **kwargs)
 

--- a/datastore/unit_tests/test__gax.py
+++ b/datastore/unit_tests/test__gax.py
@@ -20,12 +20,12 @@ from google.cloud.datastore.client import _HAVE_GRPC
 
 
 @unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
-class Test__grpc_catch_rendezvous(unittest.TestCase):
+class Test__catch_remap_gax_error(unittest.TestCase):
 
     def _call_fut(self):
-        from google.cloud.datastore._gax import _grpc_catch_rendezvous
+        from google.cloud.datastore._gax import _catch_remap_gax_error
 
-        return _grpc_catch_rendezvous()
+        return _catch_remap_gax_error()
 
     @staticmethod
     def _fake_method(exc, result=None):
@@ -48,37 +48,7 @@ class Test__grpc_catch_rendezvous(unittest.TestCase):
             result = self._fake_method(None, expected)
         self.assertIs(result, expected)
 
-    def test_failure_aborted(self):
-        from grpc import StatusCode
-        from google.cloud.exceptions import Conflict
-
-        details = 'Bad things.'
-        exc = self._make_rendezvous(StatusCode.ABORTED, details)
-        with self.assertRaises(Conflict):
-            with self._call_fut():
-                self._fake_method(exc)
-
-    def test_failure_invalid_argument(self):
-        from grpc import StatusCode
-        from google.cloud.exceptions import BadRequest
-
-        details = ('Cannot have inequality filters on multiple '
-                   'properties: [created, priority]')
-        exc = self._make_rendezvous(StatusCode.INVALID_ARGUMENT, details)
-        with self.assertRaises(BadRequest):
-            with self._call_fut():
-                self._fake_method(exc)
-
-    def test_failure_cancelled(self):
-        from google.cloud.exceptions import GrpcRendezvous
-        from grpc import StatusCode
-
-        exc = self._make_rendezvous(StatusCode.CANCELLED, None)
-        with self.assertRaises(GrpcRendezvous):
-            with self._call_fut():
-                self._fake_method(exc)
-
-    def test_commit_failure_non_grpc_err(self):
+    def test_non_grpc_err(self):
         exc = RuntimeError('Not a gRPC error')
         with self.assertRaises(RuntimeError):
             with self._call_fut():
@@ -132,7 +102,7 @@ class TestGAPICDatastoreAPI(unittest.TestCase):
             return_value=None)
         patch2 = mock.patch.object(datastore_client.DatastoreClient, 'lookup')
         patch3 = mock.patch(
-            'google.cloud.datastore._gax._grpc_catch_rendezvous')
+            'google.cloud.datastore._gax._catch_remap_gax_error')
 
         with patch1 as mock_constructor:
             ds_api = self._make_one()
@@ -153,7 +123,7 @@ class TestGAPICDatastoreAPI(unittest.TestCase):
         patch2 = mock.patch.object(
             datastore_client.DatastoreClient, 'run_query')
         patch3 = mock.patch(
-            'google.cloud.datastore._gax._grpc_catch_rendezvous')
+            'google.cloud.datastore._gax._catch_remap_gax_error')
 
         with patch1 as mock_constructor:
             ds_api = self._make_one()
@@ -174,7 +144,7 @@ class TestGAPICDatastoreAPI(unittest.TestCase):
         patch2 = mock.patch.object(
             datastore_client.DatastoreClient, 'begin_transaction')
         patch3 = mock.patch(
-            'google.cloud.datastore._gax._grpc_catch_rendezvous')
+            'google.cloud.datastore._gax._catch_remap_gax_error')
 
         with patch1 as mock_constructor:
             ds_api = self._make_one()
@@ -195,7 +165,7 @@ class TestGAPICDatastoreAPI(unittest.TestCase):
             return_value=None)
         patch2 = mock.patch.object(datastore_client.DatastoreClient, 'commit')
         patch3 = mock.patch(
-            'google.cloud.datastore._gax._grpc_catch_rendezvous')
+            'google.cloud.datastore._gax._catch_remap_gax_error')
 
         with patch1 as mock_constructor:
             ds_api = self._make_one()
@@ -216,7 +186,7 @@ class TestGAPICDatastoreAPI(unittest.TestCase):
         patch2 = mock.patch.object(
             datastore_client.DatastoreClient, 'rollback')
         patch3 = mock.patch(
-            'google.cloud.datastore._gax._grpc_catch_rendezvous')
+            'google.cloud.datastore._gax._catch_remap_gax_error')
 
         with patch1 as mock_constructor:
             ds_api = self._make_one()
@@ -237,7 +207,7 @@ class TestGAPICDatastoreAPI(unittest.TestCase):
         patch2 = mock.patch.object(
             datastore_client.DatastoreClient, 'allocate_ids')
         patch3 = mock.patch(
-            'google.cloud.datastore._gax._grpc_catch_rendezvous')
+            'google.cloud.datastore._gax._catch_remap_gax_error')
 
         with patch1 as mock_constructor:
             ds_api = self._make_one()


### PR DESCRIPTION
Follow-up to #2746.