### PR TITLE
Add language_hints support to detect_full_text.

### DIFF
--- a/system_tests/vision.py
+++ b/system_tests/vision.py
@@ -102,13 +102,13 @@ class TestVisionFullText(unittest.TestCase):
         client = Config.CLIENT
         with open(FULL_TEXT_FILE, 'rb') as image_file:
             image = client.image(content=image_file.read())
-        full_text = image.detect_full_text()
+        full_text = image.detect_full_text(language_hints=['en'])
         self._assert_full_text(full_text)
 
     def test_detect_full_text_filename(self):
         client = Config.CLIENT
         image = client.image(filename=FULL_TEXT_FILE)
-        full_text = image.detect_full_text()
+        full_text = image.detect_full_text(language_hints=['en'])
         self._assert_full_text(full_text)
 
     def test_detect_full_text_gcs(self):
@@ -123,7 +123,7 @@ class TestVisionFullText(unittest.TestCase):
 
         client = Config.CLIENT
         image = client.image(source_uri=source_uri)
-        full_text = image.detect_full_text()
+        full_text = image.detect_full_text(language_hints=['en'])
         self._assert_full_text(full_text)
 
 

--- a/vision/google/cloud/vision/image.py
+++ b/vision/google/cloud/vision/image.py
@@ -182,17 +182,28 @@ class Image(object):
         annotations = self.detect(features)
         return annotations[0].faces
 
-    def detect_full_text(self, limit=10):
+    def detect_full_text(self, language_hints=None, limit=10):
         """Detect a full document's text.
 
+        :type language_hints: list
+        :param language_hints: (Optional) A list of BCP-47 language codes. See:
+                               https://cloud.google.com/vision/docs/languages
+
         :type limit: int
-        :param limit: The number of documents to detect.
+        :param limit: (Optional) The number of documents to detect.
 
         :rtype: list
         :returns: List of :class:`~google.cloud.vision.text.TextAnnotation`.
         """
-        features = [Feature(FeatureTypes.DOCUMENT_TEXT_DETECTION, limit)]
-        annotations = self.detect(features)
+        feature_type = image_annotator_pb2.Feature.DOCUMENT_TEXT_DETECTION
+        feature = image_annotator_pb2.Feature(type=feature_type,
+                                              max_results=limit)
+        image = _to_gapic_image(self)
+        image_context = image_annotator_pb2.ImageContext(
+            language_hints=language_hints)
+        request = image_annotator_pb2.AnnotateImageRequest(
+            image=image, features=[feature], image_context=image_context)
+        annotations = self._detect_annotation_from_pb([request])
         return annotations[0].full_texts
 
     def detect_labels(self, limit=10):

--- a/vision/unit_tests/test_client.py
+++ b/vision/unit_tests/test_client.py
@@ -309,7 +309,7 @@ class TestClient(unittest.TestCase):
         api = client._vision_api
         api._connection = _Connection(returned)
         image = client.image(source_uri=IMAGE_SOURCE)
-        full_text = image.detect_full_text(limit=2)
+        full_text = image.detect_full_text(language_hints=['en'], limit=2)
 
         self.assertIsInstance(full_text, TextAnnotation)
         self.assertEqual(full_text.text, 'The Republic\nBy Plato')
@@ -324,7 +324,11 @@ class TestClient(unittest.TestCase):
 
         image_request = api._connection._requested[0]['data']['requests'][0]
         self.assertEqual(
-            image_request['image']['source']['gcs_image_uri'], IMAGE_SOURCE)
+            image_request['image']['source']['gcsImageUri'], IMAGE_SOURCE)
+        self.assertEqual(
+            len(image_request['imageContext']['languageHints']), 1)
+        self.assertEqual(
+            image_request['imageContext']['languageHints'][0], 'en')
         self.assertEqual(image_request['features'][0]['maxResults'], 2)
         self.assertEqual(
             image_request['features'][0]['type'], 'DOCUMENT_TEXT_DETECTION')


### PR DESCRIPTION
Fixes: #3124

Towards:  #3132.

Support `language_hints` argument for `detect_full_text()`.