### PR TITLE
Add system tests for all scalar query parameter types. 

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -21,10 +21,11 @@ import datetime
 from google.cloud._helpers import UTC
 from google.cloud._helpers import _date_from_iso8601_date
 from google.cloud._helpers import _datetime_from_microseconds
-from google.cloud._helpers import _datetime_to_rfc3339
 from google.cloud._helpers import _RFC3339_NO_FRACTION
 from google.cloud._helpers import _time_from_iso8601_time_naive
 from google.cloud._helpers import _to_bytes
+
+_RFC3339_MICROS_NO_ZULU = '%Y-%m-%dT%H:%M:%S.%f'
 
 
 def _not_null(value, field):
@@ -161,7 +162,7 @@ def _timestamp_to_json(value):
 def _datetime_to_json(value):
     """Coerce 'value' to an JSON-compatible representation."""
     if isinstance(value, datetime.datetime):
-        value = _datetime_to_rfc3339(value)
+        value = value.strftime(_RFC3339_MICROS_NO_ZULU)
     return value
 
 

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -58,7 +58,7 @@ def _string_from_json(value, _):
 def _bytes_from_json(value, field):
     """Base64-decode value"""
     if _not_null(value, field):
-        return base64.decodestring(_to_bytes(value))
+        return base64.standard_b64decode(_to_bytes(value))
 
 
 def _timestamp_from_json(value, field):
@@ -143,7 +143,7 @@ def _bool_to_json(value):
 def _bytes_to_json(value):
     """Coerce 'value' to an JSON-compatible representation."""
     if isinstance(value, bytes):
-        value = base64.encodestring(value)
+        value = base64.standard_b64encode(value)
     return value
 
 

--- a/bigquery/unit_tests/test__helpers.py
+++ b/bigquery/unit_tests/test__helpers.py
@@ -145,7 +145,7 @@ class Test_bytes_from_json(unittest.TestCase):
         import base64
 
         expected = b'Wonderful!'
-        encoded = base64.encodestring(expected)
+        encoded = base64.standard_b64encode(expected)
         coerced = self._call_fut(encoded, object())
         self.assertEqual(coerced, expected)
 
@@ -153,7 +153,7 @@ class Test_bytes_from_json(unittest.TestCase):
         import base64
 
         expected = b'Wonderful!'
-        encoded = base64.encodestring(expected).decode('ascii')
+        encoded = base64.standard_b64encode(expected).decode('ascii')
         coerced = self._call_fut(encoded, object())
         self.assertEqual(coerced, expected)
 
@@ -558,7 +558,7 @@ class Test_bytes_to_json(unittest.TestCase):
         import base64
 
         source = b'source'
-        expected = base64.encodestring(source)
+        expected = base64.standard_b64encode(source)
         self.assertEqual(self._call_fut(source), expected)
 
 

--- a/bigquery/unit_tests/test__helpers.py
+++ b/bigquery/unit_tests/test__helpers.py
@@ -621,7 +621,7 @@ class Test_datetime_to_json(unittest.TestCase):
         from google.cloud._helpers import UTC
 
         when = datetime.datetime(2016, 12, 3, 14, 11, 27, 123456, tzinfo=UTC)
-        self.assertEqual(self._call_fut(when), '2016-12-03T14:11:27.123456Z')
+        self.assertEqual(self._call_fut(when), '2016-12-03T14:11:27.123456')
 
 
 class Test_date_to_json(unittest.TestCase):
@@ -1017,7 +1017,7 @@ class Test_ScalarQueryParameter(unittest.TestCase):
                 'type': 'DATETIME',
             },
             'parameterValue': {
-                'value': _datetime_to_rfc3339(now),
+                'value': _datetime_to_rfc3339(now)[:-1],  # strip trailing 'Z'
             },
         }
         klass = self._get_target_class()

--- a/system_tests/bigquery.py
+++ b/system_tests/bigquery.py
@@ -538,17 +538,32 @@ class TestBigQuery(unittest.TestCase):
         from google.cloud.bigquery._helpers import ArrayQueryParameter
         from google.cloud.bigquery._helpers import ScalarQueryParameter
         from google.cloud.bigquery._helpers import StructQueryParameter
-        naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
-        stamp = '%s %s' % (naive.date().isoformat(), naive.time().isoformat())
-        zoned = naive.replace(tzinfo=UTC)
-        zoned_param = ScalarQueryParameter(
-            name='zoned', type_='TIMESTAMP', value=zoned)
         question = 'What is the answer to life, the universe, and everything?'
         question_param = ScalarQueryParameter(
             name='question', type_='STRING', value=question)
         answer = 42
         answer_param = ScalarQueryParameter(
             name='answer', type_='INT64', value=answer)
+        pi = 3.1415926
+        pi_param = ScalarQueryParameter(
+            name='pi', type_='FLOAT64', value=pi)
+        truthy = True
+        truthy_param = ScalarQueryParameter(
+            name='truthy', type_='BOOL', value=truthy)
+        beef = b'DEADBEEF'
+        beef_param = ScalarQueryParameter(
+            name='beef', type_='BYTES', value=beef)
+        naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
+        stamp = '%s %s' % (naive.date().isoformat(), naive.time().isoformat())
+        naive_param = ScalarQueryParameter(
+            name='naive', type_='DATETIME', value=naive)
+        naive_date_param = ScalarQueryParameter(
+            name='naive_date', type_='DATE', value=naive.date())
+        naive_time_param = ScalarQueryParameter(
+            name='naive_time', type_='TIME', value=naive.time())
+        zoned = naive.replace(tzinfo=UTC)
+        zoned_param = ScalarQueryParameter(
+            name='zoned', type_='TIMESTAMP', value=zoned)
         array_param = ArrayQueryParameter(
             name='array_param', array_type='INT64', values=[1, 2])
         struct_param = StructQueryParameter(
@@ -628,6 +643,46 @@ class TestBigQuery(unittest.TestCase):
             {
                 'sql': 'SELECT ARRAY(SELECT STRUCT([1, 2]))',
                 'expected': [{u'_field_1': [1, 2]}],
+            },
+            {
+                'sql': 'SELECT @question',
+                'expected': question,
+                'query_parameters': [question_param],
+            },
+            {
+                'sql': 'SELECT @answer',
+                'expected': answer,
+                'query_parameters': [answer_param],
+            },
+            {
+                'sql': 'SELECT @pi',
+                'expected': pi,
+                'query_parameters': [pi_param],
+            },
+            {
+                'sql': 'SELECT @truthy',
+                'expected': truthy,
+                'query_parameters': [truthy_param],
+            },
+            {
+                'sql': 'SELECT @beef',
+                'expected': beef,
+                'query_parameters': [beef_param],
+            },
+            {
+                'sql': 'SELECT @naive',
+                'expected': naive,
+                'query_parameters': [naive_param],
+            },
+            {
+                'sql': 'SELECT @naive_date',
+                'expected': naive.date(),
+                'query_parameters': [naive_date_param],
+            },
+            {
+                'sql': 'SELECT @naive_time',
+                'expected': naive.time(),
+                'query_parameters': [naive_time_param],
             },
             {
                 'sql': 'SELECT @zoned',


### PR DESCRIPTION
Toward #3029.

Fix two issues found by the new tests:

- `BYTES` values must *not* have the trailing newline introduced by the stdlib's "legacy" `base64.encodestring` API.
- `DATETIME` values must *not* have a trailing `Z`:  they are conceptually "naive" / zoneless.