### PR TITLE
Fixes #3150 - Ignores resource key when it isn't present

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -870,13 +870,12 @@ class Blob(_PropertyMixin):
             _target_object=self)
         rewritten = int(api_response['totalBytesRewritten'])
         size = int(api_response['objectSize'])
-        try:
-            self._set_properties(api_response['resource'])
-        except KeyError:
-            # API might not return resource key
-            pass
 
+        # The resource key is set if and only if the API response is
+        # completely done. Additionally, there is no rewrite token to return
+        # in this case.
         if api_response['done']:
+            self._set_properties(api_response['resource'])
             return None, rewritten, size
 
         return api_response['rewriteToken'], rewritten, size

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -868,9 +868,13 @@ class Blob(_PropertyMixin):
             method='POST', path=source.path + '/rewriteTo' + self.path,
             query_params=query_params, data=self._properties, headers=headers,
             _target_object=self)
-        self._set_properties(api_response['resource'])
         rewritten = int(api_response['totalBytesRewritten'])
         size = int(api_response['objectSize'])
+        try:
+            self._set_properties(api_response['resource'])
+        except KeyError:
+            # API might not return resource key
+            pass
 
         if api_response['done']:
             return None, rewritten, size

--- a/storage/unit_tests/test_blob.py
+++ b/storage/unit_tests/test_blob.py
@@ -1288,6 +1288,33 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['path'], '/b/name/o/%s/compose' % DESTINATION)
         self.assertEqual(kw[0]['data'], SENT)
 
+    def test_rewrite_response_without_resource(self):
+        from six.moves.http_client import OK
+
+        SOURCE_BLOB = 'source'
+        DEST_BLOB = 'dest'
+        DEST_BUCKET = 'other-bucket'
+        TOKEN = 'TOKEN'
+        RESPONSE = {
+            'totalBytesRewritten': 33,
+            'objectSize': 42,
+            'done': False,
+            'rewriteToken': TOKEN,
+        }
+        response = ({'status': OK}, RESPONSE)
+        connection = _Connection(response)
+        client = _Client(connection)
+        source_bucket = _Bucket(client=client)
+        source_blob = self._make_one(SOURCE_BLOB, bucket=source_bucket)
+        dest_bucket = _Bucket(client=client, name=DEST_BUCKET)
+        dest_blob = self._make_one(DEST_BLOB, bucket=dest_bucket)
+
+        token, rewritten, size = dest_blob.rewrite(source_blob)
+
+        self.assertEqual(token, TOKEN)
+        self.assertEqual(rewritten, 33)
+        self.assertEqual(size, 42)
+
     def test_rewrite_other_bucket_other_name_no_encryption_partial(self):
         from six.moves.http_client import OK
 


### PR DESCRIPTION
- The new test fails with the KeyError experienced by customer.
- Tests passing on Python 2.7 and 3.4 (I don't have 3.5 on my env).