### PR TITLE
Adjust Spanner tests for grpcio 1.2.0

### DIFF
--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -51,7 +51,7 @@ SETUP_BASE = {
 
 REQUIREMENTS = [
     'google-cloud-core >= 0.23.1, < 0.24dev',
-    'grpcio >= 1.0.2, < 2.0dev',
+    'grpcio >= 1.2.0, < 2.0dev',
     'gapic-google-cloud-spanner-v1 >= 0.15.0, < 0.16dev',
     'gapic-google-cloud-spanner-admin-database-v1 >= 0.15.0, < 0.16dev',
     'gapic-google-cloud-spanner-admin-instance-v1 >= 0.15.0, < 0.16dev',

--- a/spanner/unit_tests/test_session.py
+++ b/spanner/unit_tests/test_session.py
@@ -847,15 +847,15 @@ class _SpannerApi(_GAXBaseAPI):
     def _trailing_metadata(self):
         from google.protobuf.duration_pb2 import Duration
         from google.rpc.error_details_pb2 import RetryInfo
-        from grpc._common import cygrpc_metadata
+        from grpc._common import to_cygrpc_metadata
 
         if self._commit_abort_retry_nanos is None:
-            return cygrpc_metadata(())
+            return to_cygrpc_metadata(())
         retry_info = RetryInfo(
             retry_delay=Duration(
                 seconds=self._commit_abort_retry_seconds,
                 nanos=self._commit_abort_retry_nanos))
-        return cygrpc_metadata([
+        return to_cygrpc_metadata([
             ('google.rpc.retryinfo-bin', retry_info.SerializeToString())])
 
     def commit(self, session, mutations,


### PR DESCRIPTION
The GRPC team released grpcio 1.2.0 yesterday, and renamed an internal method that we were using directly in our Spanner unit tests. This PR updates us to use the new name.

See #3170 for the [original build failure][1].

  [1]: https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1291