### PR TITLE
Ensure that base64-encoded bytes get decoded to text for JSON.

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -144,7 +144,7 @@ def _bool_to_json(value):
 def _bytes_to_json(value):
     """Coerce 'value' to an JSON-compatible representation."""
     if isinstance(value, bytes):
-        value = base64.standard_b64encode(value)
+        value = base64.standard_b64encode(value).decode('ascii')
     return value
 
 

--- a/bigquery/unit_tests/test__helpers.py
+++ b/bigquery/unit_tests/test__helpers.py
@@ -555,11 +555,10 @@ class Test_bytes_to_json(unittest.TestCase):
         self.assertIs(self._call_fut(non_bytes), non_bytes)
 
     def test_w_bytes(self):
-        import base64
-
         source = b'source'
-        expected = base64.standard_b64encode(source)
-        self.assertEqual(self._call_fut(source), expected)
+        expected = u'c291cmNl'
+        converted = self._call_fut(source)
+        self.assertEqual(converted, expected)
 
 
 class Test_timestamp_to_json(unittest.TestCase):


### PR DESCRIPTION
Closes #3193.