### PR TITLE
Fix translate links.

### DIFF
--- a/docs/translate-usage.rst
+++ b/docs/translate-usage.rst
@@ -112,8 +112,8 @@ or to use a non-default target language:
          },
      ]
 
-.. _Google Cloud Translation: https://cloud.google.com/translation
-.. _Pricing: https://cloud.google.com/translation/pricing
-.. _FAQ: https://cloud.google.com/translation/faq
-.. _Identifying your application to Google: https://cloud.google.com/translation/docs/translating-text
-.. _confidence: https://cloud.google.com/translation/docs/detecting-language
+.. _Google Cloud Translation: https://cloud.google.com/translate/
+.. _Pricing: https://cloud.google.com/translate/pricing
+.. _FAQ: https://cloud.google.com/translate/faq
+.. _Identifying your application to Google: https://cloud.google.com/translate/docs/translating-text
+.. _confidence: https://cloud.google.com/translate/docs/detecting-language

--- a/translate/google/cloud/translate/client.py
+++ b/translate/google/cloud/translate/client.py
@@ -69,8 +69,8 @@ class Client(BaseClient):
 
         Response
 
-        See: https://cloud.google.com/translate/v2/\
-        discovering-supported-languages-with-rest
+        See:
+        https://cloud.google.com/translate/docs/discovering-supported-languages
 
         :type target_language: str
         :param target_language: (Optional) The language used to localize
@@ -96,8 +96,7 @@ class Client(BaseClient):
     def detect_language(self, values):
         """Detect the language of a string or list of strings.
 
-        See: https://cloud.google.com/translate/v2/\
-        detecting-language-with-rest
+        See: https://cloud.google.com/translate/docs/detecting-language
 
         :type values: str or list
         :param values: String or list of strings that will have


### PR DESCRIPTION
Bad continuation for a link. Update `translation` to `translate`.