### PR TITLE
Speech: Expose the GAPIC client config on the manual layer.

### DIFF
--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -43,8 +43,14 @@ class GAPICSpeechAPI(object):
 
     :type client: `~google.cloud.core.client.Client`
     :param client: Instance of ``Client`.
+
+    :type client_config: dict
+    :param client_config: A dictionary for call options for each method. See
+                :func:`google.gax.construct_settings` for the structure of
+                this data. Falls back to the default config if not specified
+                or the specified config is missing data points.
     """
-    def __init__(self, client=None):
+    def __init__(self, client=None, client_config=None):
         self._client = client
         credentials = self._client._credentials
         channel = make_secure_channel(
@@ -52,6 +58,7 @@ class GAPICSpeechAPI(object):
             SpeechClient.SERVICE_ADDRESS)
         self._gapic_api = SpeechClient(
             channel=channel,
+            client_config=client_config,
             lib_name='gccl',
             lib_version=__version__,
         )

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -47,7 +47,14 @@ class Client(BaseClient):
     :param use_gax: (Optional) Explicitly specifies whether
                     to use the gRPC transport (via GAX) or HTTP. If unset,
                     falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
-                    variable
+                    variable.
+
+    :type client_config: dict
+    :param client_config: A dictionary for call options for each method. See
+                :func:`google.gax.construct_settings` for the structure of
+                this data. Falls back to the default config if not specified
+                or the specified config is missing data points.
+                Only used with the gRPC transport.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
@@ -55,8 +62,11 @@ class Client(BaseClient):
 
     _speech_api = None
 
-    def __init__(self, credentials=None, http=None, use_gax=None):
+    def __init__(self, credentials=None, http=None, use_gax=None,
+                 client_config=None):
         super(Client, self).__init__(credentials=credentials, http=http)
+        self._client_config = client_config
+
         # Save on the actual client class whether we use GAX or not.
         if use_gax is None:
             self._use_gax = _USE_GAX
@@ -105,7 +115,10 @@ class Client(BaseClient):
         """Helper for speech-related API calls."""
         if self._speech_api is None:
             if self._use_gax:
-                self._speech_api = GAPICSpeechAPI(self)
+                self._speech_api = GAPICSpeechAPI(
+                    self,
+                    client_config=self._client_config,
+                )
             else:
                 self._speech_api = HTTPSpeechAPI(self)
         return self._speech_api

--- a/speech/tests/unit/test__gax.py
+++ b/speech/tests/unit/test__gax.py
@@ -63,8 +63,9 @@ class TestGAPICSpeechAPI(unittest.TestCase):
             mock_cnxn.credentials, DEFAULT_USER_AGENT,
             operations_grpc.OperationsStub, OPERATIONS_API_HOST)
         mocked_cls.assert_called_once_with(
-            channel=mock.sentinel.channel, lib_name='gccl',
-            lib_version=__version__)
+            channel=mock.sentinel.channel,
+            client_config=None,
+            lib_name='gccl', lib_version=__version__)
         mocked_channel.assert_called_once_with(
             mock_cnxn.credentials, DEFAULT_USER_AGENT,
             mocked_cls.SERVICE_ADDRESS)


### PR DESCRIPTION
This PR is a response to #3165 but I somewhat doubt we should take it exactly as-is. This is meant to be a discussion starter.

#### Context

Definitely go read #3165 to understand the whole thing, but the basic situation is that the OP had a problem with the Speech API that he got around by overriding the GAPIC `client_config`. He did this by modifying the actual JSON file in the installed GAPIC, which probably is something we should not force our users to do.

#### Solution

The first and most obvious thing we should do is set a more sane default for this one configuration option in Speech. I am going to do that momentarily.

Additionally, I assert that we should expose the `client_config` as an option in our `Client` classes, so that our users _do_ have the option to override these things.

This PR makes this change only for Speech, which is almost certainly the wrong final solution. Either we should do this in every API that depends on a GAPIC or we should do it in none of them. I wanted to put this in place so we can see what the solution looks like and discuss whether it should be done everywhere or nowhere. (If we do it everywhere, then the `self._client_config` part in Speech's `Client` class would migrate into core.)

#### Discussion

Should we do this?