### PR TITLE
Fixing up some format strings in nox configs.

### DIFF
--- a/bigquery/nox.py
+++ b/bigquery/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/bigtable/nox.py
+++ b/bigtable/nox.py
@@ -24,7 +24,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -48,7 +48,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/core/nox.py
+++ b/core/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov',

--- a/datastore/nox.py
+++ b/datastore/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/dns/nox.py
+++ b/dns/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')

--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')

--- a/language/nox.py
+++ b/language/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/logging/nox.py
+++ b/logging/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/monitoring/nox.py
+++ b/monitoring/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/pubsub/nox.py
+++ b/pubsub/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/resource_manager/nox.py
+++ b/resource_manager/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')

--- a/runtimeconfig/nox.py
+++ b/runtimeconfig/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')

--- a/spanner/nox.py
+++ b/spanner/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/speech/nox.py
+++ b/speech/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/storage/nox.py
+++ b/storage/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/translate/nox.py
+++ b/translate/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.

--- a/vision/nox.py
+++ b/vision/nox.py
@@ -25,7 +25,7 @@ def unit_tests(session, python_version):
     """Run the unit test suite."""
 
     # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', '../core/')
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
         return
 
     # Run the system tests against latest Python 2 and Python 3 only.
-    session.interpreter = 'python%s' % python_version
+    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package into the
     # virutalenv's dist-packages.


### PR DESCRIPTION
Using `STRING_TEMPLATE % VARIABLE` can introduce hard-to-find bugs if `VARIABLE` is expected to be a string but ends up being a tuple. Instead of using percent formatting, just using `.format`.

Also making tweaks to `get_target_packages` to make some path manipulation / checks OS-independent.