### PR TITLE
Add integration test for Unicode filenames.

### DIFF
--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -53,7 +53,7 @@ class _PropertyMixin(object):
     """
 
     def __init__(self, name=None):
-        self.name = _validate_name(name)
+        self.name = name
         self._properties = {}
         self._changes = set()
 

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -29,6 +29,7 @@ from google.cloud.exceptions import NotFound
 from google.cloud.iterator import HTTPIterator
 from google.cloud.storage._helpers import _PropertyMixin
 from google.cloud.storage._helpers import _scalar_property
+from google.cloud.storage._helpers import _validate_name
 from google.cloud.storage.acl import BucketACL
 from google.cloud.storage.acl import DefaultObjectACL
 from google.cloud.storage.blob import Blob
@@ -107,6 +108,7 @@ class Bucket(_PropertyMixin):
     """
 
     def __init__(self, client, name=None):
+        name = _validate_name(name)
         super(Bucket, self).__init__(name=name)
         self._client = client
         self._acl = BucketACL(self)

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -245,6 +245,27 @@ class TestStorageWriteFiles(TestStorageFiles):
         self.assertEqual(base_contents, copied_contents)
 
 
+class TestUnicode(unittest.TestCase):
+    @unittest.skipIf(six.PY2, 'Unicode URLs only work on Python 3.')
+    def test_fetch_object_and_check_content(self):
+        client = storage.Client()
+        bucket = client.bucket('storage-library-test-bucket')
+
+        # Note: These files are public.
+        # Normalization form C: a single character for e-acute;
+        # URL should end with Cafe%CC%81
+        # Normalization Form D: an ASCII e followed by U+0301 combining
+        # character; URL should end with Caf%C3%A9
+        test_data = {
+            u'Caf\u00e9': b'Normalization Form C',
+            u'Cafe\u0301': b'Normalization Form D',
+        }
+        for blob_name, file_contents in test_data.items():
+            blob = bucket.blob(blob_name)
+            self.assertEqual(blob.name, blob_name)
+            self.assertEqual(blob.download_as_string(), file_contents)
+
+
 class TestStorageListFiles(TestStorageFiles):
 
     FILENAMES = ('CloudLogo1', 'CloudLogo2', 'CloudLogo3')

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -246,7 +246,6 @@ class TestStorageWriteFiles(TestStorageFiles):
 
 
 class TestUnicode(unittest.TestCase):
-    @unittest.skipIf(six.PY2, 'Unicode URLs only work on Python 3.')
     def test_fetch_object_and_check_content(self):
         client = storage.Client()
         bucket = client.bucket('storage-library-test-bucket')
@@ -257,8 +256,8 @@ class TestUnicode(unittest.TestCase):
         # Normalization Form D: an ASCII e followed by U+0301 combining
         # character; URL should end with Caf%C3%A9
         test_data = {
-            u'Caf\u00e9': b'Normalization Form C',
-            u'Cafe\u0301': b'Normalization Form D',
+            u'Caf\u00e9'.encode('utf-8'): b'Normalization Form C',
+            u'Cafe\u0301'.encode('utf-8'): b'Normalization Form D',
         }
         for blob_name, file_contents in test_data.items():
             blob = bucket.blob(blob_name)

--- a/storage/tests/unit/test__helpers.py
+++ b/storage/tests/unit/test__helpers.py
@@ -46,19 +46,6 @@ class Test_PropertyMixin(unittest.TestCase):
         mixin = self._make_one()
         self.assertRaises(NotImplementedError, lambda: mixin.client)
 
-    def test_bucket_name_value(self):
-        bucket_name = 'testing123'
-        mixin = self._make_one(name=bucket_name)
-        self.assertEqual(mixin.name, bucket_name)
-
-        bad_start_bucket_name = '/testing123'
-        with self.assertRaises(ValueError):
-            self._make_one(name=bad_start_bucket_name)
-
-        bad_end_bucket_name = 'testing123/'
-        with self.assertRaises(ValueError):
-            self._make_one(name=bad_end_bucket_name)
-
     def test_reload(self):
         connection = _Connection({'foo': 'Foo'})
         client = _Client(connection)

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -72,6 +72,19 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(blob.chunk_size, CHUNK_SIZE)
         self.assertEqual(blob._encryption_key, KEY)
 
+    def test_bucket_name_value(self):
+        bucket_name = 'testing123'
+        mixin = self._make_one(name=bucket_name)
+        self.assertEqual(mixin.name, bucket_name)
+
+        bad_start_bucket_name = '/testing123'
+        with self.assertRaises(ValueError):
+            self._make_one(name=bad_start_bucket_name)
+
+        bad_end_bucket_name = 'testing123/'
+        with self.assertRaises(ValueError):
+            self._make_one(name=bad_end_bucket_name)
+
     def test_exists_miss(self):
         from google.cloud.exceptions import NotFound
 


### PR DESCRIPTION
This is a port of GoogleCloudPlatform/google-cloud-dotnet#933.

This also exposes the fact that Python 2 cannot handle some Unicode in URLs at all, because `urllib.quote` raises `KeyError` (wha....?) if you use Unicode. That is an issue with the Python standard library, however.