### PR TITLE
Prep error-reporting-0.23.2

### DIFF
--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-error-reporting',
-    version='0.23.1',
+    version='0.23.2',
     description='Python Client for Stackdriver Error Reporting',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Draft changelog for release:


## google-cloud-error-reporting 0.23.2

- Bugfix: Fix make_report_error_api usage of Client._project. (#3159)