### PR TITLE
Fix untested logging snippet examples.

### DIFF
--- a/docs/logging-stdlib-usage.rst
+++ b/docs/logging-stdlib-usage.rst
@@ -53,7 +53,7 @@ You can also exclude certain loggers:
 
 .. code-block:: python
 
-   >>> setup_logging(handler, excluded_loggers=('werkzeug',)))
+   >>> setup_logging(handler, excluded_loggers=('werkzeug',))
 
 
 
@@ -68,4 +68,3 @@ The Python logging handler can use different transports. The default is
 
  1. :class:`google.cloud.logging.handlers.SyncTransport` this handler does a direct API call on each
  logging statement to write the entry.
-

--- a/logging/google/cloud/logging/handlers/handlers.py
+++ b/logging/google/cloud/logging/handlers/handlers.py
@@ -52,6 +52,7 @@ class CloudLoggingHandler(logging.StreamHandler):
 
     .. code-block:: python
 
+        import logging
         import google.cloud.logging
         from google.cloud.logging.handlers import CloudLoggingHandler
 
@@ -62,7 +63,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         cloud_logger.setLevel(logging.INFO)
         cloud_logger.addHandler(handler)
 
-        cloud.logger.error('bad news')  # API call
+        cloud_logger.error('bad news')  # API call
 
     """
 
@@ -117,7 +118,7 @@ def setup_logging(handler, excluded_loggers=EXCLUDED_LOGGER_DEFAULTS,
 
         client = google.cloud.logging.Client()
         handler = CloudLoggingHandler(client)
-        google.cloud.logging.setup_logging(handler)
+        google.cloud.logging.handlers.setup_logging(handler)
         logging.getLogger().setLevel(logging.DEBUG)
 
         logging.error('bad news')  # API call


### PR DESCRIPTION
These snippets aren't covered in `logging_snippets.py` and they had a couple small syntax issues.