### PR TITLE
Check out docs submodule with SSH.

### DIFF
--- a/test_utils/scripts/update_docs.sh
+++ b/test_utils/scripts/update_docs.sh
@@ -92,4 +92,4 @@ git commit -m "Update docs after merge to master."
 
 # NOTE: This may fail if two docs updates (on merges to master)
 #       happen in close proximity.
-git push -q git@github.com:${GH_OWNER}/${GH_PROJECT_NAME} HEAD:gh-pages
+git push -q origin HEAD:gh-pages

--- a/test_utils/scripts/update_docs.sh
+++ b/test_utils/scripts/update_docs.sh
@@ -16,8 +16,8 @@
 
 set -ev
 
-GH_OWNER="GoogleCloudPlatform"
-GH_PROJECT_NAME="google-cloud-python"
+GH_OWNER='GoogleCloudPlatform'
+GH_PROJECT_NAME='google-cloud-python'
 
 # Function to build the docs.
 function build_docs {
@@ -40,10 +40,9 @@ fi
 
 # Adding GitHub pages branch. `git submodule add` checks it
 # out at HEAD.
-GH_PAGES_DIR="ghpages"
+GH_PAGES_DIR='ghpages'
 git submodule add -q -b gh-pages \
-    "https://${GH_OAUTH_TOKEN}@github.com/${GH_OWNER}/${GH_PROJECT_NAME}" \
-    ${GH_PAGES_DIR}
+    "git@github.com:${GH_OWNER}/${GH_PROJECT_NAME}" ${GH_PAGES_DIR}
 
 # Determine if we are building a new tag or are building docs
 # for master. Then build new docs in docs/_build from master.
@@ -87,12 +86,10 @@ if [[ -z "$(git status --porcelain)" ]]; then
 fi
 
 # Commit to gh-pages branch to apply changes.
-git config --global user.email "circle@circleci.com"
-git config --global user.name "CircleCI"
+git config --global user.email "googleapis-publisher@google.com"
+git config --global user.name "Google APIs Publisher"
 git commit -m "Update docs after merge to master."
 
 # NOTE: This may fail if two docs updates (on merges to master)
 #       happen in close proximity.
-git push -q \
-    "https://${GH_OAUTH_TOKEN}@github.com/${GH_OWNER}/${GH_PROJECT_NAME}" \
-    HEAD:gh-pages
+git push -q git@github.com:${GH_OWNER}/${GH_PROJECT_NAME} HEAD:gh-pages


### PR DESCRIPTION
This commit moves docs publishing to use SSH instead of an OAuth key
over HTTP. The SSH key is attached to a robot user configured in
CI.

@dhermes: Please review, but there might be some unavoidable post-merge
thrashing if problems arise.