### PR TITLE
Make clients explicitly unpickleable.

### DIFF
--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -14,6 +14,8 @@
 
 """Base classes for client used to interact with Google Cloud APIs."""
 
+from pickle import PicklingError
+
 import google.auth.credentials
 from google.oauth2 import service_account
 import google_auth_httplib2
@@ -125,6 +127,14 @@ class Client(_ClientFactoryMixin):
         self._credentials = google.auth.credentials.with_scopes_if_required(
             credentials, self.SCOPE)
         self._http_internal = http
+
+    def __getstate__(self):
+        """Explicitly state that clients are not pickleable."""
+
+        raise PicklingError('\n'.join([
+            'Pickling client objects is explicitly not supported.',
+            'Clients have non-trivial state that is local and unpickleable.',
+        ]))
 
     @property
     def _http(self):

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -130,7 +130,6 @@ class Client(_ClientFactoryMixin):
 
     def __getstate__(self):
         """Explicitly state that clients are not pickleable."""
-
         raise PicklingError('\n'.join([
             'Pickling client objects is explicitly not supported.',
             'Clients have non-trivial state that is local and unpickleable.',

--- a/core/tests/unit/test_client.py
+++ b/core/tests/unit/test_client.py
@@ -50,7 +50,10 @@ class TestClient(unittest.TestCase):
     def test_unpickleable(self):
         import pickle
 
-        client = self._make_one()
+        CREDENTIALS = _make_credentials()
+        HTTP = object()
+        
+        client_obj = self._make_one(credentials=CREDENTIALS, http=HTTP)
         with self.assertRaises(pickle.PicklingError):
             pickle.dumps(client)
 

--- a/core/tests/unit/test_client.py
+++ b/core/tests/unit/test_client.py
@@ -47,6 +47,13 @@ class TestClient(unittest.TestCase):
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
+    def test_unpickleable(self):
+        import pickle
+
+        client = self._make_one()
+        with self.assertRaises(pickle.PicklingError):
+            pickle.dumps(client)
+
     def test_ctor_defaults(self):
         from google.cloud._testing import _Monkey
         from google.cloud import client

--- a/core/tests/unit/test_client.py
+++ b/core/tests/unit/test_client.py
@@ -52,10 +52,10 @@ class TestClient(unittest.TestCase):
 
         CREDENTIALS = _make_credentials()
         HTTP = object()
-        
+
         client_obj = self._make_one(credentials=CREDENTIALS, http=HTTP)
         with self.assertRaises(pickle.PicklingError):
-            pickle.dumps(client)
+            pickle.dumps(client_obj)
 
     def test_ctor_defaults(self):
         from google.cloud._testing import _Monkey


### PR DESCRIPTION
Closes #3211.