### PR TITLE
Renaming http argument(s) as _http.

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -70,6 +70,8 @@ class Client(ClientWithProject):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/bigquery',

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -60,25 +60,25 @@ class Client(ClientWithProject):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/bigquery',
              'https://www.googleapis.com/auth/cloud-platform')
     """The scopes required for authenticating as a BigQuery consumer."""
 
-    def __init__(self, project=None, credentials=None, http=None):
+    def __init__(self, project=None, credentials=None, _http=None):
         super(Client, self).__init__(
-            project=project, credentials=credentials, http=http)
+            project=project, credentials=credentials, _http=_http)
         self._connection = Connection(self)
 
     def list_projects(self, max_results=None, page_token=None):

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -40,7 +40,7 @@ class TestClient(unittest.TestCase):
         PROJECT = 'PROJECT'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection.credentials, creds)
         self.assertIs(client._connection.http, http)
@@ -195,7 +195,7 @@ class TestClient(unittest.TestCase):
         DATASET = 'dataset_name'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         dataset = client.dataset(DATASET)
         self.assertIsInstance(dataset, Dataset)
         self.assertEqual(dataset.name, DATASET)
@@ -438,7 +438,7 @@ class TestClient(unittest.TestCase):
         SOURCE_URI = 'http://example.com/source.csv'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         dataset = client.dataset(DATASET)
         destination = dataset.table(DESTINATION)
         job = client.load_table_from_storage(JOB, destination, SOURCE_URI)
@@ -458,7 +458,7 @@ class TestClient(unittest.TestCase):
         DESTINATION = 'destination_table'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         dataset = client.dataset(DATASET)
         source = dataset.table(SOURCE)
         destination = dataset.table(DESTINATION)
@@ -479,7 +479,7 @@ class TestClient(unittest.TestCase):
         DESTINATION = 'gs://bucket_name/object_name'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         dataset = client.dataset(DATASET)
         source = dataset.table(SOURCE)
         job = client.extract_table_to_storage(JOB, source, DESTINATION)
@@ -497,7 +497,7 @@ class TestClient(unittest.TestCase):
         QUERY = 'select count(*) from persons'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         job = client.run_async_query(JOB, QUERY)
         self.assertIsInstance(job, QueryJob)
         self.assertIs(job._client, client)
@@ -516,7 +516,7 @@ class TestClient(unittest.TestCase):
         QUERY = 'select count(*) from persons'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         udf_resources = [UDFResource("resourceUri", RESOURCE_URI)]
         job = client.run_async_query(JOB, QUERY, udf_resources=udf_resources)
         self.assertIsInstance(job, QueryJob)
@@ -535,7 +535,7 @@ class TestClient(unittest.TestCase):
         QUERY = 'select count(*) from persons'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         query_parameters = [ScalarQueryParameter('foo', 'INT64', 123)]
         job = client.run_async_query(JOB, QUERY,
                                      query_parameters=query_parameters)
@@ -553,7 +553,7 @@ class TestClient(unittest.TestCase):
         QUERY = 'select count(*) from persons'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         query = client.run_sync_query(QUERY)
         self.assertIsInstance(query, QueryResults)
         self.assertIs(query._client, client)
@@ -571,7 +571,7 @@ class TestClient(unittest.TestCase):
         QUERY = 'select count(*) from persons'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         udf_resources = [UDFResource("resourceUri", RESOURCE_URI)]
         query = client.run_sync_query(QUERY, udf_resources=udf_resources)
         self.assertIsInstance(query, QueryResults)
@@ -589,7 +589,7 @@ class TestClient(unittest.TestCase):
         QUERY = 'select count(*) from persons'
         creds = _make_credentials()
         http = object()
-        client = self._make_one(project=PROJECT, credentials=creds, http=http)
+        client = self._make_one(project=PROJECT, credentials=creds, _http=http)
         query_parameters = [ScalarQueryParameter('foo', 'INT64', 123)]
         query = client.run_sync_query(QUERY, query_parameters=query_parameters)
         self.assertIsInstance(query, QueryResults)

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -72,12 +72,12 @@ class _ClientFactoryMixin(object):
 class Client(_ClientFactoryMixin):
     """Client to bundle configuration needed for API requests.
 
-    Stores ``credentials`` and ``http`` object so that subclasses
+    Stores ``credentials`` and an HTTP object so that subclasses
     can pass them along to a connection class.
 
-    If no value is passed in for ``http``, a :class:`httplib2.Http` object
+    If no value is passed in for ``_http``, a :class:`httplib2.Http` object
     will be created and authorized with the ``credentials``. If not, the
-    ``credentials`` and ``http`` need not be related.
+    ``credentials`` and ``_http`` need not be related.
 
     Callers and subclasses may seek to use the private key from
     ``credentials`` to sign data.
@@ -92,21 +92,21 @@ class Client(_ClientFactoryMixin):
 
     In addition, ``redirections`` and ``connection_type`` may be used.
 
-    A custom ``http`` object will also need to be able to add a bearer token
+    A custom ``_http`` object will also need to be able to add a bearer token
     to API requests and handle token refresh on 401 errors.
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
     """
 
     SCOPE = None
@@ -115,16 +115,16 @@ class Client(_ClientFactoryMixin):
     Needs to be set by subclasses.
     """
 
-    def __init__(self, credentials=None, http=None):
+    def __init__(self, credentials=None, _http=None):
         if (credentials is not None and
                 not isinstance(
                     credentials, google.auth.credentials.Credentials)):
             raise ValueError(_GOOGLE_AUTH_CREDENTIALS_HELP)
-        if credentials is None and http is None:
+        if credentials is None and _http is None:
             credentials = get_credentials()
         self._credentials = google.auth.credentials.with_scopes_if_required(
             credentials, self.SCOPE)
-        self._http_internal = http
+        self._http_internal = _http
 
     @property
     def _http(self):
@@ -179,21 +179,21 @@ class ClientWithProject(Client, _ClientProjectMixin):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
 
     :raises: :class:`ValueError` if the project is neither passed in nor
              set in the environment.
     """
 
-    def __init__(self, project=None, credentials=None, http=None):
+    def __init__(self, project=None, credentials=None, _http=None):
         _ClientProjectMixin.__init__(self, project=project)
-        Client.__init__(self, credentials=credentials, http=http)
+        Client.__init__(self, credentials=credentials, _http=_http)

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -107,6 +107,8 @@ class Client(_ClientFactoryMixin):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
     """
 
     SCOPE = None
@@ -189,6 +191,8 @@ class ClientWithProject(Client, _ClientProjectMixin):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
 
     :raises: :class:`ValueError` if the project is neither passed in nor
              set in the environment.

--- a/core/tests/unit/test_client.py
+++ b/core/tests/unit/test_client.py
@@ -68,7 +68,7 @@ class TestClient(unittest.TestCase):
     def test_ctor_explicit(self):
         CREDENTIALS = _make_credentials()
         HTTP = object()
-        client_obj = self._make_one(credentials=CREDENTIALS, http=HTTP)
+        client_obj = self._make_one(credentials=CREDENTIALS, _http=HTTP)
 
         self.assertIs(client_obj._credentials, CREDENTIALS)
         self.assertIs(client_obj._http_internal, HTTP)
@@ -106,7 +106,7 @@ class TestClient(unittest.TestCase):
     def test__http_property_existing(self):
         credentials = _make_credentials()
         http = object()
-        client = self._make_one(credentials=credentials, http=http)
+        client = self._make_one(credentials=credentials, _http=http)
         self.assertIs(client._http_internal, http)
         self.assertIs(client._http, http)
 
@@ -186,7 +186,7 @@ class TestClientWithProject(unittest.TestCase):
         HTTP = object()
         with self.assertRaises(ValueError):
             self._make_one(project=object(), credentials=CREDENTIALS,
-                           http=HTTP)
+                           _http=HTTP)
 
     def _explicit_ctor_helper(self, project):
         import six
@@ -195,7 +195,7 @@ class TestClientWithProject(unittest.TestCase):
         HTTP = object()
 
         client_obj = self._make_one(project=project, credentials=CREDENTIALS,
-                                    http=HTTP)
+                                    _http=HTTP)
 
         if isinstance(project, six.binary_type):
             self.assertEqual(client_obj.project, project.decode('utf-8'))

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -173,16 +173,16 @@ class Client(ClientWithProject):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
 
     :type use_gax: bool
     :param use_gax: (Optional) Explicitly specifies whether
@@ -195,9 +195,9 @@ class Client(ClientWithProject):
     """The scopes required for authenticating as a Cloud Datastore consumer."""
 
     def __init__(self, project=None, namespace=None,
-                 credentials=None, http=None, use_gax=None):
+                 credentials=None, _http=None, use_gax=None):
         super(Client, self).__init__(
-            project=project, credentials=credentials, http=http)
+            project=project, credentials=credentials, _http=_http)
         self.namespace = namespace
         self._batch_stack = _LocalStack()
         self._datastore_api_internal = None

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -45,7 +45,7 @@ _MAX_LOOPS = 128
 _DATASTORE_BASE_URL = 'https://datastore.googleapis.com'
 """Datastore API request URL base."""
 
-_USE_GAX = _HAVE_GRPC and not os.getenv(DISABLE_GRPC, False)
+_USE_GRPC = _HAVE_GRPC and not os.getenv(DISABLE_GRPC, False)
 
 
 def _get_gcd_project():
@@ -184,27 +184,27 @@ class Client(ClientWithProject):
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
 
-    :type use_gax: bool
-    :param use_gax: (Optional) Explicitly specifies whether
-                    to use the gRPC transport (via GAX) or HTTP. If unset,
-                    falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
-                    variable.
+    :type _use_grpc: bool
+    :param _use_grpc: (Optional) Explicitly specifies whether
+                      to use the gRPC transport (via GAX) or HTTP. If unset,
+                      falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
+                      environment variable.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/datastore',)
     """The scopes required for authenticating as a Cloud Datastore consumer."""
 
     def __init__(self, project=None, namespace=None,
-                 credentials=None, _http=None, use_gax=None):
+                 credentials=None, _http=None, _use_grpc=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, _http=_http)
         self.namespace = namespace
         self._batch_stack = _LocalStack()
         self._datastore_api_internal = None
-        if use_gax is None:
-            self._use_gax = _USE_GAX
+        if _use_grpc is None:
+            self._use_grpc = _USE_GRPC
         else:
-            self._use_gax = use_gax
+            self._use_grpc = _use_grpc
         try:
             host = os.environ[GCD_HOST]
             self._base_url = 'http://' + host
@@ -220,7 +220,7 @@ class Client(ClientWithProject):
     def _datastore_api(self):
         """Getter for a wrapped API object."""
         if self._datastore_api_internal is None:
-            if self._use_gax:
+            if self._use_grpc:
                 self._datastore_api_internal = make_datastore_api(self)
             else:
                 self._datastore_api_internal = HTTPDatastoreAPI(self)

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -183,12 +183,16 @@ class Client(ClientWithProject):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
 
     :type _use_grpc: bool
     :param _use_grpc: (Optional) Explicitly specifies whether
                       to use the gRPC transport (via GAX) or HTTP. If unset,
                       falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
                       environment variable.
+                      This parameter should be considered private, and could
+                      change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/datastore',)

--- a/datastore/tests/system/test_system.py
+++ b/datastore/tests/system/test_system.py
@@ -46,7 +46,7 @@ def clone_client(client):
     return datastore.Client(project=client.project,
                             namespace=client.namespace,
                             credentials=client._credentials,
-                            http=client._http)
+                            _http=client._http)
 
 
 def setUpModule():
@@ -61,7 +61,7 @@ def setUpModule():
         Config.CLIENT = datastore.Client(project=emulator_dataset,
                                          namespace=test_namespace,
                                          credentials=credentials,
-                                         http=http)
+                                         _http=http)
 
 
 def tearDownModule():

--- a/datastore/tests/unit/test_client.py
+++ b/datastore/tests/unit/test_client.py
@@ -127,11 +127,11 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _make_one(self, project=PROJECT, namespace=None,
-                  credentials=None, http=None, use_gax=None):
+                  credentials=None, _http=None, use_gax=None):
         return self._get_target_class()(project=project,
                                         namespace=namespace,
                                         credentials=credentials,
-                                        http=http,
+                                        _http=_http,
                                         use_gax=use_gax)
 
     def test_constructor_w_project_no_environ(self):
@@ -186,7 +186,7 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=other,
                                 namespace=namespace,
                                 credentials=creds,
-                                http=http)
+                                _http=http)
         self.assertEqual(client.project, other)
         self.assertEqual(client.namespace, namespace)
         self.assertIs(client._credentials, creds)
@@ -204,21 +204,21 @@ class TestClient(unittest.TestCase):
 
         with mock.patch.object(MUT, '_USE_GAX', new=True):
             client1 = self._make_one(
-                project=project, credentials=creds, http=http)
+                project=project, credentials=creds, _http=http)
             self.assertTrue(client1._use_gax)
             # Explicitly over-ride the environment.
             client2 = self._make_one(
-                project=project, credentials=creds, http=http,
+                project=project, credentials=creds, _http=http,
                 use_gax=False)
             self.assertFalse(client2._use_gax)
 
         with mock.patch.object(MUT, '_USE_GAX', new=False):
             client3 = self._make_one(
-                project=project, credentials=creds, http=http)
+                project=project, credentials=creds, _http=http)
             self.assertFalse(client3._use_gax)
             # Explicitly over-ride the environment.
             client4 = self._make_one(
-                project=project, credentials=creds, http=http,
+                project=project, credentials=creds, _http=http,
                 use_gax=True)
             self.assertTrue(client4._use_gax)
 
@@ -233,13 +233,13 @@ class TestClient(unittest.TestCase):
 
         with mock.patch('os.environ', new=fake_environ):
             client = self._make_one(
-                project=project, credentials=creds, http=http)
+                project=project, credentials=creds, _http=http)
             self.assertEqual(client._base_url, 'http://' + host)
 
     def test__datastore_api_property_gax(self):
         client = self._make_one(
             project='prahj-ekt', credentials=_make_credentials(),
-            http=object(), use_gax=True)
+            _http=object(), use_gax=True)
 
         self.assertIsNone(client._datastore_api_internal)
         patch = mock.patch(
@@ -262,7 +262,7 @@ class TestClient(unittest.TestCase):
 
         client = self._make_one(
             project='prahj-ekt', credentials=_make_credentials(),
-            http=object(), use_gax=False)
+            _http=object(), use_gax=False)
 
         self.assertIsNone(client._datastore_api_internal)
         ds_api = client._datastore_api

--- a/datastore/tests/unit/test_client.py
+++ b/datastore/tests/unit/test_client.py
@@ -127,12 +127,12 @@ class TestClient(unittest.TestCase):
         return Client
 
     def _make_one(self, project=PROJECT, namespace=None,
-                  credentials=None, _http=None, use_gax=None):
+                  credentials=None, _http=None, _use_grpc=None):
         return self._get_target_class()(project=project,
                                         namespace=namespace,
                                         credentials=credentials,
                                         _http=_http,
-                                        use_gax=use_gax)
+                                        _use_grpc=_use_grpc)
 
     def test_constructor_w_project_no_environ(self):
         # Some environments (e.g. AppVeyor CI) run in GCE, so
@@ -195,32 +195,32 @@ class TestClient(unittest.TestCase):
         self.assertEqual(list(client._batch_stack), [])
         self.assertEqual(client._base_url, _DATASTORE_BASE_URL)
 
-    def test_constructor_use_gax_default(self):
+    def test_constructor_use_grpc_default(self):
         import google.cloud.datastore.client as MUT
 
         project = 'PROJECT'
         creds = _make_credentials()
         http = object()
 
-        with mock.patch.object(MUT, '_USE_GAX', new=True):
+        with mock.patch.object(MUT, '_USE_GRPC', new=True):
             client1 = self._make_one(
                 project=project, credentials=creds, _http=http)
-            self.assertTrue(client1._use_gax)
+            self.assertTrue(client1._use_grpc)
             # Explicitly over-ride the environment.
             client2 = self._make_one(
                 project=project, credentials=creds, _http=http,
-                use_gax=False)
-            self.assertFalse(client2._use_gax)
+                _use_grpc=False)
+            self.assertFalse(client2._use_grpc)
 
-        with mock.patch.object(MUT, '_USE_GAX', new=False):
+        with mock.patch.object(MUT, '_USE_GRPC', new=False):
             client3 = self._make_one(
                 project=project, credentials=creds, _http=http)
-            self.assertFalse(client3._use_gax)
+            self.assertFalse(client3._use_grpc)
             # Explicitly over-ride the environment.
             client4 = self._make_one(
                 project=project, credentials=creds, _http=http,
-                use_gax=True)
-            self.assertTrue(client4._use_gax)
+                _use_grpc=True)
+            self.assertTrue(client4._use_grpc)
 
     def test_constructor_gcd_host(self):
         from google.cloud.environment_vars import GCD_HOST
@@ -239,7 +239,7 @@ class TestClient(unittest.TestCase):
     def test__datastore_api_property_gax(self):
         client = self._make_one(
             project='prahj-ekt', credentials=_make_credentials(),
-            _http=object(), use_gax=True)
+            _http=object(), _use_grpc=True)
 
         self.assertIsNone(client._datastore_api_internal)
         patch = mock.patch(
@@ -262,7 +262,7 @@ class TestClient(unittest.TestCase):
 
         client = self._make_one(
             project='prahj-ekt', credentials=_make_credentials(),
-            _http=object(), use_gax=False)
+            _http=object(), _use_grpc=False)
 
         self.assertIsNone(client._datastore_api_internal)
         ds_api = client._datastore_api
@@ -816,7 +816,7 @@ class TestClient(unittest.TestCase):
         incomplete_key._id = None
 
         creds = _make_credentials()
-        client = self._make_one(credentials=creds, use_gax=False)
+        client = self._make_one(credentials=creds, _use_grpc=False)
         allocated = mock.Mock(
             keys=[_KeyPB(i) for i in range(num_ids)], spec=['keys'])
         alloc_ids = mock.Mock(return_value=allocated, spec=[])

--- a/dns/google/cloud/dns/client.py
+++ b/dns/google/cloud/dns/client.py
@@ -42,6 +42,8 @@ class Client(ClientWithProject):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/ndev.clouddns.readwrite',)

--- a/dns/google/cloud/dns/client.py
+++ b/dns/google/cloud/dns/client.py
@@ -32,24 +32,24 @@ class Client(ClientWithProject):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/ndev.clouddns.readwrite',)
     """The scopes required for authenticating as a Cloud DNS consumer."""
 
-    def __init__(self, project=None, credentials=None, http=None):
+    def __init__(self, project=None, credentials=None, _http=None):
         super(Client, self).__init__(
-            project=project, credentials=credentials, http=http)
+            project=project, credentials=credentials, _http=_http)
         self._connection = Connection(self)
 
     def quotas(self):

--- a/dns/tests/unit/test_client.py
+++ b/dns/tests/unit/test_client.py
@@ -43,7 +43,7 @@ class TestClient(unittest.TestCase):
         creds = _make_credentials()
         http = object()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                                http=http)
+                                _http=http)
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection.credentials, creds)
         self.assertIs(client._connection.http, http)

--- a/docs/google-cloud-auth.rst
+++ b/docs/google-cloud-auth.rst
@@ -300,19 +300,19 @@ Advanced Customization
 
 .. warning::
 
-    The google-cloud developers want to improve our HTTP handling to
+    The developers of this library want to improve our HTTP handling to
     support more situations more easily, and use current tooling.
 
     In order to allow this, this particular mechanism may have to be altered
     in a backwards-compatible way. Therefore, the following section should
     be considered "private API" that is subject to change.
 
-Though the ``google-cloud-python`` library uses `google-auth`_ to sign
+The ``google-cloud-python`` library uses `google-auth`_ to sign
 requests and ``httplib2`` for sending requests.
 
 .. _google-auth: http://google-auth.readthedocs.io/en/stable/
 
-This is not a stirct requirement:
+This is not a strict requirement:
 The :class:`Client <google.cloud.client.Client>` constructor accepts an
 optional ``_http`` argument in place of a ``credentials`` object.
 If passed, all HTTP requests made by the client will use your

--- a/docs/google-cloud-auth.rst
+++ b/docs/google-cloud-auth.rst
@@ -305,12 +305,12 @@ it is not a strict requirement.
 .. _google-auth: http://google-auth.readthedocs.io/en/stable/
 
 The :class:`Client <google.cloud.client.Client>` constructor accepts an optional
-``http`` argument in place of a ``credentials`` object.
+``_http`` argument in place of a ``credentials`` object.
 If passed, all HTTP requests made by the client will use your
 custom HTTP object.
 
 In order for this to be possible,
-the ``http`` object must do two things:
+the ``_http`` object must do two things:
 
 * Handle authentication on its own
 * Define a method ``request()`` that can subsitute for

--- a/docs/google-cloud-auth.rst
+++ b/docs/google-cloud-auth.rst
@@ -298,14 +298,23 @@ you add the correct scopes for the APIs you want to access:
 Advanced Customization
 ======================
 
-Though the ``google-cloud-python`` library defaults to using `google-auth`_
-to sign requests and ``httplib2`` for sending requests,
-it is not a strict requirement.
+.. warning::
+
+    The google-cloud developers want to improve our HTTP handling to
+    support more situations more easily, and use current tooling.
+
+    In order to allow this, this particular mechanism may have to be altered
+    in a backwards-compatible way. Therefore, the following section should
+    be considered "private API" that is subject to change.
+
+Though the ``google-cloud-python`` library uses `google-auth`_ to sign
+requests and ``httplib2`` for sending requests.
 
 .. _google-auth: http://google-auth.readthedocs.io/en/stable/
 
-The :class:`Client <google.cloud.client.Client>` constructor accepts an optional
-``_http`` argument in place of a ``credentials`` object.
+This is not a stirct requirement:
+The :class:`Client <google.cloud.client.Client>` constructor accepts an
+optional ``_http`` argument in place of a ``credentials`` object.
 If passed, all HTTP requests made by the client will use your
 custom HTTP object.
 

--- a/error_reporting/google/cloud/error_reporting/_logging.py
+++ b/error_reporting/google/cloud/error_reporting/_logging.py
@@ -33,18 +33,18 @@ class _ErrorReportingLoggingAPI(object):
     :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
                        :class:`NoneType`
     :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
+                        owned by this client. If not passed (and if no ``_http``
                         object is passed), falls back to the default inferred
                         from the environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`httplib2.Http` or class that defines ``request()``.
+    :param _http: An optional HTTP object to make requests. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
     """
-    def __init__(self, project, credentials=None, http=None):
+    def __init__(self, project, credentials=None, _http=None):
         self.logging_client = google.cloud.logging.client.Client(
-            project, credentials, http)
+            project, credentials, _http=_http)
 
     def report_error_event(self, error_report):
         """Report error payload.

--- a/error_reporting/google/cloud/error_reporting/_logging.py
+++ b/error_reporting/google/cloud/error_reporting/_logging.py
@@ -41,6 +41,8 @@ class _ErrorReportingLoggingAPI(object):
     :param _http: An optional HTTP object to make requests. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
     """
     def __init__(self, project, credentials=None, _http=None):
         self.logging_client = google.cloud.logging.client.Client(

--- a/error_reporting/google/cloud/error_reporting/client.py
+++ b/error_reporting/google/cloud/error_reporting/client.py
@@ -94,6 +94,8 @@ class Client(ClientWithProject):
     :param _http: An optional HTTP object to make requests. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
 
     :type service: str
     :param service: An identifier of the service, such as the name of the
@@ -114,6 +116,8 @@ class Client(ClientWithProject):
                       to use the gRPC transport (via GAX) or HTTP. If unset,
                       falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
                       environment variable.
+                      This parameter should be considered private, and could
+                      change in the future.
 
     :raises: :class:`ValueError` if the project is neither passed in nor
              set in the environment.

--- a/error_reporting/google/cloud/error_reporting/client.py
+++ b/error_reporting/google/cloud/error_reporting/client.py
@@ -86,14 +86,14 @@ class Client(ClientWithProject):
     :type credentials: :class:`oauth2client.client.OAuth2Credentials` or
                        :class:`NoneType`
     :param credentials: The OAuth2 Credentials to use for the connection
-                        owned by this client. If not passed (and if no ``http``
+                        owned by this client. If not passed (and if no ``_http``
                         object is passed), falls back to the default inferred
                         from the environment.
 
-    :type http: :class:`httplib2.Http` or class that defines ``request()``.
-    :param http: An optional HTTP object to make requests. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`httplib2.Http` or class that defines ``request()``.
+    :param _http: An optional HTTP object to make requests. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
 
     :type service: str
     :param service: An identifier of the service, such as the name of the
@@ -121,12 +121,12 @@ class Client(ClientWithProject):
 
     def __init__(self, project=None,
                  credentials=None,
-                 http=None,
+                 _http=None,
                  service=None,
                  version=None,
                  use_gax=None):
         super(Client, self).__init__(project=project, credentials=credentials,
-                                     http=http)
+                                     _http=_http)
         self._report_errors_api = None
 
         self.service = service if service else self.DEFAULT_SERVICE

--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -28,7 +28,7 @@ def unit_tests(session, python_version):
     session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', '../core/')
+    session.install('mock', 'pytest', 'pytest-cov', '../core/', '../logging/')
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/error_reporting/tests/unit/test__logging.py
+++ b/error_reporting/tests/unit/test__logging.py
@@ -45,7 +45,8 @@ class Test_ErrorReportingLoggingAPI(unittest.TestCase):
     def test_report_error_event(self, mocked_cls):
         credentials = _make_credentials()
         logging_api = self._make_one(self.PROJECT, credentials)
-        mocked_cls.assert_called_once_with(self.PROJECT, credentials, None)
+        mocked_cls.assert_called_once_with(
+            self.PROJECT, credentials, _http=None)
         self.assertIs(logging_api.logging_client, mocked_cls.return_value)
 
         logger = mock.Mock(spec=['log_struct'])

--- a/error_reporting/tests/unit/test_client.py
+++ b/error_reporting/tests/unit/test_client.py
@@ -95,7 +95,7 @@ class TestClient(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_one(project=self.PROJECT,
                                 credentials=credentials,
-                                use_gax=False)
+                                _use_grpc=False)
         patch = mock.patch(
             'google.cloud.error_reporting.client._ErrorReportingLoggingAPI'
         )

--- a/language/google/cloud/language/client.py
+++ b/language/google/cloud/language/client.py
@@ -28,24 +28,24 @@ class Client(client_module.Client):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
     """The scopes required for authenticating as an API consumer."""
 
-    def __init__(self, credentials=None, http=None):
+    def __init__(self, credentials=None, _http=None):
         super(Client, self).__init__(
-            credentials=credentials, http=http)
+            credentials=credentials, _http=_http)
         self._connection = Connection(self)
 
     def document_from_text(self, content, **kwargs):

--- a/language/google/cloud/language/client.py
+++ b/language/google/cloud/language/client.py
@@ -38,6 +38,8 @@ class Client(client_module.Client):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)

--- a/language/tests/unit/test_client.py
+++ b/language/tests/unit/test_client.py
@@ -40,7 +40,7 @@ class TestClient(unittest.TestCase):
 
         creds = make_mock_credentials()
         http = object()
-        client = self._make_one(credentials=creds, http=http)
+        client = self._make_one(credentials=creds, _http=http)
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection.credentials, creds)
         self.assertIs(client._connection.http, http)
@@ -49,7 +49,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.language.document import Document
 
         creds = make_mock_credentials()
-        client = self._make_one(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, _http=object())
 
         content = 'abc'
         language = 'es'
@@ -64,7 +64,7 @@ class TestClient(unittest.TestCase):
 
     def test_document_from_text_factory_failure(self):
         creds = make_mock_credentials()
-        client = self._make_one(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, _http=object())
 
         with self.assertRaises(TypeError):
             client.document_from_text('abc', doc_type='foo')
@@ -73,7 +73,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.language.document import Document
 
         creds = make_mock_credentials()
-        client = self._make_one(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, _http=object())
 
         content = '<html>abc</html>'
         language = 'ja'
@@ -88,7 +88,7 @@ class TestClient(unittest.TestCase):
 
     def test_document_from_html_factory_failure(self):
         creds = make_mock_credentials()
-        client = self._make_one(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, _http=object())
 
         with self.assertRaises(TypeError):
             client.document_from_html('abc', doc_type='foo')
@@ -97,7 +97,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.language.document import Document
 
         creds = make_mock_credentials()
-        client = self._make_one(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, _http=object())
 
         gcs_url = 'gs://my-text-bucket/sentiment-me.txt'
         document = client.document_from_gcs_url(gcs_url)
@@ -112,7 +112,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.language.document import Encoding
 
         creds = make_mock_credentials()
-        client = self._make_one(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, _http=object())
 
         encoding = Encoding.UTF32
         gcs_url = 'gs://my-text-bucket/sentiment-me.txt'
@@ -130,7 +130,7 @@ class TestClient(unittest.TestCase):
         import warnings
 
         creds = make_mock_credentials()
-        client = self._make_one(credentials=creds, http=object())
+        client = self._make_one(credentials=creds, _http=object())
 
         Client = self._get_target_class()
         with mock.patch.object(Client, 'document_from_gcs_url') as dfgu:

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -79,12 +79,16 @@ class Client(ClientWithProject):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
 
     :type _use_grpc: bool
     :param _use_grpc: (Optional) Explicitly specifies whether
                       to use the gRPC transport (via GAX) or HTTP. If unset,
                       falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
                       environment variable
+                      This parameter should be considered private, and could
+                      change in the future.
     """
 
     _logging_api = None

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -22,12 +22,12 @@ try:
     from google.cloud.logging._gax import make_gax_metrics_api
     from google.cloud.logging._gax import make_gax_sinks_api
 except ImportError:  # pragma: NO COVER
-    _HAVE_GAX = False
+    _HAVE_GRPC = False
     make_gax_logging_api = None
     make_gax_metrics_api = None
     make_gax_sinks_api = None
 else:
-    _HAVE_GAX = True
+    _HAVE_GRPC = True
 
 from google.cloud.client import ClientWithProject
 from google.cloud.environment_vars import DISABLE_GRPC
@@ -46,8 +46,8 @@ from google.cloud.logging.metric import Metric
 from google.cloud.logging.sink import Sink
 
 
-_DISABLE_GAX = os.getenv(DISABLE_GRPC, False)
-_USE_GAX = _HAVE_GAX and not _DISABLE_GAX
+_DISABLE_GRPC = os.getenv(DISABLE_GRPC, False)
+_USE_GRPC = _HAVE_GRPC and not _DISABLE_GRPC
 
 _APPENGINE_FLEXIBLE_ENV_VM = 'GAE_APPENGINE_HOSTNAME'
 """Environment variable set in App Engine when vm:true is set."""
@@ -80,11 +80,11 @@ class Client(ClientWithProject):
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
 
-    :type use_gax: bool
-    :param use_gax: (Optional) Explicitly specifies whether
-                    to use the gRPC transport (via GAX) or HTTP. If unset,
-                    falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
-                    variable
+    :type _use_grpc: bool
+    :param _use_grpc: (Optional) Explicitly specifies whether
+                      to use the gRPC transport (via GAX) or HTTP. If unset,
+                      falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
+                      environment variable
     """
 
     _logging_api = None
@@ -98,14 +98,14 @@ class Client(ClientWithProject):
     """The scopes required for authenticating as a Logging consumer."""
 
     def __init__(self, project=None, credentials=None,
-                 _http=None, use_gax=None):
+                 _http=None, _use_grpc=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, _http=_http)
         self._connection = Connection(self)
-        if use_gax is None:
-            self._use_gax = _USE_GAX
+        if _use_grpc is None:
+            self._use_grpc = _USE_GRPC
         else:
-            self._use_gax = use_gax
+            self._use_grpc = _use_grpc
 
     @property
     def logging_api(self):
@@ -116,7 +116,7 @@ class Client(ClientWithProject):
         https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.logs
         """
         if self._logging_api is None:
-            if self._use_gax:
+            if self._use_grpc:
                 self._logging_api = make_gax_logging_api(self)
             else:
                 self._logging_api = JSONLoggingAPI(self)
@@ -130,7 +130,7 @@ class Client(ClientWithProject):
         https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks
         """
         if self._sinks_api is None:
-            if self._use_gax:
+            if self._use_grpc:
                 self._sinks_api = make_gax_sinks_api(self)
             else:
                 self._sinks_api = JSONSinksAPI(self)
@@ -144,7 +144,7 @@ class Client(ClientWithProject):
         https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.metrics
         """
         if self._metrics_api is None:
-            if self._use_gax:
+            if self._use_grpc:
                 self._metrics_api = make_gax_metrics_api(self)
             else:
                 self._metrics_api = JSONMetricsAPI(self)

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -69,16 +69,16 @@ class Client(ClientWithProject):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
 
     :type use_gax: bool
     :param use_gax: (Optional) Explicitly specifies whether
@@ -98,9 +98,9 @@ class Client(ClientWithProject):
     """The scopes required for authenticating as a Logging consumer."""
 
     def __init__(self, project=None, credentials=None,
-                 http=None, use_gax=None):
+                 _http=None, use_gax=None):
         super(Client, self).__init__(
-            project=project, credentials=credentials, http=http)
+            project=project, credentials=credentials, _http=_http)
         self._connection = Connection(self)
         if use_gax is None:
             self._use_gax = _USE_GAX

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -171,11 +171,11 @@ class _Logger(object):
 
 class _Client(object):
 
-    def __init__(self, project, http=None, credentials=None):
+    def __init__(self, project, _http=None, credentials=None):
         import mock
 
         self.project = project
-        self._http = http
+        self._http = _http
         self._credentials = credentials
         self._connection = mock.Mock(
             credentials=credentials, spec=['credentials'])

--- a/logging/tests/unit/test__gax.py
+++ b/logging/tests/unit/test__gax.py
@@ -21,9 +21,9 @@ try:
     import google.cloud.logging._gax
     # pylint: enable=unused-import
 except ImportError:  # pragma: NO COVER
-    _HAVE_GAX = False
+    _HAVE_GRPC = False
 else:
-    _HAVE_GAX = True
+    _HAVE_GRPC = True
 
 from google.cloud._testing import _GAXBaseAPI
 
@@ -45,7 +45,7 @@ class _Base(object):
         return self._get_target_class()(*args, **kw)
 
 
-@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_LoggingAPI(_Base, unittest.TestCase):
     LOG_NAME = 'log_name'
     LOG_PATH = 'projects/%s/logs/%s' % (_Base.PROJECT, LOG_NAME)
@@ -90,7 +90,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([entry_pb], page_token=TOKEN)
         gax_api = _GAXLoggingAPI(_list_log_entries_response=response)
         client = Client(project=self.PROJECT, credentials=_make_credentials(),
-                        use_gax=True)
+                        _use_grpc=True)
         api = self._make_one(gax_api, client)
 
         iterator = api.list_entries(
@@ -147,7 +147,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([entry_pb], page_token=NEW_TOKEN)
         gax_api = _GAXLoggingAPI(_list_log_entries_response=response)
         client = Client(project=self.PROJECT, credentials=_make_credentials(),
-                        use_gax=True)
+                        _use_grpc=True)
         api = self._make_one(gax_api, client)
 
         iterator = api.list_entries(
@@ -288,7 +288,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         response = _GAXPageIterator([entry_pb], page_token=NEW_TOKEN)
         gax_api = _GAXLoggingAPI(_list_log_entries_response=response)
         client = Client(project=self.PROJECT, credentials=_make_credentials(),
-                        use_gax=True)
+                        _use_grpc=True)
         api = self._make_one(gax_api, client)
 
         iterator = api.list_entries(
@@ -614,7 +614,7 @@ class Test_LoggingAPI(_Base, unittest.TestCase):
         self.assertIsNone(options)
 
 
-@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_SinksAPI(_Base, unittest.TestCase):
     SINK_NAME = 'sink_name'
     SINK_PATH = 'projects/%s/sinks/%s' % (_Base.PROJECT, SINK_NAME)
@@ -858,7 +858,7 @@ class Test_SinksAPI(_Base, unittest.TestCase):
         self.assertIsNone(options)
 
 
-@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_MetricsAPI(_Base, unittest.TestCase):
     METRIC_NAME = 'metric_name'
     METRIC_PATH = 'projects/%s/metrics/%s' % (_Base.PROJECT, METRIC_NAME)
@@ -1100,7 +1100,7 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
         self.assertIsNone(options)
 
 
-@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_make_gax_logging_api(unittest.TestCase):
 
     def _call_fut(self, client):
@@ -1153,7 +1153,7 @@ class Test_make_gax_logging_api(unittest.TestCase):
         self.assertIs(logging_api._client, client)
 
 
-@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_make_gax_metrics_api(unittest.TestCase):
 
     def _call_fut(self, client):
@@ -1206,7 +1206,7 @@ class Test_make_gax_metrics_api(unittest.TestCase):
         self.assertIs(metrics_api._client, client)
 
 
-@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_make_gax_sinks_api(unittest.TestCase):
 
     def _call_fut(self, client):

--- a/logging/tests/unit/test__http.py
+++ b/logging/tests/unit/test__http.py
@@ -132,7 +132,7 @@ class Test_LoggingAPI(unittest.TestCase):
             'nextPageToken': TOKEN,
         }
         client = Client(project=self.PROJECT, credentials=_make_credentials(),
-                        use_gax=False)
+                        _use_grpc=False)
         client._connection = _Connection(RETURNED)
         api = self._make_one(client)
 
@@ -210,7 +210,7 @@ class Test_LoggingAPI(unittest.TestCase):
             }],
         }
         client = Client(project=self.PROJECT, credentials=_make_credentials(),
-                        use_gax=False)
+                        _use_grpc=False)
         client._connection = _Connection(RETURNED)
         api = self._make_one(client)
 

--- a/logging/tests/unit/test_client.py
+++ b/logging/tests/unit/test_client.py
@@ -53,7 +53,7 @@ class TestClient(unittest.TestCase):
 
         client = self._make_one(self.PROJECT,
                                 credentials=_make_credentials(),
-                                use_gax=False)
+                                _use_grpc=False)
 
         conn = client._connection = _Connection()
         api = client.logging_api
@@ -74,7 +74,7 @@ class TestClient(unittest.TestCase):
 
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                                use_gax=True)
+                                _use_grpc=True)
 
         patch = mock.patch(
             'google.cloud.logging.client.make_gax_logging_api',
@@ -93,11 +93,11 @@ class TestClient(unittest.TestCase):
 
         creds = _make_credentials()
         patch = mock.patch(
-            'google.cloud.logging.client._USE_GAX',
+            'google.cloud.logging.client._USE_GRPC',
             new=True)
         with patch:
             client = self._make_one(project=self.PROJECT, credentials=creds,
-                                    use_gax=False)
+                                    _use_grpc=False)
 
         api = client.logging_api
         self.assertIsInstance(api, _LoggingAPI)
@@ -107,7 +107,7 @@ class TestClient(unittest.TestCase):
 
         client = self._make_one(
             self.PROJECT, credentials=_make_credentials(),
-            use_gax=False)
+            _use_grpc=False)
 
         conn = client._connection = _Connection()
         api = client.sinks_api
@@ -128,7 +128,7 @@ class TestClient(unittest.TestCase):
 
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                                use_gax=True)
+                                _use_grpc=True)
 
         patch = mock.patch(
             'google.cloud.logging.client.make_gax_sinks_api',
@@ -147,7 +147,7 @@ class TestClient(unittest.TestCase):
 
         client = self._make_one(
             self.PROJECT, credentials=_make_credentials(),
-            use_gax=False)
+            _use_grpc=False)
 
         conn = client._connection = _Connection()
         api = client.metrics_api
@@ -168,7 +168,7 @@ class TestClient(unittest.TestCase):
 
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                                use_gax=True)
+                                _use_grpc=True)
 
         patch = mock.patch(
             'google.cloud.logging.client.make_gax_metrics_api',
@@ -211,7 +211,7 @@ class TestClient(unittest.TestCase):
         }]
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                                use_gax=False)
+                                _use_grpc=False)
         returned = {
             'entries': ENTRIES,
             'nextPageToken': TOKEN,
@@ -275,7 +275,7 @@ class TestClient(unittest.TestCase):
                 self.PROJECT, self.LOGGER_NAME),
         }]
         client = self._make_one(self.PROJECT, credentials=_make_credentials(),
-                                use_gax=False)
+                                _use_grpc=False)
         returned = {'entries': ENTRIES}
         client._connection = _Connection(returned)
 
@@ -364,7 +364,7 @@ class TestClient(unittest.TestCase):
         }]
         client = self._make_one(project=PROJECT,
                                 credentials=_make_credentials(),
-                                use_gax=False)
+                                _use_grpc=False)
         returned = {
             'sinks': SINKS,
             'nextPageToken': TOKEN,
@@ -410,7 +410,7 @@ class TestClient(unittest.TestCase):
             'destination': self.DESTINATION_URI,
         }]
         client = self._make_one(
-            project=PROJECT, credentials=_make_credentials(), use_gax=False)
+            project=PROJECT, credentials=_make_credentials(), _use_grpc=False)
         returned = {
             'sinks': SINKS,
         }
@@ -482,7 +482,7 @@ class TestClient(unittest.TestCase):
         }]
         client = self._make_one(
             project=self.PROJECT, credentials=_make_credentials(),
-            use_gax=False)
+            _use_grpc=False)
         returned = {
             'metrics': metrics,
         }
@@ -524,7 +524,7 @@ class TestClient(unittest.TestCase):
         }]
         client = self._make_one(
             project=self.PROJECT, credentials=_make_credentials(),
-            use_gax=False)
+            _use_grpc=False)
         returned = {
             'metrics': metrics,
             'nextPageToken': next_token,
@@ -569,7 +569,7 @@ class TestClient(unittest.TestCase):
 
         client = self._make_one(project=self.PROJECT,
                                 credentials=_make_credentials(),
-                                use_gax=False)
+                                _use_grpc=False)
 
         with _tempdir() as tempdir:
             temp_log_path = os.path.join(tempdir, '{pid}')
@@ -588,7 +588,7 @@ class TestClient(unittest.TestCase):
 
         client = self._make_one(project=self.PROJECT,
                                 credentials=_make_credentials(),
-                                use_gax=False)
+                                _use_grpc=False)
 
         with _Monkey(os, environ={_CONTAINER_ENGINE_ENV: 'True'}):
             handler = client.get_default_handler()
@@ -606,7 +606,7 @@ class TestClient(unittest.TestCase):
         with mock.patch('copy.deepcopy', new=deepcopy):
             client = self._make_one(project=self.PROJECT,
                                     credentials=credentials,
-                                    use_gax=False)
+                                    _use_grpc=False)
             handler = client.get_default_handler()
             deepcopy.assert_called_once_with(client._http)
 
@@ -626,7 +626,7 @@ class TestClient(unittest.TestCase):
                             new=setup_logging):
                 client = self._make_one(project=self.PROJECT,
                                         credentials=credentials,
-                                        use_gax=False)
+                                        _use_grpc=False)
                 client.setup_logging()
                 deepcopy.assert_called_once_with(client._http)
 

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -442,7 +442,7 @@ class TestLogger(unittest.TestCase):
 
         client = Client(project=self.PROJECT,
                         credentials=_make_credentials(),
-                        use_gax=False)
+                        _use_grpc=False)
         returned = {
             'nextPageToken': TOKEN,
         }
@@ -480,7 +480,7 @@ class TestLogger(unittest.TestCase):
         PAGE_SIZE = 42
         client = Client(project=self.PROJECT,
                         credentials=_make_credentials(),
-                        use_gax=False)
+                        _use_grpc=False)
         client._connection = _Connection({})
         logger = self._make_one(self.LOGGER_NAME, client=client)
         iterator = logger.list_entries(

--- a/monitoring/google/cloud/monitoring/client.py
+++ b/monitoring/google/cloud/monitoring/client.py
@@ -58,16 +58,16 @@ class Client(ClientWithProject):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/monitoring.read',
@@ -75,9 +75,9 @@ class Client(ClientWithProject):
              'https://www.googleapis.com/auth/cloud-platform')
     """The scopes required for authenticating as a Monitoring consumer."""
 
-    def __init__(self, project=None, credentials=None, http=None):
+    def __init__(self, project=None, credentials=None, _http=None):
         super(Client, self).__init__(
-            project=project, credentials=credentials, http=http)
+            project=project, credentials=credentials, _http=_http)
         self._connection = Connection(self)
 
     def query(self,

--- a/monitoring/google/cloud/monitoring/client.py
+++ b/monitoring/google/cloud/monitoring/client.py
@@ -68,6 +68,8 @@ class Client(ClientWithProject):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/monitoring.read',

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -30,17 +30,17 @@ try:
     from google.cloud.pubsub._gax import make_gax_publisher_api
     from google.cloud.pubsub._gax import make_gax_subscriber_api
 except ImportError:  # pragma: NO COVER
-    _HAVE_GAX = False
+    _HAVE_GRPC = False
     GAXPublisherAPI = None
     GAXSubscriberAPI = None
     make_gax_publisher_api = None
     make_gax_subscriber_api = None
 else:
-    _HAVE_GAX = True
+    _HAVE_GRPC = True
 
 
-_DISABLE_GAX = os.getenv(DISABLE_GRPC, False)
-_USE_GAX = _HAVE_GAX and not _DISABLE_GAX
+_DISABLE_GRPC = os.getenv(DISABLE_GRPC, False)
+_USE_GRPC = _HAVE_GRPC and not _DISABLE_GRPC
 
 
 class Client(ClientWithProject):
@@ -64,11 +64,11 @@ class Client(ClientWithProject):
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
 
-    :type use_gax: bool
-    :param use_gax: (Optional) Explicitly specifies whether
-                    to use the gRPC transport (via GAX) or HTTP. If unset,
-                    falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
-                    variable
+    :type _use_grpc: bool
+    :param _use_grpc: (Optional) Explicitly specifies whether
+                      to use the gRPC transport (via GAX) or HTTP. If unset,
+                      falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
+                      environment variable.
     """
 
     _publisher_api = None
@@ -80,20 +80,20 @@ class Client(ClientWithProject):
     """The scopes required for authenticating as a Cloud Pub/Sub consumer."""
 
     def __init__(self, project=None, credentials=None,
-                 _http=None, use_gax=None):
+                 _http=None, _use_grpc=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, _http=_http)
         self._connection = Connection(self)
-        if use_gax is None:
-            self._use_gax = _USE_GAX
+        if _use_grpc is None:
+            self._use_grpc = _USE_GRPC
         else:
-            self._use_gax = use_gax
+            self._use_grpc = _use_grpc
 
     @property
     def publisher_api(self):
         """Helper for publisher-related API calls."""
         if self._publisher_api is None:
-            if self._use_gax:
+            if self._use_grpc:
                 if self._connection.in_emulator:
                     generated = make_gax_publisher_api(
                         host=self._connection.host)
@@ -109,7 +109,7 @@ class Client(ClientWithProject):
     def subscriber_api(self):
         """Helper for subscriber-related API calls."""
         if self._subscriber_api is None:
-            if self._use_gax:
+            if self._use_grpc:
                 if self._connection.in_emulator:
                     generated = make_gax_subscriber_api(
                         host=self._connection.host)

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -53,16 +53,16 @@ class Client(ClientWithProject):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
 
     :type use_gax: bool
     :param use_gax: (Optional) Explicitly specifies whether
@@ -80,9 +80,9 @@ class Client(ClientWithProject):
     """The scopes required for authenticating as a Cloud Pub/Sub consumer."""
 
     def __init__(self, project=None, credentials=None,
-                 http=None, use_gax=None):
+                 _http=None, use_gax=None):
         super(Client, self).__init__(
-            project=project, credentials=credentials, http=http)
+            project=project, credentials=credentials, _http=_http)
         self._connection = Connection(self)
         if use_gax is None:
             self._use_gax = _USE_GAX

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -63,12 +63,16 @@ class Client(ClientWithProject):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
 
     :type _use_grpc: bool
     :param _use_grpc: (Optional) Explicitly specifies whether
                       to use the gRPC transport (via GAX) or HTTP. If unset,
                       falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
                       environment variable.
+                      This parameter should be considered private, and could
+                      change in the future.
     """
 
     _publisher_api = None

--- a/pubsub/tests/system.py
+++ b/pubsub/tests/system.py
@@ -53,7 +53,7 @@ def setUpModule():
         credentials = EmulatorCreds()
         http = httplib2.Http()  # Un-authorized.
         Config.CLIENT = client.Client(credentials=credentials,
-                                      http=http)
+                                      _http=http)
     else:
         Config.CLIENT = client.Client()
 

--- a/pubsub/tests/unit/test__gax.py
+++ b/pubsub/tests/unit/test__gax.py
@@ -21,9 +21,9 @@ try:
     import google.cloud.pubsub._gax
     # pylint: enable=unused-import
 except ImportError:  # pragma: NO COVER
-    _HAVE_GAX = False
+    _HAVE_GRPC = False
 else:
-    _HAVE_GAX = True
+    _HAVE_GRPC = True
 
 from google.cloud._testing import _GAXBaseAPI
 
@@ -50,7 +50,7 @@ class _Base(object):
         return self._get_target_class()(*args, **kw)
 
 
-@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_PublisherAPI(_Base, unittest.TestCase):
 
     @staticmethod
@@ -418,7 +418,7 @@ class Test_PublisherAPI(_Base, unittest.TestCase):
         self.assertIs(options.page_token, INITIAL_PAGE)
 
 
-@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_SubscriberAPI(_Base, unittest.TestCase):
 
     PUSH_ENDPOINT = 'https://api.example.com/push'
@@ -925,7 +925,7 @@ class Test_SubscriberAPI(_Base, unittest.TestCase):
         self.assertIsNone(options)
 
 
-@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_make_gax_publisher_api(_Base, unittest.TestCase):
 
     def _call_fut(self, *args, **kwargs):
@@ -1005,7 +1005,7 @@ class Test_make_gax_publisher_api(_Base, unittest.TestCase):
         self.assertEqual(insecure_args, [host])
 
 
-@unittest.skipUnless(_HAVE_GAX, 'No gax-python')
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_make_gax_subscriber_api(_Base, unittest.TestCase):
 
     def _call_fut(self, *args, **kwargs):

--- a/pubsub/tests/unit/test_client.py
+++ b/pubsub/tests/unit/test_client.py
@@ -46,7 +46,7 @@ class TestClient(unittest.TestCase):
 
         client = self._make_one(
             project=self.PROJECT, credentials=creds,
-            use_gax=False)
+            _use_grpc=False)
 
         conn = client._connection = _Connection()
         api = client.publisher_api
@@ -61,12 +61,12 @@ class TestClient(unittest.TestCase):
         from google.cloud.pubsub._http import _PublisherAPI
 
         creds = _make_credentials()
-        with mock.patch('google.cloud.pubsub.client._USE_GAX',
+        with mock.patch('google.cloud.pubsub.client._USE_GRPC',
                         new=True):
             client = self._make_one(project=self.PROJECT, credentials=creds,
-                                    use_gax=False)
+                                    _use_grpc=False)
 
-        self.assertFalse(client._use_gax)
+        self.assertFalse(client._use_grpc)
         api = client.publisher_api
         self.assertIsInstance(api, _PublisherAPI)
 
@@ -89,7 +89,7 @@ class TestClient(unittest.TestCase):
         creds = _make_credentials()
         client = self._make_one(
             project=self.PROJECT, credentials=creds,
-            use_gax=True)
+            _use_grpc=True)
         client._connection.in_emulator = emulator
 
         patch = mock.patch.multiple(
@@ -123,7 +123,7 @@ class TestClient(unittest.TestCase):
         creds = _make_credentials()
         client = self._make_one(
             project=self.PROJECT, credentials=creds,
-            use_gax=False)
+            _use_grpc=False)
 
         conn = client._connection = _Connection()
         api = client.subscriber_api
@@ -153,7 +153,7 @@ class TestClient(unittest.TestCase):
         creds = _make_credentials()
         client = self._make_one(
             project=self.PROJECT, credentials=creds,
-            use_gax=True)
+            _use_grpc=True)
         client._connection.in_emulator = emulator
 
         patch = mock.patch.multiple(
@@ -261,7 +261,7 @@ class TestClient(unittest.TestCase):
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                                use_gax=False)
+                                _use_grpc=False)
         returned = {'subscriptions': [SUB_INFO]}
         client._connection = _Connection(returned)
 
@@ -299,7 +299,7 @@ class TestClient(unittest.TestCase):
         SUB_INFO = {'name': self.SUB_PATH, 'topic': self.TOPIC_PATH}
         creds = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=creds,
-                                use_gax=False)
+                                _use_grpc=False)
 
         # Set up the mock response.
         ACK_DEADLINE = 42

--- a/pubsub/tests/unit/test_topic.py
+++ b/pubsub/tests/unit/test_topic.py
@@ -324,7 +324,7 @@ class TestTopic(unittest.TestCase):
         from google.cloud.pubsub.subscription import Subscription
 
         client = Client(project=self.PROJECT,
-                        credentials=_make_credentials(), use_gax=False)
+                        credentials=_make_credentials(), _use_grpc=False)
 
         SUB_NAME_1 = 'subscription_1'
         SUB_PATH_1 = 'projects/%s/subscriptions/%s' % (
@@ -374,7 +374,7 @@ class TestTopic(unittest.TestCase):
         from google.cloud.pubsub.subscription import Subscription
 
         client = Client(project=self.PROJECT,
-                        credentials=_make_credentials(), use_gax=False)
+                        credentials=_make_credentials(), _use_grpc=False)
 
         SUB_NAME_1 = 'subscription_1'
         SUB_PATH_1 = 'projects/%s/subscriptions/%s' % (
@@ -424,7 +424,7 @@ class TestTopic(unittest.TestCase):
         from google.cloud.pubsub.client import Client
 
         client = Client(project=self.PROJECT,
-                        credentials=_make_credentials(), use_gax=False)
+                        credentials=_make_credentials(), _use_grpc=False)
         client._connection = _Connection({})
         topic = self._make_one(self.TOPIC_NAME, client=client)
 

--- a/resource_manager/google/cloud/resource_manager/client.py
+++ b/resource_manager/google/cloud/resource_manager/client.py
@@ -36,24 +36,24 @@ class Client(BaseClient):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
     """The scopes required for authenticating as a Resouce Manager consumer."""
 
-    def __init__(self, credentials=None, http=None):
+    def __init__(self, credentials=None, _http=None):
         super(Client, self).__init__(
-            credentials=credentials, http=http)
+            credentials=credentials, _http=_http)
         self._connection = Connection(self)
 
     def new_project(self, project_id, name=None, labels=None):

--- a/resource_manager/google/cloud/resource_manager/client.py
+++ b/resource_manager/google/cloud/resource_manager/client.py
@@ -46,6 +46,8 @@ class Client(BaseClient):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)

--- a/resource_manager/tests/unit/test_client.py
+++ b/resource_manager/tests/unit/test_client.py
@@ -39,7 +39,7 @@ class TestClient(unittest.TestCase):
 
         http = object()
         credentials = _make_credentials()
-        client = self._make_one(credentials=credentials, http=http)
+        client = self._make_one(credentials=credentials, _http=http)
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._credentials, credentials)
         self.assertIs(client._http_internal, http)

--- a/runtimeconfig/google/cloud/runtimeconfig/client.py
+++ b/runtimeconfig/google/cloud/runtimeconfig/client.py
@@ -41,6 +41,8 @@ class Client(ClientWithProject):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloudruntimeconfig',)

--- a/runtimeconfig/google/cloud/runtimeconfig/client.py
+++ b/runtimeconfig/google/cloud/runtimeconfig/client.py
@@ -31,24 +31,24 @@ class Client(ClientWithProject):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloudruntimeconfig',)
     """The scopes required for authenticating as a RuntimeConfig consumer."""
 
-    def __init__(self, project=None, credentials=None, http=None):
+    def __init__(self, project=None, credentials=None, _http=None):
         super(Client, self).__init__(
-            project=project, credentials=credentials, http=http)
+            project=project, credentials=credentials, _http=_http)
         self._connection = Connection(self)
 
     def config(self, config_name):

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -32,16 +32,16 @@ class Client(BaseClient):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
 
     :type use_gax: bool
     :param use_gax: (Optional) Explicitly specifies whether
@@ -55,8 +55,8 @@ class Client(BaseClient):
 
     _speech_api = None
 
-    def __init__(self, credentials=None, http=None, use_gax=None):
-        super(Client, self).__init__(credentials=credentials, http=http)
+    def __init__(self, credentials=None, _http=None, use_gax=None):
+        super(Client, self).__init__(credentials=credentials, _http=_http)
         # Save on the actual client class whether we use GAX or not.
         if use_gax is None:
             self._use_gax = _USE_GAX

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -24,7 +24,7 @@ from google.cloud.speech._http import HTTPSpeechAPI
 from google.cloud.speech.sample import Sample
 
 
-_USE_GAX = not os.getenv(DISABLE_GRPC, False)
+_USE_GRPC = not os.getenv(DISABLE_GRPC, False)
 
 
 class Client(BaseClient):
@@ -43,11 +43,11 @@ class Client(BaseClient):
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
 
-    :type use_gax: bool
-    :param use_gax: (Optional) Explicitly specifies whether
-                    to use the gRPC transport (via GAX) or HTTP. If unset,
-                    falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
-                    variable
+    :type _use_grpc: bool
+    :param _use_grpc: (Optional) Explicitly specifies whether
+                      to use the gRPC transport (via GAX) or HTTP. If unset,
+                      falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
+                      environment variable.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
@@ -55,13 +55,13 @@ class Client(BaseClient):
 
     _speech_api = None
 
-    def __init__(self, credentials=None, _http=None, use_gax=None):
+    def __init__(self, credentials=None, _http=None, _use_grpc=None):
         super(Client, self).__init__(credentials=credentials, _http=_http)
         # Save on the actual client class whether we use GAX or not.
-        if use_gax is None:
-            self._use_gax = _USE_GAX
+        if _use_grpc is None:
+            self._use_grpc = _USE_GRPC
         else:
-            self._use_gax = use_gax
+            self._use_grpc = _use_grpc
 
     def sample(self, content=None, source_uri=None, stream=None, encoding=None,
                sample_rate=None):
@@ -104,7 +104,7 @@ class Client(BaseClient):
     def speech_api(self):
         """Helper for speech-related API calls."""
         if self._speech_api is None:
-            if self._use_gax:
+            if self._use_grpc:
                 self._speech_api = GAPICSpeechAPI(self)
             else:
                 self._speech_api = HTTPSpeechAPI(self)

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -42,12 +42,16 @@ class Client(BaseClient):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
 
     :type _use_grpc: bool
     :param _use_grpc: (Optional) Explicitly specifies whether
                       to use the gRPC transport (via GAX) or HTTP. If unset,
                       falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
                       environment variable.
+                      This parameter should be considered private, and could
+                      change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)

--- a/speech/google/cloud/speech/sample.py
+++ b/speech/google/cloud/speech/sample.py
@@ -247,7 +247,7 @@ class Sample(object):
 
         :raises: EnvironmentError if gRPC is not available.
         """
-        if not self._client._use_gax:
+        if not self._client._use_grpc:
             raise EnvironmentError('gRPC is required to use this API.')
 
         api = self._client.speech_api

--- a/speech/tests/system.py
+++ b/speech/tests/system.py
@@ -58,12 +58,12 @@ class Config(object):
     """
     CLIENT = None
     TEST_BUCKET = None
-    USE_GAX = True
+    USE_GRPC = True
 
 
 def setUpModule():
     Config.CLIENT = speech.Client()
-    Config.USE_GAX = Config.CLIENT._use_gax
+    Config.USE_GRPC = Config.CLIENT._use_grpc
     # Now create a bucket for GCS stored content.
     storage_client = storage.Client()
     bucket_name = 'new' + unique_resource_id()
@@ -195,7 +195,7 @@ class TestSpeechClient(unittest.TestCase):
         self._check_results(alternatives, 2)
 
     def test_stream_recognize(self):
-        if not Config.USE_GAX:
+        if not Config.USE_GRPC:
             self.skipTest('gRPC is required for Speech Streaming Recognize.')
 
         with open(AUDIO_FILE, 'rb') as file_obj:
@@ -203,7 +203,7 @@ class TestSpeechClient(unittest.TestCase):
                 self._check_results(results.alternatives)
 
     def test_stream_recognize_interim_results(self):
-        if not Config.USE_GAX:
+        if not Config.USE_GRPC:
             self.skipTest('gRPC is required for Speech Streaming Recognize.')
 
         # These extra words are interim_results that the API returns as it's
@@ -223,7 +223,7 @@ class TestSpeechClient(unittest.TestCase):
             self._check_results(responses[-1].alternatives)
 
     def test_stream_recognize_single_utterance(self):
-        if not Config.USE_GAX:
+        if not Config.USE_GRPC:
             self.skipTest('gRPC is required for Speech Streaming Recognize.')
 
         with open(AUDIO_FILE, 'rb') as file_obj:

--- a/speech/tests/unit/test_client.py
+++ b/speech/tests/unit/test_client.py
@@ -91,11 +91,11 @@ class TestClient(unittest.TestCase):
         self.assertTrue(client._credentials is creds)
         self.assertTrue(client._http is http)
 
-    def test_ctor_use_gax_preset(self):
+    def test_ctor_use_grpc_preset(self):
         creds = _make_credentials()
         http = object()
-        client = self._make_one(credentials=creds, _http=http, use_gax=True)
-        self.assertTrue(client._use_gax)
+        client = self._make_one(credentials=creds, _http=http, _use_grpc=True)
+        self.assertTrue(client._use_grpc)
 
     def test_create_sample_from_client(self):
         from google.cloud import speech
@@ -148,7 +148,7 @@ class TestClient(unittest.TestCase):
             }
         }
         credentials = _make_credentials()
-        client = self._make_one(credentials=credentials, use_gax=False)
+        client = self._make_one(credentials=credentials, _use_grpc=False)
         speech_api = client.speech_api
         connection = _Connection(SYNC_RECOGNIZE_RESPONSE)
         speech_api._connection = connection
@@ -196,7 +196,7 @@ class TestClient(unittest.TestCase):
             },
         }
         credentials = _make_credentials()
-        client = self._make_one(credentials=credentials, use_gax=False)
+        client = self._make_one(credentials=credentials, _use_grpc=False)
         speech_api = client.speech_api
         connection = _Connection(SYNC_RECOGNIZE_RESPONSE)
         speech_api._connection = connection
@@ -233,7 +233,7 @@ class TestClient(unittest.TestCase):
         from tests.unit._fixtures import SYNC_RECOGNIZE_EMPTY_RESPONSE
 
         credentials = _make_credentials()
-        client = self._make_one(credentials=credentials, use_gax=False)
+        client = self._make_one(credentials=credentials, _use_grpc=False)
         speech_api = client.speech_api
         speech_api._connection = _Connection(SYNC_RECOGNIZE_EMPTY_RESPONSE)
 
@@ -251,7 +251,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech import _gax
 
         credentials = _make_credentials()
-        client = self._make_one(credentials=credentials, use_gax=True)
+        client = self._make_one(credentials=credentials, _use_grpc=True)
         client._credentials = credentials
 
         channel_args = []
@@ -293,7 +293,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech import _gax
 
         creds = _make_credentials()
-        client = self._make_one(credentials=creds, use_gax=True)
+        client = self._make_one(credentials=creds, _use_grpc=True)
         client._credentials = creds
 
         alternatives = [{
@@ -354,7 +354,7 @@ class TestClient(unittest.TestCase):
         from google.cloud import speech
 
         credentials = _make_credentials()
-        client = self._make_one(credentials=credentials, use_gax=True)
+        client = self._make_one(credentials=credentials, _use_grpc=True)
 
         sample = client.sample(
             source_uri=self.AUDIO_SOURCE_URI, encoding=speech.Encoding.FLAC,
@@ -370,7 +370,7 @@ class TestClient(unittest.TestCase):
         RETURNED = ASYNC_RECOGNIZE_RESPONSE
 
         credentials = _make_credentials()
-        client = self._make_one(credentials=credentials, use_gax=False)
+        client = self._make_one(credentials=credentials, _use_grpc=False)
         speech_api = client.speech_api
         speech_api._connection = _Connection(RETURNED)
 
@@ -393,7 +393,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech.operation import Operation
 
         credentials = _make_credentials()
-        client = self._make_one(credentials=credentials, use_gax=True)
+        client = self._make_one(credentials=credentials, _use_grpc=True)
         client._credentials = credentials
 
         channel_args = []
@@ -433,7 +433,7 @@ class TestClient(unittest.TestCase):
         from google.cloud import speech
 
         credentials = _make_credentials()
-        client = self._make_one(credentials=credentials, use_gax=False)
+        client = self._make_one(credentials=credentials, _use_grpc=False)
         sample = client.sample(
             content=self.AUDIO_CONTENT, encoding=speech.Encoding.LINEAR16,
             sample_rate=self.SAMPLE_RATE)
@@ -673,7 +673,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech import _gax
 
         creds = _make_credentials()
-        client = self._make_one(credentials=creds, use_gax=True)
+        client = self._make_one(credentials=creds, _use_grpc=True)
         client._credentials = creds
 
         channel_args = []
@@ -705,7 +705,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.speech._http import HTTPSpeechAPI
 
         creds = _make_credentials()
-        client = self._make_one(credentials=creds, use_gax=False)
+        client = self._make_one(credentials=creds, _use_grpc=False)
         self.assertIsNone(client._speech_api)
         self.assertIsInstance(client.speech_api, HTTPSpeechAPI)
         self.assertIsInstance(client.speech_api._connection, Connection)

--- a/speech/tests/unit/test_client.py
+++ b/speech/tests/unit/test_client.py
@@ -87,14 +87,14 @@ class TestClient(unittest.TestCase):
     def test_ctor(self):
         creds = _make_credentials()
         http = object()
-        client = self._make_one(credentials=creds, http=http)
+        client = self._make_one(credentials=creds, _http=http)
         self.assertTrue(client._credentials is creds)
         self.assertTrue(client._http is http)
 
     def test_ctor_use_gax_preset(self):
         creds = _make_credentials()
         http = object()
-        client = self._make_one(credentials=creds, http=http, use_gax=True)
+        client = self._make_one(credentials=creds, _http=http, use_gax=True)
         self.assertTrue(client._use_gax)
 
     def test_create_sample_from_client(self):

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -44,6 +44,8 @@ class Client(ClientWithProject):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/devstorage.full_control',

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -34,16 +34,16 @@ class Client(ClientWithProject):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/devstorage.full_control',
@@ -51,10 +51,10 @@ class Client(ClientWithProject):
              'https://www.googleapis.com/auth/devstorage.read_write')
     """The scopes required for authenticating as a Cloud Storage consumer."""
 
-    def __init__(self, project=None, credentials=None, http=None):
+    def __init__(self, project=None, credentials=None, _http=None):
         self._base_connection = None
         super(Client, self).__init__(project=project, credentials=credentials,
-                                     http=http)
+                                     _http=_http)
         self._connection = Connection(self)
         self._batch_stack = _LocalStack()
 

--- a/translate/google/cloud/translate/client.py
+++ b/translate/google/cloud/translate/client.py
@@ -43,25 +43,25 @@ class Client(BaseClient):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
     """The scopes required for authenticating."""
 
     def __init__(self, target_language=ENGLISH_ISO_639,
-                 credentials=None, http=None):
+                 credentials=None, _http=None):
         self.target_language = target_language
-        super(Client, self).__init__(credentials=credentials, http=http)
+        super(Client, self).__init__(credentials=credentials, _http=_http)
         self._connection = Connection(self)
 
     def get_languages(self, target_language=None):

--- a/translate/google/cloud/translate/client.py
+++ b/translate/google/cloud/translate/client.py
@@ -53,6 +53,8 @@ class Client(BaseClient):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)

--- a/translate/tests/unit/test_client.py
+++ b/translate/tests/unit/test_client.py
@@ -31,7 +31,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.translate.client import ENGLISH_ISO_639
 
         http = object()
-        client = self._make_one(http=http)
+        client = self._make_one(_http=http)
         self.assertIsInstance(client._connection, Connection)
         self.assertIsNone(client._connection.credentials)
         self.assertIs(client._connection.http, http)
@@ -42,7 +42,7 @@ class TestClient(unittest.TestCase):
 
         http = object()
         target = 'es'
-        client = self._make_one(target_language=target, http=http)
+        client = self._make_one(target_language=target, _http=http)
         self.assertIsInstance(client._connection, Connection)
         self.assertIsNone(client._connection.credentials)
         self.assertIs(client._connection.http, http)
@@ -51,7 +51,7 @@ class TestClient(unittest.TestCase):
     def test_get_languages(self):
         from google.cloud.translate.client import ENGLISH_ISO_639
 
-        client = self._make_one(http=object())
+        client = self._make_one(_http=object())
         supported = [
             {'language': 'en', 'name': 'English'},
             {'language': 'af', 'name': 'Afrikaans'},
@@ -77,7 +77,7 @@ class TestClient(unittest.TestCase):
 
     def test_get_languages_no_target(self):
         client = self._make_one(
-            target_language=None, http=object())
+            target_language=None, _http=object())
         supported = [
             {'language': 'en'},
             {'language': 'af'},
@@ -102,7 +102,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], {})
 
     def test_get_languages_explicit_target(self):
-        client = self._make_one(http=object())
+        client = self._make_one(_http=object())
         target_language = 'en'
         supported = [
             {'language': 'en', 'name': 'Spanish'},
@@ -128,7 +128,7 @@ class TestClient(unittest.TestCase):
                          {'target': target_language})
 
     def test_detect_language_bad_result(self):
-        client = self._make_one(http=object())
+        client = self._make_one(_http=object())
         value = 'takoy'
         conn = client._connection = _Connection({})
 
@@ -146,7 +146,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_detect_language_single_value(self):
-        client = self._make_one(http=object())
+        client = self._make_one(_http=object())
         value = 'takoy'
         detection = {
             'confidence': 1.0,
@@ -175,7 +175,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_detect_language_multiple_values(self):
-        client = self._make_one(http=object())
+        client = self._make_one(_http=object())
         value1 = u'fa\xe7ade'  # facade (with a cedilla)
         detection1 = {
             'confidence': 0.6166008,
@@ -215,7 +215,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_detect_language_multiple_results(self):
-        client = self._make_one(http=object())
+        client = self._make_one(_http=object())
         value = 'soy'
         detection1 = {
             'confidence': 0.81496066,
@@ -240,7 +240,7 @@ class TestClient(unittest.TestCase):
             client.detect_language(value)
 
     def test_translate_bad_result(self):
-        client = self._make_one(http=object())
+        client = self._make_one(_http=object())
         value = 'hvala ti'
         conn = client._connection = _Connection({})
 
@@ -259,7 +259,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_translate_defaults(self):
-        client = self._make_one(http=object())
+        client = self._make_one(_http=object())
         value = 'hvala ti'
         translation = {
             'detectedSourceLanguage': 'hr',
@@ -288,7 +288,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_translate_multiple(self):
-        client = self._make_one(http=object())
+        client = self._make_one(_http=object())
         value1 = 'hvala ti'
         translation1 = {
             'detectedSourceLanguage': 'hr',
@@ -324,7 +324,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], query_params)
 
     def test_translate_explicit(self):
-        client = self._make_one(http=object())
+        client = self._make_one(_http=object())
         value = 'thank you'
         target_language = 'eo'
         source_language = 'en'

--- a/vision/google/cloud/vision/client.py
+++ b/vision/google/cloud/vision/client.py
@@ -48,12 +48,16 @@ class Client(ClientWithProject):
                   :meth:`~httplib2.Http.request`. If not passed, an
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
+                  This parameter should be considered private, and could
+                  change in the future.
 
     :type _use_grpc: bool
     :param _use_grpc: (Optional) Explicitly specifies whether
                       to use the gRPC transport (via GAX) or HTTP. If unset,
                       falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
                       environment variable.
+                      This parameter should be considered private, and could
+                      change in the future.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)

--- a/vision/google/cloud/vision/client.py
+++ b/vision/google/cloud/vision/client.py
@@ -25,7 +25,7 @@ from google.cloud.vision.batch import Batch
 from google.cloud.vision.image import Image
 
 
-_USE_GAX = not os.getenv(DISABLE_GRPC, False)
+_USE_GRPC = not os.getenv(DISABLE_GRPC, False)
 
 
 class Client(ClientWithProject):
@@ -49,11 +49,11 @@ class Client(ClientWithProject):
                   ``_http`` object is created that is bound to the
                   ``credentials`` for the current object.
 
-    :type use_gax: bool
-    :param use_gax: (Optional) Explicitly specifies whether
-                    to use the gRPC transport (via GAX) or HTTP. If unset,
-                    falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC`` environment
-                    variable
+    :type _use_grpc: bool
+    :param _use_grpc: (Optional) Explicitly specifies whether
+                      to use the gRPC transport (via GAX) or HTTP. If unset,
+                      falls back to the ``GOOGLE_CLOUD_DISABLE_GRPC``
+                      environment variable.
     """
 
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
@@ -62,13 +62,13 @@ class Client(ClientWithProject):
     _vision_api_internal = None
 
     def __init__(self, project=None, credentials=None, _http=None,
-                 use_gax=None):
+                 _use_grpc=None):
         super(Client, self).__init__(
             project=project, credentials=credentials, _http=_http)
-        if use_gax is None:
-            self._use_gax = _USE_GAX
+        if _use_grpc is None:
+            self._use_grpc = _USE_GRPC
         else:
-            self._use_gax = use_gax
+            self._use_grpc = _use_grpc
 
     def batch(self):
         """Batch multiple images into a single API request.
@@ -106,7 +106,7 @@ class Client(ClientWithProject):
                   make requests.
         """
         if self._vision_api_internal is None:
-            if self._use_gax:
+            if self._use_grpc:
                 self._vision_api_internal = _GAPICVisionAPI(self)
             else:
                 self._vision_api_internal = _HTTPVisionAPI(self)

--- a/vision/google/cloud/vision/client.py
+++ b/vision/google/cloud/vision/client.py
@@ -38,16 +38,16 @@ class Client(ClientWithProject):
 
     :type credentials: :class:`~google.auth.credentials.Credentials`
     :param credentials: (Optional) The OAuth2 Credentials to use for this
-                        client. If not passed (and if no ``http`` object is
+                        client. If not passed (and if no ``_http`` object is
                         passed), falls back to the default inferred from the
                         environment.
 
-    :type http: :class:`~httplib2.Http`
-    :param http: (Optional) HTTP object to make requests. Can be any object
-                 that defines ``request()`` with the same interface as
-                 :meth:`~httplib2.Http.request`. If not passed, an
-                 ``http`` object is created that is bound to the
-                 ``credentials`` for the current object.
+    :type _http: :class:`~httplib2.Http`
+    :param _http: (Optional) HTTP object to make requests. Can be any object
+                  that defines ``request()`` with the same interface as
+                  :meth:`~httplib2.Http.request`. If not passed, an
+                  ``_http`` object is created that is bound to the
+                  ``credentials`` for the current object.
 
     :type use_gax: bool
     :param use_gax: (Optional) Explicitly specifies whether
@@ -61,10 +61,10 @@ class Client(ClientWithProject):
 
     _vision_api_internal = None
 
-    def __init__(self, project=None, credentials=None, http=None,
+    def __init__(self, project=None, credentials=None, _http=None,
                  use_gax=None):
         super(Client, self).__init__(
-            project=project, credentials=credentials, http=http)
+            project=project, credentials=credentials, _http=_http)
         if use_gax is None:
             self._use_gax = _USE_GAX
         else:

--- a/vision/tests/system.py
+++ b/vision/tests/system.py
@@ -78,7 +78,7 @@ class BaseVisionTestCase(unittest.TestCase):
         self.assertIn(likelihood, levels)
 
     def _pb_not_implemented_skip(self, message):
-        if Config.CLIENT._use_gax:
+        if Config.CLIENT._use_grpc:
             self.skipTest(message)
 
 

--- a/vision/tests/unit/test_client.py
+++ b/vision/tests/unit/test_client.py
@@ -63,7 +63,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=None)
+            project=PROJECT, credentials=credentials, _use_grpc=None)
         vision_api = client._vision_api
         vision_api._connection = _Connection()
         with mock.patch('google.cloud.vision.client._GAPICVisionAPI',
@@ -75,7 +75,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         self.assertIsInstance(client._vision_api, _HTTPVisionAPI)
 
     def test_face_annotation(self):
@@ -101,7 +101,7 @@ class TestClient(unittest.TestCase):
         }
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(returned)
         vision_api._connection = connection
@@ -133,7 +133,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         raw_image = client.image(content=IMAGE_CONTENT)
         self.assertIsInstance(raw_image, Image)
         self.assertEqual(raw_image.content, IMAGE_CONTENT)
@@ -145,7 +145,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         with patch('google.cloud.vision.image.open',
                    mock_open(read_data=IMAGE_CONTENT)) as m:
             file_image = client.image(filename='my_image.jpg')
@@ -166,7 +166,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=credentials,
-                                use_gax=False)
+                                _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(returned)
         vision_api._connection = connection
@@ -218,7 +218,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         api = client._vision_api
         api._connection = _Connection(CROP_HINTS_RESPONSE)
         image = client.image(source_uri=IMAGE_SOURCE)
@@ -241,7 +241,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(FACE_DETECTION_RESPONSE)
         vision_api._connection = connection
@@ -263,7 +263,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(FACE_DETECTION_RESPONSE)
         vision_api._connection = connection
@@ -284,7 +284,7 @@ class TestClient(unittest.TestCase):
         }
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(returned)
         vision_api._connection = connection
@@ -305,7 +305,7 @@ class TestClient(unittest.TestCase):
         returned = FULL_TEXT_RESPONSE
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         api = client._vision_api
         api._connection = _Connection(returned)
         image = client.image(source_uri=IMAGE_SOURCE)
@@ -339,7 +339,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(LABEL_DETECTION_RESPONSE)
         vision_api._connection = connection
@@ -364,7 +364,7 @@ class TestClient(unittest.TestCase):
         }
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         vision_api._connection = _Connection(returned)
 
@@ -379,7 +379,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=credentials,
-                                use_gax=False)
+                                _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(LANDMARK_DETECTION_RESPONSE)
         vision_api._connection = connection
@@ -405,7 +405,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(LANDMARK_DETECTION_RESPONSE)
         vision_api._connection = connection
@@ -425,7 +425,7 @@ class TestClient(unittest.TestCase):
         }
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         vision_api._connection = _Connection(returned)
 
@@ -440,7 +440,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(LOGO_DETECTION_RESPONSE)
         vision_api._connection = connection
@@ -461,7 +461,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(LOGO_DETECTION_RESPONSE)
         vision_api._connection = connection
@@ -481,7 +481,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(TEXT_DETECTION_RESPONSE)
         vision_api._connection = connection
@@ -507,7 +507,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(SAFE_SEARCH_DETECTION_RESPONSE)
         vision_api._connection = connection
@@ -530,7 +530,7 @@ class TestClient(unittest.TestCase):
         }
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         vision_api._connection = _Connection(returned)
 
@@ -545,7 +545,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         connection = _Connection(IMAGE_PROPERTIES_RESPONSE)
         vision_api._connection = connection
@@ -570,7 +570,7 @@ class TestClient(unittest.TestCase):
         }
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         vision_api = client._vision_api
         vision_api._connection = _Connection(returned)
 
@@ -587,7 +587,7 @@ class TestClient(unittest.TestCase):
 
         credentials = _make_credentials()
         client = self._make_one(
-            project=PROJECT, credentials=credentials, use_gax=False)
+            project=PROJECT, credentials=credentials, _use_grpc=False)
         api = client._vision_api
         api._connection = _Connection(WEB_DETECTION_RESPONSE)
         image = client.image(source_uri=IMAGE_SOURCE)


### PR DESCRIPTION
Will also shortly be sending a commit to this PR which renames `use_gax` and `_use_grpc`.

`grep`-ing for `http` and `http=` was pretty ad-hoc, so I'm not sure if there are lingering things needing to be changed (e.g. docs which refer to `http` instead of `_http`)

Note in the commit about `use_gax` the following commands were used:

```
$ git grep -l use_gax | xargs sed -i s/use_gax/_use_grpc/g
$ git grep -l __use_grpc | xargs sed -i s/__use_grpc/_use_grpc/g
$ git grep -l USE_GAX | xargs sed -i s/USE_GAX/USE_GRPC/g
$ git grep -l HAVE_GAX | xargs sed -i s/HAVE_GAX/HAVE_GRPC/g
$ git grep -l DISABLE_GAX | xargs sed -i s/DISABLE_GAX/DISABLE_GRPC/g
```