### PR TITLE
Fixing usage of http= vs. _http= in core unit test.

### DIFF
--- a/core/tests/unit/test_client.py
+++ b/core/tests/unit/test_client.py
@@ -53,7 +53,7 @@ class TestClient(unittest.TestCase):
         CREDENTIALS = _make_credentials()
         HTTP = object()
 
-        client_obj = self._make_one(credentials=CREDENTIALS, http=HTTP)
+        client_obj = self._make_one(credentials=CREDENTIALS, _http=HTTP)
         with self.assertRaises(pickle.PicklingError):
             pickle.dumps(client_obj)
 


### PR DESCRIPTION
Issue caused by two unrelated PRs merging in close proximity: #3235 and #3230.