### PR TITLE
Make logging system tests verbose.

### DIFF
--- a/logging/nox.py
+++ b/logging/nox.py
@@ -59,7 +59,7 @@ def system_tests(session, python_version):
     session.install('.')
 
     # Run py.test against the system tests.
-    session.run('py.test', '--quiet', 'tests/system.py')
+    session.run('py.test', '-vvv', 'tests/system.py')
 
 
 @nox.session


### PR DESCRIPTION
@dhermes This is a more permanent change we can make for the logging system tests while we are watching them over the next few days.