### PR TITLE
Adding CircleCI 1.0 config into our 2.0 config to support tag builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,3 +140,15 @@ jobs:
           name: Push to PyPI (if this is a release tag).
           command: test_utils/scripts/circleci/twine_upload.sh
     working_directory: /var/code/gcp/
+
+deployment:
+  tag_build_for_cci2:
+    # 1.0 style config for tag builds workaround
+    # For context, see:
+    # - https://discuss.circleci.com/t/build-on-tag/9864/30
+    # - https://discuss.circleci.com/t/git-tag-deploys-in-2-0/9493/8
+    # - https://circleci.com/gh/keybits/circulate/58#config/containers/0
+    # See "test_utils/scripts/circleci/get_tagged_package.py" for info on REGEX
+    tag: /(([a-z]+)-)*([0-9]+)\.([0-9]+)\.([0-9]+)/
+    commands:
+      - true


### PR DESCRIPTION
For context see:

- https://discuss.circleci.com/t/build-on-tag/9864/30
- https://discuss.circleci.com/t/git-tag-deploys-in-2-0/9493/8
- https://circleci.com/gh/keybits/circulate/58#config/containers/0