### PR TITLE
Fixing "repo-relative" directory in `get_tagged_package`.

### DIFF
--- a/test_utils/scripts/circleci/get_tagged_package.py
+++ b/test_utils/scripts/circleci/get_tagged_package.py
@@ -33,8 +33,9 @@ TAG_RE = re.compile(r"""
 TAG_ENV = 'CIRCLE_TAG'
 ERROR_MSG = '%s env. var. not set' % (TAG_ENV,)
 BAD_TAG_MSG = 'Invalid tag name: %s. Expected pkg-name-x.y.z'
-_SCRIPTS_DIR = os.path.dirname(__file__)
-ROOT_DIR = os.path.abspath(os.path.join(_SCRIPTS_DIR, '..'))
+CIRCLE_CI_SCRIPTS_DIR = os.path.dirname(__file__)
+ROOT_DIR = os.path.realpath(
+    os.path.join(CIRCLE_CI_SCRIPTS_DIR, '..', '..', '..'))
 
 
 def main():


### PR DESCRIPTION
See carnage:

- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1502
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1503
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1504
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1505
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1506
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1507
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1508
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1509
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1510
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1511
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1512
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1513
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1514
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1515
- https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1516