### PR TITLE
Add twine and setuptools install as step before twine upload.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,12 @@ jobs:
           name: Update the docs
           command: nox -e docs
       - deploy:
+          name: Setup to Push to PyPI
+          command: |
+            if [[ -n "$CIRCLE_TAG" ]]; then
+              pip install --upgrade setuptools twine
+            fi
+      - deploy:
           name: Push to PyPI (if this is a release tag).
           command: test_utils/scripts/circleci/twine_upload.sh
     working_directory: /var/code/gcp/


### PR DESCRIPTION
This is a "temporary" fix, these dependencies should be in the docker image?