### PR TITLE
Speech v1

### DIFF
--- a/docs/speech-usage.rst
+++ b/docs/speech-usage.rst
@@ -34,10 +34,10 @@ create an instance of :class:`~google.cloud.speech.client.Client`.
 Asynchronous Recognition
 ------------------------
 
-The :meth:`~google.cloud.speech.Client.async_recognize` sends audio data to the
-Speech API and initiates a Long Running Operation. Using this operation, you
-can periodically poll for recognition results. Use asynchronous requests for
-audio data of any duration up to 80 minutes.
+The :meth:`~google.cloud.speech.Client.long_running_recognize` sends audio
+data to the Speech API and initiates a Long Running Operation. Using this
+operation, you can periodically poll for recognition results. Use asynchronous
+requests for audio data of any duration up to 80 minutes.
 
 .. note::
 
@@ -54,8 +54,11 @@ See: `Speech Asynchronous Recognize`_
     >>> client = speech.Client()
     >>> sample = client.sample(source_uri='gs://my-bucket/recording.flac',
     ...                        encoding=speech.Encoding.LINEAR16,
-    ...                        sample_rate=44100)
-    >>> operation = sample.async_recognize(max_alternatives=2)
+    ...                        sample_rate_hertz=44100)
+    >>> operation = sample.long_running_recognize(
+    ...     language_code='en-US',
+    ...     max_alternatives=2,
+    ... )
     >>> retry_count = 100
     >>> while retry_count > 0 and not operation.complete:
     ...     retry_count -= 1
@@ -76,7 +79,7 @@ See: `Speech Asynchronous Recognize`_
 Synchronous Recognition
 -----------------------
 
-The :meth:`~google.cloud.speech.Client.sync_recognize` method converts speech
+The :meth:`~google.cloud.speech.Client.recognize` method converts speech
 data to text and returns alternative text transcriptions.
 
 This example uses ``language_code='en-GB'`` to better recognize a dialect from
@@ -88,8 +91,8 @@ Great Britain.
     >>> client = speech.Client()
     >>> sample = client.sample(source_uri='gs://my-bucket/recording.flac',
     ...                        encoding=speech.Encoding.FLAC,
-    ...                        sample_rate=44100)
-    >>> results = sample.sync_recognize(
+    ...                        sample_rate_hertz=44100)
+    >>> results = sample.recognize(
     ...     language_code='en-GB', max_alternatives=2)
     >>> for result in results:
     ...     for alternative in result.alternatives:
@@ -111,9 +114,12 @@ Example of using the profanity filter.
     >>> client = speech.Client()
     >>> sample = client.sample(source_uri='gs://my-bucket/recording.flac',
     ...                        encoding=speech.Encoding.FLAC,
-    ...                        sample_rate=44100)
-    >>> results = sample.sync_recognize(max_alternatives=1,
-    ...                                 profanity_filter=True)
+    ...                        sample_rate_hertz=44100)
+    >>> results = sample.recognize(
+    ...     language_code='en-US',
+    ...     max_alternatives=1,
+    ...     profanity_filter=True,
+    ... )
     >>> for result in results:
     ...     for alternative in result.alternatives:
     ...         print('=' * 20)
@@ -133,10 +139,13 @@ words to the vocabulary of the recognizer.
     >>> client = speech.Client()
     >>> sample = client.sample(source_uri='gs://my-bucket/recording.flac',
     ...                        encoding=speech.Encoding.FLAC,
-    ...                        sample_rate=44100)
+    ...                        sample_rate_hertz=44100)
     >>> hints = ['hi', 'good afternoon']
-    >>> results = sample.sync_recognize(max_alternatives=2,
-    ...                                 speech_context=hints)
+    >>> results = sample.recognize(
+    ...     language_code='en-US',
+    ...     max_alternatives=2,
+    ...     speech_context=hints,
+    ... )
     >>> for result in results:
     ...     for alternative in result.alternatives:
     ...         print('=' * 20)
@@ -165,8 +174,8 @@ speech data to possible text alternatives on the fly.
     >>> with open('./hello.wav', 'rb') as stream:
     ...     sample = client.sample(stream=stream,
     ...                            encoding=speech.Encoding.LINEAR16,
-    ...                            sample_rate=16000)
-    ...     results = sample.streaming_recognize()
+    ...                            sample_rate_hertz=16000)
+    ...     results = sample.streaming_recognize(language_code='en-US')
     ...     for result in results:
     ...         for alternative in result.alternatives:
     ...             print('=' * 20)
@@ -192,8 +201,11 @@ See: `Single Utterance`_
     >>> with open('./hello_pause_goodbye.wav', 'rb') as stream:
     ...     sample = client.sample(stream=stream,
     ...                            encoding=speech.Encoding.LINEAR16,
-    ...                            sample_rate=16000)
-    ...     results = sample.streaming_recognize(single_utterance=True)
+    ...                            sample_rate_hertz=16000)
+    ...     results = sample.streaming_recognize(
+    ...         language_code='en-US',
+    ...         single_utterance=True,
+    ...     )
     ...     for result in results:
     ...         for alternative in result.alternatives:
     ...             print('=' * 20)
@@ -214,7 +226,10 @@ If ``interim_results`` is set to :data:`True`, interim results
     ...     sample = client.sample(stream=stream,
     ...                            encoding=speech.Encoding.LINEAR16,
     ...                            sample_rate=16000)
-    ...     results = sample.streaming_recognize(interim_results=True):
+    ...     results = sample.streaming_recognize(
+    ...         interim_results=True,
+    ...         language_code='en-US',
+    ...     )
     ...     for result in results:
     ...         for alternative in result.alternatives:
     ...             print('=' * 20)

--- a/speech/google/cloud/speech/_gax.py
+++ b/speech/google/cloud/speech/_gax.py
@@ -15,15 +15,15 @@
 """GAX/GAPIC module for managing Speech API requests."""
 
 
-from google.cloud.gapic.speech.v1beta1.speech_client import SpeechClient
-from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import RecognitionAudio
-from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+from google.cloud.gapic.speech.v1.speech_client import SpeechClient
+from google.cloud.proto.speech.v1.cloud_speech_pb2 import RecognitionAudio
+from google.cloud.proto.speech.v1.cloud_speech_pb2 import (
     RecognitionConfig)
-from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+from google.cloud.proto.speech.v1.cloud_speech_pb2 import (
     SpeechContext)
-from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+from google.cloud.proto.speech.v1.cloud_speech_pb2 import (
     StreamingRecognitionConfig)
-from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+from google.cloud.proto.speech.v1.cloud_speech_pb2 import (
     StreamingRecognizeRequest)
 from google.longrunning import operations_grpc
 
@@ -62,13 +62,13 @@ class GAPICSpeechAPI(object):
             OPERATIONS_API_HOST,
         )
 
-    def async_recognize(self, sample, language_code=None,
+    def async_recognize(self, sample, language_code,
                         max_alternatives=None, profanity_filter=None,
                         speech_context=None):
         """Asychronous Recognize request to Google Speech API.
 
         .. _async_recognize: https://cloud.google.com/speech/reference/\
-                             rest/v1beta1/speech/asyncrecognize
+                             rest/v1/speech/asyncrecognize
 
         See `async_recognize`_.
 
@@ -76,9 +76,8 @@ class GAPICSpeechAPI(object):
         :param sample: Instance of ``Sample`` containing audio information.
 
         :type language_code: str
-        :param language_code: (Optional) The language of the supplied audio as
-                              BCP-47 language tag. Example: ``'en-GB'``.
-                              If omitted, defaults to ``'en-US'``.
+        :param language_code: The language of the supplied audio as
+                              BCP-47 language tag. Example: ``'en-US'``.
 
         :type max_alternatives: int
         :param max_alternatives: (Optional) Maximum number of recognition
@@ -118,7 +117,7 @@ class GAPICSpeechAPI(object):
 
         return Operation.from_pb(operation_future.last_operation_data(), self)
 
-    def streaming_recognize(self, sample, language_code=None,
+    def streaming_recognize(self, sample, language_code,
                             max_alternatives=None, profanity_filter=None,
                             speech_context=None, single_utterance=False,
                             interim_results=False):
@@ -136,9 +135,8 @@ class GAPICSpeechAPI(object):
         :param sample: Instance of ``Sample`` containing audio information.
 
         :type language_code: str
-        :param language_code: (Optional) The language of the supplied audio as
-                              BCP-47 language tag. Example: ``'en-GB'``.
-                              If omitted, defaults to ``'en-US'``.
+        :param language_code: The language of the supplied audio as
+                              BCP-47 language tag. Example: ``'en-US'``.
 
         :type max_alternatives: int
         :param max_alternatives: (Optional) Maximum number of recognition
@@ -190,7 +188,7 @@ class GAPICSpeechAPI(object):
         :raises: :class:`ValueError` if sample.content is not a file-like
                  object. :class:`ValueError` if stream has closed.
 
-        :rtype: :class:`~google.cloud.grpc.speech.v1beta1\
+        :rtype: :class:`~google.cloud.grpc.speech.v1\
                        .cloud_speech_pb2.StreamingRecognizeResponse`
         :returns: ``StreamingRecognizeResponse`` instances.
         """
@@ -207,12 +205,12 @@ class GAPICSpeechAPI(object):
         responses = api.streaming_recognize(requests)
         return responses
 
-    def sync_recognize(self, sample, language_code=None, max_alternatives=None,
+    def sync_recognize(self, sample, language_code, max_alternatives=None,
                        profanity_filter=None, speech_context=None):
         """Synchronous Speech Recognition.
 
         .. _sync_recognize: https://cloud.google.com/speech/reference/\
-                            rest/v1beta1/speech/syncrecognize
+                            rest/v1/speech/syncrecognize
 
         See `sync_recognize`_.
 
@@ -220,9 +218,8 @@ class GAPICSpeechAPI(object):
         :param sample: Instance of ``Sample`` containing audio information.
 
         :type language_code: str
-        :param language_code: (Optional) The language of the supplied audio as
-                              BCP-47 language tag. Example: ``'en-GB'``.
-                              If omitted, defaults to ``'en-US'``.
+        :param language_code: The language of the supplied audio as
+                              BCP-47 language tag. Example: ``'en-US'``.
 
         :type max_alternatives: int
         :param max_alternatives: (Optional) Maximum number of recognition
@@ -269,7 +266,7 @@ class GAPICSpeechAPI(object):
         return [Result.from_pb(result) for result in api_response.results]
 
 
-def _stream_requests(sample, language_code=None, max_alternatives=None,
+def _stream_requests(sample, language_code, max_alternatives=None,
                      profanity_filter=None, speech_context=None,
                      single_utterance=None, interim_results=None):
     """Generate stream of requests from sample.
@@ -278,9 +275,8 @@ def _stream_requests(sample, language_code=None, max_alternatives=None,
     :param sample: Instance of ``Sample`` containing audio information.
 
     :type language_code: str
-    :param language_code: (Optional) The language of the supplied audio as
-                          BCP-47 language tag. Example: ``'en-GB'``.
-                          If omitted, defaults to ``'en-US'``.
+    :param language_code: The language of the supplied audio as
+                          BCP-47 language tag. Example: ``'en-US'``.
 
     :type max_alternatives: int
     :param max_alternatives: (Optional) Maximum number of recognition
@@ -409,7 +405,7 @@ def _make_streaming_request(sample, language_code,
                             returned.
 
     :rtype:
-        :class:`~grpc.speech.v1beta1.cloud_speech_pb2.StreamingRecognizeRequest`
+        :class:`~grpc.speech.v1.cloud_speech_pb2.StreamingRecognizeRequest`
     :returns: Instance of ``StreamingRecognizeRequest``.
     """
     config = RecognitionConfig(

--- a/speech/google/cloud/speech/_http.py
+++ b/speech/google/cloud/speech/_http.py
@@ -59,15 +59,15 @@ class HTTPSpeechAPI(object):
         self._client = client
         self._connection = Connection(client)
 
-    def async_recognize(self, sample, language_code,
-                        max_alternatives=None, profanity_filter=None,
-                        speech_context=None):
-        """Asychronous Recognize request to Google Speech API.
+    def long_running_recognize(self, sample, language_code,
+                               max_alternatives=None, profanity_filter=None,
+                               speech_contexts=()):
+        """Long-running Recognize request to Google Speech API.
 
-        .. _async_recognize: https://cloud.google.com/speech/reference/\
-                             rest/v1/speech/asyncrecognize
+        .. _long_running_recognize: https://cloud.google.com/speech/reference/\
+                                    rest/v1/speech/longrunningrecognize
 
-        See `async_recognize`_.
+        See `long_running_recognize`_.
 
         :type sample: :class:`~google.cloud.speech.sample.Sample`
         :param sample: Instance of ``Sample`` containing audio information.
@@ -90,8 +90,8 @@ class HTTPSpeechAPI(object):
                                  asterisks, e.g. ``'f***'``. If False or
                                  omitted, profanities won't be filtered out.
 
-        :type speech_context: list
-        :param speech_context: A list of strings (max 50) containing words and
+        :type speech_contexts: list
+        :param speech_contexts: A list of strings (max 50) containing words and
                                phrases "hints" so that the speech recognition
                                is more likely to recognize them. This can be
                                used to improve the accuracy for specific words
@@ -102,22 +102,22 @@ class HTTPSpeechAPI(object):
         :returns: Operation for asynchronous request to Google Speech API.
         """
         data = _build_request_data(sample, language_code, max_alternatives,
-                                   profanity_filter, speech_context)
+                                   profanity_filter, speech_contexts)
         api_response = self._connection.api_request(
-            method='POST', path='speech:asyncrecognize', data=data)
+            method='POST', path='speech:longrunningrecognize', data=data)
 
         operation = Operation.from_dict(api_response, self._client)
         operation.caller_metadata['request_type'] = 'LongRunningRecognize'
         return operation
 
-    def sync_recognize(self, sample, language_code, max_alternatives=None,
-                       profanity_filter=None, speech_context=None):
+    def recognize(self, sample, language_code, max_alternatives=None,
+                  profanity_filter=None, speech_contexts=()):
         """Synchronous Speech Recognition.
 
-        .. _sync_recognize: https://cloud.google.com/speech/reference/\
-                            rest/v1/speech/syncrecognize
+        .. _recognize: https://cloud.google.com/speech/reference/\
+                       rest/v1/speech/recognize
 
-        See `sync_recognize`_.
+        See `recognize`_.
 
         :type sample: :class:`~google.cloud.speech.sample.Sample`
         :param sample: Instance of ``Sample`` containing audio information.
@@ -140,8 +140,8 @@ class HTTPSpeechAPI(object):
                                  asterisks, e.g. ``'f***'``. If False or
                                  omitted, profanities won't be filtered out.
 
-        :type speech_context: list
-        :param speech_context: A list of strings (max 50) containing words and
+        :type speech_contexts: list
+        :param speech_contexts: A list of strings (max 50) containing words and
                                phrases "hints" so that the speech recognition
                                is more likely to recognize them. This can be
                                used to improve the accuracy for specific words
@@ -160,9 +160,9 @@ class HTTPSpeechAPI(object):
         :raises: ValueError if more than one result is returned or no results.
         """
         data = _build_request_data(sample, language_code, max_alternatives,
-                                   profanity_filter, speech_context)
+                                   profanity_filter, speech_contexts)
         api_response = self._connection.api_request(
-            method='POST', path='speech:syncrecognize', data=data)
+            method='POST', path='speech:recognize', data=data)
 
         if len(api_response['results']) > 0:
             results = api_response['results']
@@ -172,7 +172,7 @@ class HTTPSpeechAPI(object):
 
 
 def _build_request_data(sample, language_code, max_alternatives=None,
-                        profanity_filter=None, speech_context=None):
+                        profanity_filter=None, speech_contexts=()):
     """Builds the request data before making API request.
 
     :type sample: :class:`~google.cloud.speech.sample.Sample`
@@ -196,8 +196,8 @@ def _build_request_data(sample, language_code, max_alternatives=None,
                              asterisks, e.g. ``'f***'``. If False or
                              omitted, profanities won't be filtered out.
 
-    :type speech_context: list
-    :param speech_context: A list of strings (max 50) containing words and
+    :type speech_contexts: list
+    :param speech_contexts: A list of strings (max 50) containing words and
                            phrases "hints" so that the speech recognition
                            is more likely to recognize them. This can be
                            used to improve the accuracy for specific words
@@ -216,15 +216,15 @@ def _build_request_data(sample, language_code, max_alternatives=None,
     config = {
         'encoding': sample.encoding,
         'languageCode': language_code,
-        'sampleRate': sample.sample_rate,
+        'sampleRateHertz': sample.sample_rate_hertz,
     }
 
     if max_alternatives is not None:
         config['maxAlternatives'] = max_alternatives
     if profanity_filter is not None:
         config['profanityFilter'] = profanity_filter
-    if speech_context is not None:
-        config['speechContext'] = {'phrases': speech_context}
+    if speech_contexts:
+        config['speechContext'] = {'phrases': speech_contexts}
 
     data = {
         'audio': audio,

--- a/speech/google/cloud/speech/alternative.py
+++ b/speech/google/cloud/speech/alternative.py
@@ -45,7 +45,7 @@ class Alternative(object):
         """Factory: construct ``Alternative`` from protobuf response.
 
         :type alternative:
-            :class:`google.cloud.speech.v1beta1.SpeechRecognitionAlternative`
+            :class:`google.cloud.speech.v1.SpeechRecognitionAlternative`
         :param alternative: Instance of ``SpeechRecognitionAlternative``
                            from protobuf.
 

--- a/speech/google/cloud/speech/client.py
+++ b/speech/google/cloud/speech/client.py
@@ -68,7 +68,7 @@ class Client(BaseClient):
             self._use_grpc = _use_grpc
 
     def sample(self, content=None, source_uri=None, stream=None, encoding=None,
-               sample_rate=None):
+               sample_rate_hertz=None):
         """Factory: construct Sample to use when making recognize requests.
 
         :type content: bytes
@@ -90,19 +90,21 @@ class Client(BaseClient):
                          :attr:`~.Encoding.FLAC`, :attr:`~.Encoding.MULAW`,
                          :attr:`~.Encoding.AMR`, :attr:`~.Encoding.AMR_WB`
 
-        :type sample_rate: int
-        :param sample_rate: Sample rate in Hertz of the audio data sent in all
-                            requests. Valid values are: 8000-48000. For best
-                            results, set the sampling rate of the audio source
-                            to 16000 Hz. If that's not possible, use the
-                            native sample rate of the audio source (instead of
-                            re-sampling).
+        :type sample_rate_hertz: int
+        :param sample_rate_hertz: Sample rate in Hertz of the audio data sent
+                                  in all requests. Valid values are:
+                                  8000-48000. For best results, set the
+                                  sampling rate of the audio source
+                                  to 16000 Hz. If that's not possible, use the
+                                  native sample rate of the audio source
+                                  (instead of re-sampling).
 
         :rtype: :class:`~google.cloud.speech.sample.Sample`
         :returns: Instance of ``Sample``.
         """
         return Sample(content=content, source_uri=source_uri, stream=stream,
-                      encoding=encoding, sample_rate=sample_rate, client=self)
+                      encoding=encoding, sample_rate_hertz=sample_rate_hertz,
+                      client=self)
 
     @property
     def speech_api(self):

--- a/speech/google/cloud/speech/encoding.py
+++ b/speech/google/cloud/speech/encoding.py
@@ -19,7 +19,7 @@ class Encoding(object):
     """Audio encoding types.
 
     See:
-    https://cloud.google.com/speech/reference/rest/v1beta1/RecognitionConfig#AudioEncoding
+    https://cloud.google.com/speech/reference/rest/v1/RecognitionConfig#AudioEncoding
     """
 
     LINEAR16 = 'LINEAR16'

--- a/speech/google/cloud/speech/operation.py
+++ b/speech/google/cloud/speech/operation.py
@@ -14,14 +14,14 @@
 
 """Long running operation representation for Google Speech API"""
 
-from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
+from google.cloud.proto.speech.v1 import cloud_speech_pb2
 
 from google.cloud import operation
 from google.cloud.speech.result import Result
 
 
-operation.register_type(cloud_speech_pb2.AsyncRecognizeMetadata)
-operation.register_type(cloud_speech_pb2.AsyncRecognizeResponse)
+operation.register_type(cloud_speech_pb2.LongRunningRecognizeMetadata)
+operation.register_type(cloud_speech_pb2.LongRunningRecognizeResponse)
 
 
 class Operation(operation.Operation):

--- a/speech/google/cloud/speech/result.py
+++ b/speech/google/cloud/speech/result.py
@@ -34,7 +34,7 @@ class Result(object):
     def from_pb(cls, result):
         """Factory: construct instance of ``Result``.
 
-        :type result: :class:`~google.cloud.proto.speech.v1beta1\
+        :type result: :class:`~google.cloud.proto.speech.v1\
                                .cloud_speech_pb2.SpeechRecognitionResult`
         :param result: Instance of ``SpeechRecognitionResult`` protobuf.
 
@@ -51,7 +51,7 @@ class Result(object):
 
         :type result: dict
         :param result: Dictionary of a :class:`~google.cloud.proto.speech.\
-            v1beta1.cloud_speech_pb2.SpeechRecognitionResult`
+            v1.cloud_speech_pb2.SpeechRecognitionResult`
 
         :rtype: :class:`~google.cloud.speech.result.Result`
         :returns: Instance of ``Result``.
@@ -101,7 +101,7 @@ class StreamingSpeechResult(object):
     def from_pb(cls, response):
         """Factory: construct instance of ``StreamingSpeechResult``.
 
-        :type response: :class:`~google.cloud.proto.speech.v1beta1\
+        :type response: :class:`~google.cloud.proto.speech.v1\
                                .cloud_speech_pb2.StreamingRecognizeResult`
         :param response: Instance of ``StreamingRecognizeResult`` protobuf.
 

--- a/speech/google/cloud/speech/sample.py
+++ b/speech/google/cloud/speech/sample.py
@@ -137,7 +137,7 @@ class Sample(object):
         """Asychronous Recognize request to Google Speech API.
 
         .. _async_recognize: https://cloud.google.com/speech/reference/\
-                             rest/v1beta1/speech/asyncrecognize
+                             rest/v1/speech/asyncrecognize
 
         See `async_recognize`_.
 
@@ -265,7 +265,7 @@ class Sample(object):
         """Synchronous Speech Recognition.
 
         .. _sync_recognize: https://cloud.google.com/speech/reference/\
-                            rest/v1beta1/speech/syncrecognize
+                            rest/v1/speech/syncrecognize
 
         See `sync_recognize`_.
 

--- a/speech/google/cloud/speech/sample.py
+++ b/speech/google/cloud/speech/sample.py
@@ -68,9 +68,9 @@ class Sample(object):
         self._stream = stream
 
         if (sample_rate_hertz is not None and
-                    not 8000 <= sample_rate_hertz <= 48000):
-            raise ValueError('The value of sample_rate must be between 8000 '
-                             'and 48000.')
+                not 8000 <= sample_rate_hertz <= 48000):
+            raise ValueError('The value of sample_rate_hertz must be between '
+                             '8000 and 48000.')
         self._sample_rate_hertz = sample_rate_hertz
 
         if encoding is not None and getattr(Encoding, encoding, False):
@@ -172,7 +172,7 @@ class Sample(object):
         """
         if self.encoding is not Encoding.LINEAR16:
             raise ValueError('Only LINEAR16 encoding is supported by '
-                             'asynchronous speech requests.')
+                             'long-running speech requests.')
         api = self._client.speech_api
         return api.long_running_recognize(
             self, language_code, max_alternatives, profanity_filter,

--- a/speech/setup.py
+++ b/speech/setup.py
@@ -50,14 +50,14 @@ SETUP_BASE = {
 }
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.25dev',
+    'google-cloud-core >= 0.24.0, < 0.26dev',
     'grpcio >= 1.0.2, < 2.0dev',
-    'gapic-google-cloud-speech-v1beta1 >= 0.15.2, < 0.16dev',
+    'gapic-google-cloud-speech-v1 >= 0.15.3, < 0.16dev',
 ]
 
 setup(
     name='google-cloud-speech',
-    version='0.24.0',
+    version='0.25.0',
     description='Python Client for Google Cloud Speech',
     long_description=README,
     namespace_packages=[

--- a/speech/setup.py
+++ b/speech/setup.py
@@ -50,14 +50,14 @@ SETUP_BASE = {
 }
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.26dev',
+    'google-cloud-core >= 0.24.0, < 0.25dev',
     'grpcio >= 1.0.2, < 2.0dev',
     'gapic-google-cloud-speech-v1 >= 0.15.3, < 0.16dev',
 ]
 
 setup(
     name='google-cloud-speech',
-    version='0.25.0',
+    version='0.24.0',
     description='Python Client for Google Cloud Speech',
     long_description=README,
     namespace_packages=[

--- a/speech/tests/system.py
+++ b/speech/tests/system.py
@@ -94,26 +94,34 @@ class TestSpeechClient(unittest.TestCase):
     def _make_sync_request(self, content=None, source_uri=None,
                            max_alternatives=None):
         client = Config.CLIENT
-        sample = client.sample(content=content,
-                               source_uri=source_uri,
-                               encoding=speech.Encoding.LINEAR16,
-                               sample_rate=16000)
-        return sample.sync_recognize(language_code='en-US',
-                                     max_alternatives=max_alternatives,
-                                     profanity_filter=True,
-                                     speech_context=['Google', 'cloud'])
+        sample = client.sample(
+            content=content,
+            encoding=speech.Encoding.LINEAR16,
+            sample_rate_hertz=16000,
+            source_uri=source_uri,
+        )
+        return sample.recognize(
+            language_code='en-US',
+            max_alternatives=max_alternatives,
+            profanity_filter=True,
+            speech_contexts=['Google', 'cloud'],
+        )
 
     def _make_async_request(self, content=None, source_uri=None,
                             max_alternatives=None):
         client = Config.CLIENT
-        sample = client.sample(content=content,
-                               source_uri=source_uri,
-                               encoding=speech.Encoding.LINEAR16,
-                               sample_rate=16000)
-        return sample.async_recognize(language_code='en-US',
-                                      max_alternatives=max_alternatives,
-                                      profanity_filter=True,
-                                      speech_context=['Google', 'cloud'])
+        sample = client.sample(
+            content=content,
+            encoding=speech.Encoding.LINEAR16,
+            sample_rate_hertz=16000,
+            source_uri=source_uri,
+        )
+        return sample.long_running_recognize(
+            language_code='en-US',
+            max_alternatives=max_alternatives,
+            profanity_filter=True,
+            speech_contexts=['Google', 'cloud'],
+        )
 
     def _make_streaming_request(self, file_obj, single_utterance=True,
                                 interim_results=False):
@@ -123,7 +131,7 @@ class TestSpeechClient(unittest.TestCase):
                                sample_rate=16000)
         return sample.streaming_recognize(single_utterance=single_utterance,
                                           interim_results=interim_results,
-                                          speech_context=['hello', 'google'])
+                                          speech_contexts=['hello', 'google'])
 
     def _check_results(self, alternatives, num_results=1):
         self.assertEqual(len(alternatives), num_results)

--- a/speech/tests/system.py
+++ b/speech/tests/system.py
@@ -128,10 +128,13 @@ class TestSpeechClient(unittest.TestCase):
         client = Config.CLIENT
         sample = client.sample(stream=file_obj,
                                encoding=speech.Encoding.LINEAR16,
-                               sample_rate=16000)
-        return sample.streaming_recognize(single_utterance=single_utterance,
-                                          interim_results=interim_results,
-                                          speech_contexts=['hello', 'google'])
+                               sample_rate_hertz=16000)
+        return sample.streaming_recognize(
+            interim_results=interim_results,
+            language_code='en-US',
+            single_utterance=single_utterance,
+            speech_contexts=['hello', 'google'],
+        )
 
     def _check_results(self, alternatives, num_results=1):
         self.assertEqual(len(alternatives), num_results)

--- a/speech/tests/system.py
+++ b/speech/tests/system.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import time
 import unittest
 
 from google.cloud import exceptions
@@ -46,6 +47,9 @@ def _wait_until_complete(operation, max_attempts=10):
     :rtype: bool
     :returns: Boolean indicating if the operation is complete.
     """
+    # This bizarre delay is necessary because the v1 API seems to return
+    # the v1beta1 type URL sometimes if you poll too soon.
+    time.sleep(3)
     retry = RetryResult(_operation_complete, max_tries=max_attempts)
     return retry(operation.poll)()
 
@@ -180,7 +184,6 @@ class TestSpeechClient(unittest.TestCase):
 
         operation = self._make_async_request(content=content,
                                              max_alternatives=2)
-
         _wait_until_complete(operation)
         self.assertEqual(len(operation.results), 1)
         alternatives = operation.results[0].alternatives

--- a/speech/tests/unit/_fixtures.py
+++ b/speech/tests/unit/_fixtures.py
@@ -37,7 +37,7 @@ OPERATION_COMPLETE_RESPONSE = {
     'name': '123456789',
     'metadata': {
         '@type': ('type.googleapis.com/'
-                  'google.cloud.speech.v1beta1.AsyncRecognizeMetadata'),
+                  'google.cloud.speech.v1.LongRunningRecognizeMetadata'),
         'progressPercent': 100,
         'startTime': '2016-09-22T17:52:25.536964Z',
         'lastUpdateTime': '2016-09-22T17:52:27.802902Z',
@@ -45,7 +45,7 @@ OPERATION_COMPLETE_RESPONSE = {
     'done': True,
     'response': {
         '@type': ('type.googleapis.com/'
-                  'google.cloud.speech.v1beta1.AsyncRecognizeResponse'),
+                  'google.cloud.speech.v1.LongRunningRecognizeResponse'),
         'results': [
             {
                 'alternatives': [
@@ -63,7 +63,7 @@ OPERATION_INCOMPLETE_RESPONSE = {
     'name': '123456789',
     'metadata': {
         '@type': ('type.googleapis.com/'
-                  'google.cloud.speech.v1beta1.AsyncRecognizeMetadata'),
+                  'google.cloud.speech.v1.LongRunningRecognizeMetadata'),
         'progressPercent': 27,
         'startTime': '2016-09-22T17:52:25.536964Z',
         'lastUpdateTime': '2016-09-22T17:52:27.802902Z',

--- a/speech/tests/unit/test__gax.py
+++ b/speech/tests/unit/test__gax.py
@@ -38,7 +38,7 @@ class TestGAPICSpeechAPI(unittest.TestCase):
         'google.cloud._helpers.make_secure_channel',
         return_value=mock.sentinel.channel)
     @mock.patch(
-        'google.cloud.gapic.speech.v1beta1.speech_client.SpeechClient',
+        'google.cloud.gapic.speech.v1.speech_client.SpeechClient',
         SERVICE_ADDRESS='hey.you.guys')
     @mock.patch(
         'google.cloud._helpers.make_secure_stub',
@@ -89,7 +89,7 @@ class TestSpeechGAXMakeRequests(unittest.TestCase):
     def test_ctor(self):
         from google.cloud import speech
         from google.cloud.speech.sample import Sample
-        from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+        from google.cloud.proto.speech.v1.cloud_speech_pb2 import (
             RecognitionConfig, SpeechContext, StreamingRecognitionConfig,
             StreamingRecognizeRequest)
 
@@ -148,7 +148,7 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
         from io import BytesIO
         from google.cloud import speech
         from google.cloud.speech.sample import Sample
-        from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
+        from google.cloud.proto.speech.v1.cloud_speech_pb2 import (
             StreamingRecognitionConfig, StreamingRecognizeRequest)
 
         sample = Sample(

--- a/speech/tests/unit/test__gax.py
+++ b/speech/tests/unit/test__gax.py
@@ -76,14 +76,14 @@ class TestSpeechGAXMakeRequests(unittest.TestCase):
     AUDIO_CONTENT = b'/9j/4QNURXhpZgAASUkq'
 
     def _call_fut(self, sample, language_code, max_alternatives,
-                  profanity_filter, speech_context, single_utterance,
+                  profanity_filter, speech_contexts, single_utterance,
                   interim_results):
         from google.cloud.speech._gax import _make_streaming_request
 
         return _make_streaming_request(
             sample=sample, language_code=language_code,
             max_alternatives=max_alternatives,
-            profanity_filter=profanity_filter, speech_context=speech_context,
+            profanity_filter=profanity_filter, speech_contexts=speech_contexts,
             single_utterance=single_utterance, interim_results=interim_results)
 
     def test_ctor(self):
@@ -95,17 +95,17 @@ class TestSpeechGAXMakeRequests(unittest.TestCase):
 
         sample = Sample(
             content=self.AUDIO_CONTENT, encoding=speech.Encoding.FLAC,
-            sample_rate=self.SAMPLE_RATE)
+            sample_rate_hertz=self.SAMPLE_RATE)
         language_code = 'US-en'
         max_alternatives = 2
         profanity_filter = True
-        speech_context = SpeechContext(phrases=self.HINTS)
+        speech_contexts = [SpeechContext(phrases=self.HINTS)]
         single_utterance = True
         interim_results = False
 
         streaming_request = self._call_fut(
             sample, language_code, max_alternatives, profanity_filter,
-            speech_context, single_utterance, interim_results)
+            speech_contexts, single_utterance, interim_results)
         self.assertIsInstance(streaming_request, StreamingRecognizeRequest)
 
         # This isn't set by _make_streaming_request().
@@ -121,11 +121,11 @@ class TestSpeechGAXMakeRequests(unittest.TestCase):
         config = streaming_config.config
         self.assertIsInstance(config, RecognitionConfig)
         self.assertEqual(config.encoding, 2)  # speech.Encoding.FLAC maps to 2.
-        self.assertEqual(config.sample_rate, self.SAMPLE_RATE)
+        self.assertEqual(config.sample_rate_hertz, self.SAMPLE_RATE)
         self.assertEqual(config.language_code, language_code)
         self.assertEqual(config.max_alternatives, max_alternatives)
         self.assertTrue(config.profanity_filter)
-        self.assertEqual(config.speech_context.phrases, self.HINTS)
+        self.assertEqual(config.speech_contexts[0].phrases, self.HINTS)
 
 
 class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
@@ -134,14 +134,14 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
     AUDIO_CONTENT = b'/9j/4QNURXhpZgAASUkq'
 
     def _call_fut(self, sample, language_code, max_alternatives,
-                  profanity_filter, speech_context, single_utterance,
+                  profanity_filter, speech_contexts, single_utterance,
                   interim_results):
         from google.cloud.speech._gax import _stream_requests
 
         return _stream_requests(
             sample=sample, language_code=language_code,
             max_alternatives=max_alternatives,
-            profanity_filter=profanity_filter, speech_context=speech_context,
+            profanity_filter=profanity_filter, speech_contexts=speech_contexts,
             single_utterance=single_utterance, interim_results=interim_results)
 
     def test_stream_requests(self):
@@ -153,16 +153,16 @@ class TestSpeechGAXMakeRequestsStream(unittest.TestCase):
 
         sample = Sample(
             stream=BytesIO(self.AUDIO_CONTENT), encoding=speech.Encoding.FLAC,
-            sample_rate=self.SAMPLE_RATE)
+            sample_rate_hertz=self.SAMPLE_RATE)
         language_code = 'US-en'
         max_alternatives = 2
         profanity_filter = True
-        speech_context = self.HINTS
+        speech_contexts = self.HINTS
         single_utterance = True
         interim_results = False
         streaming_requests = self._call_fut(
             sample, language_code, max_alternatives, profanity_filter,
-            speech_context, single_utterance, interim_results)
+            speech_contexts, single_utterance, interim_results)
         all_requests = []
         for streaming_request in streaming_requests:
             self.assertIsInstance(streaming_request, StreamingRecognizeRequest)

--- a/speech/tests/unit/test_alternative.py
+++ b/speech/tests/unit/test_alternative.py
@@ -54,7 +54,7 @@ class TestAlternative(unittest.TestCase):
         self.assertIsNone(alternative.confidence)
 
     def test_from_pb_with_no_confidence(self):
-        from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
+        from google.cloud.proto.speech.v1 import cloud_speech_pb2
 
         text = 'the double trouble'
         pb_value = cloud_speech_pb2.SpeechRecognitionAlternative(

--- a/speech/tests/unit/test_client.py
+++ b/speech/tests/unit/test_client.py
@@ -24,7 +24,7 @@ def _make_credentials():
 
 
 def _make_result(alternatives=()):
-    from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
+    from google.cloud.proto.speech.v1 import cloud_speech_pb2
 
     return cloud_speech_pb2.SpeechRecognitionResult(
         alternatives=[
@@ -37,7 +37,7 @@ def _make_result(alternatives=()):
 
 
 def _make_streaming_result(alternatives=(), is_final=True, stability=1.0):
-    from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
+    from google.cloud.proto.speech.v1 import cloud_speech_pb2
 
     return cloud_speech_pb2.StreamingRecognitionResult(
         alternatives=[
@@ -52,7 +52,7 @@ def _make_streaming_result(alternatives=(), is_final=True, stability=1.0):
 
 
 def _make_streaming_response(*results):
-    from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
+    from google.cloud.proto.speech.v1 import cloud_speech_pb2
 
     response = cloud_speech_pb2.StreamingRecognizeResponse(
         results=results,
@@ -61,9 +61,9 @@ def _make_streaming_response(*results):
 
 
 def _make_sync_response(*results):
-    from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
+    from google.cloud.proto.speech.v1 import cloud_speech_pb2
 
-    response = cloud_speech_pb2.SyncRecognizeResponse(
+    response = cloud_speech_pb2.RecognizeResponse(
         results=results,
     )
     return response
@@ -381,7 +381,7 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(operation, Operation)
         self.assertIs(operation.client, client)
         self.assertEqual(
-            operation.caller_metadata, {'request_type': 'AsyncRecognize'})
+            operation.caller_metadata, {'request_type': 'LongRunningRecognize'})
         self.assertFalse(operation.complete)
         self.assertIsNone(operation.metadata)
 
@@ -735,14 +735,14 @@ class _MockGAPICSpeechAPI(object):
         from google.gapic.longrunning.operations_client import OperationsClient
         from google.gax import _OperationFuture
         from google.longrunning.operations_pb2 import Operation
-        from google.cloud.proto.speech.v1beta1.cloud_speech_pb2 import (
-            AsyncRecognizeResponse)
+        from google.cloud.proto.speech.v1.cloud_speech_pb2 import (
+            LongRunningRecognizeResponse)
 
         self.config = config
         self.audio = audio
         operations_client = mock.Mock(spec=OperationsClient)
         operation_future = _OperationFuture(
-            Operation(), operations_client, AsyncRecognizeResponse, {})
+            Operation(), operations_client, LongRunningRecognizeResponse, {})
         return operation_future
 
     def sync_recognize(self, config, audio):

--- a/speech/tests/unit/test_operation.py
+++ b/speech/tests/unit/test_operation.py
@@ -44,7 +44,7 @@ class TestOperation(unittest.TestCase):
 
     @staticmethod
     def _make_result(transcript, confidence):
-        from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
+        from google.cloud.proto.speech.v1 import cloud_speech_pb2
 
         return cloud_speech_pb2.SpeechRecognitionResult(
             alternatives=[
@@ -56,13 +56,13 @@ class TestOperation(unittest.TestCase):
         )
 
     def _make_operation_pb(self, *results):
-        from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
+        from google.cloud.proto.speech.v1 import cloud_speech_pb2
         from google.longrunning import operations_pb2
         from google.protobuf.any_pb2 import Any
 
         any_pb = None
         if results:
-            result_pb = cloud_speech_pb2.AsyncRecognizeResponse(
+            result_pb = cloud_speech_pb2.LongRunningRecognizeResponse(
                 results=results,
             )
             type_url = 'type.googleapis.com/%s' % (
@@ -108,13 +108,13 @@ class TestOperation(unittest.TestCase):
             self.assertIsInstance(result.alternatives[0], Alternative)
 
     def test__update_state_with_empty_response(self):
-        from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
+        from google.cloud.proto.speech.v1 import cloud_speech_pb2
         from google.longrunning import operations_pb2
         from google.protobuf.any_pb2 import Any
 
         # Simulate an empty response (rather than no response yet, which
         # is distinct).
-        response = cloud_speech_pb2.AsyncRecognizeResponse(results=[])
+        response = cloud_speech_pb2.LongRunningRecognizeResponse(results=[])
         type_url = 'type.googleapis.com/%s' % response.DESCRIPTOR.full_name
         any_pb = Any(
             type_url=type_url,

--- a/speech/tests/unit/test_result.py
+++ b/speech/tests/unit/test_result.py
@@ -30,7 +30,7 @@ class TestResult(unittest.TestCase):
         self.assertIsInstance(result, self._get_target_class())
 
     def test_from_pb(self):
-        from google.cloud.proto.speech.v1beta1 import cloud_speech_pb2
+        from google.cloud.proto.speech.v1 import cloud_speech_pb2
 
         confidence = 0.625
         transcript = 'this is a test transcript'

--- a/speech/tests/unit/test_sample.py
+++ b/speech/tests/unit/test_sample.py
@@ -114,8 +114,19 @@ class TestSample(unittest.TestCase):
                 source_uri=self.AUDIO_SOURCE_URI,
             )
         sample = self._make_one(
+            encoding=Encoding.FLAC,
             sample_rate_hertz=self.SAMPLE_RATE,
             source_uri=self.AUDIO_SOURCE_URI,
-            encoding=Encoding.FLAC,
         )
         self.assertEqual(sample.encoding, Encoding.FLAC)
+
+    def test_async_linear16_only(self):
+        from google.cloud.speech.encoding import Encoding
+
+        sample = self._make_one(
+            encoding=Encoding.FLAC,
+            sample_rate_hertz=self.SAMPLE_RATE,
+            source_uri=self.AUDIO_SOURCE_URI,
+        )
+        with self.assertRaises(ValueError):
+            sample.long_running_recognize(language_code='en-US')

--- a/speech/tests/unit/test_sample.py
+++ b/speech/tests/unit/test_sample.py
@@ -33,10 +33,10 @@ class TestSample(unittest.TestCase):
 
         sample = self._make_one(
             source_uri=self.AUDIO_SOURCE_URI, encoding=Encoding.FLAC,
-            sample_rate=self.SAMPLE_RATE)
+            sample_rate_hertz=self.SAMPLE_RATE)
         self.assertEqual(sample.source_uri, self.AUDIO_SOURCE_URI)
         self.assertEqual(sample.encoding, Encoding.FLAC)
-        self.assertEqual(sample.sample_rate, self.SAMPLE_RATE)
+        self.assertEqual(sample.sample_rate_hertz, self.SAMPLE_RATE)
 
     def test_content_and_source_uri(self):
         from io import BytesIO
@@ -64,7 +64,7 @@ class TestSample(unittest.TestCase):
         stream = BytesIO(data)
         sample = self._make_one(
             stream=stream, encoding=Encoding.FLAC,
-            sample_rate=self.SAMPLE_RATE)
+            sample_rate_hertz=self.SAMPLE_RATE)
         self.assertEqual(sample.stream, stream)
         self.assertEqual(sample.stream.read(), data)
 
@@ -76,25 +76,27 @@ class TestSample(unittest.TestCase):
 
         sample = Sample(
             content=test_bytes, encoding=speech.Encoding.FLAC,
-            sample_rate=self.SAMPLE_RATE)
+            sample_rate_hertz=self.SAMPLE_RATE)
         self.assertEqual(sample.content, test_bytes)
         self.assertEqual(sample.encoding, speech.Encoding.FLAC)
-        self.assertEqual(sample.sample_rate, self.SAMPLE_RATE)
+        self.assertEqual(sample.sample_rate_hertz, self.SAMPLE_RATE)
 
     def test_sample_rates(self):
         from google.cloud.speech.encoding import Encoding
 
         with self.assertRaises(ValueError):
             self._make_one(
-                source_uri=self.AUDIO_SOURCE_URI, sample_rate=7999)
+                source_uri=self.AUDIO_SOURCE_URI, sample_rate_hertz=7999)
         with self.assertRaises(ValueError):
             self._make_one(
-                source_uri=self.AUDIO_SOURCE_URI, sample_rate=48001)
+                source_uri=self.AUDIO_SOURCE_URI, sample_rate_hertz=48001)
 
         sample = self._make_one(
-            source_uri=self.AUDIO_SOURCE_URI, sample_rate=self.SAMPLE_RATE,
-            encoding=Encoding.FLAC)
-        self.assertEqual(sample.sample_rate, self.SAMPLE_RATE)
+            encoding=Encoding.FLAC,
+            sample_rate_hertz=self.SAMPLE_RATE,
+            source_uri=self.AUDIO_SOURCE_URI,
+        )
+        self.assertEqual(sample.sample_rate_hertz, self.SAMPLE_RATE)
         self.assertEqual(sample.encoding, Encoding.FLAC)
 
     def test_encoding(self):
@@ -102,12 +104,18 @@ class TestSample(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self._make_one(
-                source_uri=self.AUDIO_SOURCE_URI, sample_rate=self.SAMPLE_RATE,
-                encoding='OGG')
+                encoding='OGG',
+                sample_rate_hertz=self.SAMPLE_RATE,
+                source_uri=self.AUDIO_SOURCE_URI,
+            )
         with self.assertRaises(ValueError):
             self._make_one(
-                source_uri=self.AUDIO_SOURCE_URI, sample_rate=self.SAMPLE_RATE)
+                sample_rate_hertz=self.SAMPLE_RATE,
+                source_uri=self.AUDIO_SOURCE_URI,
+            )
         sample = self._make_one(
-            source_uri=self.AUDIO_SOURCE_URI, sample_rate=self.SAMPLE_RATE,
-            encoding=Encoding.FLAC)
+            sample_rate_hertz=self.SAMPLE_RATE,
+            source_uri=self.AUDIO_SOURCE_URI,
+            encoding=Encoding.FLAC,
+        )
         self.assertEqual(sample.encoding, Encoding.FLAC)


### PR DESCRIPTION
This updates our manual client library to the Speech v1 API.

This entails several **backwards incompatible changes**:

  * The `language_code` parameter is no longer optional anywhere. It must be explicitly specified, and does _not_ default to `'en-US'`.
  * The `sync_recognize` method has been renamed to `recognize` on every class where it appears.
  * The `async_recognize` method has been renamed to `long_running_recognize` on every class where it appears.
  * The `sample_rate` parameter and property has been renamed to `sample_rate_hertz` everywhere it appears.

Additionally, the backend API contains a backwards incompatible change which does not require a code change in the client library, but will likely require one downstream: The `START_OF_SPEECH`, `END_OF_SPEECH`, and `END_OF_AUDIO` events have been removed.