### PR TITLE
Gracefully continue if LogEntry.proto_payload type URL is not in registry.

### DIFF
--- a/logging/google/cloud/logging/_http.py
+++ b/logging/google/cloud/logging/_http.py
@@ -286,6 +286,9 @@ class _SinksAPI(object):
         :type destination: str
         :param destination: destination URI for the entries exported by
                             the sink.
+
+        :rtype: dict
+        :returns: The returned (updated) resource.
         """
         target = '/projects/%s/sinks/%s' % (project, sink_name)
         data = {
@@ -421,6 +424,9 @@ class _MetricsAPI(object):
 
         :type description: str
         :param description: description of the metric.
+
+        :rtype: dict
+        :returns: The returned (updated) resource.
         """
         target = '/projects/%s/metrics/%s' % (project, metric_name)
         data = {

--- a/logging/google/cloud/logging/_http.py
+++ b/logging/google/cloud/logging/_http.py
@@ -293,7 +293,7 @@ class _SinksAPI(object):
             'filter': filter_,
             'destination': destination,
         }
-        self.api_request(method='PUT', path=target, data=data)
+        return self.api_request(method='PUT', path=target, data=data)
 
     def sink_delete(self, project, sink_name):
         """API call:  delete a sink resource.
@@ -428,7 +428,7 @@ class _MetricsAPI(object):
             'filter': filter_,
             'description': description,
         }
-        self.api_request(method='PUT', path=target, data=data)
+        return self.api_request(method='PUT', path=target, data=data)
 
     def metric_delete(self, project, metric_name):
         """API call:  delete a metric resource.

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -48,13 +48,11 @@ def logger_name_from_path(path):
 
 
 class _BaseEntry(object):
-    """Base class for TextEntry, StructEntry.
+    """Base class for TextEntry, StructEntry, ProtobufEntry.
 
     :type payload: text or dict
     :param payload: The payload passed as ``textPayload``, ``jsonPayload``,
-                    or ``protoPayload``. This also may be passed as a raw
-                    :class:`.any_pb2.Any` if the ``protoPayload`` could
-                    not be deserialized.
+                    or ``protoPayload``.
 
     :type logger: :class:`google.cloud.logging.logger.Logger`
     :param logger: the logger used to write the entry.
@@ -77,13 +75,7 @@ class _BaseEntry(object):
     """
     def __init__(self, payload, logger, insert_id=None, timestamp=None,
                  labels=None, severity=None, http_request=None):
-        if isinstance(payload, any_pb2.Any):
-            self.payload = None
-            self.payload_pb = payload
-        else:
-            self.payload = payload
-            self.payload_pb = None
-
+        self.payload = payload
         self.logger = logger
         self.insert_id = insert_id
         self.timestamp = timestamp
@@ -153,8 +145,44 @@ class ProtobufEntry(_BaseEntry):
 
     See:
     https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+
+    :type payload: text or dict
+    :param payload: The payload passed as ``textPayload``, ``jsonPayload``,
+                    or ``protoPayload``. This also may be passed as a raw
+                    :class:`.any_pb2.Any` if the ``protoPayload`` could
+                    not be deserialized.
+
+    :type logger: :class:`google.cloud.logging.logger.Logger`
+    :param logger: the logger used to write the entry.
+
+    :type insert_id: text
+    :param insert_id: (optional) the ID used to identify an entry uniquely.
+
+    :type timestamp: :class:`datetime.datetime`
+    :param timestamp: (optional) timestamp for the entry
+
+    :type labels: dict
+    :param labels: (optional) mapping of labels for the entry
+
+    :type severity: str
+    :param severity: (optional) severity of event being logged.
+
+    :type http_request: dict
+    :param http_request: (optional) info about HTTP request associated with
+                         the entry
     """
     _PAYLOAD_KEY = 'protoPayload'
+
+    def __init__(self, payload, logger, insert_id=None, timestamp=None,
+                 labels=None, severity=None, http_request=None):
+        super(ProtobufEntry, self).__init__(
+            payload, logger, insert_id=insert_id, timestamp=timestamp,
+            labels=labels, severity=severity, http_request=http_request)
+        if isinstance(self.payload, any_pb2.Any):
+            self.payload_pb = self.payload
+            self.payload = None
+        else:
+            self.payload_pb = None
 
     def parse_message(self, message):
         """Parse payload into a protobuf message.

--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -146,16 +146,16 @@ class ProtobufEntry(_BaseEntry):
     See:
     https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
 
-    :type payload: text or dict
+    :type payload: str, dict or any_pb2.Any
     :param payload: The payload passed as ``textPayload``, ``jsonPayload``,
                     or ``protoPayload``. This also may be passed as a raw
                     :class:`.any_pb2.Any` if the ``protoPayload`` could
                     not be deserialized.
 
-    :type logger: :class:`google.cloud.logging.logger.Logger`
+    :type logger: :class:`~google.cloud.logging.logger.Logger`
     :param logger: the logger used to write the entry.
 
-    :type insert_id: text
+    :type insert_id: str
     :param insert_id: (optional) the ID used to identify an entry uniquely.
 
     :type timestamp: :class:`datetime.datetime`

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -14,8 +14,6 @@
 
 """Define API Loggers."""
 
-import json
-
 from google.protobuf.json_format import MessageToDict
 from google.cloud._helpers import _datetime_to_rfc3339
 

--- a/logging/tests/unit/test__gax.py
+++ b/logging/tests/unit/test__gax.py
@@ -1101,6 +1101,172 @@ class Test_MetricsAPI(_Base, unittest.TestCase):
 
 
 @unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
+class Test__parse_log_entry(unittest.TestCase):
+
+    @staticmethod
+    def _call_fut(*args, **kwargs):
+        from google.cloud.logging._gax import _parse_log_entry
+
+        return _parse_log_entry(*args, **kwargs)
+
+    def test_simple(self):
+        from google.cloud.proto.logging.v2.log_entry_pb2 import LogEntry
+
+        entry_pb = LogEntry(log_name=u'lol-jk', text_payload=u'bah humbug')
+        result = self._call_fut(entry_pb)
+        expected = {
+            'logName': entry_pb.log_name,
+            'textPayload': entry_pb.text_payload,
+        }
+        self.assertEqual(result, expected)
+
+    @mock.patch('google.cloud.logging._gax.MessageToDict',
+                side_effect=TypeError)
+    def test_non_registry_failure(self, msg_to_dict_mock):
+        entry_pb = mock.Mock(spec=['HasField'])
+        entry_pb.HasField.return_value = False
+        with self.assertRaises(TypeError):
+            self._call_fut(entry_pb)
+
+        entry_pb.HasField.assert_called_once_with('proto_payload')
+        msg_to_dict_mock.assert_called_once_with(entry_pb)
+
+    def test_unregistered_type(self):
+        from google.cloud.proto.logging.v2.log_entry_pb2 import LogEntry
+        from google.protobuf import any_pb2
+        from google.protobuf import descriptor_pool
+        from google.protobuf.timestamp_pb2 import Timestamp
+
+        pool = descriptor_pool.Default()
+        type_name = 'google.bigtable.admin.v2.UpdateClusterMetadata'
+        # Make sure the descriptor is not known in the registry.
+        with self.assertRaises(KeyError):
+            pool.FindMessageTypeByName(type_name)
+
+        type_url = 'type.googleapis.com/' + type_name
+        metadata_bytes = (
+            b'\n\n\n\x03foo\x12\x03bar\x12\x06\x08\xbd\xb6\xfb\xc6\x05')
+        any_pb = any_pb2.Any(type_url=type_url, value=metadata_bytes)
+        timestamp = Timestamp(seconds=61, nanos=1234000)
+
+        entry_pb = LogEntry(proto_payload=any_pb, timestamp=timestamp)
+        result = self._call_fut(entry_pb)
+        expected = {
+            'protoPayload': any_pb,
+            'timestamp': '1970-01-01T00:01:01.001234Z',
+        }
+        self.assertEqual(result, expected)
+
+    def test_registered_type(self):
+        from google.cloud.proto.logging.v2.log_entry_pb2 import LogEntry
+        from google.protobuf import any_pb2
+        from google.protobuf import descriptor_pool
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
+        pool = descriptor_pool.Default()
+        type_name = 'google.protobuf.Struct'
+        # Make sure the descriptor is known in the registry.
+        descriptor = pool.FindMessageTypeByName(type_name)
+        self.assertEqual(descriptor.name, 'Struct')
+
+        type_url = 'type.googleapis.com/' + type_name
+        field_name = 'foo'
+        field_value = u'Bar'
+        struct_pb = Struct(
+            fields={field_name: Value(string_value=field_value)})
+        any_pb = any_pb2.Any(
+            type_url=type_url,
+            value=struct_pb.SerializeToString(),
+        )
+
+        entry_pb = LogEntry(proto_payload=any_pb, log_name=u'all-good')
+        result = self._call_fut(entry_pb)
+        expected_proto = {
+            'logName': entry_pb.log_name,
+            'protoPayload': {
+                '@type': type_url,
+                'value': {field_name: field_value},
+            },
+        }
+        self.assertEqual(result, expected_proto)
+
+
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
+class Test__log_entry_mapping_to_pb(unittest.TestCase):
+
+    @staticmethod
+    def _call_fut(*args, **kwargs):
+        from google.cloud.logging._gax import _log_entry_mapping_to_pb
+
+        return _log_entry_mapping_to_pb(*args, **kwargs)
+
+    def test_simple(self):
+        from google.cloud.proto.logging.v2.log_entry_pb2 import LogEntry
+
+        result = self._call_fut({})
+        self.assertEqual(result, LogEntry())
+
+    def test_unregistered_type(self):
+        from google.protobuf import descriptor_pool
+        from google.protobuf.json_format import ParseError
+
+        pool = descriptor_pool.Default()
+        type_name = 'google.bigtable.admin.v2.UpdateClusterMetadata'
+        # Make sure the descriptor is not known in the registry.
+        with self.assertRaises(KeyError):
+            pool.FindMessageTypeByName(type_name)
+
+        type_url = 'type.googleapis.com/' + type_name
+        json_mapping = {
+            'protoPayload': {
+                '@type': type_url,
+                'originalRequest': {
+                    'name': 'foo',
+                    'location': 'bar',
+                },
+                'requestTime': {
+                    'seconds': 1491000125,
+                }
+            }
+        }
+        with self.assertRaises(ParseError):
+            self._call_fut(json_mapping)
+
+    def test_registered_type(self):
+        from google.cloud.proto.logging.v2.log_entry_pb2 import LogEntry
+        from google.protobuf import any_pb2
+        from google.protobuf import descriptor_pool
+
+        pool = descriptor_pool.Default()
+        type_name = 'google.protobuf.Struct'
+        # Make sure the descriptor is known in the registry.
+        descriptor = pool.FindMessageTypeByName(type_name)
+        self.assertEqual(descriptor.name, 'Struct')
+
+        type_url = 'type.googleapis.com/' + type_name
+        field_name = 'foo'
+        field_value = u'Bar'
+        json_mapping = {
+            'logName': u'hi-everybody',
+            'protoPayload': {
+                '@type': type_url,
+                'value': {field_name: field_value},
+            },
+        }
+        # Convert to a valid LogEntry.
+        result = self._call_fut(json_mapping)
+        entry_pb = LogEntry(
+            log_name=json_mapping['logName'],
+            proto_payload=any_pb2.Any(
+                type_url=type_url,
+                value=b'\n\014\n\003foo\022\005\032\003Bar',
+            ),
+        )
+        self.assertEqual(result, entry_pb)
+
+
+@unittest.skipUnless(_HAVE_GRPC, 'No gax-python')
 class Test_make_gax_logging_api(unittest.TestCase):
 
     def _call_fut(self, client):

--- a/logging/tests/unit/test__gax.py
+++ b/logging/tests/unit/test__gax.py
@@ -1227,8 +1227,8 @@ class Test__log_entry_mapping_to_pb(unittest.TestCase):
                 },
                 'requestTime': {
                     'seconds': 1491000125,
-                }
-            }
+                },
+            },
         }
         with self.assertRaises(ParseError):
             self._call_fut(json_mapping)

--- a/logging/tests/unit/test_entries.py
+++ b/logging/tests/unit/test_entries.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class Test_logger_name_from_path(unittest.TestCase):
 
@@ -206,6 +208,32 @@ class TestProtobufEntry(unittest.TestCase):
 
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
+
+    def test_constructor_basic(self):
+        payload = {'foo': 'bar'}
+        pb_entry = self._make_one(payload, mock.sentinel.logger)
+        self.assertEqual(pb_entry.payload, payload)
+        self.assertIsNone(pb_entry.payload_pb)
+        self.assertIs(pb_entry.logger, mock.sentinel.logger)
+        self.assertIsNone(pb_entry.insert_id)
+        self.assertIsNone(pb_entry.timestamp)
+        self.assertIsNone(pb_entry.labels)
+        self.assertIsNone(pb_entry.severity)
+        self.assertIsNone(pb_entry.http_request)
+
+    def test_constructor_with_any(self):
+        from google.protobuf.any_pb2 import Any
+
+        payload = Any()
+        pb_entry = self._make_one(payload, mock.sentinel.logger)
+        self.assertIs(pb_entry.payload_pb, payload)
+        self.assertIsNone(pb_entry.payload)
+        self.assertIs(pb_entry.logger, mock.sentinel.logger)
+        self.assertIsNone(pb_entry.insert_id)
+        self.assertIsNone(pb_entry.timestamp)
+        self.assertIsNone(pb_entry.labels)
+        self.assertIsNone(pb_entry.severity)
+        self.assertIsNone(pb_entry.http_request)
 
     def test_parse_message(self):
         import json


### PR DESCRIPTION
Fixes #2674.

@lukesneeringer @tseaver I am unfortunately "out of time" until Wednesday so if either of you want to take this over the finish line (e.g. unit tests and maybe a system test with an unregistered type URL?) I would not protest.