### PR TITLE
Fix missing BYTES merger

### DIFF
--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -253,6 +253,7 @@ _MERGE_BY_TYPE = {
     type_pb2.STRING: _merge_string,
     type_pb2.ARRAY: _merge_array,
     type_pb2.STRUCT: _merge_struct,
+    type_pb2.BYTES: _merge_string,
 }
 
 

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -185,6 +185,21 @@ class TestStreamedResultSet(unittest.TestCase):
         self.assertEqual(merged.string_value, u'phredwylma')
         self.assertIsNone(streamed._pending_chunk)
 
+    def test__merge_chunk_string_w_bytes(self):
+        iterator = _MockCancellableIterator()
+        streamed = self._make_one(iterator)
+        FIELDS = [
+            self._makeScalarField('image', 'BYTES'),
+        ]
+        streamed._metadata = _ResultSetMetadataPB(FIELDS)
+        streamed._pending_chunk = self._makeValue(u'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\n')
+        chunk = self._makeValue(u'B3RJTUUH4QQGFwsBTL3HMwAAABJpVFh0Q29tbWVudAAAAAAAU0FNUExFMG3E+AAAAApJREFUCNdj\nYAAAAAIAAeIhvDMAAAAASUVORK5CYII=\n')
+
+        merged = streamed._merge_chunk(chunk)
+
+        self.assertEqual(merged.string_value, u'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\nB3RJTUUH4QQGFwsBTL3HMwAAABJpVFh0Q29tbWVudAAAAAAAU0FNUExFMG3E+AAAAApJREFUCNdj\nYAAAAAIAAeIhvDMAAAAASUVORK5CYII=\n')
+        self.assertIsNone(streamed._pending_chunk)     
+
     def test__merge_chunk_array_of_bool(self):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)


### PR DESCRIPTION
Client needs to know which merger to use when merging column type BYTES that is consumed in chunks as part of a read. Without this fix, client gives a traceback:
```
.../venv/lib/python2.7/site-packages/google/cloud/spanner/streamed.py", line 262, in _merge_by_type
    merger = _MERGE_BY_TYPE[type_.code]
KeyError: 7
```
Type 7 is BYTES from the [proto](https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/type.proto) definition 
The error condition will arise if you write an image (a few MB in size) as base64 encoded in a bytes column. When trying to read the column back using the client, the above traceback will be given. With this fix, the client will use the string merger (treating bytes as a string) and allow the row to be consumed. The test is to read the entire column (with this fix) and write the bytes back to a file (base64 decoded).