### PR TITLE
Language: Expose an api_version parameter on the Client.

### DIFF
--- a/language/google/cloud/language/_http.py
+++ b/language/google/cloud/language/_http.py
@@ -41,3 +41,14 @@ class Connection(_http.JSONConnection):
     _EXTRA_HEADERS = {
         _http.CLIENT_INFO_HEADER: _CLIENT_INFO,
     }
+
+
+class V1Beta2Connection(Connection):
+    """A connection to Google Cloud Natural Language JSON 1.1 REST API.
+
+    :type client: :class:`~google.cloud.language.client.Client`
+    :param client: The client that owns the current connection.
+    """
+
+    API_VERSION = 'v1beta2'
+    """The version of the API, used in building the API call's URL."""

--- a/language/google/cloud/language/client.py
+++ b/language/google/cloud/language/client.py
@@ -20,6 +20,7 @@ import warnings
 from google.cloud import client as client_module
 
 from google.cloud.language._http import Connection
+from google.cloud.language._http import V1Beta2Connection
 from google.cloud.language.document import Document
 
 
@@ -45,10 +46,16 @@ class Client(client_module.Client):
     SCOPE = ('https://www.googleapis.com/auth/cloud-platform',)
     """The scopes required for authenticating as an API consumer."""
 
-    def __init__(self, credentials=None, _http=None):
+    _CONNECTION_CLASSES = {
+        'v1': Connection,
+        'v1beta2': V1Beta2Connection,
+    }
+
+    def __init__(self, credentials=None, api_version='v1', _http=None):
         super(Client, self).__init__(
             credentials=credentials, _http=_http)
-        self._connection = Connection(self)
+        ConnectionClass = self._CONNECTION_CLASSES[api_version]
+        self._connection = ConnectionClass(self)
 
     def document_from_text(self, content, **kwargs):
         """Create a plain text document bound to this client.

--- a/language/google/cloud/language/document.py
+++ b/language/google/cloud/language/document.py
@@ -188,6 +188,32 @@ class Document(object):
             method='POST', path='analyzeEntities', data=data)
         return api_responses.EntityResponse.from_api_repr(api_response)
 
+    def analyze_entity_sentiment(self):
+        """Analyze the entity sentiment.
+
+        Finds entities, similar to `AnalyzeEntities` in the text and
+        analyzes sentiment associated with each entity and its mentions.
+
+        :rtype: :class:`~language.entity.EntitySentimentResponse`
+        :returns: A representation of the entity sentiment response.
+        """
+        # Sanity check: Not available on v1.
+        if self.client._connection.API_VERSION == 'v1':
+            raise NotImplementedError(
+                'The `analyze_entity_sentiment` method is only available '
+                'on the Natural Language 1.1 beta. Use version="v1beta2" '
+                'as a keyword argument to the constructor.',
+            )
+
+        # Perform the API request.
+        data = {
+            'document': self._to_dict(),
+            'encodingType': self.encoding,
+        }
+        api_response = self.client._connection.api_request(
+            method='POST', path='analyzeEntitySentiment', data=data)
+        return api_responses.EntityResponse.from_api_repr(api_response)
+
     def analyze_sentiment(self):
         """Analyze the sentiment in the current document.
 

--- a/language/google/cloud/language/entity.py
+++ b/language/google/cloud/language/entity.py
@@ -17,6 +17,8 @@
 An entity is used to describe a proper name extracted from text.
 """
 
+from google.cloud.language.sentiment import Sentiment
+
 
 class EntityType(object):
     """List of possible entity types."""
@@ -152,14 +154,20 @@ class Entity(object):
 
     :type mentions: list
     :param mentions: List of strings that mention the entity.
+
+    :type sentiment: :class:`~.language.sentiment.Sentiment`
+    :params sentiment: The sentiment; sent only on `analyze_entity_sentiment`
+                       calls.
     """
 
-    def __init__(self, name, entity_type, metadata, salience, mentions):
+    def __init__(self, name, entity_type, metadata, salience, mentions,
+                 sentiment):
         self.name = name
         self.entity_type = entity_type
         self.metadata = metadata
         self.salience = salience
         self.mentions = mentions
+        self.sentiment = sentiment
 
     @classmethod
     def from_api_repr(cls, payload):
@@ -176,4 +184,7 @@ class Entity(object):
         metadata = payload['metadata']
         salience = payload['salience']
         mentions = [Mention.from_api_repr(val) for val in payload['mentions']]
-        return cls(name, entity_type, metadata, salience, mentions)
+        sentiment = None
+        if payload.get('sentiment'):
+            sentiment = Sentiment.from_api_repr(payload['sentiment'])
+        return cls(name, entity_type, metadata, salience, mentions, sentiment)

--- a/language/tests/unit/test_entity.py
+++ b/language/tests/unit/test_entity.py
@@ -43,8 +43,9 @@ class TestEntity(unittest.TestCase):
             mention_type=MentionType.PROPER,
             text=TextSpan(content='Italian', begin_offset=0),
         )]
+        sentiment = None
         entity = self._make_one(name, entity_type, metadata,
-                                salience, mentions)
+                                salience, mentions, sentiment)
         self.assertEqual(entity.name, name)
         self.assertEqual(entity.entity_type, entity_type)
         self.assertEqual(entity.metadata, metadata)
@@ -55,6 +56,7 @@ class TestEntity(unittest.TestCase):
         from google.cloud.language.entity import EntityType
         from google.cloud.language.entity import Mention
         from google.cloud.language.entity import MentionType
+        from google.cloud.language.sentiment import Sentiment
 
         klass = self._get_target_class()
         name = 'Italy'
@@ -100,6 +102,20 @@ class TestEntity(unittest.TestCase):
         # Assert that the mention types are preserved.
         for mention in entity.mentions:
             self.assertEqual(mention.mention_type, MentionType.PROPER)
+
+        # Assert that there is no sentiment.
+        self.assertIs(entity.sentiment, None)
+
+        # Assert that there *is* sentiment if it is provided.
+        payload_with_sentiment = dict(payload, sentiment={
+            'magnitude': 42,
+            'score': 0.15,
+        })
+        entity_with_sentiment = klass.from_api_repr(payload_with_sentiment)
+        self.assertIsInstance(entity_with_sentiment.sentiment, Sentiment)
+        sentiment = entity_with_sentiment.sentiment
+        self.assertEqual(sentiment.magnitude, 42)
+        self.assertAlmostEqual(sentiment.score, 0.15)
 
 
 class TestMention(unittest.TestCase):


### PR DESCRIPTION
This commit adds an `api_version` parameter to the `Client` constructor to provide access to the v1beta2 API methods.

Instantiation looks like:

```python
client = Client(api_version='v1beta2')
```

The default value is `'v1'`, and anything other than `'v1'` or `'v1beta2'` is an error.
Note that using the `'v1beta2'` version will route _all_ calls made to the object through that endpoint, and so existing methods will also get `v1beta2` behavior.

Note that neither `v1` nor `v1beta2` actually use the GAPIC.