### PR TITLE
Replace httpContext with httpRequest

### DIFF
--- a/error_reporting/google/cloud/error_reporting/client.py
+++ b/error_reporting/google/cloud/error_reporting/client.py
@@ -224,11 +224,10 @@ class Client(ClientWithProject):
         if http_context:
             http_context_dict = http_context.__dict__
             # strip out None values
-            payload['context']['httpContext'] = {
+            payload['context']['httpRequest'] = {
                 key: value for key, value in six.iteritems(http_context_dict)
                 if value is not None
             }
-
         if user:
             payload['context']['user'] = user
         return payload

--- a/error_reporting/tests/unit/test_client.py
+++ b/error_reporting/tests/unit/test_client.py
@@ -149,9 +149,9 @@ class TestClient(unittest.TestCase):
             payload['message'])
         self.assertIn('test_client.py', payload['message'])
         self.assertEqual(
-            payload['context']['httpContext']['responseStatusCode'], 500)
+            payload['context']['httpRequest']['responseStatusCode'], 500)
         self.assertEqual(
-            payload['context']['httpContext']['method'], 'GET')
+            payload['context']['httpRequest']['method'], 'GET')
         self.assertEqual(payload['context']['user'], user)
 
     @mock.patch('google.cloud.error_reporting.client.make_report_error_api')


### PR DESCRIPTION
This fixes #2877 and probably fixes #3263 .

I will work on a followup system test since clearly needed. 

NB: The reason for this bug and lack of system test is the pre-gRPC code went through Logging which was basically untyped, the errors were showing up despite the incorrect parameter names (and at the time without the full API there was no good way to system test).