### PR TITLE
Set `retain_acked_messages` in seek system test

### DIFF
--- a/pubsub/tests/system.py
+++ b/pubsub/tests/system.py
@@ -360,7 +360,8 @@ class TestPubsub(unittest.TestCase):
         self.to_delete.append(topic)
 
         SUBSCRIPTION_NAME = 'subscribing-to-seek' + unique_resource_id('-')
-        subscription = topic.subscription(SUBSCRIPTION_NAME)
+        subscription = topic.subscription(
+            SUBSCRIPTION_NAME, retain_acked_messages=True)
         self.assertFalse(subscription.exists())
         subscription.create()
         self.to_delete.append(subscription)


### PR DESCRIPTION
This should prevent the (as of yet, unexperienced) error case where
the API deletes the acked messages before we have a chance to seek
to them.