### PR TITLE
Adding check (in datastore) that setup.py README is valid RST.

### DIFF
--- a/datastore/nox.py
+++ b/datastore/nox.py
@@ -102,6 +102,15 @@ def lint(session):
 
 
 @nox.session
+def lint_setup_py(session):
+    """Verify that setup.py is valid (including RST check)."""
+    session.interpreter = 'python3.6'
+    session.install('docutils', 'Pygments')
+    session.run(
+        'python', 'setup.py', 'check', '--restructuredtext', '--strict')
+
+
+@nox.session
 def cover(session):
     """Run the final coverage report.
 


### PR DESCRIPTION
/cc @jonparrott 

@lukesneeringer You mentioned that you'd prefer a standalone session for this. I am unclear why you prefer this. To me, checking that the `README` isn't invalid in `setup.py` **is** linting.
