### PR TITLE
Ignore tests (rather than unit_tests) in setup.py files.

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -63,7 +63,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -64,7 +64,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/core/setup.py
+++ b/core/setup.py
@@ -68,7 +68,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -65,7 +65,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/dns/setup.py
+++ b/dns/setup.py
@@ -63,7 +63,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -65,7 +65,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/language/setup.py
+++ b/language/setup.py
@@ -63,7 +63,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -65,7 +65,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -63,7 +63,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -65,7 +65,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/resource_manager/setup.py
+++ b/resource_manager/setup.py
@@ -63,7 +63,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/runtimeconfig/setup.py
+++ b/runtimeconfig/setup.py
@@ -63,7 +63,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -67,7 +67,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/speech/setup.py
+++ b/speech/setup.py
@@ -64,7 +64,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -63,7 +63,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/translate/setup.py
+++ b/translate/setup.py
@@ -63,7 +63,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -65,7 +65,7 @@ setup(
         'google',
         'google.cloud',
     ],
-    packages=find_packages(exclude=('unit_tests*',)),
+    packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
     **SETUP_BASE
 )


### PR DESCRIPTION
These seem to have lost their intent during the one-big-giant-test-config PR.

/cc @jonparrott Since I think he was the original author of the `exclude=` argument.