### PR TITLE
Update BQ Query parameter reference

### DIFF
--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -383,7 +383,7 @@ class QueryResults(object):
 
         :type timeout_ms: int
         :param timeout_ms:
-            (Optional) timeout, in milliseconds, to wait for query to complete
+            (Optional) timeout, in milliseconds, to wait for request to complete
 
         :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -386,10 +386,11 @@ class QueryResults(object):
             (Optional) How long to wait for the query to complete, in
             milliseconds, before the request times out and returns. Note that
             this is only a timeout for the request, not the query. If the query
-            takes longer to run than the timeout value, the call returns without
-            any results and with the 'jobComplete' flag set to false. You can
-            call GetQueryResults() to wait for the query to complete and read
-            the results. The default value is 10000 milliseconds (10 seconds).
+            takes longer to run than the timeout value, the call returns
+            without any results and with the 'jobComplete' flag set to false.
+            You can call GetQueryResults() to wait for the query to complete
+            and read the results. The default value is 10000 milliseconds (10
+            seconds).
 
         :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -383,8 +383,8 @@ class QueryResults(object):
 
         :type timeout_ms: int
         :param timeout_ms:
-            (Optional) timeout, in milliseconds, to wait for http request 
-            to complete
+            (Optional) timeout, in milliseconds, to wait for http request
+            to complete.
 
         :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -383,7 +383,8 @@ class QueryResults(object):
 
         :type timeout_ms: int
         :param timeout_ms:
-            (Optional) timeout, in milliseconds, to wait for request to complete
+            (Optional) timeout, in milliseconds, to wait for http request 
+            to complete
 
         :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -383,8 +383,13 @@ class QueryResults(object):
 
         :type timeout_ms: int
         :param timeout_ms:
-            (Optional) timeout, in milliseconds, to wait for http request
-            to complete.
+            (Optional) How long to wait for the query to complete, in
+            milliseconds, before the request times out and returns. Note that
+            this is only a timeout for the request, not the query. If the query
+            takes longer to run than the timeout value, the call returns without
+            any results and with the 'jobComplete' flag set to false. You can
+            call GetQueryResults() to wait for the query to complete and read
+            the results. The default value is 10000 milliseconds (10 seconds).
 
         :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``


### PR DESCRIPTION
Update BigQuery Query parameter reference to indicate that timeout_ms sets timeout on the request, not on the query. Should address https://github.com/GoogleCloudPlatform/google-cloud-python/issues/3317