### PR TITLE
Making Blob.storage_class settable.

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -95,7 +95,7 @@ class Blob(_PropertyMixin):
 
     .. note::
        This list does not include 'DURABLE_REDUCED_AVAILABILITY', which
-       is only documented for buckets (and deprectated.
+       is only documented for buckets (and deprecated).
 
     .. note::
        The documentation does *not* mention 'STANDARD', but it is the value
@@ -1220,18 +1220,21 @@ class Blob(_PropertyMixin):
         if size is not None:
             return int(size)
 
-    @property
-    def storage_class(self):
-        """Retrieve the storage class for the object.
+    storage_class = _scalar_property('storageClass')
+    """Retrieve the storage class for the object.
 
-        See: https://cloud.google.com/storage/docs/storage-classes
+    This can only be set at blob / object **creation** time. If you'd
+    like to change the storage class **after** the blob / object already
+    exists in a bucket, call :meth:`update_storage_class` (which uses
+    the "storage.objects.rewrite" method).
 
-        :rtype: str or ``NoneType``
-        :returns: If set, one of "MULTI_REGIONAL", "REGIONAL",
-                  "NEARLINE", "COLDLINE", "STANDARD", or
-                  "DURABLE_REDUCED_AVAILABILITY", else ``None``.
-        """
-        return self._properties.get('storageClass')
+    See: https://cloud.google.com/storage/docs/storage-classes
+
+    :rtype: str or ``NoneType``
+    :returns: If set, one of "MULTI_REGIONAL", "REGIONAL",
+              "NEARLINE", "COLDLINE", "STANDARD", or
+              "DURABLE_REDUCED_AVAILABILITY", else ``None``.
+    """
 
     @property
     def time_deleted(self):

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -2057,13 +2057,23 @@ class Test_Blob(unittest.TestCase):
                               properties={'size': str(SIZE)})
         self.assertEqual(blob.size, SIZE)
 
-    def test_storage_class(self):
-        BLOB_NAME = 'blob-name'
+    def test_storage_class_getter(self):
+        blob_name = 'blob-name'
         bucket = _Bucket()
-        STORAGE_CLASS = 'http://example.com/self/'
-        properties = {'storageClass': STORAGE_CLASS}
-        blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
-        self.assertEqual(blob.storage_class, STORAGE_CLASS)
+        storage_class = 'MULTI_REGIONAL'
+        properties = {'storageClass': storage_class}
+        blob = self._make_one(blob_name, bucket=bucket, properties=properties)
+        self.assertEqual(blob.storage_class, storage_class)
+
+    def test_storage_class_setter(self):
+        blob_name = 'blob-name'
+        bucket = _Bucket()
+        storage_class = 'COLDLINE'
+        blob = self._make_one(blob_name, bucket=bucket)
+        self.assertIsNone(blob.storage_class)
+        blob.storage_class = storage_class
+        self.assertEqual(blob.storage_class, storage_class)
+        self.assertEqual(blob._properties, {'storageClass': storage_class})
 
     def test_time_deleted(self):
         import datetime


### PR DESCRIPTION
In some sense, this setter should be **disabled** for objects / blobs that already exist, but there is no way to tell without calling `exists()` and we SHOULD NOT require a round trip just to use a `@property` setter.

Instead, we rely on the backend (and the documentation) to inform users when it is OK to use the setter.