### PR TITLE
Add basic system test for error reporting

### DIFF
--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -63,6 +63,25 @@ def lint_setup_py(session):
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')
 
+@nox.session
+@nox.parametrize('python_version', ['2.7', '3.6'])
+def system_tests(session, python_version):
+    """Run the system test suite."""
+
+    # Sanity check: Only run system tests if the environment variable is set.
+    if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
+        return
+
+    # Run the system tests against latest Python 2 and Python 3 only.
+    session.interpreter = 'python{}'.format(python_version)
+
+    # Install all test dependencies, then install this package into the
+    # virtualenv's dist-packages.
+    session.install('.')
+
+    # Run py.test against the system tests.
+    session.run('py.test', '-vvv', 'tests/system.py')
+
 
 @nox.session
 def cover(session):

--- a/error_reporting/tests/system.py
+++ b/error_reporting/tests/system.py
@@ -1,0 +1,27 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from google.cloud import error_reporting
+
+
+class TestErrorReporting(unittest.TestCase):
+
+    def test_report_exception(self):
+        client = error_reporting.Client()
+        try:
+            raise NameError
+        except NameError:
+            client.report_exception()


### PR DESCRIPTION
This is the bare minimal system test that just makes a client call, it did go red before the scope fix at least.

Can add more asserts but need to add more code to authenticate a separate gax client to list errors, can add that to this PR or a new one.

Fixes #3335