### PR TITLE
Allowing "dank" or "danke" when "dankon" translated from Esperanto to German.

### DIFF
--- a/translate/tests/system.py
+++ b/translate/tests/system.py
@@ -66,8 +66,10 @@ class TestTranslate(unittest.TestCase):
 
         self.assertEqual(
             translations[1]['detectedSourceLanguage'], 'eo')
-        self.assertEqual(
-            translations[1]['translatedText'], 'dank')
+        # For some reason this is translated as both "dank" and "danke"
+        # in a seemingly non-deterministic way.
+        self.assertIn(
+            translations[1]['translatedText'], ('dank', 'danke'))
 
         self.assertEqual(
             translations[2]['detectedSourceLanguage'], 'es')


### PR DESCRIPTION
This test has been non-deterministic for some reason, e.g.:
https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1682