### PR TITLE
Add error reporting system test

### DIFF
--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -78,7 +78,9 @@ def system_tests(session, python_version):
 
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
-    session.install('flake8', *LOCAL_DEPS)
+    session.install('mock', 'pytest', *LOCAL_DEPS)
+    session.install('../test_utils/', '../bigquery/', '../pubsub/',
+                '../storage/')
     session.install('.')
 
     # Run py.test against the system tests.

--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -63,6 +63,7 @@ def lint_setup_py(session):
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')
 
+
 @nox.session
 @nox.parametrize('python_version', ['2.7', '3.6'])
 def system_tests(session, python_version):
@@ -77,6 +78,7 @@ def system_tests(session, python_version):
 
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
+    session.install('flake8', *LOCAL_DEPS)
     session.install('.')
 
     # Run py.test against the system tests.

--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -63,6 +63,25 @@ def lint_setup_py(session):
     session.run(
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')
 
+@nox.session
+@nox.parametrize('python_version', ['2.7', '3.6'])
+def system_tests(session, python_version):
+    """Run the system test suite."""
+
+    # Sanity check: Only run system tests if the environment variable is set.
+    if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
+        return
+
+    # Run the system tests against latest Python 2 and Python 3 only.
+    session.interpreter = 'python{}'.format(python_version)
+
+    # Install all test dependencies, then install this package into the
+    # virtualenv's dist-packages.
+    session.install('.')
+
+    # Run py.test against the system tests.
+    session.run('py.test', '-vvv', 'tests/system.py')
+
 
 @nox.session
 def cover(session):

--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -79,8 +79,7 @@ def system_tests(session, python_version):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install('../test_utils/', '../bigquery/', '../pubsub/',
-                '../storage/')
+    session.install('../test_utils/')
     session.install('.')
 
     # Run py.test against the system tests.

--- a/error_reporting/tests/system.py
+++ b/error_reporting/tests/system.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
+import functools
+import operator
 import unittest
 
 from google.cloud import error_reporting
@@ -22,8 +23,12 @@ from google.cloud.proto.devtools.clouderrorreporting.v1beta1 import (
     error_stats_service_pb2)
 from google.protobuf.duration_pb2 import Duration
 
+from test_utils.retry import RetryResult
+from test_utils.system import unique_resource_id
 
-ERROR_NAME = 'Stackdriver Error Reporting System Test'
+
+ERROR_MSG = 'Stackdriver Error Reporting System Test'
+
 
 def setUpModule():
     Config.CLIENT = error_reporting.Client()
@@ -38,56 +43,81 @@ class Config(object):
     CLIENT = None
 
 
-def _list_groups(project):
+def _list_groups(client):
     """List Error Groups from the last 60 seconds.
 
     This class provides a wrapper around making calls to the GAX
     API. It's used by the system tests to find the appropriate error group
     to verify the error was successfully reported.
 
-    :type project: str
-    :param project: Google Cloud Project ID
+    :type client: :class:`~google.cloud.error_reporting.client.Client`
+    :param client: The client containing a project and credentials.
+
+    :rtype: :class:`~google.gax.ResourceIterator`
+    :returns: Iterable of :class:`~.error_stats_service_pb2.ErrorGroupStats`.
     """
     gax_api = error_stats_service_client.ErrorStatsServiceClient(
-        credentials=Config.CLIENT._credentials)
-    project_name = gax_api.project_path(project)
+        credentials=client._credentials)
+    project_name = gax_api.project_path(client.project)
 
     time_range = error_stats_service_pb2.QueryTimeRange()
     time_range.period = error_stats_service_pb2.QueryTimeRange.PERIOD_1_HOUR
 
-    duration = Duration(seconds=60*60)
+    duration = Duration(seconds=60 * 60)
 
     return gax_api.list_group_stats(
         project_name, time_range, timed_count_duration=duration)
 
 
-def _simulate_exception():
-    """Simulates an exception to verify it was reported."""
+def _simulate_exception(class_name, client):
+    """Simulates an exception to verify it was reported.
+
+    :type class_name: str
+    :param class_name: The name of a custom error class to
+                       create (and raise).
+
+    :type client: :class:`~google.cloud.error_reporting.client.Client`
+    :param client: The client that will report the exception.
+    """
+    custom_exc = type(class_name, (RuntimeError,), {})
     try:
-        raise RuntimeError(ERROR_NAME)
+        raise custom_exc(ERROR_MSG)
     except RuntimeError:
-        Config.CLIENT.report_exception()
+        client.report_exception()
+
+
+def _get_error_count(class_name, client):
+    """Counts the number of errors in the group of the test exception.
+
+    :type class_name: str
+    :param class_name: The name of a custom error class used.
+
+    :type client: :class:`~google.cloud.error_reporting.client.Client`
+    :param client: The client containing a project and credentials.
+
+    :rtype: int
+    :returns: Group count for errors that match ``class_name``. If no
+              match is found, returns :data:`None`.
+    """
+    groups = _list_groups(client)
+    for group in groups:
+        if class_name in group.representative.message:
+            return group.count
 
 
 class TestErrorReporting(unittest.TestCase):
 
-    def _get_error_count(self):
-        """Counts the number of errors in the group of the test exception."""
-        groups = _list_groups(Config.CLIENT.project)
-        for group in groups:
-            if ERROR_NAME in group.representative.message:
-                return group.count
-
     def test_report_exception(self):
-        # If test has never run, group won't exist until we report first
-        # exception, so first simulate it just to create the group
-        _simulate_exception()
-        time.sleep(2)
+        # Get a class name unique to this test case.
+        class_name = 'RuntimeError' + unique_resource_id('_')
 
-        initial_count = self._get_error_count()
-        _simulate_exception()
+        # Simulate an error: group won't exist until we report
+        # first exception.
+        _simulate_exception(class_name, Config.CLIENT)
 
-        time.sleep(2)
-        new_count = self._get_error_count()
+        is_one = functools.partial(operator.eq, 1)
+        is_one.__name__ = 'is_one'  # partial() has no name.
+        wrapped_get_count = RetryResult(is_one)(_get_error_count)
 
-        self.assertEqual(new_count, initial_count + 1)
+        error_count = wrapped_get_count(class_name, Config.CLIENT)
+        self.assertEqual(error_count, 1)

--- a/error_reporting/tests/system.py
+++ b/error_reporting/tests/system.py
@@ -81,11 +81,11 @@ class TestErrorReporting(unittest.TestCase):
     def test_report_exception(self):
         # If test has never run, group won't exist until we report first
         # exception, so first simulate it just to create the group
-        self._simulate_exception()
+        _simulate_exception()
         time.sleep(2)
 
         initial_count = self._get_error_count()
-        self._simulate_exception()
+        _simulate_exception()
 
         time.sleep(2)
         new_count = self._get_error_count()

--- a/error_reporting/tests/system.py
+++ b/error_reporting/tests/system.py
@@ -1,0 +1,96 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import unittest
+
+from google.cloud import error_reporting
+from google.cloud.gapic.errorreporting.v1beta1 import (
+    error_stats_service_client)
+from google.cloud.proto.devtools.clouderrorreporting.v1beta1 import (
+    error_stats_service_pb2)
+from google.protobuf.duration_pb2 import Duration
+
+from test_utils.retry import RetryResult
+
+
+class _ErrorStatsGaxApi(object):
+    """Helper mapping Error Reporting-related APIs
+
+    This class provides a small wrapper around making calls to the GAX
+    API. It's used by the system tests to find the appropriate error group
+    to verify the error was successfully reported.
+
+    :type project: str
+    :param project: Google Cloud Project ID
+    """
+    def __init__(self, project):
+        self._project = project
+        self._gax_api = error_stats_service_client.ErrorStatsServiceClient()
+
+    def list_groups(self):
+        """Helper to list the groups that have had errors in the last hour."""
+        project_name = self._gax_api.project_path(self._project)
+        time_range = error_stats_service_pb2.QueryTimeRange()
+        time_range.period = (
+            error_stats_service_pb2.QueryTimeRange.PERIOD_1_HOUR
+        )
+
+        duration = Duration()
+        duration.seconds = 60 * 60
+
+        return self._gax_api.list_group_stats(
+            project_name, time_range, timed_count_duration=duration)
+
+
+def _is_incremented(initial, new):
+    """Helper to retry until new error is counted."""
+    return new == initial + 1
+
+
+class TestErrorReporting(unittest.TestCase):
+
+    def setUp(self):
+        self._client = error_reporting.Client()
+        self._error_name = 'Stackdriver Error Reporting System Test'
+
+    def _simulate_exception(self):
+        """Simulates an exception to verify it was reported."""
+        try:
+            raise RuntimeError(self._error_name)
+        except RuntimeError:
+            self._client.report_exception()
+
+    def _get_error_count(self):
+        """Counts the number of errors in the group of the test exception."""
+        error_stats_api = _ErrorStatsGaxApi(self._client.project)
+        groups = error_stats_api.list_groups()
+        for group in groups:
+            if self._error_name in group.representative.message:
+                return group.count
+
+    def test_report_exception(self):
+        """Verifies the exception reported increases the group count by one."""
+        # If test has never run, group won't exist until we report first
+        # exception, so first simulate it just to create the group
+        self._simulate_exception()
+
+        initial_count = self._get_error_count()
+        self._simulate_exception()
+
+        is_incremented = functools.partial(_is_incremented, initial_count)
+        retry_get_count = RetryResult(is_incremented)(self._get_error_count)
+        new_count = retry_get_count()
+
+        self.assertEqual(new_count, initial_count + 1)


### PR DESCRIPTION
This actually uses the gapic client to verify counts.

It doesn't expose the gapic client outside of the system methods since unlikely they will need to be used (and we can wait on the general gapic doc improvements for those who do want it).

Fixes #3335.