### PR TITLE
Fix `speech_context` typo in speech-usage docs.

### DIFF
--- a/docs/speech-usage.rst
+++ b/docs/speech-usage.rst
@@ -134,7 +134,7 @@ words to the vocabulary of the recognizer.
     >>> results = sample.recognize(
     ...     language_code='en-US',
     ...     max_alternatives=2,
-    ...     speech_context=hints,
+    ...     speech_contexts=hints,
     ... )
     >>> for result in results:
     ...     for alternative in result.alternatives:


### PR DESCRIPTION
Fix speech context example in speech-usage docs to match argument name change in a9268a3e2777c35405c6c114c6b358e4d4c02335.

Closes #3349.