### PR TITLE
Bugfix release of Storage.

### DIFF
--- a/storage/setup.py
+++ b/storage/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-storage',
-    version='1.1.0',
+    version='1.1.1',
     description='Python Client for Google Cloud Storage',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Release notes will be simple

## google-cloud-storage 1.1.1

- Bug fix: Only using `Blob.updated` if it is set in `download_to_filename()`. (#3352)

/cc @danigosa