### PR TITLE
Add trace_id to log payload to enable log aggregation in GAE Flex

### DIFF
--- a/logging/google/cloud/logging/handlers/_helpers.py
+++ b/logging/google/cloud/logging/handlers/_helpers.py
@@ -16,6 +16,7 @@
 
 import math
 import json
+import os
 
 
 def format_stackdriver_json(record, message):
@@ -26,6 +27,7 @@ def format_stackdriver_json(record, message):
     """
     subsecond, second = math.modf(record.created)
 
+    # Assemble a dictionary with the log string as the message.
     payload = {
         'message': message,
         'timestamp': {
@@ -36,4 +38,44 @@ def format_stackdriver_json(record, message):
         'severity': record.levelname,
     }
 
+    # Make a best effort to add the trace id.
+    # First try to extract the trace_id from HTTP header, only support flask framework for now.
+    trace_id = parse_flask_request_header()
+
+    # If that didn't work, try to get the trace_id from the 'extras' of the record.
+    if not trace_id:
+        trace_id = getattr(record, 'trace_id', None)
+
+    # If still cannot get the trace_id, try to get it from environment.
+    if not trace_id:
+        trace_id = os.getenv('HTTP_X_CLOUD_TRACE_CONTEXT', '').split('/')[0]
+
+    # Add trace_id to payload if it was found.
+    if trace_id:
+        payload['traceId'] = trace_id
+
     return json.dumps(payload)
+
+
+def parse_flask_request_header():
+    """Parse flask request header to get trace_id.
+    
+        :rtype: str
+        :return: trace_id get from flask header
+    """
+    # Import the web framework to parse HTTP header.
+    try:
+        import flask
+    except ImportError:
+        flask = None
+
+    # Extract the trace_id
+    if flask:
+        try:
+            trace_id = flask.request.headers['X-Cloud-Trace-Context'].split('/')[0]
+        except KeyError:
+            trace_id = None
+    else:
+        trace_id = None
+
+    return trace_id


### PR DESCRIPTION
Extract trace_id from HTTP request header and add it to application log. The pantheon UI will show the app logs grouped by trace_id and show them aggregated in one request.

Below is the screenshot of the aggregated log:
![screenshot from 2017-05-01 17 37 44](https://cloud.githubusercontent.com/assets/12888824/25640479/8d65b2b2-2f44-11e7-83ba-383e3167ae8d.png)
