### PR TITLE
Fix new partitioned table

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -473,8 +473,9 @@ class Table(object):
             resource['schema'] = {
                 'fields': _build_schema_resource(self._schema)
             }
-        else:
-            raise ValueError("Set either 'view_query' or 'schema'.")
+        elif self.partitioning_type is None:
+            raise ValueError(
+                "Set either 'view_query' or 'schema' or 'partitioning_type'.")
 
         return resource
 

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -469,13 +469,11 @@ class Table(object):
         if self.view_query is not None:
             view = resource['view'] = {}
             view['query'] = self.view_query
-        elif self._schema:
+
+        if self._schema:
             resource['schema'] = {
                 'fields': _build_schema_resource(self._schema)
             }
-        elif self.partitioning_type is None:
-            raise ValueError(
-                "Set either 'view_query' or 'schema' or 'partitioning_type'.")
 
         return resource
 

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -395,7 +395,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertIs(table._dataset._client, client)
         self._verifyResourceProperties(table, RESOURCE)
 
-    def test_create_no_view_query_no_schema(self):
+    def test_create_no_view_query_no_schema_no_partitioning(self):
         conn = _Connection()
         client = _Client(project=self.PROJECT, connection=conn)
         dataset = _Dataset(client)
@@ -403,6 +403,30 @@ class TestTable(unittest.TestCase, _SchemaBase):
 
         with self.assertRaises(ValueError):
             table.create()
+
+    def test_create_new_day_partitioned_table(self):
+        PATH = 'projects/%s/datasets/%s/tables' % (self.PROJECT, self.DS_NAME)
+        RESOURCE = self._makeResource()
+        conn = _Connection(RESOURCE)
+        client = _Client(project=self.PROJECT, connection=conn)
+        dataset = _Dataset(client)
+        table = self._make_one(self.TABLE_NAME, dataset)
+        table.partitioning_type = 'DAY'
+        table.create()            
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % PATH)
+        SENT = {
+            'tableReference': {
+                'projectId': self.PROJECT,
+                'datasetId': self.DS_NAME,
+                'tableId': self.TABLE_NAME},
+            'timePartitioning': {'type': 'DAY'},
+        }
+        self.assertEqual(req['data'], SENT)
+        self._verifyResourceProperties(table, RESOURCE)
 
     def test_create_w_bound_client(self):
         from google.cloud.bigquery.table import SchemaField

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -395,15 +395,6 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertIs(table._dataset._client, client)
         self._verifyResourceProperties(table, RESOURCE)
 
-    def test_create_no_view_query_no_schema_no_partitioning(self):
-        conn = _Connection()
-        client = _Client(project=self.PROJECT, connection=conn)
-        dataset = _Dataset(client)
-        table = self._make_one(self.TABLE_NAME, dataset)
-
-        with self.assertRaises(ValueError):
-            table.create()
-
     def test_create_new_day_partitioned_table(self):
         PATH = 'projects/%s/datasets/%s/tables' % (self.PROJECT, self.DS_NAME)
         RESOURCE = self._makeResource()
@@ -671,7 +662,6 @@ class TestTable(unittest.TestCase, _SchemaBase):
         import datetime
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _millis
-        from google.cloud.bigquery.table import SchemaField
 
         PATH = 'projects/%s/datasets/%s/tables' % (self.PROJECT, self.DS_NAME)
         DESCRIPTION = 'DESCRIPTION'
@@ -691,10 +681,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         conn2 = _Connection(RESOURCE)
         client2 = _Client(project=self.PROJECT, connection=conn2)
         dataset = _Dataset(client=client1)
-        full_name = SchemaField('full_name', 'STRING', mode='REQUIRED')
-        age = SchemaField('age', 'INTEGER', mode='REQUIRED')
-        table = self._make_one(self.TABLE_NAME, dataset=dataset,
-                               schema=[full_name, age])
+        table = self._make_one(self.TABLE_NAME, dataset=dataset)
         table.friendly_name = TITLE
         table.description = DESCRIPTION
         table.view_query = QUERY


### PR DESCRIPTION
[This is a re-do of the pull request #3366 to fix the author email address to use my `google.com` email]

I moved the `partitioning_type` check into the `if` / `elif` block to avoid a `ValueError` that should not have been thrown.

See:
https://cloud.google.com/bigquery/docs/creating-partitioned-tables#creating_a_partitioned_table and the "API" example.

Before my change, the following code failed with the `ValueError` thrown by this function, but with my change, I was able to successfully create the partitioned table:

```python
destination_table = dataset.table(table_shortname)

if not destination_table.exists(): 
    destination_table.partitioning_type = 'DAY'
    destination_table.create()

# Use a table partition
destination_partition = dataset.table(table_shortname + '$' + partition_date)
```