### PR TITLE
Making enum34 dependency conditional on Python version.

### DIFF
--- a/vision/setup.py
+++ b/vision/setup.py
@@ -51,10 +51,12 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'enum34',
     'google-cloud-core >= 0.24.0, < 0.25dev',
     'gapic-google-cloud-vision-v1 >= 0.90.3, < 0.91dev',
 ]
+EXTRAS_REQUIRE = {
+    ':python_version<"3.4"': ['enum34'],
+}
 
 setup(
     name='google-cloud-vision',
@@ -67,5 +69,6 @@ setup(
     ],
     packages=find_packages(exclude=('tests*',)),
     install_requires=REQUIREMENTS,
+    extras_require=EXTRAS_REQUIRE,
     **SETUP_BASE
 )


### PR DESCRIPTION
Fixes #3398.

----

After using this and running the unit tests, the dependency is indeed only present in Python 2.7:

```bash
$ .nox/unit_tests-python_version-2-7/bin/pip freeze > 27.txt
$ .nox/unit_tests-python_version-3-4/bin/pip freeze > 34.txt
$ .nox/unit_tests-python_version-3-5/bin/pip freeze > 35.txt
$ .nox/unit_tests-python_version-3-6/bin/pip freeze > 36.txt
$
$ diff -s 34.txt 35.txt
Files 34.txt and 35.txt are identical
$ diff -s 34.txt 36.txt
Files 34.txt and 36.txt are identical
$
$ diff -s 27.txt 34.txt
--- 27.txt      2017-05-11 10:28:41.369890164 -0700
+++ 34.txt      2017-05-11 10:28:36.081426963 -0700
@@ -2,10 +2,7 @@
 cachetools==2.0.0
 coverage==4.4
 dill==0.2.6
-enum34==1.1.6
-funcsigs==1.0.2
 future==0.16.0
-futures==3.1.1
 gapic-google-cloud-vision-v1==0.90.3
 google-auth==1.0.1
 google-auth-httplib2==0.0.2
```