### PR TITLE
Stop writing to '/var/log/app_engine/' and write logs to Stackdriver logging API

### DIFF
--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -303,7 +303,7 @@ class Client(ClientWithProject):
         """
         if (_APPENGINE_FLEXIBLE_ENV_VM in os.environ or
                 _APPENGINE_FLEXIBLE_ENV_FLEX in os.environ):
-            return AppEngineHandler()
+            return AppEngineHandler(self)
         elif _CONTAINER_ENGINE_ENV in os.environ:
             return ContainerEngineHandler()
         else:

--- a/logging/google/cloud/logging/handlers/app_engine.py
+++ b/logging/google/cloud/logging/handlers/app_engine.py
@@ -57,7 +57,7 @@ class AppEngineHandler(CloudLoggingHandler):
                      to the global resource type.
     """
 
-    DEFAULT_LOGGER_NAME = 'projects/{}/logs/app'.format(os.environ.get(_GAE_PROJECT_ENV))
+    DEFAULT_LOGGER_NAME = 'app'
 
     def __init__(self, client,
                  transport=BackgroundThreadTransport):

--- a/logging/google/cloud/logging/handlers/app_engine.py
+++ b/logging/google/cloud/logging/handlers/app_engine.py
@@ -58,7 +58,6 @@ class AppEngineHandler(CloudLoggingHandler):
         :rtype: :class:`~google.cloud.logging.resource.Resource`
         :returns: Monitored resource for GAE.
         """
-
         gae_resource = Resource(
             type='gae_app',
             labels={

--- a/logging/google/cloud/logging/handlers/app_engine.py
+++ b/logging/google/cloud/logging/handlers/app_engine.py
@@ -14,7 +14,8 @@
 
 """Logging handler for App Engine Flexible
 
-Sends logs to the Stackdriver Logging API with the appropriate resource and labels for App Engine logs.
+Sends logs to the Stackdriver Logging API with the appropriate resource
+and labels for App Engine logs.
 """
 
 import os
@@ -23,49 +24,41 @@ from google.cloud.logging.handlers.handlers import CloudLoggingHandler
 from google.cloud.logging.handlers.transports import BackgroundThreadTransport
 from google.cloud.logging.resource import Resource
 
+_DEFAULT_GAE_LOGGER_NAME = 'app'
+
 _GAE_PROJECT_ENV = 'GCLOUD_PROJECT'
 _GAE_SERVICE_ENV = 'GAE_SERVICE'
 _GAE_VERSION_ENV = 'GAE_VERSION'
 
 
 class AppEngineHandler(CloudLoggingHandler):
-    """A handler that directly makes Stackdriver logging API calls.
+    """A logging handler that sends App Engine-formatted logs to Stackdriver.
 
-    This handler can be used to route Python standard logging messages directly
-    to the Stackdriver Logging API.
-
-    This handler supports both an asynchronous and synchronous transport.
-
-    :type client: :class:`google.cloud.logging.client`
-    :param client: the authenticated Google Cloud Logging client for this
-                   handler to use
-
-    :type name: str
-    :param name: the name of the custom log in Stackdriver Logging. Defaults
-                 to 'python'. The name of the Python logger will be represented
-                 in the ``python_logger`` field.
+    :type client: :class:`~google.cloud.logging.client.Client`
+    :param client: The authenticated Google Cloud Logging client for this
+                   handler to use.
 
     :type transport: type
-    :param transport: Class for creating new transport objects. It should
-                      extend from the base :class:`.Transport` type and
-                      implement :meth`.Transport.send`. Defaults to
-                      :class:`.BackgroundThreadTransport`. The other
-                      option is :class:`.SyncTransport`.
-
-    :type resource: :class:`~google.cloud.logging.resource.Resource`
-    :param resource: Monitored resource of the entry, defaults
-                     to the global resource type.
+    :param transport: The transport class. It should be a subclass
+                      of :class:`.Transport`. If unspecified,
+                      :class:`.BackgroundThreadTransport` will be used.
     """
-
-    DEFAULT_LOGGER_NAME = 'app'
 
     def __init__(self, client,
                  transport=BackgroundThreadTransport):
-        super(AppEngineHandler, self).__init__(client, name=self.DEFAULT_LOGGER_NAME,
-                                               transport=transport, resource=self.gae_resource)
+        super(AppEngineHandler, self).__init__(
+            client,
+            name=_DEFAULT_GAE_LOGGER_NAME,
+            transport=transport,
+            resource=self.get_gae_resource())
 
-    @property
-    def gae_resource(self):
+    def get_gae_resource(self):
+        """Return the GAE resource using the environment variables.
+
+        :rtype: :class:`~google.cloud.logging.resource.Resource`
+        :returns: Monitored resource for GAE.
+        """
+
         gae_resource = Resource(
             type='gae_app',
             labels={

--- a/logging/google/cloud/logging/handlers/handlers.py
+++ b/logging/google/cloud/logging/handlers/handlers.py
@@ -54,7 +54,8 @@ class CloudLoggingHandler(logging.StreamHandler):
                       option is :class:`.SyncTransport`.
 
     :type resource: :class:`~google.cloud.logging.resource.Resource`
-    :param resource: (Optional) Monitored resource of the entry
+    :param resource: (Optional) Monitored resource of the entry, defaults
+                     to the global resource type.
 
     Example:
 

--- a/logging/google/cloud/logging/handlers/handlers.py
+++ b/logging/google/cloud/logging/handlers/handlers.py
@@ -17,6 +17,7 @@
 import logging
 
 from google.cloud.logging.handlers.transports import BackgroundThreadTransport
+from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
 DEFAULT_LOGGER_NAME = 'python'
 
@@ -52,6 +53,9 @@ class CloudLoggingHandler(logging.StreamHandler):
                       :class:`.BackgroundThreadTransport`. The other
                       option is :class:`.SyncTransport`.
 
+    :type resource: :class:`~google.cloud.logging.resource.Resource`
+    :param resource: (Optional) Monitored resource of the entry
+
     Example:
 
     .. code-block:: python
@@ -73,11 +77,13 @@ class CloudLoggingHandler(logging.StreamHandler):
 
     def __init__(self, client,
                  name=DEFAULT_LOGGER_NAME,
-                 transport=BackgroundThreadTransport):
+                 transport=BackgroundThreadTransport,
+                 resource=_GLOBAL_RESOURCE):
         super(CloudLoggingHandler, self).__init__()
         self.name = name
         self.client = client
         self.transport = transport(client, name)
+        self.resource=resource
 
     def emit(self, record):
         """Actually log the specified logging record.
@@ -90,7 +96,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         :param record: The record to be logged.
         """
         message = super(CloudLoggingHandler, self).format(record)
-        self.transport.send(record, message)
+        self.transport.send(record, message, self.resource)
 
 
 def setup_logging(handler, excluded_loggers=EXCLUDED_LOGGER_DEFAULTS,

--- a/logging/google/cloud/logging/handlers/handlers.py
+++ b/logging/google/cloud/logging/handlers/handlers.py
@@ -83,7 +83,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         self.name = name
         self.client = client
         self.transport = transport(client, name)
-        self.resource=resource
+        self.resource = resource
 
     def emit(self, record):
         """Actually log the specified logging record.
@@ -96,7 +96,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         :param record: The record to be logged.
         """
         message = super(CloudLoggingHandler, self).format(record)
-        self.transport.send(record, message, self.resource)
+        self.transport.send(record, message, resource=self.resource)
 
 
 def setup_logging(handler, excluded_loggers=EXCLUDED_LOGGER_DEFAULTS,

--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -212,7 +212,7 @@ class _Worker(object):
         :type message: str
         :param message: The message from the ``LogRecord`` after being
                         formatted by the associated log formatters.
-        
+
         :type resource: :class:`~google.cloud.logging.resource.Resource`
         :param resource: (Optional) Monitored resource of the entry
         """
@@ -268,8 +268,7 @@ class BackgroundThreadTransport(Transport):
                         formatted by the associated log formatters.
 
         :type resource: :class:`~google.cloud.logging.resource.Resource`
-        :param resource: Monitored resource of the entry, defaults
-                         to the global resource type.
+        :param resource: (Optional) Monitored resource of the entry.
         """
         self.worker.enqueue(record, message, resource=resource)
 

--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -28,7 +28,6 @@ from six.moves import range
 from six.moves import queue
 
 from google.cloud.logging.handlers.transports.base import Transport
-from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
 _DEFAULT_GRACE_PERIOD = 5.0  # Seconds
 _DEFAULT_MAX_BATCH_SIZE = 10
@@ -258,7 +257,7 @@ class BackgroundThreadTransport(Transport):
         self.worker = _Worker(logger)
         self.worker.start()
 
-    def send(self, record, message, resource=_GLOBAL_RESOURCE):
+    def send(self, record, message, resource=None):
         """Overrides Transport.send().
 
         :type record: :class:`logging.LogRecord`
@@ -272,7 +271,7 @@ class BackgroundThreadTransport(Transport):
         :param resource: Monitored resource of the entry, defaults
                          to the global resource type.
         """
-        self.worker.enqueue(record, message, resource)
+        self.worker.enqueue(record, message, resource=resource)
 
     def flush(self):
         """Submit any pending log records."""

--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -28,15 +28,13 @@ from six.moves import range
 from six.moves import queue
 
 from google.cloud.logging.handlers.transports.base import Transport
-from google.cloud.logging.resource import Resource
-
+from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
 _DEFAULT_GRACE_PERIOD = 5.0  # Seconds
 _DEFAULT_MAX_BATCH_SIZE = 10
 _WORKER_THREAD_NAME = 'google.cloud.logging.Worker'
 _WORKER_TERMINATOR = object()
 _LOGGER = logging.getLogger(__name__)
-_GLOBAL_RESOURCE = Resource(type='global', labels={})
 
 
 def _get_many(queue_, max_items=None):

--- a/logging/google/cloud/logging/handlers/transports/base.py
+++ b/logging/google/cloud/logging/handlers/transports/base.py
@@ -22,7 +22,7 @@ class Transport(object):
     client and name object, and must override :meth:`send`.
     """
 
-    def send(self, record, message):
+    def send(self, record, message, resource):
         """Transport send to be implemented by subclasses.
 
         :type record: :class:`logging.LogRecord`
@@ -31,6 +31,10 @@ class Transport(object):
         :type message: str
         :param message: The message from the ``LogRecord`` after being
                         formatted by the associated log formatters.
+
+        :type resource: :class:`~google.cloud.logging.resource.Resource`
+        :param resource: Monitored resource of the entry, defaults
+                         to the global resource type.
         """
         raise NotImplementedError
 

--- a/logging/google/cloud/logging/handlers/transports/base.py
+++ b/logging/google/cloud/logging/handlers/transports/base.py
@@ -33,8 +33,7 @@ class Transport(object):
                         formatted by the associated log formatters.
 
         :type resource: :class:`~google.cloud.logging.resource.Resource`
-        :param resource: Monitored resource of the entry, defaults
-                         to the global resource type.
+        :param resource: (Optional) Monitored resource of the entry.
         """
         raise NotImplementedError
 

--- a/logging/google/cloud/logging/handlers/transports/base.py
+++ b/logging/google/cloud/logging/handlers/transports/base.py
@@ -22,7 +22,7 @@ class Transport(object):
     client and name object, and must override :meth:`send`.
     """
 
-    def send(self, record, message, resource):
+    def send(self, record, message, resource=None):
         """Transport send to be implemented by subclasses.
 
         :type record: :class:`logging.LogRecord`

--- a/logging/google/cloud/logging/handlers/transports/sync.py
+++ b/logging/google/cloud/logging/handlers/transports/sync.py
@@ -18,6 +18,10 @@ Logs directly to the the Stackdriver Logging API with a synchronous call.
 """
 
 from google.cloud.logging.handlers.transports.base import Transport
+from google.cloud.logging.resource import Resource
+
+
+_GLOBAL_RESOURCE = Resource(type='global', labels={})
 
 
 class SyncTransport(Transport):
@@ -29,7 +33,7 @@ class SyncTransport(Transport):
     def __init__(self, client, name):
         self.logger = client.logger(name)
 
-    def send(self, record, message):
+    def send(self, record, message, resource=_GLOBAL_RESOURCE):
         """Overrides transport.send().
 
         :type record: :class:`logging.LogRecord`
@@ -40,4 +44,4 @@ class SyncTransport(Transport):
                         formatted by the associated log formatters.
         """
         info = {'message': message, 'python_logger': record.name}
-        self.logger.log_struct(info, severity=record.levelname)
+        self.logger.log_struct(info, severity=record.levelname, resource=resource)

--- a/logging/google/cloud/logging/handlers/transports/sync.py
+++ b/logging/google/cloud/logging/handlers/transports/sync.py
@@ -21,9 +21,6 @@ from google.cloud.logging.handlers.transports.base import Transport
 from google.cloud.logging.resource import Resource
 
 
-_GLOBAL_RESOURCE = Resource(type='global', labels={})
-
-
 class SyncTransport(Transport):
     """Basic sychronous transport.
 
@@ -33,7 +30,7 @@ class SyncTransport(Transport):
     def __init__(self, client, name):
         self.logger = client.logger(name)
 
-    def send(self, record, message, resource=_GLOBAL_RESOURCE):
+    def send(self, record, message, resource=None):
         """Overrides transport.send().
 
         :type record: :class:`logging.LogRecord`

--- a/logging/google/cloud/logging/handlers/transports/sync.py
+++ b/logging/google/cloud/logging/handlers/transports/sync.py
@@ -18,7 +18,6 @@ Logs directly to the the Stackdriver Logging API with a synchronous call.
 """
 
 from google.cloud.logging.handlers.transports.base import Transport
-from google.cloud.logging.resource import Resource
 
 
 class SyncTransport(Transport):
@@ -41,4 +40,6 @@ class SyncTransport(Transport):
                         formatted by the associated log formatters.
         """
         info = {'message': message, 'python_logger': record.name}
-        self.logger.log_struct(info, severity=record.levelname, resource=resource)
+        self.logger.log_struct(info,
+                               severity=record.levelname,
+                               resource=resource)

--- a/logging/tests/unit/handlers/test_app_engine.py
+++ b/logging/tests/unit/handlers/test_app_engine.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 import unittest
 from google.cloud.logging.resource import Resource
 
@@ -37,12 +38,14 @@ class TestAppEngineHandlerHandler(unittest.TestCase):
         RESOURCE = Resource(
             type='gae_app',
             labels={
-                'module_id': 'default',
-                'version_id': 'test',
-        })
+                'project_id': os.getenv('GCLOUD_PROJECT'),
+                'module_id': os.getenv('GAE_SERVICE'),
+                'version_id': os.getenv('GAE_VERSION'),
+            },
+        )
 
         client = _Client(self.PROJECT)
-        handler = self._make_one(client, transport=_Transport, resource=RESOURCE)
+        handler = self._make_one(client, transport=_Transport)
         logname = 'loggername'
         message = 'hello world'
         record = logging.LogRecord(logname, logging, None, None, message,

--- a/logging/tests/unit/handlers/test_app_engine.py
+++ b/logging/tests/unit/handlers/test_app_engine.py
@@ -50,19 +50,22 @@ class TestAppEngineHandlerHandler(unittest.TestCase):
         client = mock.Mock(project=self.PROJECT, spec=['project'])
         handler = self._make_one(client, transport=_Transport)
         gae_resource = handler.get_gae_resource()
-        logname = 'loggername'
+        logname = 'app'
         message = 'hello world'
         record = logging.LogRecord(logname, logging, None, None, message,
                                    None, None)
         handler.emit(record)
 
+        self.assertIs(handler.transport.client, client)
+        self.assertEqual(handler.transport.name, logname)
         self.assertEqual(handler.transport.send_called_with, (record, message, gae_resource))
 
 
 class _Transport(object):
 
     def __init__(self, client, name):
-        pass
+        self.client = client
+        self.name = name
 
     def send(self, record, message, resource):
         self.send_called_with = (record, message, resource)

--- a/logging/tests/unit/handlers/test_handlers.py
+++ b/logging/tests/unit/handlers/test_handlers.py
@@ -35,15 +35,17 @@ class TestCloudLoggingHandler(unittest.TestCase):
         self.assertEqual(handler.client, client)
 
     def test_emit(self):
+        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+
         client = _Client(self.PROJECT)
-        handler = self._make_one(client, transport=_Transport)
+        handler = self._make_one(client, transport=_Transport, resource=_GLOBAL_RESOURCE)
         logname = 'loggername'
         message = 'hello world'
         record = logging.LogRecord(logname, logging, None, None, message,
                                    None, None)
         handler.emit(record)
 
-        self.assertEqual(handler.transport.send_called_with, (record, message))
+        self.assertEqual(handler.transport.send_called_with, (record, message, _GLOBAL_RESOURCE))
 
 
 class TestSetupLogging(unittest.TestCase):
@@ -108,5 +110,5 @@ class _Transport(object):
     def __init__(self, client, name):
         pass
 
-    def send(self, record, message):
-        self.send_called_with = (record, message)
+    def send(self, record, message, resource):
+        self.send_called_with = (record, message, resource)

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -281,14 +281,18 @@ class _Thread(object):
 
 
 class _Batch(object):
-    from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
     def __init__(self):
         self.entries = []
         self.commit_called = False
         self.commit_count = None
 
-    def log_struct(self, info, severity=logging.INFO, resource=_GLOBAL_RESOURCE):
+    def log_struct(self, info, severity=logging.INFO, resource=None):
+        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+
+        if resource is None:
+            resource = _GLOBAL_RESOURCE
+
         self.log_struct_called_with = (info, severity, resource)
         self.entries.append(info)
 

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -14,7 +14,6 @@
 
 import logging
 import unittest
-from google.cloud.logging.resource import Resource
 
 import mock
 from six.moves import queue
@@ -48,12 +47,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
         self.assertEqual(logger.name, name)
 
     def test_send(self):
-        RESOURCE = Resource(
-            type='gae_app',
-            labels={
-                'module_id': 'default',
-                'version_id': 'test',
-        })
+        from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
         client = _Client(self.PROJECT)
         name = 'python_logger'
@@ -67,9 +61,9 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             python_logger_name, logging.INFO,
             None, None, message, None, None)
 
-        transport.send(record, message, RESOURCE)
+        transport.send(record, message, _GLOBAL_RESOURCE)
 
-        transport.worker.enqueue.assert_called_once_with(record, message, RESOURCE)
+        transport.worker.enqueue.assert_called_once_with(record, message, _GLOBAL_RESOURCE)
 
     def test_flush(self):
         client = _Client(self.PROJECT)

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -294,9 +294,9 @@ class _Batch(object):
         self.commit_called = False
         self.commit_count = None
 
-    def log_struct(self, record, severity=logging.INFO, resource=_GLOBAL_RESOURCE):
-        self.log_struct_called_with = (record, severity, resource)
-        self.entries.append(record)
+    def log_struct(self, info, severity=logging.INFO, resource=_GLOBAL_RESOURCE):
+        self.log_struct_called_with = (info, severity, resource)
+        self.entries.append(info)
 
     def commit(self):
         self.commit_called = True

--- a/logging/tests/unit/handlers/transports/test_base.py
+++ b/logging/tests/unit/handlers/transports/test_base.py
@@ -31,7 +31,7 @@ class TestBaseHandler(unittest.TestCase):
     def test_send_is_abstract(self):
         target = self._make_one()
         with self.assertRaises(NotImplementedError):
-            target.send(None, None)
+            target.send(None, None, None)
 
     def test_flush_is_abstract_and_optional(self):
         target = self._make_one()

--- a/logging/tests/unit/handlers/transports/test_sync.py
+++ b/logging/tests/unit/handlers/transports/test_sync.py
@@ -14,8 +14,6 @@
 
 import logging
 import unittest
-from google.cloud.logging.resource import Resource
-from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
 
 class TestSyncHandler(unittest.TestCase):
@@ -38,12 +36,7 @@ class TestSyncHandler(unittest.TestCase):
         self.assertEqual(transport.logger.name, 'python_logger')
 
     def test_send(self):
-        RESOURCE = Resource(
-            type='gae_app',
-            labels={
-                'module_id': 'default',
-                'version_id': 'test',
-        })
+        from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
         client = _Client(self.PROJECT)
 
@@ -54,17 +47,18 @@ class TestSyncHandler(unittest.TestCase):
         record = logging.LogRecord(python_logger_name, logging.INFO,
                                    None, None, message, None, None)
 
-        transport.send(record, message, RESOURCE)
+        transport.send(record, message, _GLOBAL_RESOURCE)
         EXPECTED_STRUCT = {
             'message': message,
             'python_logger': python_logger_name,
         }
-        EXPECTED_SENT = (EXPECTED_STRUCT, 'INFO', RESOURCE)
+        EXPECTED_SENT = (EXPECTED_STRUCT, 'INFO', _GLOBAL_RESOURCE)
         self.assertEqual(
             transport.logger.log_struct_called_with, EXPECTED_SENT)
 
 
 class _Logger(object):
+    from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
     def __init__(self, name):
         self.name = name


### PR DESCRIPTION
For #2997 .  Modified the AppEngineHandler to extend the CloudLoggingHandler and directly write logs to Stackdriver Logging API.

Screenshot of the gae_app log with AppEngineHandler:
![test_gae_app_logging](https://cloud.githubusercontent.com/assets/12888824/26014356/0a14ba46-3711-11e7-8f71-3b8c9001fbb5.png)
