### PR TITLE
Fix "broken" docs build.

### DIFF
--- a/docs/logging-usage.rst
+++ b/docs/logging-usage.rst
@@ -20,19 +20,17 @@ Authentication and Configuration
   non-empty string, e.g.:  ``$ export GOOGLE_CLOUD_DISABLE_GRPC=true``.
 
 - After configuring your environment, create a
-  :class:`Client <google.cloud.logging.client.Client>`
+  :class:`~google.cloud.logging.client.Client`
 
   .. literalinclude:: logging_snippets.py
      :start-after: [START client_create_default]
      :end-before: [END client_create_default]
-     :dedent: 4
 
   or pass in ``credentials`` and ``project`` explicitly
 
   .. literalinclude:: logging_snippets.py
      :start-after: [START client_create_explicit]
      :end-before: [END client_create_explicit]
-     :dedent: 4
 
 
 Writing log entries
@@ -45,21 +43,18 @@ which to associate the entries:
 .. literalinclude:: logging_snippets.py
     :start-after: [START logger_create]
     :end-before: [END logger_create]
-    :dedent: 4
 
 Write a simple text entry to the logger.
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START logger_log_text]
     :end-before: [END logger_log_text]
-    :dedent: 4
 
 Write a dictionary entry to the logger.
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START logger_log_struct]
     :end-before: [END logger_log_struct]
-    :dedent: 4
 
 
 Retrieving log entries
@@ -70,14 +65,12 @@ Fetch entries for the default project.
 .. literalinclude:: logging_snippets.py
     :start-after: [START client_list_entries_default]
     :end-before: [END client_list_entries_default]
-    :dedent: 4
 
 Fetch entries across multiple projects.
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START client_list_entries_multi_project]
     :end-before: [END client_list_entries_multi_project]
-    :dedent: 4
 
 Filter entries retrieved using the `Advanced Logs Filters`_ syntax
 
@@ -88,28 +81,24 @@ Fetch entries for the default project.
 .. literalinclude:: logging_snippets.py
     :start-after: [START client_list_entries_filter]
     :end-before: [END client_list_entries_filter]
-    :dedent: 4
 
 Sort entries in descending timestamp order.
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START client_list_entries_order_by]
     :end-before: [END client_list_entries_order_by]
-    :dedent: 4
 
 Retrieve entries in batches of 10, iterating until done.
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START client_list_entries_paged]
     :end-before: [END client_list_entries_paged]
-    :dedent: 4
 
 Retrieve entries for a single logger, sorting in descending timestamp order:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START logger_list_entries]
     :end-before: [END logger_list_entries]
-    :dedent: 4
 
 
 Delete all entries for a logger
@@ -118,7 +107,6 @@ Delete all entries for a logger
 .. literalinclude:: logging_snippets.py
     :start-after: [START logger_delete]
     :end-before: [END logger_delete]
-    :dedent: 8
 
 
 Manage log metrics
@@ -132,35 +120,30 @@ List all metrics for a project:
 .. literalinclude:: logging_snippets.py
     :start-after: [START client_list_metrics]
     :end-before: [END client_list_metrics]
-    :dedent: 4
 
 Create a metric:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START metric_create]
     :end-before: [END metric_create]
-    :dedent: 4
 
 Refresh local information about a metric:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START metric_reload]
     :end-before: [END metric_reload]
-    :dedent: 4
 
 Update a metric:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START metric_update]
     :end-before: [END metric_update]
-    :dedent: 4
 
 Delete a metric:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START metric_delete]
     :end-before: [END metric_delete]
-    :dedent: 4
 
 Export log entries using sinks
 ------------------------------
@@ -182,14 +165,12 @@ Add ``cloud-logs@google.com`` as the owner of the bucket:
 .. literalinclude:: logging_snippets.py
     :start-after: [START sink_bucket_permissions]
     :end-before: [END sink_bucket_permissions]
-    :dedent: 4
 
 Create a Cloud Storage sink:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START sink_storage_create]
     :end-before: [END sink_storage_create]
-    :dedent: 4
 
 
 Export to BigQuery
@@ -205,14 +186,12 @@ See: `Setting permissions for BigQuery`_
 .. literalinclude:: logging_snippets.py
     :start-after: [START sink_dataset_permissions]
     :end-before: [END sink_dataset_permissions]
-    :dedent: 4
 
 Create a BigQuery sink:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START sink_bigquery_create]
     :end-before: [END sink_bigquery_create]
-    :dedent: 4
 
 
 Export to Pub/Sub
@@ -228,14 +207,12 @@ See: `Setting permissions for Pub/Sub`_
 .. literalinclude:: logging_snippets.py
     :start-after: [START sink_topic_permissions]
     :end-before: [END sink_topic_permissions]
-    :dedent: 4
 
 Create a Cloud Pub/Sub sink:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START sink_pubsub_create]
     :end-before: [END sink_pubsub_create]
-    :dedent: 4
 
 Manage Sinks
 ~~~~~~~~~~~~
@@ -245,28 +222,24 @@ List all sinks for a project:
 .. literalinclude:: logging_snippets.py
     :start-after: [START client_list_sinks]
     :end-before: [END client_list_sinks]
-    :dedent: 4
 
 Refresh local information about a sink:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START sink_reload]
     :end-before: [END sink_reload]
-    :dedent: 4
 
 Update a sink:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START sink_update]
     :end-before: [END sink_update]
-    :dedent: 4
 
 Delete a sink:
 
 .. literalinclude:: logging_snippets.py
     :start-after: [START sink_delete]
     :end-before: [END sink_delete]
-    :dedent: 4
 
 Integration with Python logging module
 --------------------------------------
@@ -279,7 +252,6 @@ To automatically pick the default for your current environment, use
 .. literalinclude:: logging_snippets.py
     :start-after: [START create_default_handler]
     :end-before: [END create_default_handler]
-    :dedent: 4
 
 It is also possible to attach the handler to the root Python logger, so that
 for example a plain ``logging.warn`` call would be sent to Stackdriver Logging,
@@ -290,7 +262,6 @@ to configure this automatically.
 .. literalinclude:: logging_snippets.py
     :start-after: [START setup_logging]
     :end-before: [END setup_logging]
-    :dedent: 4
 
 .. note::
 
@@ -302,7 +273,6 @@ You can also exclude certain loggers:
 .. literalinclude:: logging_snippets.py
     :start-after: [START setup_logging_excludes]
     :end-before: [END setup_logging_excludes]
-    :dedent: 4
 
 Cloud Logging Handler
 =====================
@@ -316,7 +286,6 @@ which will write directly to the API.
 .. literalinclude:: logging_snippets.py
     :start-after: [START create_cloud_handler]
     :end-before: [END create_cloud_handler]
-    :dedent: 4
 
 .. note::
 
@@ -332,7 +301,6 @@ of the Python logger will be included in the structured log entry under the
 .. literalinclude:: logging_snippets.py
     :start-after: [START create_named_handler]
     :end-before: [END create_named_handler]
-    :dedent: 4
 
 fluentd logging handlers
 ========================

--- a/pubsub/google/cloud/pubsub/client.py
+++ b/pubsub/google/cloud/pubsub/client.py
@@ -226,7 +226,6 @@ class Client(ClientWithProject):
         .. literalinclude:: pubsub_snippets.py
            :start-after: [START client_topic]
            :end-before: [END client_topic]
-           :dedent: 4
 
         :type name: str
         :param name: the name of the topic to be constructed.
@@ -249,7 +248,6 @@ class Client(ClientWithProject):
         .. literalinclude:: pubsub_snippets.py
            :start-after: [START client_subscription]
            :end-before: [END client_subscription]
-           :dedent: 4
 
         :type name: str
         :param name: the name of the subscription to be constructed.

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -442,7 +442,6 @@ class Blob(_PropertyMixin):
          .. literalinclude:: storage_snippets.py
             :start-after: [START download_to_file]
             :end-before: [END download_to_file]
-            :dedent: 4
 
         The ``encryption_key`` should be a str or bytes with a length of at
         least 32.
@@ -844,7 +843,6 @@ class Blob(_PropertyMixin):
         .. literalinclude:: storage_snippets.py
             :start-after: [START upload_from_file]
             :end-before: [END upload_from_file]
-            :dedent: 4
 
         The ``encryption_key`` should be a str or bytes with a length of at
         least 32.


### PR DESCRIPTION
Examples:
https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1895
https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/1896

```
Warning, treated as error:
/var/code/gcp/docs/logging-usage.rst.rst:25:Over dedent has detected
```

Caused by new release of Sphinx:
https://pypi.python.org/pypi/Sphinx/1.6.1

----

I was **hoping** that this meant that Sphinx had added some magic dedent detection and we were contradicting it, but this is not the case:

![screenshot from 2017-05-16 10-13-51](https://cloud.githubusercontent.com/assets/520669/26118969/85c92b06-3a20-11e7-8fce-f728d6f328bb.png)
