### PR TITLE
iam.Policy: return empty set on missing key.

### DIFF
--- a/core/google/cloud/iam.py
+++ b/core/google/cloud/iam.py
@@ -59,7 +59,7 @@ class Policy(collections.MutableMapping):
     def __init__(self, etag=None, version=None):
         self.etag = etag
         self.version = version
-        self._bindings = {}
+        self._bindings = collections.defaultdict(set)
 
     def __iter__(self):
         return iter(self._bindings)

--- a/core/tests/unit/test_iam.py
+++ b/core/tests/unit/test_iam.py
@@ -52,8 +52,7 @@ class TestPolicy(unittest.TestCase):
 
     def test___getitem___miss(self):
         policy = self._make_one()
-        with self.assertRaises(KeyError):
-            policy['nonesuch']
+        self.assertEqual(policy['nonesuch'], set())
 
     def test___setitem__(self):
         USER = 'user:phred@example.com'


### PR DESCRIPTION
Closes #3346.