### PR TITLE
Adding optional switch to capture project ID in from_service_account_json().

### DIFF
--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -207,6 +207,7 @@ class Client(_ClientFactoryMixin, _ClientProjectMixin):
     _instance_stub_internal = None
     _operations_stub_internal = None
     _table_stub_internal = None
+    _SET_PROJECT = True  # Used by from_service_account_json()
 
     def __init__(self, project=None, credentials=None,
                  read_only=False, admin=False, user_agent=DEFAULT_USER_AGENT):

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -14,6 +14,8 @@
 
 """Base classes for client used to interact with Google Cloud APIs."""
 
+import io
+import json
 from pickle import PicklingError
 
 import google.auth.credentials
@@ -40,6 +42,8 @@ class _ClientFactoryMixin(object):
         This class is virtual.
     """
 
+    _SET_PROJECT = False
+
     @classmethod
     def from_service_account_json(cls, json_credentials_path, *args, **kwargs):
         """Factory to retrieve JSON credentials while creating client.
@@ -58,15 +62,21 @@ class _ClientFactoryMixin(object):
         :type kwargs: dict
         :param kwargs: Remaining keyword arguments to pass to constructor.
 
-        :rtype: :class:`google.cloud.pubsub.client.Client`
+        :rtype: :class:`_ClientFactoryMixin`
         :returns: The client created with the retrieved JSON credentials.
         :raises: :class:`TypeError` if there is a conflict with the kwargs
                  and the credentials created by the factory.
         """
         if 'credentials' in kwargs:
             raise TypeError('credentials must not be in keyword arguments')
-        credentials = service_account.Credentials.from_service_account_file(
-            json_credentials_path)
+        with io.open(json_credentials_path, 'r', encoding='utf-8') as json_fi:
+            credentials_info = json.load(json_fi)
+        credentials = service_account.Credentials.from_service_account_info(
+            credentials_info)
+        if cls._SET_PROJECT:
+            if 'project' not in kwargs:
+                kwargs['project'] = credentials_info.get('project_id')
+
         kwargs['credentials'] = credentials
         return cls(*args, **kwargs)
 
@@ -206,6 +216,8 @@ class ClientWithProject(Client, _ClientProjectMixin):
     :raises: :class:`ValueError` if the project is neither passed in nor
              set in the environment.
     """
+
+    _SET_PROJECT = True  # Used by from_service_account_json()
 
     def __init__(self, project=None, credentials=None, _http=None):
         _ClientProjectMixin.__init__(self, project=project)

--- a/core/nox.py
+++ b/core/nox.py
@@ -33,7 +33,8 @@ def unit_tests(session, python_version):
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
-    session.run('py.test', '--quiet',
+    session.run(
+        'py.test', '--quiet',
         '--cov=google.cloud', '--cov=tests.unit', '--cov-append',
         '--cov-config=.coveragerc', '--cov-report=', '--cov-fail-under=97',
         'tests/unit',

--- a/spanner/google/cloud/spanner/client.py
+++ b/spanner/google/cloud/spanner/client.py
@@ -102,6 +102,7 @@ class Client(_ClientFactoryMixin, _ClientProjectMixin):
     """
     _instance_admin_api = None
     _database_admin_api = None
+    _SET_PROJECT = True  # Used by from_service_account_json()
 
     def __init__(self, project=None, credentials=None,
                  user_agent=DEFAULT_USER_AGENT):


### PR DESCRIPTION
Fixes #1883.

@lukesneeringer This is a long-standing bug but should really make it into a `google-cloud-core` release. I know you hate releasing `core`.