### PR TITLE
Move '_catch_remap_gax_error' to 'core.exceptions'.

### DIFF
--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -52,7 +52,6 @@ SETUP_BASE = {
 
 REQUIREMENTS = [
     'google-cloud-core >= 0.24.0, < 0.25dev',
-    'google-gax>=0.15.7, <0.16dev',
 ]
 
 setup(

--- a/core/google/cloud/exceptions.py
+++ b/core/google/cloud/exceptions.py
@@ -27,16 +27,10 @@ import sys
 
 import six
 
-try:
-    from google.gax.errors import GaxError
-    from google.gax.grpc import exc_to_code
-    from grpc import StatusCode
-    from grpc._channel import _Rendezvous
-except ImportError:  # pragma: NO COVER
-    _HAVE_GRPC = False
-    _Rendezvous = None
-else:
-    _HAVE_GRPC = True
+from google.gax.errors import GaxError
+from google.gax.grpc import exc_to_code
+from grpc import StatusCode
+from grpc._channel import _Rendezvous
 
 from google.cloud._helpers import _to_bytes
 
@@ -259,6 +253,7 @@ for _eklass in _walk_subclasses(GoogleCloudError):
     code = getattr(_eklass, 'code', None)
     if code is not None:
         _HTTP_CODE_TO_EXCEPTION[code] = _eklass
+
 
 _GRPC_ERROR_MAPPING = {
     StatusCode.UNKNOWN: InternalServerError,

--- a/core/setup.py
+++ b/core/setup.py
@@ -56,6 +56,7 @@ REQUIREMENTS = [
     'protobuf >= 3.0.0',
     'google-auth >= 0.4.0, < 2.0.0dev',
     'google-auth-httplib2',
+    'google-gax>=0.15.7, <0.16dev',
     'six',
 ]
 

--- a/core/tests/unit/test_exceptions.py
+++ b/core/tests/unit/test_exceptions.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+from google.cloud.exceptions import _HAVE_GRPC
+
 
 class Test_GoogleCloudError(unittest.TestCase):
 
@@ -143,6 +145,69 @@ class Test_make_exception(unittest.TestCase):
         self.assertIsInstance(exception, TooManyRequests)
         self.assertEqual(exception.message, content)
         self.assertEqual(list(exception.errors), [])
+
+
+@unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
+class Test__catch_remap_gax_error(unittest.TestCase):
+
+    def _call_fut(self):
+        from google.cloud.exceptions import _catch_remap_gax_error
+
+        return _catch_remap_gax_error()
+
+    @staticmethod
+    def _fake_method(exc, result=None):
+        if exc is None:
+            return result
+        else:
+            raise exc
+
+    @staticmethod
+    def _make_rendezvous(status_code, details):
+        from grpc._channel import _RPCState
+        from google.cloud.exceptions import GrpcRendezvous
+
+        exc_state = _RPCState((), None, None, status_code, details)
+        return GrpcRendezvous(exc_state, None, None, None)
+
+    def test_success(self):
+        expected = object()
+        with self._call_fut():
+            result = self._fake_method(None, expected)
+        self.assertIs(result, expected)
+
+    def test_non_grpc_err(self):
+        exc = RuntimeError('Not a gRPC error')
+        with self.assertRaises(RuntimeError):
+            with self._call_fut():
+                self._fake_method(exc)
+
+    def test_gax_error(self):
+        from google.gax.errors import GaxError
+        from grpc import StatusCode
+        from google.cloud.exceptions import Forbidden
+
+        # First, create low-level GrpcRendezvous exception.
+        details = 'Some error details.'
+        cause = self._make_rendezvous(StatusCode.PERMISSION_DENIED, details)
+        # Then put it into a high-level GaxError.
+        msg = 'GAX Error content.'
+        exc = GaxError(msg, cause=cause)
+
+        with self.assertRaises(Forbidden):
+            with self._call_fut():
+                self._fake_method(exc)
+
+    def test_gax_error_not_mapped(self):
+        from google.gax.errors import GaxError
+        from grpc import StatusCode
+
+        cause = self._make_rendezvous(StatusCode.CANCELLED, None)
+        exc = GaxError(None, cause=cause)
+
+        with self.assertRaises(GaxError):
+            with self._call_fut():
+                self._fake_method(exc)
 
 
 class _Response(object):

--- a/core/tests/unit/test_exceptions.py
+++ b/core/tests/unit/test_exceptions.py
@@ -14,8 +14,6 @@
 
 import unittest
 
-from google.cloud.exceptions import _HAVE_GRPC
-
 
 class Test_GoogleCloudError(unittest.TestCase):
 
@@ -147,7 +145,6 @@ class Test_make_exception(unittest.TestCase):
         self.assertEqual(list(exception.errors), [])
 
 
-@unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
 class Test__catch_remap_gax_error(unittest.TestCase):
 
     def _call_fut(self):

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -52,7 +52,6 @@ SETUP_BASE = {
 
 REQUIREMENTS = [
     'google-cloud-core >= 0.24.0, < 0.25dev',
-    'google-gax>=0.15.7, <0.16dev',
     'gapic-google-cloud-datastore-v1 >= 0.15.0, < 0.16dev',
 ]
 

--- a/datastore/tests/unit/test__gax.py
+++ b/datastore/tests/unit/test__gax.py
@@ -20,69 +20,6 @@ from google.cloud.datastore.client import _HAVE_GRPC
 
 
 @unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
-class Test__catch_remap_gax_error(unittest.TestCase):
-
-    def _call_fut(self):
-        from google.cloud.datastore._gax import _catch_remap_gax_error
-
-        return _catch_remap_gax_error()
-
-    @staticmethod
-    def _fake_method(exc, result=None):
-        if exc is None:
-            return result
-        else:
-            raise exc
-
-    @staticmethod
-    def _make_rendezvous(status_code, details):
-        from grpc._channel import _RPCState
-        from google.cloud.exceptions import GrpcRendezvous
-
-        exc_state = _RPCState((), None, None, status_code, details)
-        return GrpcRendezvous(exc_state, None, None, None)
-
-    def test_success(self):
-        expected = object()
-        with self._call_fut():
-            result = self._fake_method(None, expected)
-        self.assertIs(result, expected)
-
-    def test_non_grpc_err(self):
-        exc = RuntimeError('Not a gRPC error')
-        with self.assertRaises(RuntimeError):
-            with self._call_fut():
-                self._fake_method(exc)
-
-    def test_gax_error(self):
-        from google.gax.errors import GaxError
-        from grpc import StatusCode
-        from google.cloud.exceptions import Forbidden
-
-        # First, create low-level GrpcRendezvous exception.
-        details = 'Some error details.'
-        cause = self._make_rendezvous(StatusCode.PERMISSION_DENIED, details)
-        # Then put it into a high-level GaxError.
-        msg = 'GAX Error content.'
-        exc = GaxError(msg, cause=cause)
-
-        with self.assertRaises(Forbidden):
-            with self._call_fut():
-                self._fake_method(exc)
-
-    def test_gax_error_not_mapped(self):
-        from google.gax.errors import GaxError
-        from grpc import StatusCode
-
-        cause = self._make_rendezvous(StatusCode.CANCELLED, None)
-        exc = GaxError(None, cause=cause)
-
-        with self.assertRaises(GaxError):
-            with self._call_fut():
-                self._fake_method(exc)
-
-
-@unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
 class TestGAPICDatastoreAPI(unittest.TestCase):
 
     @staticmethod

--- a/videointelligence/setup.py
+++ b/videointelligence/setup.py
@@ -43,7 +43,6 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     install_requires=(
         'googleapis-common-protos >= 1.5.2, < 2.0dev',
-        'google-gax >= 0.15.12, < 0.16dev',
         'six >= 1.10.0',
     ),
     url='https://github.com/GoogleCloudPlatform/google-cloud-python',


### PR DESCRIPTION
Toward #3175.

This is the first step toward applying a more uniform mapping of GAX error codes to our exception hierarchy.  For a narrower, pubsub-only fix for #3175, see #3443.