### PR TITLE
Fix a couple of video intelligence issues.

### DIFF
--- a/videointelligence/google/cloud/videointelligence_v1beta1/__init__.py
+++ b/videointelligence/google/cloud/videointelligence_v1beta1/__init__.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from google.cloud.gapic.videointelligence.v1beta1.video_intelligence_service_client import VideoIntelligenceServiceClient
 from google.cloud.gapic.videointelligence.v1beta1 import enums
 
-from google.cloud.gapic.videointelligence_v1beta1 import types
+from google.cloud.videointelligence_v1beta1 import types
 
 
 

--- a/videointelligence/google/cloud/videointelligence_v1beta1/types.py
+++ b/videointelligence/google/cloud/videointelligence_v1beta1/types.py
@@ -20,7 +20,7 @@ from google.gax.utils.messages import get_messages
 
 
 names = []
-for name, message in get_messages(video_intelligence_pb2):
+for name, message in get_messages(video_intelligence_pb2).items():
     setattr(sys.modules[__name__], name, message)
     names.append(name)
 


### PR DESCRIPTION
  * [x] Incorrect import from `google.cloud.gapic.videointelligence_v1beta1` (should omit `.gapic.`)
  * [x] Missed an `.items()` on an iteration over a dict.

I think the package we released actually had these fixed, because otherwise there is no way it worked at all.