### PR TITLE
Using part of speech "tag" in system test.

### DIFF
--- a/language/tests/system.py
+++ b/language/tests/system.py
@@ -130,7 +130,7 @@ class TestLanguage(unittest.TestCase):
 
         self.assertIsInstance(token, Token)
         self.assertEqual(token.text_content, text_content)
-        self.assertEqual(token.part_of_speech, part_of_speech)
+        self.assertEqual(token.part_of_speech.tag, part_of_speech)
         self.assertEqual(token.lemma, lemma)
 
     def _check_analyze_syntax_result(self, tokens):


### PR DESCRIPTION
`Token.part_of_speech` is now a `PartOfSpeech `rather than a string scalar. (This test breakage was accidentally introduced in #3457.)

See [breakage][1]

[1]: https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/2088