### PR TITLE
Skipping system tests when credentials env. var is unset.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: googleapis/nox:0.11.2
+      - image: googleapis/nox:0.17.0
     steps:
       - checkout
       - run:

--- a/appveyor/requirements.txt
+++ b/appveyor/requirements.txt
@@ -3,4 +3,4 @@
 # pip will build them from source using the MSVC compiler matching the
 # target Python version and architecture
 wheel
-nox-automation==0.11.2
+nox-automation>=0.17.0

--- a/bigquery/nox.py
+++ b/bigquery/nox.py
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/bigtable/nox.py
+++ b/bigtable/nox.py
@@ -48,7 +48,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/datastore/nox.py
+++ b/datastore/nox.py
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)
@@ -70,7 +70,7 @@ def doctests(session):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Doctests run against Python 3.6 only.
     # It is difficult to make doctests run against both Python 2 and Python 3

--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -78,7 +78,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/language/nox.py
+++ b/language/nox.py
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/logging/nox.py
+++ b/logging/nox.py
@@ -52,7 +52,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/monitoring/nox.py
+++ b/monitoring/nox.py
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/pubsub/nox.py
+++ b/pubsub/nox.py
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/spanner/nox.py
+++ b/spanner/nox.py
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/speech/nox.py
+++ b/speech/nox.py
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/storage/nox.py
+++ b/storage/nox.py
@@ -50,7 +50,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/translate/nox.py
+++ b/translate/nox.py
@@ -49,7 +49,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run the system tests against latest Python 2 and Python 3 only.
     session.interpreter = 'python{}'.format(python_version)

--- a/vision/nox.py
+++ b/vision/nox.py
@@ -46,7 +46,7 @@ def system_tests(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run unit tests against all supported versions of Python.
     session.interpreter = 'python{}'.format(python_version)
@@ -67,7 +67,7 @@ def system_tests_manual_layer(session, python_version):
 
     # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
-        return
+        session.skip('Credentials must be set via environment variable.')
 
     # Run unit tests against all supported versions of Python.
     session.interpreter = 'python{}'.format(python_version)


### PR DESCRIPTION
This is labeled "don't merge" because it is **wrong** in it's current state.

So @lukesneeringer @tseaver @jonparrott WDYT the "correct" form should be? We don't want it to raise on PRs, we want it to gracefully do nothing. Otherwise, this is a helpful message and status for people running tests locally with a "bad" setup.