### PR TITLE
Add 'Bucket.requester_pays' property.

### DIFF
--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -806,8 +806,9 @@ class Bucket(_PropertyMixin):
     def requester_pays(self):
         """Does the requester pay for API requests for this bucket?
 
-        See  https://cloud.google.com/storage/docs/<DOCS-MISSING> for
-        details.
+        .. note::
+
+           No public docs exist yet for the "requester pays" feature.
 
         :setter: Update whether requester pays for this bucket.
         :getter: Query whether requester pays for this bucket.

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -798,9 +798,38 @@ class Bucket(_PropertyMixin):
         details.
 
         :type value: convertible to boolean
-        :param value: should versioning be anabled for the bucket?
+        :param value: should versioning be enabled for the bucket?
         """
         self._patch_property('versioning', {'enabled': bool(value)})
+
+    @property
+    def requester_pays(self):
+        """Does the requester pay for API requests for this bucket?
+
+        See  https://cloud.google.com/storage/docs/<DOCS-MISSING> for
+        details.
+
+        :setter: Update whether requester pays for this bucket.
+        :getter: Query whether requester pays for this bucket.
+
+        :rtype: bool
+        :returns: True if requester pays for API requests for the bucket,
+                  else False.
+        """
+        versioning = self._properties.get('billing', {})
+        return versioning.get('requesterPays', False)
+
+    @requester_pays.setter
+    def requester_pays(self, value):
+        """Update whether requester pays for API requests for this bucket.
+
+        See  https://cloud.google.com/storage/docs/<DOCS-MISSING> for
+        details.
+
+        :type value: convertible to boolean
+        :param value: should requester pay for API requests for the bucket?
+        """
+        self._patch_property('billing', {'requesterPays': bool(value)})
 
     def configure_website(self, main_page_suffix=None, not_found_page=None):
         """Configure website-related properties.

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -194,7 +194,7 @@ class Client(ClientWithProject):
         except NotFound:
             return None
 
-    def create_bucket(self, bucket_name):
+    def create_bucket(self, bucket_name, requester_pays=None):
         """Create a new bucket.
 
         For example:
@@ -211,10 +211,16 @@ class Client(ClientWithProject):
         :type bucket_name: str
         :param bucket_name: The bucket name to create.
 
+        :type requester_pays: bool
+        :param requester_pays: (Optional) Whether requester pays for
+            API requests for this bucket and its blobs.
+
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
         :returns: The newly created bucket.
         """
         bucket = Bucket(self, name=bucket_name)
+        if requester_pays is not None:
+            bucket.requester_pays = requester_pays
         bucket.create(client=self)
         return bucket
 

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -212,8 +212,9 @@ class Client(ClientWithProject):
         :param bucket_name: The bucket name to create.
 
         :type requester_pays: bool
-        :param requester_pays: (Optional) Whether requester pays for
-            API requests for this bucket and its blobs.
+        :param requester_pays:
+            (Optional) Whether requester pays for API requests for this
+            bucket and its blobs.
 
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
         :returns: The newly created bucket.

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -30,6 +30,8 @@ from test_utils.system import unique_resource_id
 
 HTTP = httplib2.Http()
 
+REQUESTER_PAYS_ENABLED = False  # query from environment?
+
 
 def _bad_copy(bad_request):
     """Predicate: pass only exceptions for a failed copyTo."""
@@ -99,7 +101,7 @@ class TestStorageBuckets(unittest.TestCase):
         self.case_buckets_to_delete.append(new_bucket_name)
         self.assertEqual(created.name, new_bucket_name)
 
-    @unittest.skipIf(True, "requesterPays needs whitelisting?")
+    @unittest.skipUnless(REQUESTER_PAYS_ENABLED, "requesterPays not enabled")
     def test_create_bucket_with_requester_pays(self):
         new_bucket_name = 'w-requester-pays' + unique_resource_id('-')
         created = Config.CLIENT.create_bucket(

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -99,6 +99,16 @@ class TestStorageBuckets(unittest.TestCase):
         self.case_buckets_to_delete.append(new_bucket_name)
         self.assertEqual(created.name, new_bucket_name)
 
+    @unittest.skipIf(True, "requesterPays needs whitelisting?")
+    def test_create_bucket_with_requester_pays(self):
+        new_bucket_name = 'w-requester-pays' + unique_resource_id('-')
+        bucket = Config.CLIENT.bucket(new_bucket_name)
+        bucket.requester_pays = True
+        bucket.create()
+        self.case_buckets_to_delete.append(new_bucket_name)
+        self.assertEqual(bucket.name, new_bucket_name)
+        self.assertTrue(bucket.requester_pays)
+
     def test_list_buckets(self):
         buckets_to_create = [
             'new' + unique_resource_id(),

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -102,12 +102,11 @@ class TestStorageBuckets(unittest.TestCase):
     @unittest.skipIf(True, "requesterPays needs whitelisting?")
     def test_create_bucket_with_requester_pays(self):
         new_bucket_name = 'w-requester-pays' + unique_resource_id('-')
-        bucket = Config.CLIENT.bucket(new_bucket_name)
-        bucket.requester_pays = True
-        bucket.create()
+        created = Config.CLIENT.create_bucket(
+            new_bucket_name, requester_pays=True)
         self.case_buckets_to_delete.append(new_bucket_name)
-        self.assertEqual(bucket.name, new_bucket_name)
-        self.assertTrue(bucket.requester_pays)
+        self.assertEqual(created.name, new_bucket_name)
+        self.assertTrue(created.requester_pays)
 
     def test_list_buckets(self):
         buckets_to_create = [

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -176,6 +176,7 @@ class Test_Bucket(unittest.TestCase):
             'location': LOCATION,
             'storageClass': STORAGE_CLASS,
             'versioning': {'enabled': True},
+            'billing': {'requesterPays': True},
             'labels': LABELS,
         }
         connection = _Connection(DATA)
@@ -186,6 +187,7 @@ class Test_Bucket(unittest.TestCase):
         bucket.location = LOCATION
         bucket.storage_class = STORAGE_CLASS
         bucket.versioning_enabled = True
+        bucket.requester_pays = True
         bucket.labels = LABELS
         bucket.create()
 
@@ -865,6 +867,24 @@ class Test_Bucket(unittest.TestCase):
         self.assertFalse(bucket.versioning_enabled)
         bucket.versioning_enabled = True
         self.assertTrue(bucket.versioning_enabled)
+
+    def test_requester_pays_getter_missing(self):
+        NAME = 'name'
+        bucket = self._make_one(name=NAME)
+        self.assertEqual(bucket.requester_pays, False)
+
+    def test_requester_pays_getter(self):
+        NAME = 'name'
+        before = {'billing': {'requesterPays': True}}
+        bucket = self._make_one(name=NAME, properties=before)
+        self.assertEqual(bucket.requester_pays, True)
+
+    def test_requester_pays_setter(self):
+        NAME = 'name'
+        bucket = self._make_one(name=NAME)
+        self.assertFalse(bucket.requester_pays)
+        bucket.requester_pays = True
+        self.assertTrue(bucket.requester_pays)
 
     def test_configure_website_defaults(self):
         NAME = 'name'


### PR DESCRIPTION
Toward #3474.

Note that the new system test is skipped, because `Buckets.insert` fails with the `billing/requesterPays` field set, both in our system tests and in the 'Try It!' form in the docs.