### PR TITLE
Pass 'user_project' if set for BucketACL/BlobACL API requests

### DIFF
--- a/storage/google/cloud/storage/acl.py
+++ b/storage/google/cloud/storage/acl.py
@@ -406,10 +406,18 @@ class ACL(object):
         """
         path = self.reload_path
         client = self._require_client(client)
+        query_params = {}
+
+        if self.user_project is not None:
+            query_params['userProject'] = self.user_project
 
         self.entities.clear()
 
-        found = client._connection.api_request(method='GET', path=path)
+        found = client._connection.api_request(
+            method='GET',
+            path=path,
+            query_params=query_params,
+        )
         self.loaded = True
         for entry in found.get('items', ()):
             self.add_entity(self.entity_from_dict(entry))

--- a/storage/google/cloud/storage/acl.py
+++ b/storage/google/cloud/storage/acl.py
@@ -198,6 +198,7 @@ class ACL(object):
     # as properties).
     reload_path = None
     save_path = None
+    user_project = None
 
     def __init__(self):
         self.entities = {}
@@ -532,6 +533,11 @@ class BucketACL(ACL):
         """Compute the path for PATCH API requests for this ACL."""
         return self.bucket.path
 
+    @property
+    def user_project(self):
+        """Compute the user project charged for API requests for this ACL."""
+        return self.bucket.user_project
+
 
 class DefaultObjectACL(BucketACL):
     """A class representing the default object ACL for a bucket."""
@@ -565,3 +571,8 @@ class ObjectACL(ACL):
     def save_path(self):
         """Compute the path for PATCH API requests for this ACL."""
         return self.blob.path
+
+    @property
+    def user_project(self):
+        """Compute the user project charged for API requests for this ACL."""
+        return self.blob.user_project

--- a/storage/google/cloud/storage/acl.py
+++ b/storage/google/cloud/storage/acl.py
@@ -444,8 +444,12 @@ class ACL(object):
             acl = []
             query_params[self._PREDEFINED_QUERY_PARAM] = predefined
 
+        if self.user_project is not None:
+            query_params['userProject'] = self.user_project
+
         path = self.save_path
         client = self._require_client(client)
+
         result = client._connection.api_request(
             method='PATCH',
             path=path,

--- a/storage/tests/unit/test_acl.py
+++ b/storage/tests/unit/test_acl.py
@@ -621,30 +621,43 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/testing')
-        self.assertEqual(kw[0]['data'], {'acl': AFTER})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0], {
+            'method': 'PATCH',
+            'path': '/testing',
+            'query_params': {'projection': 'full'},
+            'data': {'acl': AFTER},
+        })
 
-    def test_save_w_acl(self):
+    def test_save_w_acl_w_user_project(self):
         ROLE1 = 'role1'
         ROLE2 = 'role2'
         STICKY = {'entity': 'allUsers', 'role': ROLE2}
+        USER_PROJECT = 'user-project-123'
         new_acl = [{'entity': 'allUsers', 'role': ROLE1}]
         connection = _Connection({'acl': [STICKY] + new_acl})
         client = _Client(connection)
         acl = self._make_one()
         acl.save_path = '/testing'
         acl.loaded = True
+        acl.user_project = USER_PROJECT
+
         acl.save(new_acl, client=client)
+
         entries = list(acl)
         self.assertEqual(len(entries), 2)
         self.assertTrue(STICKY in entries)
         self.assertTrue(new_acl[0] in entries)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'PATCH')
-        self.assertEqual(kw[0]['path'], '/testing')
-        self.assertEqual(kw[0]['data'], {'acl': new_acl})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0], {
+            'method': 'PATCH',
+            'path': '/testing',
+            'query_params': {
+                'projection': 'full',
+                'userProject': USER_PROJECT,
+            },
+            'data': {'acl': new_acl},
+        })
 
     def test_save_prefefined_invalid(self):
         connection = _Connection()
@@ -667,11 +680,15 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(len(entries), 0)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'PATCH')
-        self.assertEqual(kw[0]['path'], '/testing')
-        self.assertEqual(kw[0]['data'], {'acl': []})
-        self.assertEqual(kw[0]['query_params'],
-                         {'projection': 'full', 'predefinedAcl': PREDEFINED})
+        self.assertEqual(kw[0], {
+            'method': 'PATCH',
+            'path': '/testing',
+            'query_params': {
+                'projection': 'full',
+                'predefinedAcl': PREDEFINED,
+            },
+            'data': {'acl': []},
+        })
 
     def test_save_predefined_w_XML_alias(self):
         PREDEFINED_XML = 'project-private'
@@ -686,12 +703,15 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(len(entries), 0)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'PATCH')
-        self.assertEqual(kw[0]['path'], '/testing')
-        self.assertEqual(kw[0]['data'], {'acl': []})
-        self.assertEqual(kw[0]['query_params'],
-                         {'projection': 'full',
-                          'predefinedAcl': PREDEFINED_JSON})
+        self.assertEqual(kw[0], {
+            'method': 'PATCH',
+            'path': '/testing',
+            'query_params': {
+                'projection': 'full',
+                'predefinedAcl': PREDEFINED_JSON,
+            },
+            'data': {'acl': []},
+        })
 
     def test_save_predefined_valid_w_alternate_query_param(self):
         # Cover case where subclass overrides _PREDEFINED_QUERY_PARAM
@@ -707,11 +727,15 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(len(entries), 0)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'PATCH')
-        self.assertEqual(kw[0]['path'], '/testing')
-        self.assertEqual(kw[0]['data'], {'acl': []})
-        self.assertEqual(kw[0]['query_params'],
-                         {'projection': 'full', 'alternate': PREDEFINED})
+        self.assertEqual(kw[0], {
+            'method': 'PATCH',
+            'path': '/testing',
+            'query_params': {
+                'projection': 'full',
+                'alternate': PREDEFINED,
+            },
+            'data': {'acl': []},
+        })
 
     def test_clear(self):
         ROLE1 = 'role1'
@@ -727,10 +751,12 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(list(acl), [STICKY])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'PATCH')
-        self.assertEqual(kw[0]['path'], '/testing')
-        self.assertEqual(kw[0]['data'], {'acl': []})
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0], {
+            'method': 'PATCH',
+            'path': '/testing',
+            'query_params': {'projection': 'full'},
+            'data': {'acl': []},
+        })
 
 
 class Test_BucketACL(unittest.TestCase):

--- a/storage/tests/unit/test_acl.py
+++ b/storage/tests/unit/test_acl.py
@@ -739,6 +739,15 @@ class Test_BucketACL(unittest.TestCase):
         self.assertEqual(acl.reload_path, '/b/%s/acl' % NAME)
         self.assertEqual(acl.save_path, '/b/%s' % NAME)
 
+    def test_user_project(self):
+        NAME = 'name'
+        USER_PROJECT = 'user-project-123'
+        bucket = _Bucket(NAME)
+        acl = self._make_one(bucket)
+        self.assertIsNone(acl.user_project)
+        bucket.user_project = USER_PROJECT
+        self.assertEqual(acl.user_project, USER_PROJECT)
+
 
 class Test_DefaultObjectACL(unittest.TestCase):
 
@@ -785,8 +794,21 @@ class Test_ObjectACL(unittest.TestCase):
         self.assertEqual(acl.reload_path, '/b/%s/o/%s/acl' % (NAME, BLOB_NAME))
         self.assertEqual(acl.save_path, '/b/%s/o/%s' % (NAME, BLOB_NAME))
 
+    def test_user_project(self):
+        NAME = 'name'
+        BLOB_NAME = 'blob-name'
+        USER_PROJECT = 'user-project-123'
+        bucket = _Bucket(NAME)
+        blob = _Blob(bucket, BLOB_NAME)
+        acl = self._make_one(blob)
+        self.assertIsNone(acl.user_project)
+        blob.user_project = USER_PROJECT
+        self.assertEqual(acl.user_project, USER_PROJECT)
+
 
 class _Blob(object):
+
+    user_project = None
 
     def __init__(self, bucket, blob):
         self.bucket = bucket
@@ -798,6 +820,8 @@ class _Blob(object):
 
 
 class _Bucket(object):
+
+    user_project = None
 
     def __init__(self, name):
         self.name = name

--- a/storage/tests/unit/test_acl.py
+++ b/storage/tests/unit/test_acl.py
@@ -532,8 +532,11 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(list(acl), [])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'GET')
-        self.assertEqual(kw[0]['path'], '/testing/acl')
+        self.assertEqual(kw[0], {
+            'method': 'GET',
+            'path': '/testing/acl',
+            'query_params': {},
+        })
 
     def test_reload_empty_result_clears_local(self):
         ROLE = 'role'
@@ -543,29 +546,41 @@ class Test_ACL(unittest.TestCase):
         acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.entity('allUsers', ROLE)
+
         acl.reload(client=client)
+
         self.assertTrue(acl.loaded)
         self.assertEqual(list(acl), [])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'GET')
-        self.assertEqual(kw[0]['path'], '/testing/acl')
+        self.assertEqual(kw[0], {
+            'method': 'GET',
+            'path': '/testing/acl',
+            'query_params': {},
+        })
 
-    def test_reload_nonempty_result(self):
+    def test_reload_nonempty_result_w_user_project(self):
         ROLE = 'role'
+        USER_PROJECT = 'user-project-123'
         connection = _Connection(
             {'items': [{'entity': 'allUsers', 'role': ROLE}]})
         client = _Client(connection)
         acl = self._make_one()
         acl.reload_path = '/testing/acl'
         acl.loaded = True
+        acl.user_project = USER_PROJECT
+
         acl.reload(client=client)
+
         self.assertTrue(acl.loaded)
         self.assertEqual(list(acl), [{'entity': 'allUsers', 'role': ROLE}])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'GET')
-        self.assertEqual(kw[0]['path'], '/testing/acl')
+        self.assertEqual(kw[0], {
+            'method': 'GET',
+            'path': '/testing/acl',
+            'query_params': {'userProject': USER_PROJECT},
+        })
 
     def test_save_none_set_none_passed(self):
         connection = _Connection()


### PR DESCRIPTION
Toward #3474.