### PR TITLE
Adding @jonparrott's sphinx-docstring-typing module.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+    'sphinx_docstring_typing',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,3 +15,4 @@ storage/
 translate/
 vision/
 spanner/
+sphinx-docstring-typing >= 0.0.2

--- a/language/google/cloud/language/document.py
+++ b/language/google/cloud/language/document.py
@@ -266,10 +266,10 @@ class Document(object):
             This API is intended for users who are familiar with machine
             learning and need in-depth text features to build upon.
 
-        .. _annotateText: https://cloud.google.com/natural-language/\
+        .. _annotate-text: https://cloud.google.com/natural-language/\
                           reference/rest/v1/documents/annotateText
 
-        See `annotateText`_.
+        See `annotate-text`_.
 
         :type include_syntax: bool
         :param include_syntax: (Optional) Flag to enable syntax analysis

--- a/nox.py
+++ b/nox.py
@@ -26,7 +26,7 @@ def docs(session):
 
     # Install Sphinx and also all of the google-cloud-* packages.
     session.chdir(os.path.realpath(os.path.dirname(__file__)))
-    session.install('Sphinx >= 1.6.2', 'sphinx_rtd_theme')
+    session.install('Sphinx >= 1.6.2', 'sphinx-docstring-typing >= 0.0.2')
     session.install(
         'core/', 'bigquery/', 'bigtable/', 'datastore/', 'dns/', 'language/',
         'logging/', 'error_reporting/', 'monitoring/', 'pubsub/',

--- a/vision/google/cloud/proto/vision/v1/text_annotation_pb2.py
+++ b/vision/google/cloud/proto/vision/v1/text_annotation_pb2.py
@@ -558,13 +558,14 @@ TextAnnotation = _reflection.GeneratedProtocolMessageType('TextAnnotation', (_me
   DESCRIPTOR = _TEXTANNOTATION,
   __module__ = 'google.cloud.proto.vision.v1.text_annotation_pb2'
   ,
-  __doc__ = """TextAnnotation contains a structured representation of OCR extracted
-  text. The hierarchy of an OCR extracted text structure is like this:
-  TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol Each
+  __doc__ = """``TextAnnotation`` contains a structured representation of OCR extracted text.
+
+  The hierarchy of an OCR extracted text structure is like this:
+  ``TextAnnotation`` -> ``Page`` -> ``Block`` -> ``Paragraph`` -> ``Word`` -> ``Symbol`` Each
   structural component, starting from Page, may further have their own
   properties. Properties describe detected languages, breaks etc.. Please
   refer to the
-  [google.cloud.vision.v1.TextAnnotation.TextProperty][google.cloud.vision.v1.TextAnnotation.TextProperty]
+  ``[google.cloud.vision.v1.TextAnnotation.TextProperty][google.cloud.vision.v1.TextAnnotation.TextProperty]``
   message definition below for more detail.
   
   


### PR DESCRIPTION
This allows usage of Python 3.5+ typing module, which is very helpful.

Note that the changes to **source** docstrings are likely bugs in `sphinx-docstring-typing`, so that may be addressed on that project.

@jonparrott This is marked "don't merge" right now because I want to check with you what the issues actually are with the source docstrings.