### PR TITLE
BigQuery _EnumProperty ValueError messages are not displayed properly

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -318,7 +318,7 @@ class _EnumProperty(_ConfigurationProperty):
         :raises: ValueError if value is not allowed.
         """
         if value not in self.ALLOWED:
-            raise ValueError('Pass one of: %s' ', '.join(self.ALLOWED))
+            raise ValueError('Pass one of: %s' % ', '.join(self.ALLOWED))
 
 
 class UDFResource(object):


### PR DESCRIPTION
I found this very small bug in the error message, so I fixed it!