### PR TITLE
Prep core-0.25.0 release.

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -61,7 +61,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-core',
-    version='0.24.1',
+    version='0.25.0',
     description='API Client library for Google Cloud: Core Helpers',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Draft release notes

## google-cloud-core 0.25.0

- Set correct project when using `from_service_account_json()` (PR #3436, issue #1883)
- `iam.Policy`: return empty set on missing key. (PR #3424, issue #3346)

-----

Not included in notes:

- Add testing support for 'ALREADY_EXISTS' gRPC error code. (PR #3443)
- Fix broken link in the client Google Auth credentials help text (#3517)
- Add back pylint as info-only for core (#3515)
- Vision semi-GAPIC (#3373) (docstring tweaks)
