### PR TITLE
Prep datastore-1.1.0 release.

### DIFF
--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -51,14 +51,14 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
     'google-gax>=0.15.7, <0.16dev',
     'gapic-google-cloud-datastore-v1 >= 0.15.0, < 0.16dev',
 ]
 
 setup(
     name='google-cloud-datastore',
-    version='1.0.0',
+    version='1.1.0',
     description='Python Client for Google Cloud Datastore',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Draft release notes

## google-cloud-datastore-1.1.0

- Update `google-cloud-core` dependency to ~= 0.25.
- Add `Key.(to|from)_legacy_urlsafe`. (PR #3491)

----

Not included in notes:

- Re-enable pylint in info-only mode for all packages (#3519)
- Vision semi-GAPIC (#3373) (docstring tweaks)
- Add better documentation for support types in datastore Entity. (#3363)
- Ignore tests (rather than unit_tests) in setup.py files. (#3319)
- Adding check (in datastore) that setup.py README is valid RST. (#3316)
