### PR TITLE
Prep logging-1.1.0 release.

### DIFF
--- a/logging/setup.py
+++ b/logging/setup.py
@@ -51,14 +51,14 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
     'grpcio >= 1.2.0, < 2.0dev',
     'gapic-google-cloud-logging-v2 >= 0.91.0, < 0.92dev',
 ]
 
 setup(
     name='google-cloud-logging',
-    version='1.0.0',
+    version='1.1.0',
     description='Python Client for Stackdriver Logging',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Requires merge of #3526 to bump `core` to 0.25.0.

Draft release notes:

## google.cloud-logging-1.1.0

- Update `google-cloud-core` dependency to ~= 0.25.
- Send trace context with logs from web applications (PR #3448, issue #3359)
- Write logs via Stackdriver logging API, rather than writing to `/var/log/app_engine/` (PR #3410, issue #2997)
- Implement `flush` for cloud logging handlers (PR #3413)
- Call `start` when creating a background thread transport (PR #3412)
- Add monitored resource support to Logging (PR #3386, issues #2673, #3377)

----

Not included in notes:

- Re-enable pylint in info-only mode for all packages (#3519)
- Vision semi-GAPIC (#3373) (docstring tweaks)
- Remove uncovered / pointless branch. (#3445)
- Fixing broken logging system test. (#3325)
- Ignore tests (rather than unit_tests) in setup.py files. (#3319)
- Overhaul logging background thread transport (#3407)
- Adding check that **all** setup.py README's are valid RST. (#3318)
