### PR TITLE
Prep storage-1.2.0 release.

### DIFF
--- a/storage/setup.py
+++ b/storage/setup.py
@@ -51,7 +51,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.1, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
     'google-auth >= 1.0.0',
     'google-resumable-media >= 0.1.1',
     'requests >= 2.0.0',
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-storage',
-    version='1.1.1',
+    version='1.2.0',
     description='Python Client for Google Cloud Storage',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Requires merge of #3526 to bump core to 0.25.0.

Note that this PR creates a release for changes since `storage-1.1.1` but **prior** to the not-yet-complete "requester pays" implementation onto a new branch, `storage-1.2.0-branch`.

Draft release notes:

## google-cloud-storage-1.2.0

- Update `google-cloud-core` dependency to ~ 0.25.
- Expose that settable properties are so. (PR #3472, issue #2610)
- Add `Bucket.labels` property. (PR #3478, issue #3473)
- Remove mention of no-longer-chainable ACL methods. (PR #3428, issue #3181)
- Restore support for retries in storage uploads. (PR #3378)
- Drop internal usage of `rewind` in `Blob.upload_from_string()`. (PR #3365)
- Change `Blob.upload*()` and `Blob.create_resumable_upload_session()` methods to use `google-resumable-media`. (PRs #3362, #3357)
- Enforce explicit UTF-8 blob name. (#3354)

----

Not included in notes:

- Revert "Fix 'broken' docs build. (#3422)" (#3439)
- Vision semi-GAPIC (#3373)
- Re-organize the documentation structure in preparation to split docs among subpackages (#3459)
- Fix "broken" docs build. (#3422)
- Clean up a documentation for the storage blob module. (#3376)
