### PR TITLE
Prep bigquery-0.25.0 release.

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -51,12 +51,12 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
 ]
 
 setup(
     name='google-cloud-bigquery',
-    version='0.24.0',
+    version='0.25.0',
     description='Python Client for Google BigQuery',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Requires merge of #3526 to bump core to 0.25.0.

Draft release notes:

## google-cloud-bigquery-0.25.0

- Update `google-cloud-core` dependency to ~= 0.25.
- Fix display of `_EnumProperty` ValueError messages. (PR #3520)
- Make `QueryResponse.fetch_data` return an iterator. (PR #3484, issue #2840)
- Add read-only `Query.num_dml_affected_rows` property. (PR #3460, issue #2920)
- Marshal row data correctly in `Table.insert_data()` (PR #3426, issue #2957)
- Fix support for loading AVRO files from the local filesystem (PR #3427, issue #3416)
- Fix support for creating partitioned tables. (PR #3381)
- Update BigQuery Query parameter reference to better indicate that `timeout_ms` sets timeout on the request, not on the query. (PR #3320, issue #3317)

----

Not included in notes:

- Re-enable pylint in info-only mode for all packages (#3519)
- Reload BigQuery table in system test before fetching data. (#3468)
- Vision semi-GAPIC (#3373)
- Use binary streams for uploads in BigQuery system tests. (PR #3374, issue #3371)
- Adding check that **all** setup.py README's are valid RST. (#3318)
- Fix repeated spelling error (#3260)
