### PR TITLE
Prep pubsub-0.26.0 release.

### DIFF
--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -51,14 +51,14 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.1, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
     'grpcio >= 1.0.2, < 2.0dev',
     'gapic-google-cloud-pubsub-v1 >= 0.15.0, < 0.16dev',
 ]
 
 setup(
     name='google-cloud-pubsub',
-    version='0.25.0',
+    version='0.26.0',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Requires merge of #3526 to bump core to 0.25.0.

Draft release notes:

## google-cloud-pubsub-0.26.0

- Update `google-cloud-core` dependency to ~= 0.25.
- Provide more useful exception (from `google.cloud.exceptions`) when trying to create a topic/subscription that already exists, i.e. a "Conflict" (PR #3443, issue #3175).
- Make `Subscription.reload()` update the topic if unset. (#3397)
- Add `Client.subscription` factory (PR #3370, issue #3369).

----

Not included in notes:

- Re-enable pylint in info-only mode for all packages (#3519)
- Revert "Fix 'broken' docs build. (#3422)" (#3439)
- Vision semi-GAPIC (#3373)
- Re-organize the documentation structure in preparation to split docs among subpackages (#3459)
- Fix "broken" docs build. (#3422)
