### PR TITLE
Prep bigtable-0.25.0 release.

### DIFF
--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -51,13 +51,13 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
     'google-gax>=0.15.7, <0.16dev',
 ]
 
 setup(
     name='google-cloud-bigtable',
-    version='0.24.0',
+    version='0.25.0',
     description='Python Client for Google Cloud Bigtable',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Requires merge of #3526 to bump core to 0.25.0.

Draft release notes:

## google-cloud-bigtable-0.25.0

- Update `google-cloud-core` dependency to ~= 0.25.
- Allow bulk update of records via `MutateRows` API (PR #3401, issue #2411)
- Add getters for `Row.row_key` and `Row.table` (PR #3408)

----

Not included in notes:

- Add optional switch to capture project ID in `from_service_account_json()`. (PR #3436, issue #1883).
- Re-enable pylint in info-only mode for all packages (#3519)
- Add sentence about row ordering (#3504)
- Updating Bigtable Client docstring to reflect new credentials. (#3477)
- Vision semi-GAPIC (#3373)
- Ignore tests (rather than unit_tests) in setup.py files. (#3319)
- Adding check that **all** setup.py README's are valid RST. (#3318)
