### PR TITLE
Prep language-0.25.0 release.

### DIFF
--- a/language/setup.py
+++ b/language/setup.py
@@ -51,12 +51,12 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
 ]
 
 setup(
     name='google-cloud-language',
-    version='0.24.1',
+    version='0.25.0',
     description='Python Client for Google Cloud Natural Language',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Requires merge of #3526 to bump core to 0.25.0.

Draft release notes:

## google-cloud-language-0.25.0

- Update `google-cloud-core` dependency to ~= 0.25.
- Upgrade Part Of Speech from a string to a container for all returned data (PR #3457)

----

Excluded from notes:

- Using part of speech "tag" in system test. (#3471)
- Re-enable pylint in info-only mode for all packages (#3519)
- Ignore tests (rather than unit_tests) in setup.py files. (#3319)
- Adding check that **all** setup.py README's are valid RST. (#3318)
