### PR TITLE
Prep spanner-0.25.0 release.

### DIFF
--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -51,7 +51,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.1, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
     'grpcio >= 1.2.0, < 2.0dev',
     'gapic-google-cloud-spanner-v1 >= 0.15.0, < 0.16dev',
     'gapic-google-cloud-spanner-admin-database-v1 >= 0.15.0, < 0.16dev',
@@ -60,7 +60,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-spanner',
-    version='0.24.2',
+    version='0.25.0',
     description='Python Client for Cloud Spanner',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Requires merge of #3526 to bump core to 0.25.0.

Draft release notes:

## google-cloud-spanner-0.25.0

- Update `google-cloud-core` dependency to ~= 0.25.

----

Excluded from notes:

- Add optional switch to capture project ID in `from_service_account_json()`. (PR #3436, issue #1883)
- Re-enable pylint in info-only mode for all packages (#3519)
- Vision semi-GAPIC (#3373)
