### PR TITLE
Prep vision-0.25.0 release.

### DIFF
--- a/vision/setup.py
+++ b/vision/setup.py
@@ -25,7 +25,7 @@ with io.open(os.path.join(PACKAGE_ROOT, 'README.rst'), 'r') as readme_file:
     readme = readme_file.read()
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
     'google-gax >= 0.15.7, < 0.16dev',
     'googleapis-common-protos[grpc] >= 1.5.2, < 2.0dev',
 ]


### PR DESCRIPTION
Note that the version number was bumped prematurely in 72e6e522.

Requires merge of #3526 to bump core to 0.25.0.

@lukesneeringer can you please suggest a better description for PR #3373?

Draft release notes:

## google-cloud-vision-0.25.0

- Update `google-cloud-core` dependency to ~= 0.25.
- Make `enum34` dependency conditional on Python version. (PR #3402, issue #3398)
- Replace the manual wrapper with a thin wrapper around the GAPIC (PR #3373).

----

Excluded from notes:

- Re-enable pylint in info-only mode for all packages (#3519)
- Adding retry to test_detect_web_images_from_gcs() system test. (#3339)
- Ignore tests (rather than unit_tests) in setup.py files. (#3319)
- Adding check that **all** setup.py README's are valid RST. (#3318) 
