### PR TITLE
Back out support for 'requester pays' buckets.

### DIFF
--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -67,11 +67,6 @@ class _PropertyMixin(object):
         """Abstract getter for the object client."""
         raise NotImplementedError
 
-    @property
-    def user_project(self):
-        """Abstract getter for the object user_project."""
-        raise NotImplementedError
-
     def _require_client(self, client):
         """Check client or verify over-ride.
 
@@ -99,8 +94,6 @@ class _PropertyMixin(object):
         # Pass only '?projection=noAcl' here because 'acl' and related
         # are handled via custom endpoints.
         query_params = {'projection': 'noAcl'}
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
         api_response = client._connection.api_request(
             method='GET', path=self.path, query_params=query_params,
             _target_object=self)
@@ -147,14 +140,11 @@ class _PropertyMixin(object):
         client = self._require_client(client)
         # Pass '?projection=full' here because 'PATCH' documented not
         # to work properly w/ 'noAcl'.
-        query_params = {'projection': 'full'}
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
         update_properties = {key: self._properties[key]
                              for key in self._changes}
         api_response = client._connection.api_request(
             method='PATCH', path=self.path, data=update_properties,
-            query_params=query_params, _target_object=self)
+            query_params={'projection': 'full'}, _target_object=self)
         self._set_properties(api_response)
 
 

--- a/storage/google/cloud/storage/acl.py
+++ b/storage/google/cloud/storage/acl.py
@@ -198,7 +198,6 @@ class ACL(object):
     # as properties).
     reload_path = None
     save_path = None
-    user_project = None
 
     def __init__(self):
         self.entities = {}
@@ -406,18 +405,10 @@ class ACL(object):
         """
         path = self.reload_path
         client = self._require_client(client)
-        query_params = {}
-
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
 
         self.entities.clear()
 
-        found = client._connection.api_request(
-            method='GET',
-            path=path,
-            query_params=query_params,
-        )
+        found = client._connection.api_request(method='GET', path=path)
         self.loaded = True
         for entry in found.get('items', ()):
             self.add_entity(self.entity_from_dict(entry))
@@ -444,12 +435,8 @@ class ACL(object):
             acl = []
             query_params[self._PREDEFINED_QUERY_PARAM] = predefined
 
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
-
         path = self.save_path
         client = self._require_client(client)
-
         result = client._connection.api_request(
             method='PATCH',
             path=path,
@@ -545,11 +532,6 @@ class BucketACL(ACL):
         """Compute the path for PATCH API requests for this ACL."""
         return self.bucket.path
 
-    @property
-    def user_project(self):
-        """Compute the user project charged for API requests for this ACL."""
-        return self.bucket.user_project
-
 
 class DefaultObjectACL(BucketACL):
     """A class representing the default object ACL for a bucket."""
@@ -583,8 +565,3 @@ class ObjectACL(ACL):
     def save_path(self):
         """Compute the path for PATCH API requests for this ACL."""
         return self.blob.path
-
-    @property
-    def user_project(self):
-        """Compute the user project charged for API requests for this ACL."""
-        return self.blob.user_project

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -85,10 +85,6 @@ class Bucket(_PropertyMixin):
     :type name: str
     :param name: The name of the bucket. Bucket names must start and end with a
                  number or letter.
-
-    :type user_project: str
-    :param user_project: (Optional) the project ID to be billed for API
-                         requests made via this instance.
     """
 
     _MAX_OBJECTS_FOR_ITERATION = 256
@@ -112,13 +108,12 @@ class Bucket(_PropertyMixin):
     https://cloud.google.com/storage/docs/storage-classes
     """
 
-    def __init__(self, client, name=None, user_project=None):
+    def __init__(self, client, name=None):
         name = _validate_name(name)
         super(Bucket, self).__init__(name=name)
         self._client = client
         self._acl = BucketACL(self)
         self._default_object_acl = DefaultObjectACL(self)
-        self._user_project = user_project
 
     def __repr__(self):
         return '<Bucket: %s>' % (self.name,)
@@ -127,16 +122,6 @@ class Bucket(_PropertyMixin):
     def client(self):
         """The client bound to this bucket."""
         return self._client
-
-    @property
-    def user_project(self):
-        """Project ID to be billed for API requests made via this bucket.
-
-        If unset, API requests are billed to the bucket owner.
-
-        :rtype: str
-        """
-        return self._user_project
 
     def blob(self, blob_name, chunk_size=None, encryption_key=None):
         """Factory constructor for blob object.
@@ -175,14 +160,10 @@ class Bucket(_PropertyMixin):
         :returns: True if the bucket exists in Cloud Storage.
         """
         client = self._require_client(client)
-        # We only need the status code (200 or not) so we seek to
-        # minimize the returned payload.
-        query_params = {'fields': 'name'}
-
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
-
         try:
+            # We only need the status code (200 or not) so we seek to
+            # minimize the returned payload.
+            query_params = {'fields': 'name'}
             # We intentionally pass `_target_object=None` since fields=name
             # would limit the local properties.
             client._connection.api_request(
@@ -208,9 +189,6 @@ class Bucket(_PropertyMixin):
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the current bucket.
         """
-        if self.user_project is not None:
-            raise ValueError("Cannot create bucket with 'user_project' set.")
-
         client = self._require_client(client)
         query_params = {'project': client.project}
         properties = {key: self._properties[key] for key in self._changes}
@@ -271,18 +249,10 @@ class Bucket(_PropertyMixin):
         :returns: The blob object if it exists, otherwise None.
         """
         client = self._require_client(client)
-        query_params = {}
-
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
-
         blob = Blob(bucket=self, name=blob_name)
         try:
             response = client._connection.api_request(
-                method='GET',
-                path=blob.path,
-                query_params=query_params,
-                _target_object=blob)
+                method='GET', path=blob.path, _target_object=blob)
             # NOTE: We assume response.get('name') matches `blob_name`.
             blob._set_properties(response)
             # NOTE: This will not fail immediately in a batch. However, when
@@ -336,7 +306,7 @@ class Bucket(_PropertyMixin):
         :returns: Iterator of all :class:`~google.cloud.storage.blob.Blob`
                   in this bucket matching the arguments.
         """
-        extra_params = {'projection': projection}
+        extra_params = {}
 
         if prefix is not None:
             extra_params['prefix'] = prefix
@@ -347,11 +317,10 @@ class Bucket(_PropertyMixin):
         if versions is not None:
             extra_params['versions'] = versions
 
+        extra_params['projection'] = projection
+
         if fields is not None:
             extra_params['fields'] = fields
-
-        if self.user_project is not None:
-            extra_params['userProject'] = self.user_project
 
         client = self._require_client(client)
         path = self.path + '/o'
@@ -392,11 +361,6 @@ class Bucket(_PropertyMixin):
                  contains more than 256 objects / blobs.
         """
         client = self._require_client(client)
-        query_params = {}
-
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
-
         if force:
             blobs = list(self.list_blobs(
                 max_results=self._MAX_OBJECTS_FOR_ITERATION + 1,
@@ -418,10 +382,7 @@ class Bucket(_PropertyMixin):
         # request has no response value (whether in a standard request or
         # in a batch request).
         client._connection.api_request(
-            method='DELETE',
-            path=self.path,
-            query_params=query_params,
-            _target_object=None)
+            method='DELETE', path=self.path, _target_object=None)
 
     def delete_blob(self, blob_name, client=None):
         """Deletes a blob from the current bucket.
@@ -453,20 +414,12 @@ class Bucket(_PropertyMixin):
 
         """
         client = self._require_client(client)
-        query_params = {}
-
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
-
         blob_path = Blob.path_helper(self.path, blob_name)
         # We intentionally pass `_target_object=None` since a DELETE
         # request has no response value (whether in a standard request or
         # in a batch request).
         client._connection.api_request(
-            method='DELETE',
-            path=blob_path,
-            query_params=query_params,
-            _target_object=None)
+            method='DELETE', path=blob_path, _target_object=None)
 
     def delete_blobs(self, blobs, on_error=None, client=None):
         """Deletes a list of blobs from the current bucket.
@@ -529,26 +482,14 @@ class Bucket(_PropertyMixin):
         :returns: The new Blob.
         """
         client = self._require_client(client)
-        query_params = {}
-
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
-
         if new_name is None:
             new_name = blob.name
-
         new_blob = Blob(bucket=destination_bucket, name=new_name)
         api_path = blob.path + '/copyTo' + new_blob.path
         copy_result = client._connection.api_request(
-            method='POST',
-            path=api_path,
-            query_params=query_params,
-            _target_object=new_blob,
-            )
-
+            method='POST', path=api_path, _target_object=new_blob)
         if not preserve_acl:
             new_blob.acl.save(acl={}, client=client)
-
         new_blob._set_properties(copy_result)
         return new_blob
 
@@ -857,39 +798,9 @@ class Bucket(_PropertyMixin):
         details.
 
         :type value: convertible to boolean
-        :param value: should versioning be enabled for the bucket?
+        :param value: should versioning be anabled for the bucket?
         """
         self._patch_property('versioning', {'enabled': bool(value)})
-
-    @property
-    def requester_pays(self):
-        """Does the requester pay for API requests for this bucket?
-
-        .. note::
-
-           No public docs exist yet for the "requester pays" feature.
-
-        :setter: Update whether requester pays for this bucket.
-        :getter: Query whether requester pays for this bucket.
-
-        :rtype: bool
-        :returns: True if requester pays for API requests for the bucket,
-                  else False.
-        """
-        versioning = self._properties.get('billing', {})
-        return versioning.get('requesterPays', False)
-
-    @requester_pays.setter
-    def requester_pays(self, value):
-        """Update whether requester pays for API requests for this bucket.
-
-        See  https://cloud.google.com/storage/docs/<DOCS-MISSING> for
-        details.
-
-        :type value: convertible to boolean
-        :param value: should requester pay for API requests for the bucket?
-        """
-        self._patch_property('billing', {'requesterPays': bool(value)})
 
     def configure_website(self, main_page_suffix=None, not_found_page=None):
         """Configure website-related properties.
@@ -956,15 +867,9 @@ class Bucket(_PropertyMixin):
                   the ``getIamPolicy`` API request.
         """
         client = self._require_client(client)
-        query_params = {}
-
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
-
         info = client._connection.api_request(
             method='GET',
             path='%s/iam' % (self.path,),
-            query_params=query_params,
             _target_object=None)
         return Policy.from_api_repr(info)
 
@@ -987,17 +892,11 @@ class Bucket(_PropertyMixin):
                   the ``setIamPolicy`` API request.
         """
         client = self._require_client(client)
-        query_params = {}
-
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
-
         resource = policy.to_api_repr()
         resource['resourceId'] = self.path
         info = client._connection.api_request(
             method='PUT',
             path='%s/iam' % (self.path,),
-            query_params=query_params,
             data=resource,
             _target_object=None)
         return Policy.from_api_repr(info)
@@ -1021,16 +920,12 @@ class Bucket(_PropertyMixin):
                   request.
         """
         client = self._require_client(client)
-        query_params = {'permissions': permissions}
-
-        if self.user_project is not None:
-            query_params['userProject'] = self.user_project
-
+        query = {'permissions': permissions}
         path = '%s/iam/testPermissions' % (self.path,)
         resp = client._connection.api_request(
             method='GET',
             path=path,
-            query_params=query_params)
+            query_params=query)
         return resp.get('permissions', [])
 
     def make_public(self, recursive=False, future=False, client=None):

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -194,7 +194,7 @@ class Client(ClientWithProject):
         except NotFound:
             return None
 
-    def create_bucket(self, bucket_name, requester_pays=None):
+    def create_bucket(self, bucket_name):
         """Create a new bucket.
 
         For example:
@@ -211,17 +211,10 @@ class Client(ClientWithProject):
         :type bucket_name: str
         :param bucket_name: The bucket name to create.
 
-        :type requester_pays: bool
-        :param requester_pays:
-            (Optional) Whether requester pays for API requests for this
-            bucket and its blobs.
-
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
         :returns: The newly created bucket.
         """
         bucket = Bucket(self, name=bucket_name)
-        if requester_pays is not None:
-            bucket.requester_pays = requester_pays
         bucket.create(client=self)
         return bucket
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -30,8 +30,6 @@ from test_utils.system import unique_resource_id
 
 HTTP = httplib2.Http()
 
-REQUESTER_PAYS_ENABLED = False  # query from environment?
-
 
 def _bad_copy(bad_request):
     """Predicate: pass only exceptions for a failed copyTo."""
@@ -100,15 +98,6 @@ class TestStorageBuckets(unittest.TestCase):
         created = Config.CLIENT.create_bucket(new_bucket_name)
         self.case_buckets_to_delete.append(new_bucket_name)
         self.assertEqual(created.name, new_bucket_name)
-
-    @unittest.skipUnless(REQUESTER_PAYS_ENABLED, "requesterPays not enabled")
-    def test_create_bucket_with_requester_pays(self):
-        new_bucket_name = 'w-requester-pays' + unique_resource_id('-')
-        created = Config.CLIENT.create_bucket(
-            new_bucket_name, requester_pays=True)
-        self.case_buckets_to_delete.append(new_bucket_name)
-        self.assertEqual(created.name, new_bucket_name)
-        self.assertTrue(created.requester_pays)
 
     def test_list_buckets(self):
         buckets_to_create = [

--- a/storage/tests/unit/test__helpers.py
+++ b/storage/tests/unit/test__helpers.py
@@ -26,7 +26,7 @@ class Test_PropertyMixin(unittest.TestCase):
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
-    def _derivedClass(self, path=None, user_project=None):
+    def _derivedClass(self, path=None):
 
         class Derived(self._get_target_class()):
 
@@ -36,67 +36,30 @@ class Test_PropertyMixin(unittest.TestCase):
             def path(self):
                 return path
 
-            @property
-            def user_project(self):
-                return user_project
-
         return Derived
 
     def test_path_is_abstract(self):
         mixin = self._make_one()
-        with self.assertRaises(NotImplementedError):
-            mixin.path
+        self.assertRaises(NotImplementedError, lambda: mixin.path)
 
     def test_client_is_abstract(self):
         mixin = self._make_one()
-        with self.assertRaises(NotImplementedError):
-            mixin.client
-
-    def test_user_project_is_abstract(self):
-        mixin = self._make_one()
-        with self.assertRaises(NotImplementedError):
-            mixin.user_project
+        self.assertRaises(NotImplementedError, lambda: mixin.client)
 
     def test_reload(self):
         connection = _Connection({'foo': 'Foo'})
         client = _Client(connection)
         derived = self._derivedClass('/path')()
-        # Make sure changes is not a set instance before calling reload
-        # (which will clear / replace it with an empty set), checked below.
+        # Make sure changes is not a set, so we can observe a change.
         derived._changes = object()
         derived.reload(client=client)
         self.assertEqual(derived._properties, {'foo': 'Foo'})
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'GET',
-            'path': '/path',
-            'query_params': {'projection': 'noAcl'},
-            '_target_object': derived,
-        })
-        self.assertEqual(derived._changes, set())
-
-    def test_reload_w_user_project(self):
-        user_project = 'user-project-123'
-        connection = _Connection({'foo': 'Foo'})
-        client = _Client(connection)
-        derived = self._derivedClass('/path', user_project)()
-        # Make sure changes is not a set instance before calling reload
-        # (which will clear / replace it with an empty set), checked below.
-        derived._changes = object()
-        derived.reload(client=client)
-        self.assertEqual(derived._properties, {'foo': 'Foo'})
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'GET',
-            'path': '/path',
-            'query_params': {
-                'projection': 'noAcl',
-                'userProject': user_project,
-            },
-            '_target_object': derived,
-        })
+        self.assertEqual(kw[0]['method'], 'GET')
+        self.assertEqual(kw[0]['path'], '/path')
+        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
+        # Make sure changes get reset by reload.
         self.assertEqual(derived._changes, set())
 
     def test__set_properties(self):
@@ -124,42 +87,11 @@ class Test_PropertyMixin(unittest.TestCase):
         self.assertEqual(derived._properties, {'foo': 'Foo'})
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'PATCH',
-            'path': '/path',
-            'query_params': {'projection': 'full'},
-            # Since changes does not include `baz`, we don't see it sent.
-            'data': {'bar': BAR},
-            '_target_object': derived,
-        })
-        # Make sure changes get reset by patch().
-        self.assertEqual(derived._changes, set())
-
-    def test_patch_w_user_project(self):
-        user_project = 'user-project-123'
-        connection = _Connection({'foo': 'Foo'})
-        client = _Client(connection)
-        derived = self._derivedClass('/path', user_project)()
-        # Make sure changes is non-empty, so we can observe a change.
-        BAR = object()
-        BAZ = object()
-        derived._properties = {'bar': BAR, 'baz': BAZ}
-        derived._changes = set(['bar'])  # Ignore baz.
-        derived.patch(client=client)
-        self.assertEqual(derived._properties, {'foo': 'Foo'})
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'PATCH',
-            'path': '/path',
-            'query_params': {
-                'projection': 'full',
-                'userProject': user_project,
-            },
-            # Since changes does not include `baz`, we don't see it sent.
-            'data': {'bar': BAR},
-            '_target_object': derived,
-        })
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/path')
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        # Since changes does not include `baz`, we don't see it sent.
+        self.assertEqual(kw[0]['data'], {'bar': BAR})
         # Make sure changes get reset by patch().
         self.assertEqual(derived._changes, set())
 

--- a/storage/tests/unit/test_acl.py
+++ b/storage/tests/unit/test_acl.py
@@ -532,11 +532,8 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(list(acl), [])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'GET',
-            'path': '/testing/acl',
-            'query_params': {},
-        })
+        self.assertEqual(kw[0]['method'], 'GET')
+        self.assertEqual(kw[0]['path'], '/testing/acl')
 
     def test_reload_empty_result_clears_local(self):
         ROLE = 'role'
@@ -546,41 +543,29 @@ class Test_ACL(unittest.TestCase):
         acl.reload_path = '/testing/acl'
         acl.loaded = True
         acl.entity('allUsers', ROLE)
-
         acl.reload(client=client)
-
         self.assertTrue(acl.loaded)
         self.assertEqual(list(acl), [])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'GET',
-            'path': '/testing/acl',
-            'query_params': {},
-        })
+        self.assertEqual(kw[0]['method'], 'GET')
+        self.assertEqual(kw[0]['path'], '/testing/acl')
 
-    def test_reload_nonempty_result_w_user_project(self):
+    def test_reload_nonempty_result(self):
         ROLE = 'role'
-        USER_PROJECT = 'user-project-123'
         connection = _Connection(
             {'items': [{'entity': 'allUsers', 'role': ROLE}]})
         client = _Client(connection)
         acl = self._make_one()
         acl.reload_path = '/testing/acl'
         acl.loaded = True
-        acl.user_project = USER_PROJECT
-
         acl.reload(client=client)
-
         self.assertTrue(acl.loaded)
         self.assertEqual(list(acl), [{'entity': 'allUsers', 'role': ROLE}])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'GET',
-            'path': '/testing/acl',
-            'query_params': {'userProject': USER_PROJECT},
-        })
+        self.assertEqual(kw[0]['method'], 'GET')
+        self.assertEqual(kw[0]['path'], '/testing/acl')
 
     def test_save_none_set_none_passed(self):
         connection = _Connection()
@@ -621,43 +606,30 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PATCH')
         self.assertEqual(kw[0]['path'], '/testing')
-        self.assertEqual(kw[0], {
-            'method': 'PATCH',
-            'path': '/testing',
-            'query_params': {'projection': 'full'},
-            'data': {'acl': AFTER},
-        })
+        self.assertEqual(kw[0]['data'], {'acl': AFTER})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
 
-    def test_save_w_acl_w_user_project(self):
+    def test_save_w_acl(self):
         ROLE1 = 'role1'
         ROLE2 = 'role2'
         STICKY = {'entity': 'allUsers', 'role': ROLE2}
-        USER_PROJECT = 'user-project-123'
         new_acl = [{'entity': 'allUsers', 'role': ROLE1}]
         connection = _Connection({'acl': [STICKY] + new_acl})
         client = _Client(connection)
         acl = self._make_one()
         acl.save_path = '/testing'
         acl.loaded = True
-        acl.user_project = USER_PROJECT
-
         acl.save(new_acl, client=client)
-
         entries = list(acl)
         self.assertEqual(len(entries), 2)
         self.assertTrue(STICKY in entries)
         self.assertTrue(new_acl[0] in entries)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'PATCH',
-            'path': '/testing',
-            'query_params': {
-                'projection': 'full',
-                'userProject': USER_PROJECT,
-            },
-            'data': {'acl': new_acl},
-        })
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/testing')
+        self.assertEqual(kw[0]['data'], {'acl': new_acl})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
 
     def test_save_prefefined_invalid(self):
         connection = _Connection()
@@ -680,15 +652,11 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(len(entries), 0)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'PATCH',
-            'path': '/testing',
-            'query_params': {
-                'projection': 'full',
-                'predefinedAcl': PREDEFINED,
-            },
-            'data': {'acl': []},
-        })
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/testing')
+        self.assertEqual(kw[0]['data'], {'acl': []})
+        self.assertEqual(kw[0]['query_params'],
+                         {'projection': 'full', 'predefinedAcl': PREDEFINED})
 
     def test_save_predefined_w_XML_alias(self):
         PREDEFINED_XML = 'project-private'
@@ -703,15 +671,12 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(len(entries), 0)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'PATCH',
-            'path': '/testing',
-            'query_params': {
-                'projection': 'full',
-                'predefinedAcl': PREDEFINED_JSON,
-            },
-            'data': {'acl': []},
-        })
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/testing')
+        self.assertEqual(kw[0]['data'], {'acl': []})
+        self.assertEqual(kw[0]['query_params'],
+                         {'projection': 'full',
+                          'predefinedAcl': PREDEFINED_JSON})
 
     def test_save_predefined_valid_w_alternate_query_param(self):
         # Cover case where subclass overrides _PREDEFINED_QUERY_PARAM
@@ -727,15 +692,11 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(len(entries), 0)
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'PATCH',
-            'path': '/testing',
-            'query_params': {
-                'projection': 'full',
-                'alternate': PREDEFINED,
-            },
-            'data': {'acl': []},
-        })
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/testing')
+        self.assertEqual(kw[0]['data'], {'acl': []})
+        self.assertEqual(kw[0]['query_params'],
+                         {'projection': 'full', 'alternate': PREDEFINED})
 
     def test_clear(self):
         ROLE1 = 'role1'
@@ -751,12 +712,10 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(list(acl), [STICKY])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'PATCH',
-            'path': '/testing',
-            'query_params': {'projection': 'full'},
-            'data': {'acl': []},
-        })
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/testing')
+        self.assertEqual(kw[0]['data'], {'acl': []})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
 
 
 class Test_BucketACL(unittest.TestCase):
@@ -779,15 +738,6 @@ class Test_BucketACL(unittest.TestCase):
         self.assertIs(acl.bucket, bucket)
         self.assertEqual(acl.reload_path, '/b/%s/acl' % NAME)
         self.assertEqual(acl.save_path, '/b/%s' % NAME)
-
-    def test_user_project(self):
-        NAME = 'name'
-        USER_PROJECT = 'user-project-123'
-        bucket = _Bucket(NAME)
-        acl = self._make_one(bucket)
-        self.assertIsNone(acl.user_project)
-        bucket.user_project = USER_PROJECT
-        self.assertEqual(acl.user_project, USER_PROJECT)
 
 
 class Test_DefaultObjectACL(unittest.TestCase):
@@ -835,21 +785,8 @@ class Test_ObjectACL(unittest.TestCase):
         self.assertEqual(acl.reload_path, '/b/%s/o/%s/acl' % (NAME, BLOB_NAME))
         self.assertEqual(acl.save_path, '/b/%s/o/%s' % (NAME, BLOB_NAME))
 
-    def test_user_project(self):
-        NAME = 'name'
-        BLOB_NAME = 'blob-name'
-        USER_PROJECT = 'user-project-123'
-        bucket = _Bucket(NAME)
-        blob = _Blob(bucket, BLOB_NAME)
-        acl = self._make_one(blob)
-        self.assertIsNone(acl.user_project)
-        blob.user_project = USER_PROJECT
-        self.assertEqual(acl.user_project, USER_PROJECT)
-
 
 class _Blob(object):
-
-    user_project = None
 
     def __init__(self, bucket, blob):
         self.bucket = bucket
@@ -861,8 +798,6 @@ class _Blob(object):
 
 
 class _Bucket(object):
-
-    user_project = None
 
     def __init__(self, name):
         self.name = name

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -141,19 +141,6 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(blob_name, bucket=bucket)
         self.assertEqual(blob.path, '/b/name/o/Caf%C3%A9')
 
-    def test_client(self):
-        blob_name = 'BLOB'
-        bucket = _Bucket()
-        blob = self._make_one(blob_name, bucket=bucket)
-        self.assertIs(blob.client, bucket.client)
-
-    def test_user_project(self):
-        user_project = 'user-project-123'
-        blob_name = 'BLOB'
-        bucket = _Bucket(user_project=user_project)
-        blob = self._make_one(blob_name, bucket=bucket)
-        self.assertEqual(blob.user_project, user_project)
-
     def test_public_url(self):
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
@@ -317,31 +304,16 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket(client)
         blob = self._make_one(NONESUCH, bucket=bucket)
         self.assertFalse(blob.exists())
-        self.assertEqual(len(connection._requested), 1)
-        self.assertEqual(connection._requested[0], {
-            'method': 'GET',
-            'path': '/b/name/o/{}'.format(NONESUCH),
-            'query_params': {'fields': 'name'},
-            '_target_object': None,
-        })
 
-    def test_exists_hit_w_user_project(self):
+    def test_exists_hit(self):
         BLOB_NAME = 'blob-name'
-        USER_PROJECT = 'user-project-123'
         found_response = ({'status': http_client.OK}, b'')
         connection = _Connection(found_response)
         client = _Client(connection)
-        bucket = _Bucket(client, user_project=USER_PROJECT)
+        bucket = _Bucket(client)
         blob = self._make_one(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
         self.assertTrue(blob.exists())
-        self.assertEqual(len(connection._requested), 1)
-        self.assertEqual(connection._requested[0], {
-            'method': 'GET',
-            'path': '/b/name/o/{}'.format(BLOB_NAME),
-            'query_params': {'fields': 'name', 'userProject': USER_PROJECT},
-            '_target_object': None,
-        })
 
     def test_delete(self):
         BLOB_NAME = 'blob-name'
@@ -366,7 +338,7 @@ class Test_Blob(unittest.TestCase):
 
     def test__get_download_url_with_media_link(self):
         blob_name = 'something.txt'
-        bucket = _Bucket(name='IRRELEVANT')
+        bucket = mock.Mock(spec=[])
         blob = self._make_one(blob_name, bucket=bucket)
         media_link = 'http://test.invalid'
         # Set the media link on the blob
@@ -375,22 +347,9 @@ class Test_Blob(unittest.TestCase):
         download_url = blob._get_download_url()
         self.assertEqual(download_url, media_link)
 
-    def test__get_download_url_with_media_link_w_user_project(self):
-        blob_name = 'something.txt'
-        user_project = 'user-project-123'
-        bucket = _Bucket(name='IRRELEVANT', user_project=user_project)
-        blob = self._make_one(blob_name, bucket=bucket)
-        media_link = 'http://test.invalid'
-        # Set the media link on the blob
-        blob._properties['mediaLink'] = media_link
-
-        download_url = blob._get_download_url()
-        self.assertEqual(
-            download_url, '{}?userProject={}'.format(media_link, user_project))
-
     def test__get_download_url_on_the_fly(self):
         blob_name = 'bzzz-fly.txt'
-        bucket = _Bucket(name='buhkit')
+        bucket = mock.Mock(path='/b/buhkit', spec=['path'])
         blob = self._make_one(blob_name, bucket=bucket)
 
         self.assertIsNone(blob.media_link)
@@ -402,7 +361,7 @@ class Test_Blob(unittest.TestCase):
 
     def test__get_download_url_on_the_fly_with_generation(self):
         blob_name = 'pretend.txt'
-        bucket = _Bucket(name='fictional')
+        bucket = mock.Mock(path='/b/fictional', spec=['path'])
         blob = self._make_one(blob_name, bucket=bucket)
         generation = 1493058489532987
         # Set the media link on the blob
@@ -413,20 +372,6 @@ class Test_Blob(unittest.TestCase):
         expected_url = (
             'https://www.googleapis.com/download/storage/v1/b/'
             'fictional/o/pretend.txt?alt=media&generation=1493058489532987')
-        self.assertEqual(download_url, expected_url)
-
-    def test__get_download_url_on_the_fly_with_user_project(self):
-        blob_name = 'pretend.txt'
-        user_project = 'user-project-123'
-        bucket = _Bucket(name='fictional', user_project=user_project)
-        blob = self._make_one(blob_name, bucket=bucket)
-
-        self.assertIsNone(blob.media_link)
-        download_url = blob._get_download_url()
-        expected_url = (
-            'https://www.googleapis.com/download/storage/v1/b/'
-            'fictional/o/pretend.txt?alt=media&userProject={}'.format(
-                user_project))
         self.assertEqual(download_url, expected_url)
 
     @staticmethod
@@ -820,8 +765,8 @@ class Test_Blob(unittest.TestCase):
         return fake_transport
 
     def _do_multipart_success(self, mock_get_boundary, size=None,
-                              num_retries=None, user_project=None):
-        bucket = _Bucket(name='w00t', user_project=user_project)
+                              num_retries=None):
+        bucket = mock.Mock(path='/b/w00t', spec=[u'path'])
         blob = self._make_one(u'blob-name', bucket=bucket)
         self.assertIsNone(blob.chunk_size)
 
@@ -853,8 +798,6 @@ class Test_Blob(unittest.TestCase):
             'https://www.googleapis.com/upload/storage/v1' +
             bucket.path +
             '/o?uploadType=multipart')
-        if user_project is not None:
-            upload_url += '&userProject={}'.format(user_project)
         payload = (
             b'--==0==\r\n' +
             b'content-type: application/json; charset=UTF-8\r\n\r\n' +
@@ -879,13 +822,6 @@ class Test_Blob(unittest.TestCase):
 
     @mock.patch(u'google.resumable_media._upload.get_boundary',
                 return_value=b'==0==')
-    def test__do_multipart_upload_with_user_project(self, mock_get_boundary):
-        user_project = 'user-project-123'
-        self._do_multipart_success(
-            mock_get_boundary, user_project=user_project)
-
-    @mock.patch(u'google.resumable_media._upload.get_boundary',
-                return_value=b'==0==')
     def test__do_multipart_upload_with_retry(self, mock_get_boundary):
         self._do_multipart_success(mock_get_boundary, num_retries=8)
 
@@ -905,12 +841,11 @@ class Test_Blob(unittest.TestCase):
             'was specified but the file-like object only had', exc_contents)
         self.assertEqual(stream.tell(), len(data))
 
-    def _initiate_resumable_helper(
-            self, size=None, extra_headers=None, chunk_size=None,
-            num_retries=None, user_project=None):
+    def _initiate_resumable_helper(self, size=None, extra_headers=None,
+                                   chunk_size=None, num_retries=None):
         from google.resumable_media.requests import ResumableUpload
 
-        bucket = _Bucket(name='whammy', user_project=user_project)
+        bucket = mock.Mock(path='/b/whammy', spec=[u'path'])
         blob = self._make_one(u'blob-name', bucket=bucket)
         blob.metadata = {'rook': 'takes knight'}
         blob.chunk_size = 3 * blob._CHUNK_SIZE_MULTIPLE
@@ -944,8 +879,6 @@ class Test_Blob(unittest.TestCase):
             'https://www.googleapis.com/upload/storage/v1' +
             bucket.path +
             '/o?uploadType=resumable')
-        if user_project is not None:
-            upload_url += '&userProject={}'.format(user_project)
         self.assertEqual(upload.upload_url, upload_url)
         if extra_headers is None:
             self.assertEqual(upload._headers, {})
@@ -997,10 +930,6 @@ class Test_Blob(unittest.TestCase):
 
     def test__initiate_resumable_upload_with_size(self):
         self._initiate_resumable_helper(size=10000)
-
-    def test__initiate_resumable_upload_with_user_project(self):
-        user_project = 'user-project-123'
-        self._initiate_resumable_helper(user_project=user_project)
 
     def test__initiate_resumable_upload_with_chunk_size(self):
         one_mb = 1048576
@@ -1081,7 +1010,7 @@ class Test_Blob(unittest.TestCase):
             'PUT', resumable_url, data=payload, headers=expected_headers)
 
     def _do_resumable_helper(self, use_size=False, num_retries=None):
-        bucket = _Bucket(name='yesterday')
+        bucket = mock.Mock(path='/b/yesterday', spec=[u'path'])
         blob = self._make_one(u'blob-name', bucket=bucket)
         blob.chunk_size = blob._CHUNK_SIZE_MULTIPLE
         self.assertIsNotNone(blob.chunk_size)
@@ -1324,7 +1253,7 @@ class Test_Blob(unittest.TestCase):
 
     def _create_resumable_upload_session_helper(self, origin=None,
                                                 side_effect=None):
-        bucket = _Bucket(name='alex-trebek')
+        bucket = mock.Mock(path='/b/alex-trebek', spec=[u'path'])
         blob = self._make_one('blob-name', bucket=bucket)
         chunk_size = 99 * blob._CHUNK_SIZE_MULTIPLE
         blob.chunk_size = chunk_size
@@ -1435,49 +1364,8 @@ class Test_Blob(unittest.TestCase):
 
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'GET',
-            'path': '%s/iam' % (PATH,),
-            'query_params': {},
-            '_target_object': None,
-        })
-
-    def test_get_iam_policy_w_user_project(self):
-        from google.cloud.iam import Policy
-
-        BLOB_NAME = 'blob-name'
-        USER_PROJECT = 'user-project-123'
-        PATH = '/b/name/o/%s' % (BLOB_NAME,)
-        ETAG = 'DEADBEEF'
-        VERSION = 17
-        RETURNED = {
-            'resourceId': PATH,
-            'etag': ETAG,
-            'version': VERSION,
-            'bindings': [],
-        }
-        after = ({'status': http_client.OK}, RETURNED)
-        EXPECTED = {}
-        connection = _Connection(after)
-        client = _Client(connection)
-        bucket = _Bucket(client=client, user_project=USER_PROJECT)
-        blob = self._make_one(BLOB_NAME, bucket=bucket)
-
-        policy = blob.get_iam_policy()
-
-        self.assertIsInstance(policy, Policy)
-        self.assertEqual(policy.etag, RETURNED['etag'])
-        self.assertEqual(policy.version, RETURNED['version'])
-        self.assertEqual(dict(policy), EXPECTED)
-
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'GET',
-            'path': '%s/iam' % (PATH,),
-            'query_params': {'userProject': USER_PROJECT},
-            '_target_object': None,
-        })
+        self.assertEqual(kw[0]['method'], 'GET')
+        self.assertEqual(kw[0]['path'], '%s/iam' % (PATH,))
 
     def test_set_iam_policy(self):
         import operator
@@ -1526,7 +1414,6 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PUT')
         self.assertEqual(kw[0]['path'], '%s/iam' % (PATH,))
-        self.assertEqual(kw[0]['query_params'], {})
         sent = kw[0]['data']
         self.assertEqual(sent['resourceId'], PATH)
         self.assertEqual(len(sent['bindings']), len(BINDINGS))
@@ -1537,41 +1424,6 @@ class Test_Blob(unittest.TestCase):
             self.assertEqual(found['role'], expected['role'])
             self.assertEqual(
                 sorted(found['members']), sorted(expected['members']))
-
-    def test_set_iam_policy_w_user_project(self):
-        from google.cloud.iam import Policy
-
-        BLOB_NAME = 'blob-name'
-        USER_PROJECT = 'user-project-123'
-        PATH = '/b/name/o/%s' % (BLOB_NAME,)
-        ETAG = 'DEADBEEF'
-        VERSION = 17
-        BINDINGS = []
-        RETURNED = {
-            'etag': ETAG,
-            'version': VERSION,
-            'bindings': BINDINGS,
-        }
-        after = ({'status': http_client.OK}, RETURNED)
-        policy = Policy()
-
-        connection = _Connection(after)
-        client = _Client(connection)
-        bucket = _Bucket(client=client, user_project=USER_PROJECT)
-        blob = self._make_one(BLOB_NAME, bucket=bucket)
-
-        returned = blob.set_iam_policy(policy)
-
-        self.assertEqual(returned.etag, ETAG)
-        self.assertEqual(returned.version, VERSION)
-        self.assertEqual(dict(returned), dict(policy))
-
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'PUT')
-        self.assertEqual(kw[0]['path'], '%s/iam' % (PATH,))
-        self.assertEqual(kw[0]['query_params'], {'userProject': USER_PROJECT})
-        self.assertEqual(kw[0]['data'], {'resourceId': PATH})
 
     def test_test_iam_permissions(self):
         from google.cloud.storage.iam import STORAGE_OBJECTS_LIST
@@ -1602,39 +1454,6 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['method'], 'GET')
         self.assertEqual(kw[0]['path'], '%s/iam/testPermissions' % (PATH,))
         self.assertEqual(kw[0]['query_params'], {'permissions': PERMISSIONS})
-
-    def test_test_iam_permissions_w_user_project(self):
-        from google.cloud.storage.iam import STORAGE_OBJECTS_LIST
-        from google.cloud.storage.iam import STORAGE_BUCKETS_GET
-        from google.cloud.storage.iam import STORAGE_BUCKETS_UPDATE
-
-        BLOB_NAME = 'blob-name'
-        USER_PROJECT = 'user-project-123'
-        PATH = '/b/name/o/%s' % (BLOB_NAME,)
-        PERMISSIONS = [
-            STORAGE_OBJECTS_LIST,
-            STORAGE_BUCKETS_GET,
-            STORAGE_BUCKETS_UPDATE,
-        ]
-        ALLOWED = PERMISSIONS[1:]
-        RETURNED = {'permissions': ALLOWED}
-        after = ({'status': http_client.OK}, RETURNED)
-        connection = _Connection(after)
-        client = _Client(connection)
-        bucket = _Bucket(client=client, user_project=USER_PROJECT)
-        blob = self._make_one(BLOB_NAME, bucket=bucket)
-
-        allowed = blob.test_iam_permissions(PERMISSIONS)
-
-        self.assertEqual(allowed, ALLOWED)
-
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'GET')
-        self.assertEqual(kw[0]['path'], '%s/iam/testPermissions' % (PATH,))
-        self.assertEqual(
-            kw[0]['query_params'],
-            {'permissions': PERMISSIONS, 'userProject': USER_PROJECT})
 
     def test_make_public(self):
         from google.cloud.storage.acl import _ACLEntity
@@ -1670,18 +1489,17 @@ class Test_Blob(unittest.TestCase):
         with self.assertRaises(ValueError):
             destination.compose(sources=[source_1, source_2])
 
-    def test_compose_minimal_w_user_project(self):
+    def test_compose_minimal(self):
         SOURCE_1 = 'source-1'
         SOURCE_2 = 'source-2'
         DESTINATION = 'destinaton'
         RESOURCE = {
             'etag': 'DEADBEEF'
         }
-        USER_PROJECT = 'user-project-123'
         after = ({'status': http_client.OK}, RESOURCE)
         connection = _Connection(after)
         client = _Client(connection)
-        bucket = _Bucket(client=client, user_project=USER_PROJECT)
+        bucket = _Bucket(client=client)
         source_1 = self._make_one(SOURCE_1, bucket=bucket)
         source_2 = self._make_one(SOURCE_2, bucket=bucket)
         destination = self._make_one(DESTINATION, bucket=bucket)
@@ -1691,23 +1509,20 @@ class Test_Blob(unittest.TestCase):
 
         self.assertEqual(destination.etag, 'DEADBEEF')
 
+        SENT = {
+            'sourceObjects': [
+                {'name': source_1.name},
+                {'name': source_2.name},
+            ],
+            'destination': {
+                'contentType': 'text/plain',
+            },
+        }
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'POST',
-            'path': '/b/name/o/%s/compose' % DESTINATION,
-            'query_params': {'userProject': USER_PROJECT},
-            'data':  {
-                'sourceObjects': [
-                    {'name': source_1.name},
-                    {'name': source_2.name},
-                ],
-                'destination': {
-                    'contentType': 'text/plain',
-                },
-            },
-            '_target_object': destination,
-        })
+        self.assertEqual(kw[0]['method'], 'POST')
+        self.assertEqual(kw[0]['path'], '/b/name/o/%s/compose' % DESTINATION)
+        self.assertEqual(kw[0]['data'], SENT)
 
     def test_compose_w_additional_property_changes(self):
         SOURCE_1 = 'source-1'
@@ -1731,27 +1546,24 @@ class Test_Blob(unittest.TestCase):
 
         self.assertEqual(destination.etag, 'DEADBEEF')
 
+        SENT = {
+            'sourceObjects': [
+                {'name': source_1.name},
+                {'name': source_2.name},
+            ],
+            'destination': {
+                'contentType': 'text/plain',
+                'contentLanguage': 'en-US',
+                'metadata': {
+                    'my-key': 'my-value',
+                }
+            },
+        }
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0], {
-            'method': 'POST',
-            'path': '/b/name/o/%s/compose' % DESTINATION,
-            'query_params': {},
-            'data':  {
-                'sourceObjects': [
-                    {'name': source_1.name},
-                    {'name': source_2.name},
-                ],
-                'destination': {
-                    'contentType': 'text/plain',
-                    'contentLanguage': 'en-US',
-                    'metadata': {
-                        'my-key': 'my-value',
-                    }
-                },
-            },
-            '_target_object': destination,
-        })
+        self.assertEqual(kw[0]['method'], 'POST')
+        self.assertEqual(kw[0]['path'], '/b/name/o/%s/compose' % DESTINATION)
+        self.assertEqual(kw[0]['data'], SENT)
 
     def test_rewrite_response_without_resource(self):
         SOURCE_BLOB = 'source'
@@ -1823,7 +1635,7 @@ class Test_Blob(unittest.TestCase):
         self.assertNotIn('X-Goog-Encryption-Key', headers)
         self.assertNotIn('X-Goog-Encryption-Key-Sha256', headers)
 
-    def test_rewrite_same_name_no_old_key_new_key_done_w_user_project(self):
+    def test_rewrite_same_name_no_old_key_new_key_done(self):
         import base64
         import hashlib
 
@@ -1832,7 +1644,6 @@ class Test_Blob(unittest.TestCase):
         KEY_HASH = hashlib.sha256(KEY).digest()
         KEY_HASH_B64 = base64.b64encode(KEY_HASH).rstrip().decode('ascii')
         BLOB_NAME = 'blob'
-        USER_PROJECT = 'user-project-123'
         RESPONSE = {
             'totalBytesRewritten': 42,
             'objectSize': 42,
@@ -1842,7 +1653,7 @@ class Test_Blob(unittest.TestCase):
         response = ({'status': http_client.OK}, RESPONSE)
         connection = _Connection(response)
         client = _Client(connection)
-        bucket = _Bucket(client=client, user_project=USER_PROJECT)
+        bucket = _Bucket(client=client)
         plain = self._make_one(BLOB_NAME, bucket=bucket)
         encrypted = self._make_one(BLOB_NAME, bucket=bucket,
                                    encryption_key=KEY)
@@ -1858,7 +1669,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['method'], 'POST')
         PATH = '/b/name/o/%s/rewriteTo/b/name/o/%s' % (BLOB_NAME, BLOB_NAME)
         self.assertEqual(kw[0]['path'], PATH)
-        self.assertEqual(kw[0]['query_params'], {'userProject': USER_PROJECT})
+        self.assertEqual(kw[0]['query_params'], {})
         SENT = {}
         self.assertEqual(kw[0]['data'], SENT)
 
@@ -1961,7 +1772,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['method'], 'POST')
         PATH = '/b/name/o/%s/rewriteTo/b/name/o/%s' % (BLOB_NAME, BLOB_NAME)
         self.assertEqual(kw[0]['path'], PATH)
-        self.assertEqual(kw[0]['query_params'], {})
+        self.assertNotIn('query_params', kw[0])
         SENT = {'storageClass': STORAGE_CLASS}
         self.assertEqual(kw[0]['data'], SENT)
 
@@ -1975,7 +1786,7 @@ class Test_Blob(unittest.TestCase):
         self.assertNotIn('X-Goog-Encryption-Key', headers)
         self.assertNotIn('X-Goog-Encryption-Key-Sha256', headers)
 
-    def test_update_storage_class_w_encryption_key_w_user_project(self):
+    def test_update_storage_class_w_encryption_key(self):
         import base64
         import hashlib
 
@@ -1986,14 +1797,13 @@ class Test_Blob(unittest.TestCase):
         BLOB_KEY_HASH_B64 = base64.b64encode(
             BLOB_KEY_HASH).rstrip().decode('ascii')
         STORAGE_CLASS = u'NEARLINE'
-        USER_PROJECT = 'user-project-123'
         RESPONSE = {
             'resource': {'storageClass': STORAGE_CLASS},
         }
         response = ({'status': http_client.OK}, RESPONSE)
         connection = _Connection(response)
         client = _Client(connection)
-        bucket = _Bucket(client=client, user_project=USER_PROJECT)
+        bucket = _Bucket(client=client)
         blob = self._make_one(
             BLOB_NAME, bucket=bucket, encryption_key=BLOB_KEY)
 
@@ -2006,7 +1816,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['method'], 'POST')
         PATH = '/b/name/o/%s/rewriteTo/b/name/o/%s' % (BLOB_NAME, BLOB_NAME)
         self.assertEqual(kw[0]['path'], PATH)
-        self.assertEqual(kw[0]['query_params'], {'userProject': USER_PROJECT})
+        self.assertNotIn('query_params', kw[0])
         SENT = {'storageClass': STORAGE_CLASS}
         self.assertEqual(kw[0]['data'], SENT)
 
@@ -2443,37 +2253,6 @@ class Test__raise_from_invalid_response(unittest.TestCase):
         self.assertEqual(exc_info.exception.errors, [])
 
 
-class Test__add_query_parameters(unittest.TestCase):
-
-    @staticmethod
-    def _call_fut(*args, **kwargs):
-        from google.cloud.storage.blob import _add_query_parameters
-
-        return _add_query_parameters(*args, **kwargs)
-
-    def test_w_empty_list(self):
-        BASE_URL = 'https://test.example.com/base'
-        self.assertEqual(self._call_fut(BASE_URL, []), BASE_URL)
-
-    def test_wo_existing_qs(self):
-        BASE_URL = 'https://test.example.com/base'
-        NV_LIST = [('one', 'One'), ('two', 'Two')]
-        expected = '&'.join([
-            '{}={}'.format(name, value) for name, value in NV_LIST])
-        self.assertEqual(
-            self._call_fut(BASE_URL, NV_LIST),
-            '{}?{}'.format(BASE_URL, expected))
-
-    def test_w_existing_qs(self):
-        BASE_URL = 'https://test.example.com/base?one=Three'
-        NV_LIST = [('one', 'One'), ('two', 'Two')]
-        expected = '&'.join([
-            '{}={}'.format(name, value) for name, value in NV_LIST])
-        self.assertEqual(
-            self._call_fut(BASE_URL, NV_LIST),
-            '{}&{}'.format(BASE_URL, expected))
-
-
 class _Connection(object):
 
     API_BASE_URL = 'http://example.com'
@@ -2501,7 +2280,7 @@ class _Connection(object):
 
 class _Bucket(object):
 
-    def __init__(self, client=None, name='name', user_project=None):
+    def __init__(self, client=None, name='name'):
         if client is None:
             connection = _Connection()
             client = _Client(connection)
@@ -2511,7 +2290,6 @@ class _Bucket(object):
         self._deleted = []
         self.name = name
         self.path = '/b/' + name
-        self.user_project = user_project
 
     def delete_blob(self, blob_name, client=None):
         del self._blobs[blob_name]

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -155,22 +155,22 @@ class TestClient(unittest.TestCase):
         CREDENTIALS = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
-        BUCKET_NAME = 'bucket-name'
+        BLOB_NAME = 'blob-name'
         URI = '/'.join([
             client._connection.API_BASE_URL,
             'storage',
             client._connection.API_VERSION,
             'b',
-            '%s?projection=noAcl' % (BUCKET_NAME,),
+            '%s?projection=noAcl' % (BLOB_NAME,),
         ])
         http = client._http_internal = _Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{{"name": "{0}"}}'.format(BUCKET_NAME).encode('utf-8'),
+            '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
 
-        bucket = client.get_bucket(BUCKET_NAME)
+        bucket = client.get_bucket(BLOB_NAME)
         self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BUCKET_NAME)
+        self.assertEqual(bucket.name, BLOB_NAME)
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
 
@@ -203,34 +203,33 @@ class TestClient(unittest.TestCase):
         CREDENTIALS = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
-        BUCKET_NAME = 'bucket-name'
+        BLOB_NAME = 'blob-name'
         URI = '/'.join([
             client._connection.API_BASE_URL,
             'storage',
             client._connection.API_VERSION,
             'b',
-            '%s?projection=noAcl' % (BUCKET_NAME,),
+            '%s?projection=noAcl' % (BLOB_NAME,),
         ])
         http = client._http_internal = _Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{{"name": "{0}"}}'.format(BUCKET_NAME).encode('utf-8'),
+            '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
 
-        bucket = client.lookup_bucket(BUCKET_NAME)
+        bucket = client.lookup_bucket(BLOB_NAME)
         self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BUCKET_NAME)
+        self.assertEqual(bucket.name, BLOB_NAME)
         self.assertEqual(http._called_with['method'], 'GET')
         self.assertEqual(http._called_with['uri'], URI)
 
     def test_create_bucket_conflict(self):
-        import json
         from google.cloud.exceptions import Conflict
 
         PROJECT = 'PROJECT'
         CREDENTIALS = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
-        BUCKET_NAME = 'bucket-name'
+        BLOB_NAME = 'blob-name'
         URI = '/'.join([
             client._connection.API_BASE_URL,
             'storage',
@@ -242,21 +241,18 @@ class TestClient(unittest.TestCase):
             '{"error": {"message": "Conflict"}}',
         )
 
-        self.assertRaises(Conflict, client.create_bucket, BUCKET_NAME)
+        self.assertRaises(Conflict, client.create_bucket, BLOB_NAME)
         self.assertEqual(http._called_with['method'], 'POST')
         self.assertEqual(http._called_with['uri'], URI)
-        body = json.loads(http._called_with['body'])
-        self.assertEqual(body, {'name': BUCKET_NAME})
 
     def test_create_bucket_success(self):
-        import json
         from google.cloud.storage.bucket import Bucket
 
         PROJECT = 'PROJECT'
         CREDENTIALS = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
-        BUCKET_NAME = 'bucket-name'
+        BLOB_NAME = 'blob-name'
         URI = '/'.join([
             client._connection.API_BASE_URL,
             'storage',
@@ -265,17 +261,14 @@ class TestClient(unittest.TestCase):
         ])
         http = client._http_internal = _Http(
             {'status': '200', 'content-type': 'application/json'},
-            '{{"name": "{0}"}}'.format(BUCKET_NAME).encode('utf-8'),
+            '{{"name": "{0}"}}'.format(BLOB_NAME).encode('utf-8'),
         )
 
-        bucket = client.create_bucket(BUCKET_NAME, requester_pays=True)
+        bucket = client.create_bucket(BLOB_NAME)
         self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BUCKET_NAME)
+        self.assertEqual(bucket.name, BLOB_NAME)
         self.assertEqual(http._called_with['method'], 'POST')
         self.assertEqual(http._called_with['uri'], URI)
-        body = json.loads(http._called_with['body'])
-        self.assertEqual(
-            body, {'name': BUCKET_NAME, 'billing': {'requesterPays': True}})
 
     def test_list_buckets_empty(self):
         from six.moves.urllib.parse import parse_qs
@@ -407,7 +400,7 @@ class TestClient(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
 
-        blob_name = 'bucket-name'
+        blob_name = 'blob-name'
         response = {'items': [{'name': blob_name}]}
 
         def dummy_response():


### PR DESCRIPTION
The feature is not GA, which makes system testing problematic.

Development continues on the `storage-requester_pays-feature` [branch](https://github.com/GoogleCloudPlatform/google-cloud-python/tree/storage-requester_pays-feature)..