### PR TITLE
Prep dns-0.25.0 release.

### DIFF
--- a/dns/setup.py
+++ b/dns/setup.py
@@ -51,12 +51,12 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
 ]
 
 setup(
     name='google-cloud-dns',
-    version='0.24.0',
+    version='0.25.0',
     description='Python Client for Google Cloud DNS',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Requires merge of #3526 to bump core to 0.25.0.

Draft release notes:

## google-cloud-dns-0.25.0

- Update google-cloud-core dependency to ~= 0.25.

----

Excluded from notes:

- Re-enable pylint in info-only mode for all packages (#3519)
- Vision semi-GAPIC (#3373)
- Ignore tests (rather than unit_tests) in setup.py files. (#3319)
- Adding check that **all** setup.py README's are valid RST. (#3318)
