### PR TITLE
Prep error-reporting-0.25.0 release.

### DIFF
--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -51,14 +51,14 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.1, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
     'google-cloud-logging >= 1.0.0, < 2.0dev',
     'gapic-google-cloud-error-reporting-v1beta1 >= 0.15.0, < 0.16dev'
 ]
 
 setup(
     name='google-cloud-error-reporting',
-    version='0.24.2',
+    version='0.25.0',
     description='Python Client for Stackdriver Error Reporting',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Requires merge of #3526 to bump core to 0.25.0.

Draft release notes:

## google-cloud-error-reporting-0.25.0

- Update google-cloud-core dependency to ~= 0.25.

----

Excluded from notes:

- Re-enable pylint in info-only mode for all packages (#3519)
- Vision semi-GAPIC (#3373)
- Increasing retries from 4 to 6 for error reporting system test.
- Add error reporting system test (#3348)

