### PR TITLE
Prep speech-0.26.0 release.

### DIFF
--- a/speech/setup.py
+++ b/speech/setup.py
@@ -50,14 +50,14 @@ SETUP_BASE = {
 }
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.25dev',
+    'google-cloud-core >= 0.25.0, < 0.26dev',
     'grpcio >= 1.0.2, < 2.0dev',
     'gapic-google-cloud-speech-v1 >= 0.15.3, < 0.16dev',
 ]
 
 setup(
     name='google-cloud-speech',
-    version='0.25.1',
+    version='0.26.0',
     description='Python Client for Google Cloud Speech',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Requires merge of #3526 to bump core to 0.25.0.

Draft release notes:

## google-cloud-speech-0.26.0

- Update google-cloud-core dependency to ~= 0.25.

----

Excluded from notes:

- Re-enable pylint in info-only mode for all packages (#3519)
- Vision semi-GAPIC (#3373)
- Correct speech Operation docstring (#3379)
- Ignore tests (rather than unit_tests) in setup.py files. (#3319)
- Adding check that **all** setup.py README's are valid RST. (#3318)
