### PR TITLE
Removing google-cloud-core dependency in test_utils package.

### DIFF
--- a/test_utils/setup.py
+++ b/test_utils/setup.py
@@ -49,7 +49,6 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.24.0, < 0.25dev',
     'google-auth >= 0.4.0',
     'six',
 ]


### PR DESCRIPTION
@lukesneeringer Why is this a dependency in the `test_utils` package?