### PR TITLE
BQ: cleanup flake8 errors in tests

### DIFF
--- a/bigquery/nox.py
+++ b/bigquery/nox.py
@@ -75,6 +75,7 @@ def lint(session):
     session.install('flake8', 'pylint', 'gcp-devrel-py-tools', *LOCAL_DEPS)
     session.install('.')
     session.run('flake8', 'google/cloud/bigquery')
+    session.run('flake8', 'tests')
     session.run(
         'gcp-devrel-py-tools', 'run-pylint',
         '--config', 'pylint.config.py',

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -167,9 +167,9 @@ class TestBigQuery(unittest.TestCase):
             'newest' + unique_resource_id(),
         ]
         for dataset_name in datasets_to_create:
-            dataset = Config.CLIENT.dataset(dataset_name)
-            retry_403(dataset.create)()
-            self.to_delete.append(dataset)
+            created_dataset = Config.CLIENT.dataset(dataset_name)
+            retry_403(created_dataset.create)()
+            self.to_delete.append(created_dataset)
 
         # Retrieve the datasets.
         iterator = Config.CLIENT.list_datasets()
@@ -222,9 +222,9 @@ class TestBigQuery(unittest.TestCase):
                                          mode='REQUIRED')
         age = bigquery.SchemaField('age', 'INTEGER', mode='REQUIRED')
         for table_name in tables_to_create:
-            table = dataset.table(table_name, schema=[full_name, age])
-            table.create()
-            self.to_delete.insert(0, table)
+            created_table = dataset.table(table_name, schema=[full_name, age])
+            created_table.create()
+            self.to_delete.insert(0, created_table)
 
         # Retrieve the tables.
         iterator = dataset.list_tables()
@@ -838,7 +838,6 @@ class TestBigQuery(unittest.TestCase):
         SQL = 'SELECT * from `{}.{}.{}` LIMIT {}'.format(
             PUBLIC, DATASET_NAME, TABLE_NAME, LIMIT)
 
-        dataset = Config.CLIENT.dataset(DATASET_NAME, project=PUBLIC)
         query = Config.CLIENT.run_sync_query(SQL)
         query.use_legacy_sql = False
         query.run()

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -403,7 +403,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = _Dataset(client)
         table = self._make_one(self.TABLE_NAME, dataset)
         table.partitioning_type = 'DAY'
-        table.create()            
+        table.create()
 
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
@@ -1049,12 +1049,6 @@ class TestTable(unittest.TestCase, _SchemaBase):
         client = _Client(project=self.PROJECT)
         dataset = _Dataset(client)
         table = self._make_one(self.TABLE_NAME, dataset=dataset)
-        ROWS = [
-            ('Phred Phlyntstone', 32),
-            ('Bharney Rhubble', 33),
-            ('Wylma Phlyntstone', 29),
-            ('Bhettye Rhubble', 27),
-        ]
 
         with self.assertRaises(ValueError) as exc:
             table.fetch_data()


### PR DESCRIPTION
Errors I fixed.

    (google-cloud-python-2)
    $ flake8 tests
    tests/system.py:178:32: F812 list comprehension redefines 'dataset' from line 170
    tests/system.py:233:30: F812 list comprehension redefines 'table' from line 225
    tests/system.py:841:9: F841 local variable 'dataset' is assigned to but never used
    tests/unit/test_table.py:406:23: W291 trailing whitespace
    tests/unit/test_table.py:1052:9: F841 local variable 'ROWS' is assigned to but never used

I've also added the tests folder to flake8 in the nox config.