### PR TITLE
strip padding characters from urlsafe

### DIFF
--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -304,9 +304,8 @@ class Key(object):
         This is intended to work with the "legacy" representation of a
         datastore "Key" used within Google App Engine (a so-called
         "Reference"). The returned string can be used as the ``urlsafe``
-        argument to ``ndb.Key(urlsafe=...)``. Notice that the datastore's
-        version of urlsafe encoding does not have padding characters, unlike
-        the out of the box urlsafe_b64encode's generated urlsafe.
+        argument to ``ndb.Key(urlsafe=...)``. The base64 encoded values
+        will have padding removed.
 
         :rtype: bytes
         :returns: A bytestring containing the key encoded as URL-safe base64.
@@ -317,7 +316,7 @@ class Key(object):
             name_space=self.namespace,
         )
         raw_bytes = reference.SerializeToString()
-        return base64.urlsafe_b64encode(raw_bytes).strip("=")
+        return base64.urlsafe_b64encode(raw_bytes).strip(b'=')
 
     @classmethod
     def from_legacy_urlsafe(cls, urlsafe):
@@ -326,10 +325,8 @@ class Key(object):
         This is intended to work with the "legacy" representation of a
         datastore "Key" used within Google App Engine (a so-called
         "Reference"). This assumes that ``urlsafe`` was created within an App
-        Engine app via something like ``ndb.Key(...).urlsafe()``. Notice that
-        the datastore's version of urlsafe encoding does not have padding
-        characters, unlike the out of the box urlsafe_b64encode's generated
-        urlsafe.
+        Engine app via something like ``ndb.Key(...).urlsafe()``. The base64
+        encoded values will have padding removed.
 
         :type urlsafe: bytes or unicode
         :param urlsafe: The base64 encoded (ASCII) string corresponding to a
@@ -338,14 +335,8 @@ class Key(object):
         :rtype: :class:`~google.cloud.datastore.key.Key`.
         :returns: The key corresponding to ``urlsafe``.
         """
-        if not isinstance(urlsafe, basestring):
-            raise TypeError('urlsafe must be a string; received %r' % urlsafe)
-        if isinstance(urlsafe, unicode):
-            urlsafe = urlsafe.encode('utf8')
-
-        mod = len(urlsafe) % 4
-        if mod:
-            urlsafe += '=' * (4 - mod)
+        padding = b'=' * (-len(urlsafe) % 4)
+        urlsafe += padding
 
         urlsafe = _to_bytes(urlsafe, encoding='ascii')
         raw_bytes = base64.urlsafe_b64decode(urlsafe)

--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -325,8 +325,7 @@ class Key(object):
         This is intended to work with the "legacy" representation of a
         datastore "Key" used within Google App Engine (a so-called
         "Reference"). This assumes that ``urlsafe`` was created within an App
-        Engine app via something like ``ndb.Key(...).urlsafe()``. The base64
-        encoded values will have padding removed.
+        Engine app via something like ``ndb.Key(...).urlsafe()``.
 
         :type urlsafe: bytes or unicode
         :param urlsafe: The base64 encoded (ASCII) string corresponding to a

--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -334,10 +334,9 @@ class Key(object):
         :rtype: :class:`~google.cloud.datastore.key.Key`.
         :returns: The key corresponding to ``urlsafe``.
         """
+        urlsafe = _to_bytes(urlsafe, encoding='ascii')
         padding = b'=' * (-len(urlsafe) % 4)
         urlsafe += padding
-
-        urlsafe = _to_bytes(urlsafe, encoding='ascii')
         raw_bytes = base64.urlsafe_b64decode(urlsafe)
 
         reference = _app_engine_key_pb2.Reference()


### PR DESCRIPTION
Hi,

I am proposing a change to the Google Cloud Platform Datastore's Python client library, specifically the Key module. @dhermes and I have discussed about removing the padding characters ("=") from regular b64encoded urlsafe to match the version that is used in Datastore (which does not have the padding character "="). This is done to ensure consistency in using and reproducing Datastore's convention for urlsafe key.

Please let me know if there is any other steps I may not have included and are needed to do to improve the changes.