### PR TITLE
Remove `apt-get install openssl` from CircleCI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
           name: Decrypt credentials
           command: |
             if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
-              apt-get update && apt-get install -y openssl
               openssl aes-256-cbc -d -a -k "$GOOGLE_CREDENTIALS_PASSPHRASE" \
                   -in /var/code/gcp/test_utils/credentials.json.enc \
                   -out "$GOOGLE_APPLICATION_CREDENTIALS"


### PR DESCRIPTION
Now `openssl` is included in the Docker image.

Thanks a lot @lukesneeringer for updating the image twice!

This should not go in until #3475 does.