### PR TITLE
Change speechContext to speechContexts.

### DIFF
--- a/speech/google/cloud/speech/_http.py
+++ b/speech/google/cloud/speech/_http.py
@@ -224,7 +224,7 @@ def _build_request_data(sample, language_code, max_alternatives=None,
     if profanity_filter is not None:
         config['profanityFilter'] = profanity_filter
     if speech_contexts:
-        config['speechContext'] = {'phrases': speech_contexts}
+        config['speechContexts'] = {'phrases': speech_contexts}
 
     data = {
         'audio': audio,

--- a/speech/tests/unit/test_client.py
+++ b/speech/tests/unit/test_client.py
@@ -135,7 +135,7 @@ class TestClient(unittest.TestCase):
                 'encoding': 'FLAC',
                 'maxAlternatives': 2,
                 'sampleRateHertz': 16000,
-                'speechContext': {
+                'speechContexts': {
                     'phrases': [
                         'hi',
                     ]


### PR DESCRIPTION
Append 's' to speechContext in order to work with the API. Stracktrace without:
  File "/usr/local/lib/python2.7/dist-packages/google/cloud/speech/sample.py", line 300, in recognize
    profanity_filter, speech_contexts)
  File "/usr/local/lib/python2.7/dist-packages/google/cloud/speech/_http.py", line 165, in recognize
    method='POST', path='speech:recognize', data=data)
  File "/usr/local/lib/python2.7/dist-packages/google/cloud/_http.py", line 303, in api_request
    error_info=method + ' ' + url)
google.cloud.exceptions.BadRequest: 400 Invalid JSON payload received. Unknown name "speech_context" at 'config': Cannot find field. (POST https://speech.googleapis.com/v1/speech:recognize)
Aborted (core dumped)