### PR TITLE
Making requirements tighter for "stable" packages in error reporting 0.25.1 release.

### DIFF
--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -52,13 +52,13 @@ SETUP_BASE = {
 
 REQUIREMENTS = [
     'google-cloud-core >= 0.25.0, < 0.26dev',
-    'google-cloud-logging >= 1.0.0, < 2.0dev',
+    'google-cloud-logging >= 1.1.0, < 1.2dev',
     'gapic-google-cloud-error-reporting-v1beta1 >= 0.15.0, < 0.16dev'
 ]
 
 setup(
     name='google-cloud-error-reporting',
-    version='0.25.0',
+    version='0.25.1',
     description='Python Client for Stackdriver Error Reporting',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
See #3579 and #3586 for context.