### PR TITLE
Add support for logging the trace-id in webapp2 apps.

### DIFF
--- a/logging/google/cloud/logging/handlers/_helpers.py
+++ b/logging/google/cloud/logging/handlers/_helpers.py
@@ -34,9 +34,9 @@ except (ImportError, SyntaxError):  # pragma: NO COVER
 from google.cloud.logging.handlers.middleware.request import (
     _get_django_request)
 
-_FLASK_TRACE_HEADER = 'X_CLOUD_TRACE_CONTEXT'
-_WEBAPP2_TRACE_HEADER = 'x-cloud-trace-context'
 _DJANGO_TRACE_HEADER = 'HTTP_X_CLOUD_TRACE_CONTEXT'
+_FLASK_TRACE_HEADER = 'X_CLOUD_TRACE_CONTEXT'
+_WEBAPP2_TRACE_HEADER = 'X-CLOUD-TRACE-CONTEXT'
 
 
 def format_stackdriver_json(record, message):
@@ -64,7 +64,7 @@ def get_trace_id_from_flask():
     """Get trace_id from flask request headers.
 
     :rtype: str
-    :return: Trace_id in HTTP request headers.
+    :returns: TraceID in HTTP request headers.
     """
     if flask is None or not flask.request:
         return None
@@ -83,7 +83,7 @@ def get_trace_id_from_webapp2():
     """Get trace_id from webapp2 request headers.
 
     :rtype: str
-    :return: Trace_id in HTTP request headers.
+    :returns: TraceID in HTTP request headers.
     """
     if webapp2 is None:
         return None
@@ -110,7 +110,7 @@ def get_trace_id_from_django():
     """Get trace_id from django request headers.
 
     :rtype: str
-    :return: Trace_id in HTTP request headers.
+    :returns: TraceID in HTTP request headers.
     """
     request = _get_django_request()
 
@@ -130,9 +130,10 @@ def get_trace_id():
     """Helper to get trace_id from web application request header.
 
     :rtype: str
-    :returns: Trace_id in HTTP request headers.
+    :returns: TraceID in HTTP request headers.
     """
-    checkers = (get_trace_id_from_django, get_trace_id_from_flask,
+    checkers = (get_trace_id_from_django,
+                get_trace_id_from_flask,
                 get_trace_id_from_webapp2)
 
     for checker in checkers:

--- a/logging/nox.py
+++ b/logging/nox.py
@@ -36,7 +36,7 @@ def unit_tests(session, python_version):
     # Install all test dependencies, then install this package in-place.
     session.install(
         'mock', 'pytest', 'pytest-cov',
-        'flask', 'django', *LOCAL_DEPS)
+        'flask', 'webapp2', 'webob', 'django', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/logging/tests/unit/handlers/test__helpers.py
+++ b/logging/tests/unit/handlers/test__helpers.py
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import json
 import unittest
 
 import mock
+import six
+
+try:
+    from webapp2 import RequestHandler
+except SyntaxError:
+    # webapp2 has not been ported to python3, so it will give a syntax
+    # error if we try.  We'll just skip the webapp2 tests in that case.
+    RequestHandler = object
 
 
 class Test_get_trace_id_from_flask(unittest.TestCase):
@@ -38,11 +46,9 @@ class Test_get_trace_id_from_flask(unittest.TestCase):
 
         return app
 
-    def setUp(self):
-        self.app = self.create_app()
-
     def test_no_context_header(self):
-        with self.app.test_request_context(
+        app = self.create_app()
+        with app.test_request_context(
                 path='/',
                 headers={}):
             trace_id = self._call_fut()
@@ -54,7 +60,8 @@ class Test_get_trace_id_from_flask(unittest.TestCase):
         expected_trace_id = 'testtraceidflask'
         flask_trace_id = expected_trace_id + '/testspanid'
 
-        context = self.app.test_request_context(
+        app = self.create_app()
+        context = app.test_request_context(
             path='/',
             headers={flask_trace_header: flask_trace_id})
 
@@ -64,55 +71,52 @@ class Test_get_trace_id_from_flask(unittest.TestCase):
         self.assertEqual(trace_id, expected_trace_id)
 
 
-# webapp2 has not been ported to python3 yet, so do not try to test its
-# functionality there.
-if sys.version_info[0] == 2:
-    class Test_get_trace_id_from_webapp2(unittest.TestCase):
+class _GetTraceId(RequestHandler):
+    def get(self):
+        from google.cloud.logging.handlers import _helpers
 
-        @staticmethod
-        def create_app():
-            import webapp2
+        trace_id = _helpers.get_trace_id_from_webapp2()
+        self.response.content_type = 'application/json'
+        self.response.out.write(json.dumps(trace_id))
 
-            class GetTraceId(webapp2.RequestHandler):
-                def get(self):
-                    from google.cloud.logging.handlers import _helpers
 
-                    trace_id = _helpers.get_trace_id_from_webapp2()
-                    self.response.content_type = "text/plain"
-                    self.response.out.write(trace_id)
 
-            app = webapp2.WSGIApplication([
-                ('/', GetTraceId),
-            ])
+@unittest.skipIf(six.PY3, 'webapp2 is Python 2 only')
+class Test_get_trace_id_from_webapp2(unittest.TestCase):
 
-            return app
+    @staticmethod
+    def create_app():
+        import webapp2
 
-        def setUp(self):
-            self.app = self.create_app()
+        app = webapp2.WSGIApplication([
+            ('/', _GetTraceId),
+        ])
 
-        def test_no_context_header(self):
-            import webob
+        return app
 
-            req = webob.BaseRequest.blank('/')
-            response = req.get_response(self.app)
-            trace_id = response.body
+    def test_no_context_header(self):
+        import webob
 
-            self.assertEquals("None", trace_id)
+        req = webob.BaseRequest.blank('/')
+        response = req.get_response(self.create_app())
+        trace_id = json.loads(response.body)
 
-        def test_valid_context_header(self):
-            import webob
+        self.assertEquals(None, trace_id)
 
-            webapp2_trace_header = 'X-Cloud-Trace-Context'
-            expected_trace_id = 'testtraceidwebapp2'
-            webapp2_trace_id = expected_trace_id + '/testspanid'
+    def test_valid_context_header(self):
+        import webob
 
-            req = webob.BaseRequest.blank(
-                '/',
-                headers={webapp2_trace_header: webapp2_trace_id})
-            response = req.get_response(self.app)
-            trace_id = response.body
+        webapp2_trace_header = 'X-Cloud-Trace-Context'
+        expected_trace_id = 'testtraceidwebapp2'
+        webapp2_trace_id = expected_trace_id + '/testspanid'
 
-            self.assertEqual(trace_id, expected_trace_id)
+        req = webob.BaseRequest.blank(
+            '/',
+            headers={webapp2_trace_header: webapp2_trace_id})
+        response = req.get_response(self.create_app())
+        trace_id = json.loads(response.body)
+
+        self.assertEqual(trace_id, expected_trace_id)
 
 
 class Test_get_trace_id_from_django(unittest.TestCase):


### PR DESCRIPTION
Code was added in #3448 that set the trace-id when used in the
flask or django web frameworks.

This extends that to also support webapp2.

webapp2 is not cutting edge technology anymore -- it doesn't even work
on python3 -- but a lot of legacy GAE classic apps use webapp2, so I
think it makes sense to support it.

I tested this by running `nox` in the `logging/` directory, which as far
as I can tell is current state of the art for running tests.