### PR TITLE
Spanner p0 system tests (batch #2)

### DIFF
--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -786,6 +786,14 @@ class TestSessionAPI(unittest.TestCase, _TestData):
 
         self._check_sql_results(
             snapshot,
+            sql='SELECT description FROM all_types WHERE eye_d = @my_id',
+            params={'my_id': None},
+            param_types={'my_id': Type(code=INT64)},
+            expected=[],
+        )
+
+        self._check_sql_results(
+            snapshot,
             sql='SELECT eye_d FROM all_types WHERE description = @description',
             params={'description': u'dog'},
             param_types={'description': Type(code=STRING)},

--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -687,6 +687,26 @@ class TestSessionAPI(unittest.TestCase, _TestData):
             sql, params=params, param_types=param_types))
         self._check_row_data(rows, expected=expected)
 
+    def test_execute_sql_returning_array_of_struct(self):
+        SQL = (
+            "SELECT ARRAY(SELECT AS STRUCT C1, C2 "
+            "FROM (SELECT 'a' AS C1, 1 AS C2 "
+            "UNION ALL SELECT 'b' AS C1, 2 AS C2) "
+            "ORDER BY C1 ASC)"
+        )
+        session = self._db.session()
+        session.create()
+        self.to_delete.append(session)
+        snapshot = session.snapshot()
+        self._check_sql_results(
+            snapshot,
+            sql=SQL,
+            params=None,
+            param_types=None,
+            expected=[
+                [[['a', 1], ['b', 2]]],
+            ])
+
     def test_execute_sql_w_query_param(self):
         session = self._db.session()
         session.create()

--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -87,6 +87,10 @@ def setUpModule():
 
     configs = list(retry(Config.CLIENT.list_instance_configs)())
 
+    # Defend against back-end returning configs for regions we aren't
+    # actually allowed to use.
+    configs = [config for config in configs if '-us-' in config.name]
+
     if len(configs) < 1:
         raise ValueError('List instance configs failed in module set up.')
 


### PR DESCRIPTION
Uses #3599 as a base.

Additional system tests for `Snapshot.read`:

- Read timestamp.
- Min read timestamp.
- Max staleness.
- Exact staleness.
- Strong.