### PR TITLE
fix big query documentation broken link

### DIFF
--- a/bigquery/README.rst
+++ b/bigquery/README.rst
@@ -9,7 +9,7 @@ Python Client for Google BigQuery
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigquery-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigquery/usage.html
 
 Quick Start
 -----------


### PR DESCRIPTION
closes issue https://github.com/GoogleCloudPlatform/google-cloud-python/issues/3610