### PR TITLE
Using `CopyFrom` to set protobuf message fields (instead of `MergeFrom`).

### DIFF
--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -181,7 +181,7 @@ class Table(object):
             table_pb = table_v2_pb2.Table()
             for col_fam in column_families:
                 curr_id = col_fam.column_family_id
-                table_pb.column_families[curr_id].MergeFrom(col_fam.to_pb())
+                table_pb.column_families[curr_id].CopyFrom(col_fam.to_pb())
 
         request_pb = table_admin_messages_v2_pb2.CreateTableRequest(
             initial_splits=initial_split_keys or [],

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -255,7 +255,7 @@ class TestTable(unittest.TestCase):
             for cf in column_families:
                 cf_pb = table_pb.column_families[cf.column_family_id]
                 if cf.gc_rule is not None:
-                    cf_pb.gc_rule.MergeFrom(cf.gc_rule.to_pb())
+                    cf_pb.gc_rule.CopyFrom(cf.gc_rule.to_pb())
         request_pb = _CreateTableRequestPB(
             initial_splits=splits_pb,
             parent=self.INSTANCE_NAME,


### PR DESCRIPTION
Fixes #3571.