### PR TITLE
Add keyword arguments to google.cloud.storage.Bucket.get_blob.

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -113,7 +113,7 @@ class Blob(_PropertyMixin):
     :type encryption_key: bytes
     :param encryption_key:
         Optional 32 byte encryption key for customer-supplied encryption.
-        See https://cloud.google.com/storage/docs/encryption#customer-supplied
+        See https://cloud.google.com/storage/docs/encryption#customer-supplied.
     """
 
     _chunk_size = None  # Default value for each instance.

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -228,7 +228,7 @@ class Bucket(_PropertyMixin):
 
         return self.path_helper(self.name)
 
-    def get_blob(self, blob_name, client=None):
+    def get_blob(self, blob_name, client=None, **kwargs):
         """Get a blob object by name.
 
         This will return None if the blob doesn't exist:
@@ -245,11 +245,15 @@ class Bucket(_PropertyMixin):
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the current bucket.
 
+        :type kwargs: dict
+        :param kwargs: Keyword arguments to pass to the :class:`~google.cloud.storage.blob.Blob`
+                       constructor.
+
         :rtype: :class:`google.cloud.storage.blob.Blob` or None
         :returns: The blob object if it exists, otherwise None.
         """
         client = self._require_client(client)
-        blob = Blob(bucket=self, name=blob_name)
+        blob = Blob(bucket=self, name=blob_name, **kwargs)
         try:
             response = client._connection.api_request(
                 method='GET', path=blob.path, _target_object=blob)

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -246,8 +246,8 @@ class Bucket(_PropertyMixin):
                        to the ``client`` stored on the current bucket.
 
         :type kwargs: dict
-        :param kwargs: Keyword arguments to pass to the :class:`~google.cloud.storage.blob.Blob`
-                       constructor.
+        :param kwargs: Keyword arguments to pass to the
+                       :class:`~google.cloud.storage.blob.Blob` constructor.
 
         :rtype: :class:`google.cloud.storage.blob.Blob` or None
         :returns: The blob object if it exists, otherwise None.

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -33,7 +33,8 @@ from google.cloud.storage._helpers import _scalar_property
 from google.cloud.storage._helpers import _validate_name
 from google.cloud.storage.acl import BucketACL
 from google.cloud.storage.acl import DefaultObjectACL
-from google.cloud.storage.blob import Blob, _get_encryption_headers
+from google.cloud.storage.blob import Blob
+from google.cloud.storage.blob import _get_encryption_headers
 
 
 def _blobs_page_start(iterator, page, response):
@@ -265,8 +266,7 @@ class Bucket(_PropertyMixin):
             headers = _get_encryption_headers(encryption_key)
             response = client._connection.api_request(
                 method='GET', path=blob.path, _target_object=blob,
-                headers=headers
-            )
+                headers=headers)
             # NOTE: We assume response.get('name') matches `blob_name`.
             blob._set_properties(response)
             # NOTE: This will not fail immediately in a batch. However, when

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -246,6 +246,8 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, BLOB_NAME))
 
     def test_get_blob_hit_with_kwargs(self):
+        from google.cloud.storage.blob import _get_encryption_headers
+
         NAME = 'name'
         BLOB_NAME = 'blob-name'
         CHUNK_SIZE = 1024 * 1024
@@ -262,6 +264,7 @@ class Test_Bucket(unittest.TestCase):
         kw, = connection._requested
         self.assertEqual(kw['method'], 'GET')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, BLOB_NAME))
+        self.assertEqual(kw['headers'], _get_encryption_headers(KEY))
         self.assertEqual(blob.chunk_size, CHUNK_SIZE)
         self.assertEqual(blob._encryption_key, KEY)
 

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -245,6 +245,26 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw['method'], 'GET')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, BLOB_NAME))
 
+    def test_get_blob_hit_with_kwargs(self):
+        NAME = 'name'
+        BLOB_NAME = 'blob-name'
+        CHUNK_SIZE = 1024 * 1024
+        KEY = b'01234567890123456789012345678901'  # 32 bytes
+
+        connection = _Connection({'name': BLOB_NAME})
+        client = _Client(connection)
+        bucket = self._make_one(name=NAME)
+        blob = bucket.get_blob(
+            BLOB_NAME, client=client, encryption_key=KEY, chunk_size=CHUNK_SIZE
+        )
+        self.assertIs(blob.bucket, bucket)
+        self.assertEqual(blob.name, BLOB_NAME)
+        kw, = connection._requested
+        self.assertEqual(kw['method'], 'GET')
+        self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, BLOB_NAME))
+        self.assertEqual(blob.chunk_size, CHUNK_SIZE)
+        self.assertEqual(blob._encryption_key, KEY)
+
     def test_list_blobs_defaults(self):
         NAME = 'name'
         connection = _Connection({'items': []})


### PR DESCRIPTION
This PR adds `kwargs` to the `get_blob` method of `google.cloud.storage.Bucket` to support passing `chunk_size`, `encryption_key` and any future parameters the `Blob` constructor may have.