### PR TITLE
Implement multi-use snapshots

### DIFF
--- a/spanner/google/cloud/spanner/database.py
+++ b/spanner/google/cloud/spanner/database.py
@@ -380,8 +380,7 @@ class Database(object):
         """
         return BatchCheckout(self)
 
-    def snapshot(self, read_timestamp=None, min_read_timestamp=None,
-                 max_staleness=None, exact_staleness=None):
+    def snapshot(self, **kw):
         """Return an object which wraps a snapshot.
 
         The wrapper *must* be used as a context manager, with the snapshot
@@ -390,38 +389,15 @@ class Database(object):
         See
         https://cloud.google.com/spanner/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions.ReadOnly
 
-        If no options are passed, reads will use the ``strong`` model, reading
-        at a timestamp where all previously committed transactions are visible.
-
-        :type read_timestamp: :class:`datetime.datetime`
-        :param read_timestamp: Execute all reads at the given timestamp.
-
-        :type min_read_timestamp: :class:`datetime.datetime`
-        :param min_read_timestamp: Execute all reads at a
-                                   timestamp >= ``min_read_timestamp``.
-
-        :type max_staleness: :class:`datetime.timedelta`
-        :param max_staleness: Read data at a
-                              timestamp >= NOW - ``max_staleness`` seconds.
-
-        :type exact_staleness: :class:`datetime.timedelta`
-        :param exact_staleness: Execute all reads at a timestamp that is
-                                ``exact_staleness`` old.
-
-        :rtype: :class:`~google.cloud.spanner.snapshot.Snapshot`
-        :returns: a snapshot bound to this session
-        :raises: :exc:`ValueError` if the session has not yet been created.
+        :type kw: dict
+        :param kw:
+            Passed through to
+            :class:`~google.cloud.spanner.snapshot.Snapshot` constructor.
 
         :rtype: :class:`~google.cloud.spanner.database.SnapshotCheckout`
         :returns: new wrapper
         """
-        return SnapshotCheckout(
-            self,
-            read_timestamp=read_timestamp,
-            min_read_timestamp=min_read_timestamp,
-            max_staleness=max_staleness,
-            exact_staleness=exact_staleness,
-        )
+        return SnapshotCheckout(self, **kw)
 
 
 class BatchCheckout(object):
@@ -467,40 +443,20 @@ class SnapshotCheckout(object):
     :type database: :class:`~google.cloud.spannder.database.Database`
     :param database: database to use
 
-    :type read_timestamp: :class:`datetime.datetime`
-    :param read_timestamp: Execute all reads at the given timestamp.
-
-    :type min_read_timestamp: :class:`datetime.datetime`
-    :param min_read_timestamp: Execute all reads at a
-                               timestamp >= ``min_read_timestamp``.
-
-    :type max_staleness: :class:`datetime.timedelta`
-    :param max_staleness: Read data at a
-                          timestamp >= NOW - ``max_staleness`` seconds.
-
-    :type exact_staleness: :class:`datetime.timedelta`
-    :param exact_staleness: Execute all reads at a timestamp that is
-                            ``exact_staleness`` old.
+    :type kw: dict
+    :param kw:
+        Passed through to
+        :class:`~google.cloud.spanner.snapshot.Snapshot` constructor.
     """
-    def __init__(self, database, read_timestamp=None, min_read_timestamp=None,
-                 max_staleness=None, exact_staleness=None):
+    def __init__(self, database, **kw):
         self._database = database
         self._session = None
-        self._read_timestamp = read_timestamp
-        self._min_read_timestamp = min_read_timestamp
-        self._max_staleness = max_staleness
-        self._exact_staleness = exact_staleness
+        self._kw = kw
 
     def __enter__(self):
         """Begin ``with`` block."""
         session = self._session = self._database._pool.get()
-        return Snapshot(
-            session,
-            read_timestamp=self._read_timestamp,
-            min_read_timestamp=self._min_read_timestamp,
-            max_staleness=self._max_staleness,
-            exact_staleness=self._exact_staleness,
-        )
+        return Snapshot(session, **self._kw)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """End ``with`` block."""

--- a/spanner/google/cloud/spanner/session.py
+++ b/spanner/google/cloud/spanner/session.py
@@ -139,30 +139,15 @@ class Session(object):
                 raise NotFound(self.name)
             raise
 
-    def snapshot(self, read_timestamp=None, min_read_timestamp=None,
-                 max_staleness=None, exact_staleness=None):
+    def snapshot(self, **kw):
         """Create a snapshot to perform a set of reads with shared staleness.
 
         See
         https://cloud.google.com/spanner/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions.ReadOnly
 
-        If no options are passed, reads will use the ``strong`` model, reading
-        at a timestamp where all previously committed transactions are visible.
-
-        :type read_timestamp: :class:`datetime.datetime`
-        :param read_timestamp: Execute all reads at the given timestamp.
-
-        :type min_read_timestamp: :class:`datetime.datetime`
-        :param min_read_timestamp: Execute all reads at a
-                                   timestamp >= ``min_read_timestamp``.
-
-        :type max_staleness: :class:`datetime.timedelta`
-        :param max_staleness: Read data at a
-                              timestamp >= NOW - ``max_staleness`` seconds.
-
-        :type exact_staleness: :class:`datetime.timedelta`
-        :param exact_staleness: Execute all reads at a timestamp that is
-                                ``exact_staleness`` old.
+        :type kw: dict
+        :param kw: Passed through to
+                   :class:`~google.cloud.spanner.snapshot.Snapshot` ctor.
 
         :rtype: :class:`~google.cloud.spanner.snapshot.Snapshot`
         :returns: a snapshot bound to this session
@@ -171,11 +156,7 @@ class Session(object):
         if self._session_id is None:
             raise ValueError("Session has not been created.")
 
-        return Snapshot(self,
-                        read_timestamp=read_timestamp,
-                        min_read_timestamp=min_read_timestamp,
-                        max_staleness=max_staleness,
-                        exact_staleness=exact_staleness)
+        return Snapshot(self, **kw)
 
     def read(self, table, columns, keyset, index='', limit=0,
              resume_token=b''):

--- a/spanner/google/cloud/spanner/session.py
+++ b/spanner/google/cloud/spanner/session.py
@@ -273,7 +273,7 @@ class Session(object):
                 txn = self.transaction()
             else:
                 txn = self._transaction
-            if txn._id is None:
+            if txn._transaction_id is None:
                 txn.begin()
             try:
                 func(txn, *args, **kw)

--- a/spanner/google/cloud/spanner/snapshot.py
+++ b/spanner/google/cloud/spanner/snapshot.py
@@ -184,10 +184,11 @@ class Snapshot(_SnapshotBase):
         if len(flagged) > 1:
             raise ValueError("Supply zero or one options.")
 
-        if multi_use and (min_read_timestamp or max_staleness):
-            raise ValueError(
-                "'multi_use' is incompatile with "
-                "'min_read_timestamp' / 'max_staleness'")
+        if multi_use:
+            if min_read_timestamp is not None or max_staleness is not None:
+                raise ValueError(
+                    "'multi_use' is incompatible with "
+                    "'min_read_timestamp' / 'max_staleness'")
 
         self._strong = len(flagged) == 0
         self._read_timestamp = read_timestamp

--- a/spanner/google/cloud/spanner/snapshot.py
+++ b/spanner/google/cloud/spanner/snapshot.py
@@ -198,6 +198,9 @@ class Snapshot(_SnapshotBase):
 
     def _make_txn_selector(self):
         """Helper for :meth:`read`."""
+        if self._transaction_id is not None:
+            return TransactionSelector(id=self._transaction_id)
+
         if self._read_timestamp:
             key = 'read_timestamp'
             value = _datetime_to_pb_timestamp(self._read_timestamp)

--- a/spanner/google/cloud/spanner/snapshot.py
+++ b/spanner/google/cloud/spanner/snapshot.py
@@ -167,9 +167,10 @@ class Snapshot(_SnapshotBase):
                             ``exact_staleness`` old.
 
     :type multi_use: :class:`bool`
-    :param multi_use: If true, the first read operation creates a read-only
-                      transaction, used to ensure isolation / consistency
-                      for subsequent read operations.  Incompatible with
+    :param multi_use: If true, multipl :meth:`read` / :meth:`execute_sql`
+                      calls can be performed with the snapshot in the
+                      context of a read-only transaction, used to ensure
+                      isolation / consistency. Incompatible with
                       ``max_staleness`` and ``min_read_timestamp``.
     """
     _transaction_id = None

--- a/spanner/google/cloud/spanner/snapshot.py
+++ b/spanner/google/cloud/spanner/snapshot.py
@@ -206,4 +206,8 @@ class Snapshot(_SnapshotBase):
 
         options = TransactionOptions(
             read_only=TransactionOptions.ReadOnly(**{key: value}))
-        return TransactionSelector(single_use=options)
+
+        if self._multi_use:
+            return TransactionSelector(begin=options)
+        else:
+            return TransactionSelector(single_use=options)

--- a/spanner/google/cloud/spanner/snapshot.py
+++ b/spanner/google/cloud/spanner/snapshot.py
@@ -35,6 +35,7 @@ class _SnapshotBase(_SessionWrapper):
     :param session: the session used to perform the commit
     """
     _multi_use = False
+    _transaction_id = None
     _read_request_count = 0
 
     def _make_txn_selector(self):  # pylint: disable=redundant-returns-doc
@@ -194,8 +195,6 @@ class Snapshot(_SnapshotBase):
                       isolation / consistency. Incompatible with
                       ``max_staleness`` and ``min_read_timestamp``.
     """
-    _transaction_id = None
-
     def __init__(self, session, read_timestamp=None, min_read_timestamp=None,
                  max_staleness=None, exact_staleness=None, multi_use=False):
         super(Snapshot, self).__init__(session)

--- a/spanner/google/cloud/spanner/snapshot.py
+++ b/spanner/google/cloud/spanner/snapshot.py
@@ -73,10 +73,14 @@ class _SnapshotBase(_SessionWrapper):
 
         :rtype: :class:`~google.cloud.spanner.streamed.StreamedResultSet`
         :returns: a result set instance which can be used to consume rows.
-        :raises: ValueError for reuse of single-use snapshots.
+        :raises: ValueError for reuse of single-use snapshots, or if a
+                 transaction ID is pending for multiple-use snapshots.
         """
-        if not self._multi_use and self._read_request_count > 0:
-            raise ValueError("Cannot re-use single-use snapshot.")
+        if self._read_request_count > 0:
+            if not self._multi_use:
+                raise ValueError("Cannot re-use single-use snapshot.")
+            if self._transaction_id is None:
+                raise ValueError("Transaction ID pending.")
 
         database = self._session._database
         api = database.spanner_api
@@ -121,10 +125,14 @@ class _SnapshotBase(_SessionWrapper):
 
         :rtype: :class:`~google.cloud.spanner.streamed.StreamedResultSet`
         :returns: a result set instance which can be used to consume rows.
-        :raises: ValueError for reuse of single-use snapshots.
+        :raises: ValueError for reuse of single-use snapshots, or if a
+                 transaction ID is pending for multiple-use snapshots.
         """
-        if not self._multi_use and self._read_request_count > 0:
-            raise ValueError("Cannot re-use single-use snapshot.")
+        if self._read_request_count > 0:
+            if not self._multi_use:
+                raise ValueError("Cannot re-use single-use snapshot.")
+            if self._transaction_id is None:
+                raise ValueError("Transaction ID pending.")
 
         if params is not None:
             if param_types is None:

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -136,8 +136,9 @@ class StreamedResultSet(object):
         if self._metadata is None:  # first response
             metadata = self._metadata = response.metadata
 
-            if self._source is not None:
-                self._source._transaction_id = metadata.transaction.id
+            source = self._source
+            if source is not None and source._transaction_id is None:
+                source._transaction_id = metadata.transaction.id
 
         if response.HasField('stats'):  # last response
             self._stats = response.stats

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -32,8 +32,11 @@ class StreamedResultSet(object):
         Iterator yielding
         :class:`google.cloud.proto.spanner.v1.result_set_pb2.PartialResultSet`
         instances.
+
+    :type source: :class:`~google.cloud.spanner.snapshot.Snapshot`
+    :param source: Snapshot from which the result set was fetched.
     """
-    def __init__(self, response_iterator):
+    def __init__(self, response_iterator, source=None):
         self._response_iterator = response_iterator
         self._rows = []             # Fully-processed rows
         self._counter = 0           # Counter for processed responses
@@ -42,6 +45,7 @@ class StreamedResultSet(object):
         self._resume_token = None   # To resume from last received PRS
         self._current_row = []      # Accumulated values for incomplete row
         self._pending_chunk = None  # Incomplete value
+        self._source = source       # Source snapshot
 
     @property
     def rows(self):
@@ -130,6 +134,7 @@ class StreamedResultSet(object):
         self._resume_token = response.resume_token
 
         if self._metadata is None:  # first response
+            # XXX: copy implicit txn ID to snapshot, if present.
             self._metadata = response.metadata
 
         if response.HasField('stats'):  # last response

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -134,8 +134,10 @@ class StreamedResultSet(object):
         self._resume_token = response.resume_token
 
         if self._metadata is None:  # first response
-            # XXX: copy implicit txn ID to snapshot, if present.
-            self._metadata = response.metadata
+            metadata = self._metadata = response.metadata
+
+            if self._source is not None:
+                self._source._transaction_id = metadata.transaction.id
 
         if response.HasField('stats'):  # last response
             self._stats = response.stats

--- a/spanner/google/cloud/spanner/transaction.py
+++ b/spanner/google/cloud/spanner/transaction.py
@@ -32,6 +32,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         super(Transaction, self).__init__(session)
         self._id = None
         self._rolled_back = False
+        self._multi_use = True
 
     def _check_state(self):
         """Helper for :meth:`commit` et al.

--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -828,7 +828,7 @@ class TestSessionAPI(unittest.TestCase, _TestData):
         START = 1000
         END = 2000
         session, committed = self._set_up_table(ROW_COUNT)
-        snapshot = session.snapshot(read_timestamp=committed)
+        snapshot = session.snapshot(read_timestamp=committed, multi_use=True)
         all_data_rows = list(self._row_data(ROW_COUNT))
 
         closed_closed = KeyRange(start_closed=[START], end_closed=[END])
@@ -934,7 +934,8 @@ class TestSessionAPI(unittest.TestCase, _TestData):
                 self.ALL_TYPES_COLUMNS,
                 self.ALL_TYPES_ROWDATA)
 
-        snapshot = session.snapshot(read_timestamp=batch.committed)
+        snapshot = session.snapshot(
+            read_timestamp=batch.committed, multi_use=True)
 
         # Cannot equality-test array values.  See below for a test w/
         # array of IDs.

--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -18,6 +18,7 @@ import operator
 import os
 import struct
 import threading
+import time
 import unittest
 
 from google.cloud.proto.spanner.v1.type_pb2 import ARRAY
@@ -717,15 +718,13 @@ class TestSessionAPI(unittest.TestCase, _TestData):
         self._check_row_data(after, all_data_rows)
 
     def test_multiuse_snapshot_read_isolation_exact_staleness(self):
-        import time
-        from datetime import timedelta
         ROW_COUNT = 40
 
         session, committed = self._set_up_table(ROW_COUNT)
         all_data_rows = list(self._row_data(ROW_COUNT))
 
         time.sleep(1)
-        delta = timedelta(microseconds=1000)
+        delta = datetime.timedelta(microseconds=1000)
 
         exact = session.snapshot(exact_staleness=delta, multi_use=True)
 

--- a/spanner/tests/unit/test_database.py
+++ b/spanner/tests/unit/test_database.py
@@ -682,12 +682,9 @@ class TestDatabase(_BaseTest):
         checkout = database.snapshot()
         self.assertIsInstance(checkout, SnapshotCheckout)
         self.assertIs(checkout._database, database)
-        self.assertIsNone(checkout._read_timestamp)
-        self.assertIsNone(checkout._min_read_timestamp)
-        self.assertIsNone(checkout._max_staleness)
-        self.assertIsNone(checkout._exact_staleness)
+        self.assertEqual(checkout._kw, {})
 
-    def test_snapshot_w_read_timestamp(self):
+    def test_snapshot_w_read_timestamp_and_multi_use(self):
         import datetime
         from google.cloud._helpers import UTC
         from google.cloud.spanner.database import SnapshotCheckout
@@ -700,78 +697,12 @@ class TestDatabase(_BaseTest):
         pool.put(session)
         database = self._make_one(self.DATABASE_ID, instance, pool=pool)
 
-        checkout = database.snapshot(read_timestamp=now)
+        checkout = database.snapshot(read_timestamp=now, multi_use=True)
 
         self.assertIsInstance(checkout, SnapshotCheckout)
         self.assertIs(checkout._database, database)
-        self.assertEqual(checkout._read_timestamp, now)
-        self.assertIsNone(checkout._min_read_timestamp)
-        self.assertIsNone(checkout._max_staleness)
-        self.assertIsNone(checkout._exact_staleness)
-
-    def test_snapshot_w_min_read_timestamp(self):
-        import datetime
-        from google.cloud._helpers import UTC
-        from google.cloud.spanner.database import SnapshotCheckout
-
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
-        client = _Client()
-        instance = _Instance(self.INSTANCE_NAME, client=client)
-        pool = _Pool()
-        session = _Session()
-        pool.put(session)
-        database = self._make_one(self.DATABASE_ID, instance, pool=pool)
-
-        checkout = database.snapshot(min_read_timestamp=now)
-
-        self.assertIsInstance(checkout, SnapshotCheckout)
-        self.assertIs(checkout._database, database)
-        self.assertIsNone(checkout._read_timestamp)
-        self.assertEqual(checkout._min_read_timestamp, now)
-        self.assertIsNone(checkout._max_staleness)
-        self.assertIsNone(checkout._exact_staleness)
-
-    def test_snapshot_w_max_staleness(self):
-        import datetime
-        from google.cloud.spanner.database import SnapshotCheckout
-
-        staleness = datetime.timedelta(seconds=1, microseconds=234567)
-        client = _Client()
-        instance = _Instance(self.INSTANCE_NAME, client=client)
-        pool = _Pool()
-        session = _Session()
-        pool.put(session)
-        database = self._make_one(self.DATABASE_ID, instance, pool=pool)
-
-        checkout = database.snapshot(max_staleness=staleness)
-
-        self.assertIsInstance(checkout, SnapshotCheckout)
-        self.assertIs(checkout._database, database)
-        self.assertIsNone(checkout._read_timestamp)
-        self.assertIsNone(checkout._min_read_timestamp)
-        self.assertEqual(checkout._max_staleness, staleness)
-        self.assertIsNone(checkout._exact_staleness)
-
-    def test_snapshot_w_exact_staleness(self):
-        import datetime
-        from google.cloud.spanner.database import SnapshotCheckout
-
-        staleness = datetime.timedelta(seconds=1, microseconds=234567)
-        client = _Client()
-        instance = _Instance(self.INSTANCE_NAME, client=client)
-        pool = _Pool()
-        session = _Session()
-        pool.put(session)
-        database = self._make_one(self.DATABASE_ID, instance, pool=pool)
-
-        checkout = database.snapshot(exact_staleness=staleness)
-
-        self.assertIsInstance(checkout, SnapshotCheckout)
-        self.assertIs(checkout._database, database)
-        self.assertIsNone(checkout._read_timestamp)
-        self.assertIsNone(checkout._min_read_timestamp)
-        self.assertIsNone(checkout._max_staleness)
-        self.assertEqual(checkout._exact_staleness, staleness)
+        self.assertEqual(
+            checkout._kw, {'read_timestamp': now, 'multi_use': True})
 
 
 class TestBatchCheckout(_BaseTest):
@@ -862,20 +793,18 @@ class TestSnapshotCheckout(_BaseTest):
 
         checkout = self._make_one(database)
         self.assertIs(checkout._database, database)
-        self.assertIsNone(checkout._read_timestamp)
-        self.assertIsNone(checkout._min_read_timestamp)
-        self.assertIsNone(checkout._max_staleness)
-        self.assertIsNone(checkout._exact_staleness)
+        self.assertEqual(checkout._kw, {})
 
         with checkout as snapshot:
             self.assertIsNone(pool._session)
             self.assertIsInstance(snapshot, Snapshot)
             self.assertIs(snapshot._session, session)
             self.assertTrue(snapshot._strong)
+            self.assertFalse(snapshot._multi_use)
 
         self.assertIs(pool._session, session)
 
-    def test_ctor_w_read_timestamp(self):
+    def test_ctor_w_read_timestamp_and_multi_use(self):
         import datetime
         from google.cloud._helpers import UTC
         from google.cloud.spanner.snapshot import Snapshot
@@ -886,99 +815,17 @@ class TestSnapshotCheckout(_BaseTest):
         pool = database._pool = _Pool()
         pool.put(session)
 
-        checkout = self._make_one(database, read_timestamp=now)
+        checkout = self._make_one(database, read_timestamp=now, multi_use=True)
         self.assertIs(checkout._database, database)
-        self.assertEqual(checkout._read_timestamp, now)
-        self.assertIsNone(checkout._min_read_timestamp)
-        self.assertIsNone(checkout._max_staleness)
-        self.assertIsNone(checkout._exact_staleness)
+        self.assertEqual(checkout._kw,
+                         {'read_timestamp': now, 'multi_use': True})
 
         with checkout as snapshot:
             self.assertIsNone(pool._session)
             self.assertIsInstance(snapshot, Snapshot)
             self.assertIs(snapshot._session, session)
-            self.assertFalse(snapshot._strong)
             self.assertEqual(snapshot._read_timestamp, now)
-
-        self.assertIs(pool._session, session)
-
-    def test_ctor_w_min_read_timestamp(self):
-        import datetime
-        from google.cloud._helpers import UTC
-        from google.cloud.spanner.snapshot import Snapshot
-
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
-        database = _Database(self.DATABASE_NAME)
-        session = _Session(database)
-        pool = database._pool = _Pool()
-        pool.put(session)
-
-        checkout = self._make_one(database, min_read_timestamp=now)
-        self.assertIs(checkout._database, database)
-        self.assertIsNone(checkout._read_timestamp)
-        self.assertEqual(checkout._min_read_timestamp, now)
-        self.assertIsNone(checkout._max_staleness)
-        self.assertIsNone(checkout._exact_staleness)
-
-        with checkout as snapshot:
-            self.assertIsNone(pool._session)
-            self.assertIsInstance(snapshot, Snapshot)
-            self.assertIs(snapshot._session, session)
-            self.assertFalse(snapshot._strong)
-            self.assertEqual(snapshot._min_read_timestamp, now)
-
-        self.assertIs(pool._session, session)
-
-    def test_ctor_w_max_staleness(self):
-        import datetime
-        from google.cloud.spanner.snapshot import Snapshot
-
-        staleness = datetime.timedelta(seconds=1, microseconds=234567)
-        database = _Database(self.DATABASE_NAME)
-        session = _Session(database)
-        pool = database._pool = _Pool()
-        pool.put(session)
-
-        checkout = self._make_one(database, max_staleness=staleness)
-        self.assertIs(checkout._database, database)
-        self.assertIsNone(checkout._read_timestamp)
-        self.assertIsNone(checkout._min_read_timestamp)
-        self.assertEqual(checkout._max_staleness, staleness)
-        self.assertIsNone(checkout._exact_staleness)
-
-        with checkout as snapshot:
-            self.assertIsNone(pool._session)
-            self.assertIsInstance(snapshot, Snapshot)
-            self.assertIs(snapshot._session, session)
-            self.assertFalse(snapshot._strong)
-            self.assertEqual(snapshot._max_staleness, staleness)
-
-        self.assertIs(pool._session, session)
-
-    def test_ctor_w_exact_staleness(self):
-        import datetime
-        from google.cloud.spanner.snapshot import Snapshot
-
-        staleness = datetime.timedelta(seconds=1, microseconds=234567)
-        database = _Database(self.DATABASE_NAME)
-        session = _Session(database)
-        pool = database._pool = _Pool()
-        pool.put(session)
-
-        checkout = self._make_one(database, exact_staleness=staleness)
-
-        self.assertIs(checkout._database, database)
-        self.assertIsNone(checkout._read_timestamp)
-        self.assertIsNone(checkout._min_read_timestamp)
-        self.assertIsNone(checkout._max_staleness)
-        self.assertEqual(checkout._exact_staleness, staleness)
-
-        with checkout as snapshot:
-            self.assertIsNone(pool._session)
-            self.assertIsInstance(snapshot, Snapshot)
-            self.assertIs(snapshot._session, session)
-            self.assertFalse(snapshot._strong)
-            self.assertEqual(snapshot._exact_staleness, staleness)
+            self.assertTrue(snapshot._multi_use)
 
         self.assertIs(pool._session, session)
 

--- a/spanner/tests/unit/test_session.py
+++ b/spanner/tests/unit/test_session.py
@@ -225,6 +225,21 @@ class TestSession(unittest.TestCase):
         self.assertIsInstance(snapshot, Snapshot)
         self.assertIs(snapshot._session, session)
         self.assertTrue(snapshot._strong)
+        self.assertFalse(snapshot._multi_use)
+
+    def test_snapshot_created_w_multi_use(self):
+        from google.cloud.spanner.snapshot import Snapshot
+
+        database = _Database(self.DATABASE_NAME)
+        session = self._make_one(database)
+        session._session_id = 'DEADBEEF'  # emulate 'session.create()'
+
+        snapshot = session.snapshot(multi_use=True)
+
+        self.assertIsInstance(snapshot, Snapshot)
+        self.assertTrue(snapshot._session is session)
+        self.assertTrue(snapshot._strong)
+        self.assertTrue(snapshot._multi_use)
 
     def test_read_not_created(self):
         from google.cloud.spanner.keyset import KeySet

--- a/spanner/tests/unit/test_session.py
+++ b/spanner/tests/unit/test_session.py
@@ -418,7 +418,7 @@ class TestSession(unittest.TestCase):
         session = self._make_one(database)
         session._session_id = 'DEADBEEF'
         begun_txn = session._transaction = Transaction(session)
-        begun_txn._id = b'FACEDACE'
+        begun_txn._transaction_id = b'FACEDACE'
 
         called_with = []
 

--- a/spanner/tests/unit/test_snapshot.py
+++ b/spanner/tests/unit/test_snapshot.py
@@ -486,6 +486,36 @@ class TestSnapshot(unittest.TestCase):
         self.assertEqual(options.read_only.exact_staleness.seconds, 3)
         self.assertEqual(options.read_only.exact_staleness.nanos, 123456000)
 
+    def test__make_txn_selector_strong_w_multi_use(self):
+        session = _Session()
+        snapshot = self._make_one(session, multi_use=True)
+        selector = snapshot._make_txn_selector()
+        options = selector.begin
+        self.assertTrue(options.read_only.strong)
+
+    def test__make_txn_selector_w_read_timestamp_w_multi_use(self):
+        from google.cloud._helpers import _pb_timestamp_to_datetime
+
+        timestamp = self._makeTimestamp()
+        session = _Session()
+        snapshot = self._make_one(
+            session, read_timestamp=timestamp, multi_use=True)
+        selector = snapshot._make_txn_selector()
+        options = selector.begin
+        self.assertEqual(
+            _pb_timestamp_to_datetime(options.read_only.read_timestamp),
+            timestamp)
+
+    def test__make_txn_selector_w_exact_staleness_w_multi_use(self):
+        duration = self._makeDuration(seconds=3, microseconds=123456)
+        session = _Session()
+        snapshot = self._make_one(
+            session, exact_staleness=duration, multi_use=True)
+        selector = snapshot._make_txn_selector()
+        options = selector.begin
+        self.assertEqual(options.read_only.exact_staleness.seconds, 3)
+        self.assertEqual(options.read_only.exact_staleness.nanos, 123456000)
+
 
 class _Session(object):
 

--- a/spanner/tests/unit/test_snapshot.py
+++ b/spanner/tests/unit/test_snapshot.py
@@ -326,6 +326,7 @@ class TestSnapshot(unittest.TestCase):
         self.assertIsNone(snapshot._min_read_timestamp)
         self.assertIsNone(snapshot._max_staleness)
         self.assertIsNone(snapshot._exact_staleness)
+        self.assertFalse(snapshot._multi_use)
 
     def test_ctor_w_multiple_options(self):
         timestamp = self._makeTimestamp()
@@ -346,6 +347,7 @@ class TestSnapshot(unittest.TestCase):
         self.assertIsNone(snapshot._min_read_timestamp)
         self.assertIsNone(snapshot._max_staleness)
         self.assertIsNone(snapshot._exact_staleness)
+        self.assertFalse(snapshot._multi_use)
 
     def test_ctor_w_min_read_timestamp(self):
         timestamp = self._makeTimestamp()
@@ -357,6 +359,7 @@ class TestSnapshot(unittest.TestCase):
         self.assertEqual(snapshot._min_read_timestamp, timestamp)
         self.assertIsNone(snapshot._max_staleness)
         self.assertIsNone(snapshot._exact_staleness)
+        self.assertFalse(snapshot._multi_use)
 
     def test_ctor_w_max_staleness(self):
         duration = self._makeDuration()
@@ -368,6 +371,7 @@ class TestSnapshot(unittest.TestCase):
         self.assertIsNone(snapshot._min_read_timestamp)
         self.assertEqual(snapshot._max_staleness, duration)
         self.assertIsNone(snapshot._exact_staleness)
+        self.assertFalse(snapshot._multi_use)
 
     def test_ctor_w_exact_staleness(self):
         duration = self._makeDuration()
@@ -379,6 +383,59 @@ class TestSnapshot(unittest.TestCase):
         self.assertIsNone(snapshot._min_read_timestamp)
         self.assertIsNone(snapshot._max_staleness)
         self.assertEqual(snapshot._exact_staleness, duration)
+        self.assertFalse(snapshot._multi_use)
+
+    def test_ctor_w_multi_use(self):
+        session = _Session()
+        snapshot = self._make_one(session, multi_use=True)
+        self.assertTrue(snapshot._session is session)
+        self.assertTrue(snapshot._strong)
+        self.assertIsNone(snapshot._read_timestamp)
+        self.assertIsNone(snapshot._min_read_timestamp)
+        self.assertIsNone(snapshot._max_staleness)
+        self.assertIsNone(snapshot._exact_staleness)
+        self.assertTrue(snapshot._multi_use)
+
+    def test_ctor_w_multi_use_and_read_timestamp(self):
+        timestamp = self._makeTimestamp()
+        session = _Session()
+        snapshot = self._make_one(
+            session, read_timestamp=timestamp, multi_use=True)
+        self.assertTrue(snapshot._session is session)
+        self.assertFalse(snapshot._strong)
+        self.assertEqual(snapshot._read_timestamp, timestamp)
+        self.assertIsNone(snapshot._min_read_timestamp)
+        self.assertIsNone(snapshot._max_staleness)
+        self.assertIsNone(snapshot._exact_staleness)
+        self.assertTrue(snapshot._multi_use)
+
+    def test_ctor_w_multi_use_and_min_read_timestamp(self):
+        timestamp = self._makeTimestamp()
+        session = _Session()
+
+        with self.assertRaises(ValueError):
+            self._make_one(
+                session, min_read_timestamp=timestamp, multi_use=True)
+
+    def test_ctor_w_multi_use_and_max_staleness(self):
+        duration = self._makeDuration()
+        session = _Session()
+
+        with self.assertRaises(ValueError):
+            self._make_one(session, max_staleness=duration, multi_use=True)
+
+    def test_ctor_w_multi_use_and_exact_staleness(self):
+        duration = self._makeDuration()
+        session = _Session()
+        snapshot = self._make_one(
+            session, exact_staleness=duration, multi_use=True)
+        self.assertTrue(snapshot._session is session)
+        self.assertFalse(snapshot._strong)
+        self.assertIsNone(snapshot._read_timestamp)
+        self.assertIsNone(snapshot._min_read_timestamp)
+        self.assertIsNone(snapshot._max_staleness)
+        self.assertEqual(snapshot._exact_staleness, duration)
+        self.assertTrue(snapshot._multi_use)
 
     def test__make_txn_selector_strong(self):
         session = _Session()

--- a/spanner/tests/unit/test_snapshot.py
+++ b/spanner/tests/unit/test_snapshot.py
@@ -197,8 +197,11 @@ class Test_SnapshotBase(unittest.TestCase):
     def test_read_wo_multi_use(self):
         self._read_helper(multi_use=False)
 
-    def test_read_w_multi_use(self):
-        self._read_helper(multi_use=True)
+    def test_read_w_multi_use_wo_first(self):
+        self._read_helper(multi_use=True, first=False)
+
+    def test_read_w_multi_use_w_first(self):
+        self._read_helper(multi_use=True, first=True)
 
     def test_execute_sql_grpc_error(self):
         from google.cloud.proto.spanner.v1.transaction_pb2 import (

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -837,21 +837,6 @@ class _MockCancellableIterator(object):
         return self.next()
 
 
-class _PartialResultSetPB(object):
-
-    resume_token = b'DEADBEEF'
-
-    def __init__(self, values, metadata=None, stats=None, chunked_value=False):
-        self.values = values
-        self.metadata = metadata
-        self.stats = stats
-        self.chunked_value = chunked_value
-
-    def HasField(self, name):
-        assert name == 'stats'
-        return self.stats is not None
-
-
 class TestStreamedResultSet_JSON_acceptance_tests(unittest.TestCase):
 
     _json_tests = None

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -56,14 +56,14 @@ class TestStreamedResultSet(unittest.TestCase):
             _ = streamed.fields
 
     @staticmethod
-    def _makeScalarField(name, type_):
+    def _make_scalar_field(name, type_):
         from google.cloud.proto.spanner.v1.type_pb2 import StructType
         from google.cloud.proto.spanner.v1.type_pb2 import Type
 
         return StructType.Field(name=name, type=Type(code=type_))
 
     @staticmethod
-    def _makeArrayField(name, element_type_code=None, element_type=None):
+    def _make_array_field(name, element_type_code=None, element_type=None):
         from google.cloud.proto.spanner.v1.type_pb2 import StructType
         from google.cloud.proto.spanner.v1.type_pb2 import Type
 
@@ -74,7 +74,7 @@ class TestStreamedResultSet(unittest.TestCase):
         return StructType.Field(name=name, type=array_type)
 
     @staticmethod
-    def _makeStructType(struct_type_fields):
+    def _make_struct_type(struct_type_fields):
         from google.cloud.proto.spanner.v1.type_pb2 import StructType
         from google.cloud.proto.spanner.v1.type_pb2 import Type
 
@@ -86,13 +86,13 @@ class TestStreamedResultSet(unittest.TestCase):
         return Type(code='STRUCT', struct_type=struct_type)
 
     @staticmethod
-    def _makeValue(value):
+    def _make_value(value):
         from google.cloud.spanner._helpers import _make_value_pb
 
         return _make_value_pb(value)
 
     @staticmethod
-    def _makeListValue(values=(), value_pbs=None):
+    def _make_list_value(values=(), value_pbs=None):
         from google.protobuf.struct_pb2 import ListValue
         from google.protobuf.struct_pb2 import Value
         from google.cloud.spanner._helpers import _make_list_value_pb
@@ -102,7 +102,7 @@ class TestStreamedResultSet(unittest.TestCase):
         return Value(list_value=_make_list_value_pb(values))
 
     @staticmethod
-    def _makeResultSetMetadata(fields=(), transaction_id=None):
+    def _make_result_set_metadata(fields=(), transaction_id=None):
         from google.cloud.proto.spanner.v1.result_set_pb2 import (
             ResultSetMetadata)
         metadata = ResultSetMetadata()
@@ -113,7 +113,7 @@ class TestStreamedResultSet(unittest.TestCase):
         return metadata
 
     @staticmethod
-    def _makeResultSetStats(query_plan=None, **kw):
+    def _make_result_set_stats(query_plan=None, **kw):
         from google.cloud.proto.spanner.v1.result_set_pb2 import (
             ResultSetStats)
         from google.protobuf.struct_pb2 import Struct
@@ -127,7 +127,7 @@ class TestStreamedResultSet(unittest.TestCase):
         )
 
     @staticmethod
-    def _makePartialResultSet(
+    def _make_partial_result_set(
             values, metadata=None, stats=None, chunked_value=False):
         from google.cloud.proto.spanner.v1.result_set_pb2 import (
             PartialResultSet)
@@ -142,11 +142,11 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
         ]
-        metadata = streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        stats = streamed._stats = self._makeResultSetStats()
+        metadata = streamed._metadata = self._make_result_set_metadata(FIELDS)
+        stats = streamed._stats = self._make_result_set_stats()
         self.assertEqual(list(streamed.fields), FIELDS)
         self.assertIs(streamed.metadata, metadata)
         self.assertIs(streamed.stats, stats)
@@ -157,11 +157,11 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('registered_voter', 'BOOL'),
+            self._make_scalar_field('registered_voter', 'BOOL'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeValue(True)
-        chunk = self._makeValue(False)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_value(True)
+        chunk = self._make_value(False)
 
         with self.assertRaises(Unmergeable):
             streamed._merge_chunk(chunk)
@@ -170,11 +170,11 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('age', 'INT64'),
+            self._make_scalar_field('age', 'INT64'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeValue(42)
-        chunk = self._makeValue(13)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_value(42)
+        chunk = self._make_value(13)
 
         merged = streamed._merge_chunk(chunk)
         self.assertEqual(merged.string_value, '4213')
@@ -184,11 +184,11 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('weight', 'FLOAT64'),
+            self._make_scalar_field('weight', 'FLOAT64'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeValue(u'Na')
-        chunk = self._makeValue(u'N')
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_value(u'Na')
+        chunk = self._make_value(u'N')
 
         merged = streamed._merge_chunk(chunk)
         self.assertEqual(merged.string_value, u'NaN')
@@ -197,11 +197,11 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('weight', 'FLOAT64'),
+            self._make_scalar_field('weight', 'FLOAT64'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeValue(3.14159)
-        chunk = self._makeValue('')
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_value(3.14159)
+        chunk = self._make_value('')
 
         merged = streamed._merge_chunk(chunk)
         self.assertEqual(merged.number_value, 3.14159)
@@ -212,11 +212,11 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('weight', 'FLOAT64'),
+            self._make_scalar_field('weight', 'FLOAT64'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeValue(3.14159)
-        chunk = self._makeValue(2.71828)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_value(3.14159)
+        chunk = self._make_value(2.71828)
 
         with self.assertRaises(Unmergeable):
             streamed._merge_chunk(chunk)
@@ -225,11 +225,11 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('name', 'STRING'),
+            self._make_scalar_field('name', 'STRING'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeValue(u'phred')
-        chunk = self._makeValue(u'wylma')
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_value(u'phred')
+        chunk = self._make_value(u'wylma')
 
         merged = streamed._merge_chunk(chunk)
 
@@ -240,11 +240,11 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('image', 'BYTES'),
+            self._make_scalar_field('image', 'BYTES'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeValue(u'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\n')
-        chunk = self._makeValue(u'B3RJTUUH4QQGFwsBTL3HMwAAABJpVFh0Q29tbWVudAAAAAAAU0FNUExFMG3E+AAAAApJREFUCNdj\nYAAAAAIAAeIhvDMAAAAASUVORK5CYII=\n')
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_value(u'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\n')
+        chunk = self._make_value(u'B3RJTUUH4QQGFwsBTL3HMwAAABJpVFh0Q29tbWVudAAAAAAAU0FNUExFMG3E+AAAAApJREFUCNdj\nYAAAAAIAAeIhvDMAAAAASUVORK5CYII=\n')
 
         merged = streamed._merge_chunk(chunk)
 
@@ -255,15 +255,15 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeArrayField('name', element_type_code='BOOL'),
+            self._make_array_field('name', element_type_code='BOOL'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeListValue([True, True])
-        chunk = self._makeListValue([False, False, False])
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_list_value([True, True])
+        chunk = self._make_list_value([False, False, False])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = self._makeListValue([True, True, False, False, False])
+        expected = self._make_list_value([True, True, False, False, False])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -271,15 +271,15 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeArrayField('name', element_type_code='INT64'),
+            self._make_array_field('name', element_type_code='INT64'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeListValue([0, 1, 2])
-        chunk = self._makeListValue([3, 4, 5])
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_list_value([0, 1, 2])
+        chunk = self._make_list_value([3, 4, 5])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = self._makeListValue([0, 1, 23, 4, 5])
+        expected = self._make_list_value([0, 1, 23, 4, 5])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -293,15 +293,15 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeArrayField('name', element_type_code='FLOAT64'),
+            self._make_array_field('name', element_type_code='FLOAT64'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeListValue([PI, SQRT_2])
-        chunk = self._makeListValue(['', EULER, LOG_10])
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_list_value([PI, SQRT_2])
+        chunk = self._make_list_value(['', EULER, LOG_10])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = self._makeListValue([PI, SQRT_2, EULER, LOG_10])
+        expected = self._make_list_value([PI, SQRT_2, EULER, LOG_10])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -309,15 +309,15 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeArrayField('name', element_type_code='STRING'),
+            self._make_array_field('name', element_type_code='STRING'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeListValue([u'A', u'B', u'C'])
-        chunk = self._makeListValue([None, u'D', u'E'])
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_list_value([u'A', u'B', u'C'])
+        chunk = self._make_list_value([None, u'D', u'E'])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = self._makeListValue([u'A', u'B', u'C', None, u'D', u'E'])
+        expected = self._make_list_value([u'A', u'B', u'C', None, u'D', u'E'])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -325,15 +325,15 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeArrayField('name', element_type_code='STRING'),
+            self._make_array_field('name', element_type_code='STRING'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeListValue([u'A', u'B', u'C'])
-        chunk = self._makeListValue([u'D', u'E'])
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_list_value([u'A', u'B', u'C'])
+        chunk = self._make_list_value([u'D', u'E'])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = self._makeListValue([u'A', u'B', u'CD', u'E'])
+        expected = self._make_list_value([u'A', u'B', u'CD', u'E'])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -349,22 +349,22 @@ class TestStreamedResultSet(unittest.TestCase):
         FIELDS = [
             StructType.Field(name='loloi', type=array_type)
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeListValue(value_pbs=[
-            self._makeListValue([0, 1]),
-            self._makeListValue([2]),
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_list_value(value_pbs=[
+            self._make_list_value([0, 1]),
+            self._make_list_value([2]),
         ])
-        chunk = self._makeListValue(value_pbs=[
-            self._makeListValue([3]),
-            self._makeListValue([4, 5]),
+        chunk = self._make_list_value(value_pbs=[
+            self._make_list_value([3]),
+            self._make_list_value([4, 5]),
         ])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = self._makeListValue(value_pbs=[
-            self._makeListValue([0, 1]),
-            self._makeListValue([23]),
-            self._makeListValue([4, 5]),
+        expected = self._make_list_value(value_pbs=[
+            self._make_list_value([0, 1]),
+            self._make_list_value([23]),
+            self._make_list_value([4, 5]),
         ])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
@@ -381,22 +381,22 @@ class TestStreamedResultSet(unittest.TestCase):
         FIELDS = [
             StructType.Field(name='lolos', type=array_type)
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeListValue(value_pbs=[
-            self._makeListValue([u'A', u'B']),
-            self._makeListValue([u'C']),
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_list_value(value_pbs=[
+            self._make_list_value([u'A', u'B']),
+            self._make_list_value([u'C']),
         ])
-        chunk = self._makeListValue(value_pbs=[
-            self._makeListValue([u'D']),
-            self._makeListValue([u'E', u'F']),
+        chunk = self._make_list_value(value_pbs=[
+            self._make_list_value([u'D']),
+            self._make_list_value([u'E', u'F']),
         ])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = self._makeListValue(value_pbs=[
-            self._makeListValue([u'A', u'B']),
-            self._makeListValue([u'CD']),
-            self._makeListValue([u'E', u'F']),
+        expected = self._make_list_value(value_pbs=[
+            self._make_list_value([u'A', u'B']),
+            self._make_list_value([u'CD']),
+            self._make_list_value([u'E', u'F']),
         ])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
@@ -404,47 +404,47 @@ class TestStreamedResultSet(unittest.TestCase):
     def test__merge_chunk_array_of_struct(self):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
-        struct_type = self._makeStructType([
+        struct_type = self._make_struct_type([
             ('name', 'STRING'),
             ('age', 'INT64'),
         ])
         FIELDS = [
-            self._makeArrayField('test', element_type=struct_type),
+            self._make_array_field('test', element_type=struct_type),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        partial = self._makeListValue([u'Phred '])
-        streamed._pending_chunk = self._makeListValue(value_pbs=[partial])
-        rest = self._makeListValue([u'Phlyntstone', 31])
-        chunk = self._makeListValue(value_pbs=[rest])
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        partial = self._make_list_value([u'Phred '])
+        streamed._pending_chunk = self._make_list_value(value_pbs=[partial])
+        rest = self._make_list_value([u'Phlyntstone', 31])
+        chunk = self._make_list_value(value_pbs=[rest])
 
         merged = streamed._merge_chunk(chunk)
 
-        struct = self._makeListValue([u'Phred Phlyntstone', 31])
-        expected = self._makeListValue(value_pbs=[struct])
+        struct = self._make_list_value([u'Phred Phlyntstone', 31])
+        expected = self._make_list_value(value_pbs=[struct])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
     def test__merge_chunk_array_of_struct_unmergeable(self):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
-        struct_type = self._makeStructType([
+        struct_type = self._make_struct_type([
             ('name', 'STRING'),
             ('registered', 'BOOL'),
             ('voted', 'BOOL'),
         ])
         FIELDS = [
-            self._makeArrayField('test', element_type=struct_type),
+            self._make_array_field('test', element_type=struct_type),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        partial = self._makeListValue([u'Phred Phlyntstone', True])
-        streamed._pending_chunk = self._makeListValue(value_pbs=[partial])
-        rest = self._makeListValue([True])
-        chunk = self._makeListValue(value_pbs=[rest])
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        partial = self._make_list_value([u'Phred Phlyntstone', True])
+        streamed._pending_chunk = self._make_list_value(value_pbs=[partial])
+        rest = self._make_list_value([True])
+        chunk = self._make_list_value(value_pbs=[rest])
 
         merged = streamed._merge_chunk(chunk)
 
-        struct = self._makeListValue([u'Phred Phlyntstone', True, True])
-        expected = self._makeListValue(value_pbs=[struct])
+        struct = self._make_list_value([u'Phred Phlyntstone', True, True])
+        expected = self._make_list_value(value_pbs=[struct])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -452,11 +452,11 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
         streamed._current_row = []
         streamed._merge_values([])
         self.assertEqual(streamed.rows, [])
@@ -466,13 +466,13 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
         BARE = [u'Phred Phlyntstone', 42]
-        VALUES = [self._makeValue(bare) for bare in BARE]
+        VALUES = [self._make_value(bare) for bare in BARE]
         streamed._current_row = []
         streamed._merge_values(VALUES)
         self.assertEqual(streamed.rows, [])
@@ -482,13 +482,13 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
         BARE = [u'Phred Phlyntstone', 42, True]
-        VALUES = [self._makeValue(bare) for bare in BARE]
+        VALUES = [self._make_value(bare) for bare in BARE]
         streamed._current_row = []
         streamed._merge_values(VALUES)
         self.assertEqual(streamed.rows, [BARE])
@@ -498,17 +498,17 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
         BARE = [
             u'Phred Phlyntstone', 42, True,
             u'Bharney Rhubble', 39, True,
             u'Wylma Phlyntstone',
         ]
-        VALUES = [self._makeValue(bare) for bare in BARE]
+        VALUES = [self._make_value(bare) for bare in BARE]
         streamed._current_row = []
         streamed._merge_values(VALUES)
         self.assertEqual(streamed.rows, [BARE[0:3], BARE[3:6]])
@@ -518,11 +518,11 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
         BEFORE = [
             u'Phred Phlyntstone'
         ]
@@ -535,15 +535,15 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
         BEFORE = [u'Phred Phlyntstone']
         streamed._current_row[:] = BEFORE
         MERGED = [42]
-        TO_MERGE = [self._makeValue(item) for item in MERGED]
+        TO_MERGE = [self._make_value(item) for item in MERGED]
         streamed._merge_values(TO_MERGE)
         self.assertEqual(streamed.rows, [])
         self.assertEqual(streamed._current_row, BEFORE + MERGED)
@@ -552,17 +552,17 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
         BEFORE = [
             u'Phred Phlyntstone'
         ]
         streamed._current_row[:] = BEFORE
         MERGED = [42, True]
-        TO_MERGE = [self._makeValue(item) for item in MERGED]
+        TO_MERGE = [self._make_value(item) for item in MERGED]
         streamed._merge_values(TO_MERGE)
         self.assertEqual(streamed.rows, [BEFORE + MERGED])
         self.assertEqual(streamed._current_row, [])
@@ -571,13 +571,13 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
         BEFORE = [
-            self._makeValue(u'Phred Phlyntstone')
+            self._make_value(u'Phred Phlyntstone')
         ]
         streamed._current_row[:] = BEFORE
         MERGED = [
@@ -585,7 +585,7 @@ class TestStreamedResultSet(unittest.TestCase):
             u'Bharney Rhubble', 39, True,
             u'Wylma Phlyntstone',
         ]
-        TO_MERGE = [self._makeValue(item) for item in MERGED]
+        TO_MERGE = [self._make_value(item) for item in MERGED]
         VALUES = BEFORE + MERGED
         streamed._merge_values(TO_MERGE)
         self.assertEqual(streamed.rows, [VALUES[0:3], VALUES[3:6]])
@@ -600,14 +600,15 @@ class TestStreamedResultSet(unittest.TestCase):
     def test_consume_next_first_set_partial(self):
         TXN_ID = b'DEADBEEF'
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        metadata = self._makeResultSetMetadata(FIELDS, transaction_id=TXN_ID)
+        metadata = self._make_result_set_metadata(
+            FIELDS, transaction_id=TXN_ID)
         BARE = [u'Phred Phlyntstone', 42]
-        VALUES = [self._makeValue(bare) for bare in BARE]
-        result_set = self._makePartialResultSet(VALUES, metadata=metadata)
+        VALUES = [self._make_value(bare) for bare in BARE]
+        result_set = self._make_partial_result_set(VALUES, metadata=metadata)
         iterator = _MockCancellableIterator(result_set)
         source = mock.Mock(_transaction_id=None, spec=['_transaction_id'])
         streamed = self._make_one(iterator, source=source)
@@ -620,17 +621,17 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test_consume_next_w_partial_result(self):
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
         VALUES = [
-            self._makeValue(u'Phred '),
+            self._make_value(u'Phred '),
         ]
-        result_set = self._makePartialResultSet(VALUES, chunked_value=True)
+        result_set = self._make_partial_result_set(VALUES, chunked_value=True)
         iterator = _MockCancellableIterator(result_set)
         streamed = self._make_one(iterator)
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
         streamed.consume_next()
         self.assertEqual(streamed.rows, [])
         self.assertEqual(streamed._current_row, [])
@@ -639,21 +640,21 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test_consume_next_w_pending_chunk(self):
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
         BARE = [
             u'Phlyntstone', 42, True,
             u'Bharney Rhubble', 39, True,
             u'Wylma Phlyntstone',
         ]
-        VALUES = [self._makeValue(bare) for bare in BARE]
-        result_set = self._makePartialResultSet(VALUES)
+        VALUES = [self._make_value(bare) for bare in BARE]
+        result_set = self._make_partial_result_set(VALUES)
         iterator = _MockCancellableIterator(result_set)
         streamed = self._make_one(iterator)
-        streamed._metadata = self._makeResultSetMetadata(FIELDS)
-        streamed._pending_chunk = self._makeValue(u'Phred ')
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        streamed._pending_chunk = self._make_value(u'Phred ')
         streamed.consume_next()
         self.assertEqual(streamed.rows, [
             [u'Phred Phlyntstone', BARE[1], BARE[2]],
@@ -665,19 +666,19 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test_consume_next_last_set(self):
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        metadata = self._makeResultSetMetadata(FIELDS)
-        stats = self._makeResultSetStats(
+        metadata = self._make_result_set_metadata(FIELDS)
+        stats = self._make_result_set_stats(
             rows_returned="1",
             elapsed_time="1.23 secs",
             cpu_time="0.98 secs",
         )
         BARE = [u'Phred Phlyntstone', 42, True]
-        VALUES = [self._makeValue(bare) for bare in BARE]
-        result_set = self._makePartialResultSet(VALUES, stats=stats)
+        VALUES = [self._make_value(bare) for bare in BARE]
+        result_set = self._make_partial_result_set(VALUES, stats=stats)
         iterator = _MockCancellableIterator(result_set)
         streamed = self._make_one(iterator)
         streamed._metadata = metadata
@@ -694,14 +695,14 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test_consume_all_one_result_set_partial(self):
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        metadata = self._makeResultSetMetadata(FIELDS)
+        metadata = self._make_result_set_metadata(FIELDS)
         BARE = [u'Phred Phlyntstone', 42]
-        VALUES = [self._makeValue(bare) for bare in BARE]
-        result_set = self._makePartialResultSet(VALUES, metadata=metadata)
+        VALUES = [self._make_value(bare) for bare in BARE]
+        result_set = self._make_partial_result_set(VALUES, metadata=metadata)
         iterator = _MockCancellableIterator(result_set)
         streamed = self._make_one(iterator)
         streamed.consume_all()
@@ -711,19 +712,20 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test_consume_all_multiple_result_sets_filled(self):
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        metadata = self._makeResultSetMetadata(FIELDS)
+        metadata = self._make_result_set_metadata(FIELDS)
         BARE = [
             u'Phred Phlyntstone', 42, True,
             u'Bharney Rhubble', 39, True,
             u'Wylma Phlyntstone', 41, True,
         ]
-        VALUES = [self._makeValue(bare) for bare in BARE]
-        result_set1 = self._makePartialResultSet(VALUES[:4], metadata=metadata)
-        result_set2 = self._makePartialResultSet(VALUES[4:])
+        VALUES = [self._make_value(bare) for bare in BARE]
+        result_set1 = self._make_partial_result_set(
+            VALUES[:4], metadata=metadata)
+        result_set2 = self._make_partial_result_set(VALUES[4:])
         iterator = _MockCancellableIterator(result_set1, result_set2)
         streamed = self._make_one(iterator)
         streamed.consume_all()
@@ -743,14 +745,14 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test___iter___one_result_set_partial(self):
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        metadata = self._makeResultSetMetadata(FIELDS)
+        metadata = self._make_result_set_metadata(FIELDS)
         BARE = [u'Phred Phlyntstone', 42]
-        VALUES = [self._makeValue(bare) for bare in BARE]
-        result_set = self._makePartialResultSet(VALUES, metadata=metadata)
+        VALUES = [self._make_value(bare) for bare in BARE]
+        result_set = self._make_partial_result_set(VALUES, metadata=metadata)
         iterator = _MockCancellableIterator(result_set)
         streamed = self._make_one(iterator)
         found = list(streamed)
@@ -761,19 +763,20 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test___iter___multiple_result_sets_filled(self):
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        metadata = self._makeResultSetMetadata(FIELDS)
+        metadata = self._make_result_set_metadata(FIELDS)
         BARE = [
             u'Phred Phlyntstone', 42, True,
             u'Bharney Rhubble', 39, True,
             u'Wylma Phlyntstone', 41, True,
         ]
-        VALUES = [self._makeValue(bare) for bare in BARE]
-        result_set1 = self._makePartialResultSet(VALUES[:4], metadata=metadata)
-        result_set2 = self._makePartialResultSet(VALUES[4:])
+        VALUES = [self._make_value(bare) for bare in BARE]
+        result_set1 = self._make_partial_result_set(
+            VALUES[:4], metadata=metadata)
+        result_set2 = self._make_partial_result_set(VALUES[4:])
         iterator = _MockCancellableIterator(result_set1, result_set2)
         streamed = self._make_one(iterator)
         found = list(streamed)
@@ -788,11 +791,11 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test___iter___w_existing_rows_read(self):
         FIELDS = [
-            self._makeScalarField('full_name', 'STRING'),
-            self._makeScalarField('age', 'INT64'),
-            self._makeScalarField('married', 'BOOL'),
+            self._make_scalar_field('full_name', 'STRING'),
+            self._make_scalar_field('age', 'INT64'),
+            self._make_scalar_field('married', 'BOOL'),
         ]
-        metadata = self._makeResultSetMetadata(FIELDS)
+        metadata = self._make_result_set_metadata(FIELDS)
         ALREADY = [
             [u'Pebbylz Phlyntstone', 4, False],
             [u'Dino Rhubble', 4, False],
@@ -802,9 +805,10 @@ class TestStreamedResultSet(unittest.TestCase):
             u'Bharney Rhubble', 39, True,
             u'Wylma Phlyntstone', 41, True,
         ]
-        VALUES = [self._makeValue(bare) for bare in BARE]
-        result_set1 = self._makePartialResultSet(VALUES[:4], metadata=metadata)
-        result_set2 = self._makePartialResultSet(VALUES[4:])
+        VALUES = [self._make_value(bare) for bare in BARE]
+        result_set1 = self._make_partial_result_set(
+            VALUES[:4], metadata=metadata)
+        result_set2 = self._make_partial_result_set(VALUES[4:])
         iterator = _MockCancellableIterator(result_set1, result_set2)
         streamed = self._make_one(iterator)
         streamed._rows[:] = ALREADY

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 
-import mock
 import unittest
+
+import mock
 
 
 class TestStreamedResultSet(unittest.TestCase):

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -30,6 +30,18 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         self.assertIs(streamed._response_iterator, iterator)
+        self.assertIsNone(streamed._source)
+        self.assertEqual(streamed.rows, [])
+        self.assertIsNone(streamed.metadata)
+        self.assertIsNone(streamed.stats)
+        self.assertIsNone(streamed.resume_token)
+
+    def test_ctor_w_source(self):
+        iterator = _MockCancellableIterator()
+        source = object()
+        streamed = self._make_one(iterator, source=source)
+        self.assertIs(streamed._response_iterator, iterator)
+        self.assertIs(streamed._source, source)
         self.assertEqual(streamed.rows, [])
         self.assertIsNone(streamed.metadata)
         self.assertIsNone(streamed.stats)

--- a/spanner/tests/unit/test_transaction.py
+++ b/spanner/tests/unit/test_transaction.py
@@ -51,7 +51,8 @@ class TestTransaction(unittest.TestCase):
         self.assertIs(transaction._session, session)
         self.assertIsNone(transaction._id)
         self.assertIsNone(transaction.committed)
-        self.assertEqual(transaction._rolled_back, False)
+        self.assertFalse(transaction._rolled_back)
+        self.assertTrue(transaction._multi_use)
 
     def test__check_state_not_begun(self):
         session = _Session()

--- a/spanner/tests/unit/test_transaction.py
+++ b/spanner/tests/unit/test_transaction.py
@@ -49,7 +49,7 @@ class TestTransaction(unittest.TestCase):
         session = _Session()
         transaction = self._make_one(session)
         self.assertIs(transaction._session, session)
-        self.assertIsNone(transaction._id)
+        self.assertIsNone(transaction._transaction_id)
         self.assertIsNone(transaction.committed)
         self.assertFalse(transaction._rolled_back)
         self.assertTrue(transaction._multi_use)
@@ -63,7 +63,7 @@ class TestTransaction(unittest.TestCase):
     def test__check_state_already_committed(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._id = b'DEADBEEF'
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction.committed = object()
         with self.assertRaises(ValueError):
             transaction._check_state()
@@ -71,7 +71,7 @@ class TestTransaction(unittest.TestCase):
     def test__check_state_already_rolled_back(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._id = b'DEADBEEF'
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction._rolled_back = True
         with self.assertRaises(ValueError):
             transaction._check_state()
@@ -79,20 +79,20 @@ class TestTransaction(unittest.TestCase):
     def test__check_state_ok(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._id = b'DEADBEEF'
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction._check_state()  # does not raise
 
     def test__make_txn_selector(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         selector = transaction._make_txn_selector()
         self.assertEqual(selector.id, self.TRANSACTION_ID)
 
     def test_begin_already_begun(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         with self.assertRaises(ValueError):
             transaction.begin()
 
@@ -142,7 +142,7 @@ class TestTransaction(unittest.TestCase):
         txn_id = transaction.begin()
 
         self.assertEqual(txn_id, self.TRANSACTION_ID)
-        self.assertEqual(transaction._id, self.TRANSACTION_ID)
+        self.assertEqual(transaction._transaction_id, self.TRANSACTION_ID)
 
         session_id, txn_options, options = api._begun
         self.assertEqual(session_id, session.name)
@@ -159,7 +159,7 @@ class TestTransaction(unittest.TestCase):
     def test_rollback_already_committed(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction.committed = object()
         with self.assertRaises(ValueError):
             transaction.rollback()
@@ -167,7 +167,7 @@ class TestTransaction(unittest.TestCase):
     def test_rollback_already_rolled_back(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction._rolled_back = True
         with self.assertRaises(ValueError):
             transaction.rollback()
@@ -180,7 +180,7 @@ class TestTransaction(unittest.TestCase):
             _random_gax_error=True)
         session = _Session(database)
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction.insert(TABLE_NAME, COLUMNS, VALUES)
 
         with self.assertRaises(GaxError):
@@ -203,7 +203,7 @@ class TestTransaction(unittest.TestCase):
             _rollback_response=empty_pb)
         session = _Session(database)
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction.replace(TABLE_NAME, COLUMNS, VALUES)
 
         transaction.rollback()
@@ -225,7 +225,7 @@ class TestTransaction(unittest.TestCase):
     def test_commit_already_committed(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction.committed = object()
         with self.assertRaises(ValueError):
             transaction.commit()
@@ -233,7 +233,7 @@ class TestTransaction(unittest.TestCase):
     def test_commit_already_rolled_back(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction._rolled_back = True
         with self.assertRaises(ValueError):
             transaction.commit()
@@ -241,7 +241,7 @@ class TestTransaction(unittest.TestCase):
     def test_commit_no_mutations(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         with self.assertRaises(ValueError):
             transaction.commit()
 
@@ -253,7 +253,7 @@ class TestTransaction(unittest.TestCase):
             _random_gax_error=True)
         session = _Session(database)
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction.replace(TABLE_NAME, COLUMNS, VALUES)
 
         with self.assertRaises(GaxError):
@@ -285,7 +285,7 @@ class TestTransaction(unittest.TestCase):
             _commit_response=response)
         session = _Session(database)
         transaction = self._make_one(session)
-        transaction._id = self.TRANSACTION_ID
+        transaction._transaction_id = self.TRANSACTION_ID
         transaction.delete(TABLE_NAME, keyset)
 
         transaction.commit()


### PR DESCRIPTION
Multi-use snapshots trigger an "implicit" server-side transaction, and capture its ID on the first request.  Subsequent requests return that ID, allowing for isolation from other changes.  We default to `multi_use=False` because that mode is much more performant for the simple case.

This feature is one which we originally decided to leave out, but the P0 system test list requires that it be implemented.

I *think* that a commitwise review might be easier than reviewing the whole enchilada.