### PR TITLE
Remove references to google.cloud.operation from spanner

### DIFF
--- a/spanner/google/cloud/spanner/database.py
+++ b/spanner/google/cloud/spanner/database.py
@@ -27,7 +27,6 @@ import six
 # pylint: disable=ungrouped-imports
 from google.cloud.exceptions import Conflict
 from google.cloud.exceptions import NotFound
-from google.cloud.operation import register_type
 from google.cloud.spanner import __version__
 from google.cloud.spanner._helpers import _options_with_prefix
 from google.cloud.spanner.batch import Batch
@@ -43,10 +42,6 @@ _DATABASE_NAME_RE = re.compile(
     r'instances/(?P<instance_id>[a-z][-a-z0-9]*)/'
     r'databases/(?P<database_id>[a-z][a-z0-9_\-]*[a-z0-9])$'
     )
-
-register_type(admin_v1_pb2.Database)
-register_type(admin_v1_pb2.CreateDatabaseMetadata)
-register_type(admin_v1_pb2.UpdateDatabaseDdlMetadata)
 
 
 class Database(object):
@@ -205,7 +200,6 @@ class Database(object):
                 ))
             raise
 
-        future.caller_metadata = {'request_type': 'CreateDatabase'}
         return future
 
     def exists(self):
@@ -252,7 +246,7 @@ class Database(object):
         See
         https://cloud.google.com/spanner/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase
 
-        :rtype: :class:`google.cloud.operation.Operation`
+        :rtype: :class:`google.cloud.future.operation.Operation`
         :returns: an operation instance
         """
         client = self._instance._client
@@ -267,7 +261,6 @@ class Database(object):
                 raise NotFound(self.name)
             raise
 
-        future.caller_metadata = {'request_type': 'UpdateDatabaseDdl'}
         return future
 
     def drop(self):

--- a/spanner/google/cloud/spanner/database.py
+++ b/spanner/google/cloud/spanner/database.py
@@ -18,8 +18,6 @@ import re
 
 from google.gax.errors import GaxError
 from google.gax.grpc import exc_to_code
-from google.cloud.proto.spanner.admin.database.v1 import (
-    spanner_database_admin_pb2 as admin_v1_pb2)
 from google.cloud.gapic.spanner.v1.spanner_client import SpannerClient
 from grpc import StatusCode
 import six

--- a/spanner/google/cloud/spanner/instance.py
+++ b/spanner/google/cloud/spanner/instance.py
@@ -28,7 +28,6 @@ from grpc import StatusCode
 from google.cloud.exceptions import Conflict
 from google.cloud.exceptions import NotFound
 from google.cloud.iterator import GAXIterator
-from google.cloud.operation import register_type
 from google.cloud.spanner._helpers import _options_with_prefix
 from google.cloud.spanner.database import Database
 from google.cloud.spanner.pool import BurstyPool
@@ -40,10 +39,6 @@ _INSTANCE_NAME_RE = re.compile(
     r'instances/(?P<instance_id>[a-z][-a-z0-9]*)$')
 
 DEFAULT_NODE_COUNT = 1
-
-register_type(admin_v1_pb2.Instance)
-register_type(admin_v1_pb2.CreateInstanceMetadata)
-register_type(admin_v1_pb2.UpdateInstanceMetadata)
 
 
 class Instance(object):
@@ -204,7 +199,7 @@ class Instance(object):
 
            before calling :meth:`create`.
 
-        :rtype: :class:`google.cloud.operation.Operation`
+        :rtype: :class:`google.cloud.future.operation.Operation`
         :returns: an operation instance
         """
         api = self._client.instance_admin_api
@@ -228,7 +223,6 @@ class Instance(object):
                 raise Conflict(self.name)
             raise
 
-        future.caller_metadata = {'request_type': 'CreateInstance'}
         return future
 
     def exists(self):
@@ -285,7 +279,7 @@ class Instance(object):
 
             before calling :meth:`update`.
 
-        :rtype: :class:`google.cloud.operation.Operation`
+        :rtype: :class:`google.cloud.future.operation.Operation`
         :returns: an operation instance
         """
         api = self._client.instance_admin_api
@@ -309,7 +303,6 @@ class Instance(object):
                 raise NotFound(self.name)
             raise
 
-        future.caller_metadata = {'request_type': 'UpdateInstance'}
         return future
 
     def delete(self):

--- a/spanner/tests/unit/test_database.py
+++ b/spanner/tests/unit/test_database.py
@@ -312,8 +312,6 @@ class TestDatabase(_BaseTest):
         future = database.create()
 
         self.assertIs(future, op_future)
-        self.assertEqual(future.caller_metadata,
-                         {'request_type': 'CreateDatabase'})
 
         (parent, create_statement, extra_statements,
          options) = api._created_database
@@ -493,8 +491,6 @@ class TestDatabase(_BaseTest):
         future = database.update_ddl(DDL_STATEMENTS)
 
         self.assertIs(future, op_future)
-        self.assertEqual(future.caller_metadata,
-                         {'request_type': 'UpdateDatabaseDdl'})
 
         name, statements, op_id, options = api._updated_database_ddl
         self.assertEqual(name, self.DATABASE_NAME)

--- a/spanner/tests/unit/test_instance.py
+++ b/spanner/tests/unit/test_instance.py
@@ -241,8 +241,6 @@ class TestInstance(unittest.TestCase):
         future = instance.create()
 
         self.assertIs(future, op_future)
-        self.assertEqual(future.caller_metadata,
-                         {'request_type': 'CreateInstance'})
 
         (parent, instance_id, instance, options) = api._created_instance
         self.assertEqual(parent, self.PARENT)
@@ -424,8 +422,6 @@ class TestInstance(unittest.TestCase):
         future = instance.update()
 
         self.assertIs(future, op_future)
-        self.assertEqual(future.caller_metadata,
-                         {'request_type': 'UpdateInstance'})
 
         instance, field_mask, options = api._updated_instance
         self.assertEqual(field_mask.paths,


### PR DESCRIPTION
Spanner's docstrings were actually incorrect, as spanner is using gax futures but was documented as using google.cloud.operation. gax futures will be replaced by google.cloud.future.operation and in the meantime the interface is the same. This change removes references to google.cloud.operation.

This is *not* a breaking change for spanner.

Towards #3617