### PR TITLE
Using assertIs in unit tests where appropriate.

### DIFF
--- a/spanner/tests/unit/test__helpers.py
+++ b/spanner/tests/unit/test__helpers.py
@@ -512,7 +512,7 @@ class Test_SessionWrapper(unittest.TestCase):
     def test_ctor(self):
         session = object()
         base = self._make_one(session)
-        self.assertTrue(base._session is session)
+        self.assertIs(base._session, session)
 
 
 class Test_options_with_prefix(unittest.TestCase):

--- a/spanner/tests/unit/test_batch.py
+++ b/spanner/tests/unit/test_batch.py
@@ -65,7 +65,7 @@ class Test_BatchBase(_BaseTest):
     def test_ctor(self):
         session = _Session()
         base = self._make_one(session)
-        self.assertTrue(base._session is session)
+        self.assertIs(base._session, session)
         self.assertEqual(len(base._mutations), 0)
 
     def test__check_state_virtual(self):
@@ -177,7 +177,7 @@ class TestBatch(_BaseTest):
     def test_ctor(self):
         session = _Session()
         batch = self._make_one(session)
-        self.assertTrue(batch._session is session)
+        self.assertIs(batch._session, session)
 
     def test_commit_already_committed(self):
         from google.cloud.spanner.keyset import KeySet

--- a/spanner/tests/unit/test_client.py
+++ b/spanner/tests/unit/test_client.py
@@ -60,7 +60,7 @@ class TestClient(unittest.TestCase):
         expected_creds = expected_creds or creds.with_scopes.return_value
         self.assertIs(client._credentials, expected_creds)
 
-        self.assertTrue(client._credentials is expected_creds)
+        self.assertIs(client._credentials, expected_creds)
         if expected_scopes is not None:
             creds.with_scopes.assert_called_once_with(expected_scopes)
 
@@ -162,7 +162,7 @@ class TestClient(unittest.TestCase):
 
         self.assertTrue(isinstance(api, _Client))
         again = client.instance_admin_api
-        self.assertTrue(again is api)
+        self.assertIs(again, api)
         self.assertEqual(api.kwargs['lib_name'], 'gccl')
         self.assertIs(api.kwargs['credentials'], client.credentials)
 
@@ -183,7 +183,7 @@ class TestClient(unittest.TestCase):
 
         self.assertTrue(isinstance(api, _Client))
         again = client.database_admin_api
-        self.assertTrue(again is api)
+        self.assertIs(again, api)
         self.assertEqual(api.kwargs['lib_name'], 'gccl')
         self.assertIs(api.kwargs['credentials'], client.credentials)
 
@@ -202,7 +202,7 @@ class TestClient(unittest.TestCase):
     def test_credentials_property(self):
         credentials = _Credentials()
         client = self._make_one(project=self.PROJECT, credentials=credentials)
-        self.assertTrue(client.credentials is credentials)
+        self.assertIs(client.credentials, credentials)
 
     def test_project_name_property(self):
         credentials = _Credentials()
@@ -236,7 +236,7 @@ class TestClient(unittest.TestCase):
         project, page_size, options = api._listed_instance_configs
         self.assertEqual(project, self.PATH)
         self.assertEqual(page_size, None)
-        self.assertTrue(options.page_token is INITIAL_PAGE)
+        self.assertIs(options.page_token, INITIAL_PAGE)
         self.assertEqual(
             options.kwargs['metadata'],
             [('google-cloud-resource-prefix', client.project_name)])
@@ -292,7 +292,7 @@ class TestClient(unittest.TestCase):
         self.assertIsNone(instance.configuration_name)
         self.assertEqual(instance.display_name, self.INSTANCE_ID)
         self.assertEqual(instance.node_count, DEFAULT_NODE_COUNT)
-        self.assertTrue(instance._client is client)
+        self.assertIs(instance._client, client)
 
     def test_instance_factory_explicit(self):
         from google.cloud.spanner.instance import Instance
@@ -309,7 +309,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(instance.configuration_name, self.CONFIGURATION_NAME)
         self.assertEqual(instance.display_name, self.DISPLAY_NAME)
         self.assertEqual(instance.node_count, self.NODE_COUNT)
-        self.assertTrue(instance._client is client)
+        self.assertIs(instance._client, client)
 
     def test_list_instances_wo_paging(self):
         from google.cloud._testing import _GAXPageIterator
@@ -342,7 +342,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(project, self.PATH)
         self.assertEqual(filter_, 'name:TEST')
         self.assertEqual(page_size, None)
-        self.assertTrue(options.page_token is INITIAL_PAGE)
+        self.assertIs(options.page_token, INITIAL_PAGE)
         self.assertEqual(
             options.kwargs['metadata'],
             [('google-cloud-resource-prefix', client.project_name)])

--- a/spanner/tests/unit/test_database.py
+++ b/spanner/tests/unit/test_database.py
@@ -50,7 +50,7 @@ class TestDatabase(_BaseTest):
         database = self._make_one(self.DATABASE_ID, instance)
 
         self.assertEqual(database.database_id, self.DATABASE_ID)
-        self.assertTrue(database._instance is instance)
+        self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), [])
         self.assertIsInstance(database._pool, BurstyPool)
         # BurstyPool does not create sessions during 'bind()'.
@@ -61,7 +61,7 @@ class TestDatabase(_BaseTest):
         pool = _Pool()
         database = self._make_one(self.DATABASE_ID, instance, pool=pool)
         self.assertEqual(database.database_id, self.DATABASE_ID)
-        self.assertTrue(database._instance is instance)
+        self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), [])
         self.assertIs(database._pool, pool)
         self.assertIs(pool._bound, database)
@@ -89,7 +89,7 @@ class TestDatabase(_BaseTest):
             self.DATABASE_ID, instance, ddl_statements=DDL_STATEMENTS,
             pool=pool)
         self.assertEqual(database.database_id, self.DATABASE_ID)
-        self.assertTrue(database._instance is instance)
+        self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), DDL_STATEMENTS)
 
     def test_from_pb_bad_database_name(self):
@@ -196,10 +196,10 @@ class TestDatabase(_BaseTest):
 
         with _Monkey(MUT, SpannerClient=_mock_spanner_client):
             api = database.spanner_api
-            self.assertTrue(api is _client)
+            self.assertIs(api,  _client)
             # API instance is cached
             again = database.spanner_api
-            self.assertTrue(again is api)
+            self.assertIs(again, api)
 
     def test___eq__(self):
         instance = _Instance(self.INSTANCE_NAME)
@@ -567,8 +567,8 @@ class TestDatabase(_BaseTest):
         session = database.session()
 
         self.assertTrue(isinstance(session, Session))
-        self.assertTrue(session.session_id is None)
-        self.assertTrue(session._database is database)
+        self.assertIs(session.session_id, None)
+        self.assertIs(session._database, database)
 
     def test_execute_sql_defaults(self):
         QUERY = 'SELECT * FROM employees'
@@ -671,7 +671,7 @@ class TestDatabase(_BaseTest):
 
         checkout = database.batch()
         self.assertIsInstance(checkout, BatchCheckout)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
 
     def test_snapshot_defaults(self):
         from google.cloud.spanner.database import SnapshotCheckout
@@ -685,7 +685,7 @@ class TestDatabase(_BaseTest):
 
         checkout = database.snapshot()
         self.assertIsInstance(checkout, SnapshotCheckout)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
         self.assertIsNone(checkout._read_timestamp)
         self.assertIsNone(checkout._min_read_timestamp)
         self.assertIsNone(checkout._max_staleness)
@@ -707,7 +707,7 @@ class TestDatabase(_BaseTest):
         checkout = database.snapshot(read_timestamp=now)
 
         self.assertIsInstance(checkout, SnapshotCheckout)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
         self.assertEqual(checkout._read_timestamp, now)
         self.assertIsNone(checkout._min_read_timestamp)
         self.assertIsNone(checkout._max_staleness)
@@ -729,7 +729,7 @@ class TestDatabase(_BaseTest):
         checkout = database.snapshot(min_read_timestamp=now)
 
         self.assertIsInstance(checkout, SnapshotCheckout)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
         self.assertIsNone(checkout._read_timestamp)
         self.assertEqual(checkout._min_read_timestamp, now)
         self.assertIsNone(checkout._max_staleness)
@@ -750,7 +750,7 @@ class TestDatabase(_BaseTest):
         checkout = database.snapshot(max_staleness=staleness)
 
         self.assertIsInstance(checkout, SnapshotCheckout)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
         self.assertIsNone(checkout._read_timestamp)
         self.assertIsNone(checkout._min_read_timestamp)
         self.assertEqual(checkout._max_staleness, staleness)
@@ -771,7 +771,7 @@ class TestDatabase(_BaseTest):
         checkout = database.snapshot(exact_staleness=staleness)
 
         self.assertIsInstance(checkout, SnapshotCheckout)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
         self.assertIsNone(checkout._read_timestamp)
         self.assertIsNone(checkout._min_read_timestamp)
         self.assertIsNone(checkout._max_staleness)
@@ -788,7 +788,7 @@ class TestBatchCheckout(_BaseTest):
     def test_ctor(self):
         database = _Database(self.DATABASE_NAME)
         checkout = self._make_one(database)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
 
     def test_context_mgr_success(self):
         import datetime
@@ -865,7 +865,7 @@ class TestSnapshotCheckout(_BaseTest):
         pool.put(session)
 
         checkout = self._make_one(database)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
         self.assertIsNone(checkout._read_timestamp)
         self.assertIsNone(checkout._min_read_timestamp)
         self.assertIsNone(checkout._max_staleness)
@@ -891,7 +891,7 @@ class TestSnapshotCheckout(_BaseTest):
         pool.put(session)
 
         checkout = self._make_one(database, read_timestamp=now)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
         self.assertEqual(checkout._read_timestamp, now)
         self.assertIsNone(checkout._min_read_timestamp)
         self.assertIsNone(checkout._max_staleness)
@@ -918,7 +918,7 @@ class TestSnapshotCheckout(_BaseTest):
         pool.put(session)
 
         checkout = self._make_one(database, min_read_timestamp=now)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
         self.assertIsNone(checkout._read_timestamp)
         self.assertEqual(checkout._min_read_timestamp, now)
         self.assertIsNone(checkout._max_staleness)
@@ -944,7 +944,7 @@ class TestSnapshotCheckout(_BaseTest):
         pool.put(session)
 
         checkout = self._make_one(database, max_staleness=staleness)
-        self.assertTrue(checkout._database is database)
+        self.assertIs(checkout._database, database)
         self.assertIsNone(checkout._read_timestamp)
         self.assertIsNone(checkout._min_read_timestamp)
         self.assertEqual(checkout._max_staleness, staleness)

--- a/spanner/tests/unit/test_instance.py
+++ b/spanner/tests/unit/test_instance.py
@@ -78,10 +78,10 @@ class TestInstance(unittest.TestCase):
         new_instance = instance.copy()
 
         # Make sure the client copy succeeded.
-        self.assertFalse(new_instance._client is client)
+        self.assertIsNot(new_instance._client, client)
         self.assertEqual(new_instance._client, client)
         # Make sure the client got copied to a new instance.
-        self.assertFalse(instance is new_instance)
+        self.assertIsNot(instance, new_instance)
         self.assertEqual(instance, new_instance)
 
     def test__update_from_pb_success(self):

--- a/spanner/tests/unit/test_instance.py
+++ b/spanner/tests/unit/test_instance.py
@@ -50,8 +50,8 @@ class TestInstance(unittest.TestCase):
         client = object()
         instance = self._make_one(self.INSTANCE_ID, client)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
-        self.assertTrue(instance._client is client)
-        self.assertTrue(instance.configuration_name is None)
+        self.assertIs(instance._client, client)
+        self.assertIs(instance.configuration_name, None)
         self.assertEqual(instance.node_count, DEFAULT_NODE_COUNT)
         self.assertEqual(instance.display_name, self.INSTANCE_ID)
 
@@ -64,7 +64,7 @@ class TestInstance(unittest.TestCase):
                                   node_count=self.NODE_COUNT,
                                   display_name=DISPLAY_NAME)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
-        self.assertTrue(instance._client is client)
+        self.assertIs(instance._client, client)
         self.assertEqual(instance.configuration_name, self.CONFIG_NAME)
         self.assertEqual(instance.node_count, self.NODE_COUNT)
         self.assertEqual(instance.display_name, DISPLAY_NAME)
@@ -496,7 +496,7 @@ class TestInstance(unittest.TestCase):
 
         self.assertTrue(isinstance(database, Database))
         self.assertEqual(database.database_id, DATABASE_ID)
-        self.assertTrue(database._instance is instance)
+        self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), [])
         self.assertIsInstance(database._pool, BurstyPool)
         pool = database._pool
@@ -516,7 +516,7 @@ class TestInstance(unittest.TestCase):
 
         self.assertTrue(isinstance(database, Database))
         self.assertEqual(database.database_id, DATABASE_ID)
-        self.assertTrue(database._instance is instance)
+        self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), DDL_STATEMENTS)
         self.assertIs(database._pool, pool)
         self.assertIs(pool._bound, database)
@@ -547,7 +547,7 @@ class TestInstance(unittest.TestCase):
         instance_name, page_size, options = api._listed_databases
         self.assertEqual(instance_name, self.INSTANCE_NAME)
         self.assertEqual(page_size, None)
-        self.assertTrue(options.page_token is INITIAL_PAGE)
+        self.assertIs(options.page_token, INITIAL_PAGE)
         self.assertEqual(options.kwargs['metadata'],
                          [('google-cloud-resource-prefix', instance.name)])
 

--- a/spanner/tests/unit/test_session.py
+++ b/spanner/tests/unit/test_session.py
@@ -39,8 +39,8 @@ class TestSession(unittest.TestCase):
     def test_constructor(self):
         database = _Database(self.DATABASE_NAME)
         session = self._make_one(database)
-        self.assertTrue(session.session_id is None)
-        self.assertTrue(session._database is database)
+        self.assertIs(session.session_id, None)
+        self.assertIs(session._database, database)
 
     def test___lt___(self):
         database = _Database(self.DATABASE_NAME)
@@ -223,7 +223,7 @@ class TestSession(unittest.TestCase):
         snapshot = session.snapshot()
 
         self.assertIsInstance(snapshot, Snapshot)
-        self.assertTrue(snapshot._session is session)
+        self.assertIs(snapshot._session, session)
         self.assertTrue(snapshot._strong)
 
     def test_read_not_created(self):
@@ -352,7 +352,7 @@ class TestSession(unittest.TestCase):
         batch = session.batch()
 
         self.assertIsInstance(batch, Batch)
-        self.assertTrue(batch._session is session)
+        self.assertIs(batch._session, session)
 
     def test_transaction_not_created(self):
         database = _Database(self.DATABASE_NAME)
@@ -371,8 +371,8 @@ class TestSession(unittest.TestCase):
         transaction = session.transaction()
 
         self.assertIsInstance(transaction, Transaction)
-        self.assertTrue(transaction._session is session)
-        self.assertTrue(session._transaction is transaction)
+        self.assertIs(transaction._session, session)
+        self.assertIs(session._transaction, transaction)
 
     def test_transaction_w_existing_txn(self):
         database = _Database(self.DATABASE_NAME)
@@ -382,7 +382,7 @@ class TestSession(unittest.TestCase):
         existing = session.transaction()
         another = session.transaction()  # invalidates existing txn
 
-        self.assertTrue(session._transaction is another)
+        self.assertIs(session._transaction, another)
         self.assertTrue(existing._rolled_back)
 
     def test_retry_transaction_w_commit_error_txn_already_begun(self):

--- a/spanner/tests/unit/test_snapshot.py
+++ b/spanner/tests/unit/test_snapshot.py
@@ -66,7 +66,7 @@ class Test_SnapshotBase(unittest.TestCase):
     def test_ctor(self):
         session = _Session()
         base = self._make_one(session)
-        self.assertTrue(base._session is session)
+        self.assertIs(base._session, session)
 
     def test__make_txn_selector_virtual(self):
         session = _Session()
@@ -320,7 +320,7 @@ class TestSnapshot(unittest.TestCase):
     def test_ctor_defaults(self):
         session = _Session()
         snapshot = self._make_one(session)
-        self.assertTrue(snapshot._session is session)
+        self.assertIs(snapshot._session, session)
         self.assertTrue(snapshot._strong)
         self.assertIsNone(snapshot._read_timestamp)
         self.assertIsNone(snapshot._min_read_timestamp)
@@ -340,7 +340,7 @@ class TestSnapshot(unittest.TestCase):
         timestamp = self._makeTimestamp()
         session = _Session()
         snapshot = self._make_one(session, read_timestamp=timestamp)
-        self.assertTrue(snapshot._session is session)
+        self.assertIs(snapshot._session, session)
         self.assertFalse(snapshot._strong)
         self.assertEqual(snapshot._read_timestamp, timestamp)
         self.assertIsNone(snapshot._min_read_timestamp)
@@ -351,7 +351,7 @@ class TestSnapshot(unittest.TestCase):
         timestamp = self._makeTimestamp()
         session = _Session()
         snapshot = self._make_one(session, min_read_timestamp=timestamp)
-        self.assertTrue(snapshot._session is session)
+        self.assertIs(snapshot._session, session)
         self.assertFalse(snapshot._strong)
         self.assertIsNone(snapshot._read_timestamp)
         self.assertEqual(snapshot._min_read_timestamp, timestamp)
@@ -362,7 +362,7 @@ class TestSnapshot(unittest.TestCase):
         duration = self._makeDuration()
         session = _Session()
         snapshot = self._make_one(session, max_staleness=duration)
-        self.assertTrue(snapshot._session is session)
+        self.assertIs(snapshot._session, session)
         self.assertFalse(snapshot._strong)
         self.assertIsNone(snapshot._read_timestamp)
         self.assertIsNone(snapshot._min_read_timestamp)
@@ -373,7 +373,7 @@ class TestSnapshot(unittest.TestCase):
         duration = self._makeDuration()
         session = _Session()
         snapshot = self._make_one(session, exact_staleness=duration)
-        self.assertTrue(snapshot._session is session)
+        self.assertIs(snapshot._session, session)
         self.assertFalse(snapshot._strong)
         self.assertIsNone(snapshot._read_timestamp)
         self.assertIsNone(snapshot._min_read_timestamp)

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -561,7 +561,7 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed.consume_next()
         self.assertEqual(streamed.rows, [])
         self.assertEqual(streamed._current_row, BARE)
-        self.assertTrue(streamed.metadata is metadata)
+        self.assertIs(streamed.metadata, metadata)
         self.assertEqual(streamed.resume_token, result_set.resume_token)
 
     def test_consume_next_w_partial_result(self):
@@ -630,7 +630,7 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed.consume_next()
         self.assertEqual(streamed.rows, [BARE])
         self.assertEqual(streamed._current_row, [])
-        self.assertTrue(streamed._stats is stats)
+        self.assertIs(streamed._stats, stats)
         self.assertEqual(streamed.resume_token, result_set.resume_token)
 
     def test_consume_all_empty(self):
@@ -653,7 +653,7 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed.consume_all()
         self.assertEqual(streamed.rows, [])
         self.assertEqual(streamed._current_row, BARE)
-        self.assertTrue(streamed.metadata is metadata)
+        self.assertIs(streamed.metadata, metadata)
 
     def test_consume_all_multiple_result_sets_filled(self):
         FIELDS = [
@@ -703,7 +703,7 @@ class TestStreamedResultSet(unittest.TestCase):
         self.assertEqual(found, [])
         self.assertEqual(streamed.rows, [])
         self.assertEqual(streamed._current_row, BARE)
-        self.assertTrue(streamed.metadata is metadata)
+        self.assertIs(streamed.metadata, metadata)
 
     def test___iter___multiple_result_sets_filled(self):
         FIELDS = [

--- a/spanner/tests/unit/test_transaction.py
+++ b/spanner/tests/unit/test_transaction.py
@@ -48,7 +48,7 @@ class TestTransaction(unittest.TestCase):
     def test_ctor_defaults(self):
         session = _Session()
         transaction = self._make_one(session)
-        self.assertTrue(transaction._session is session)
+        self.assertIs(transaction._session, session)
         self.assertIsNone(transaction._id)
         self.assertIsNone(transaction.committed)
         self.assertEqual(transaction._rolled_back, False)

--- a/speech/tests/unit/test_client.py
+++ b/speech/tests/unit/test_client.py
@@ -88,8 +88,8 @@ class TestClient(unittest.TestCase):
         creds = _make_credentials()
         http = object()
         client = self._make_one(credentials=creds, _http=http)
-        self.assertTrue(client._credentials is creds)
-        self.assertTrue(client._http is http)
+        self.assertIs(client._credentials, creds)
+        self.assertIs(client._http, http)
 
     def test_ctor_use_grpc_preset(self):
         creds = _make_credentials()


### PR DESCRIPTION
Any usage of `self.assertTrue(a is b)` has become `self.assertIs(a, b)`.

I used a Python script to make this change:

```python
# Produce file via
# $ git grep -n assertTrue | grep ' is ' > change_it.txt
# Manually made changes for lines with 12 space indent and for
# the files in the Speech package

import collections

def main():
    with open('change_it.txt', 'r') as file_obj:
        lines = file_obj.read().strip().split('\n')

    by_file = collections.defaultdict(dict)
    for line in lines:
        filename, line_no, content = line.split(':')
        line_no = int(line_no)
        in_file = by_file[filename]
        if line_no in in_file:
            raise KeyError('WAT', filename, line_no)
        if content[:24] != '        self.assertTrue(':
            raise ValueError(line, 'bad 1')
        if content[-1] != ')':
            raise ValueError(line, 'bad 2')
        left, right = content[24:-1].split(' is ')
        if ' ' in left or ' ' in right:
            raise ValueError(line, 'bad 3')

        actual = '        self.assertIs({}, {})'.format(left, right)
        in_file[line_no] = (content, actual)

    for filename, in_file in by_file.items():
        with open(filename, 'r') as file_obj:
            lines = file_obj.read().split('\n')

        for line_no, pair in in_file.items():
            assert lines[line_no - 1] == pair[0]
            lines[line_no - 1] = pair[1]

        with open(filename, 'w') as file_obj:
            file_obj.write('\n'.join(lines))


if __name__ == '__main__':
    main()
```