### PR TITLE
Fixing references to "dead" docs links.

### DIFF
--- a/bigquery/README.rst
+++ b/bigquery/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/bigquery/README.rst
+++ b/bigquery/README.rst
@@ -86,7 +86,7 @@ Perform a synchronous query
 See the ``google-cloud-python`` API `BigQuery documentation`_ to learn how
 to connect to BigQuery using this Client Library.
 
-.. _BigQuery documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigquery-usage.html
+.. _BigQuery documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigquery/usage.html
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-bigquery.svg
    :target: https://pypi.python.org/pypi/google-cloud-bigquery

--- a/bigtable/README.rst
+++ b/bigtable/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/bigtable/README.rst
+++ b/bigtable/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud Bigtable
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigtable-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigtable/usage.html
 
 Quick Start
 -----------

--- a/core/README.rst
+++ b/core/README.rst
@@ -9,7 +9,7 @@ used by all of the ``google-cloud-*``.
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/google-cloud-api.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/core/modules.html
 
 Quick Start
 -----------

--- a/core/google/cloud/credentials.py
+++ b/core/google/cloud/credentials.py
@@ -60,7 +60,7 @@ def _get_signed_query_params(credentials, expiration, string_to_sign):
               signed payload.
     """
     if not isinstance(credentials, google.auth.credentials.Signing):
-        auth_uri = ('http://google-cloud-python.readthedocs.io/en/latest/'
+        auth_uri = ('https://google-cloud-python.readthedocs.io/en/latest/'
                     'core/auth.html?highlight=authentication#setting-up-'
                     'a-service-account')
         raise AttributeError('you need a private key to sign credentials.'

--- a/datastore/README.rst
+++ b/datastore/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud Datastore
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/datastore-client.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/datastore/client.html
 
 Quick Start
 -----------
@@ -44,7 +44,7 @@ queries, and eventual consistency for all other queries.
 See the ``google-cloud-python`` API `datastore documentation`_ to learn how to
 interact with the Cloud Datastore using this Client Library.
 
-.. _datastore documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/datastore-client.html
+.. _datastore documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/datastore/client.html
 
 See the `official Google Cloud Datastore documentation`_ for more details on
 how to activate Cloud Datastore for your project.

--- a/datastore/README.rst
+++ b/datastore/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/dns/README.rst
+++ b/dns/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud DNS
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/dns-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/dns/usage.html
 
 Quick Start
 -----------

--- a/dns/README.rst
+++ b/dns/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/error_reporting/README.rst
+++ b/error_reporting/README.rst
@@ -9,7 +9,7 @@ Python Client for Stackdriver Error Reporting
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/error-reporting-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/error-reporting/usage.html
 
 Quick Start
 -----------

--- a/error_reporting/README.rst
+++ b/error_reporting/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/language/README.rst
+++ b/language/README.rst
@@ -28,7 +28,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/language/README.rst
+++ b/language/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud Natural Language
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/language-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/language/usage.html
 
 Quick Start
 -----------

--- a/logging/README.rst
+++ b/logging/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/logging/README.rst
+++ b/logging/README.rst
@@ -9,7 +9,7 @@ Python Client for Stackdriver Logging
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/logging-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/logging/usage.html
 
 Quick Start
 -----------
@@ -54,7 +54,7 @@ Example of fetching entries:
 See the ``google-cloud-python`` API `logging documentation`_ to learn how to
 connect to Stackdriver Logging using this Client Library.
 
-.. _logging documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/logging-usage.html
+.. _logging documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/logging/usage.html
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg
    :target: https://pypi.python.org/pypi/google-cloud-logging

--- a/monitoring/README.rst
+++ b/monitoring/README.rst
@@ -9,7 +9,7 @@ Python Client for Stackdriver Monitoring
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/monitoring-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/monitoring/usage.html
 
 Quick Start
 -----------
@@ -64,7 +64,7 @@ Display CPU utilization across your GCE instances during the last five minutes:
 See the ``google-cloud-python`` API `monitoring documentation`_ to learn how
 to connect to Stackdriver Monitoring using this Client Library.
 
-.. _monitoring documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/monitoring-usage.html
+.. _monitoring documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/monitoring/usage.html
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-monitoring.svg
    :target: https://pypi.python.org/pypi/google-cloud-monitoring

--- a/monitoring/README.rst
+++ b/monitoring/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud Pub / Sub
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/pubsub-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/pubsub/usage.html
 
 Quick Start
 -----------
@@ -45,7 +45,7 @@ independently written applications.
 See the ``google-cloud-python`` API `Pub/Sub documentation`_ to learn how to connect
 to Cloud Pub/Sub using this Client Library.
 
-.. _Pub/Sub documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/pubsub-usage.html
+.. _Pub/Sub documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/pubsub/usage.html
 
 To get started with this API, you'll need to create
 

--- a/resource_manager/README.rst
+++ b/resource_manager/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud Resource Manager
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/resource-manager-api.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/resource-manager/api.html
 
 Quick Start
 -----------
@@ -42,7 +42,7 @@ Google Cloud Platform.
 See the ``google-cloud-python`` API `Resource Manager documentation`_ to learn
 how to manage projects using this Client Library.
 
-.. _Resource Manager documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/resource-manager-api.html
+.. _Resource Manager documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/resource-manager/api.html
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-resource-manager.svg
    :target: https://pypi.python.org/pypi/google-cloud-resource-manager

--- a/resource_manager/README.rst
+++ b/resource_manager/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/runtimeconfig/README.rst
+++ b/runtimeconfig/README.rst
@@ -30,7 +30,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/spanner/README.rst
+++ b/spanner/README.rst
@@ -3,7 +3,7 @@ Python Client for Cloud Spanner
 
     Python idiomatic client for `Cloud Spanner`_.
 
-.. _Cloud Spanner: https://googlecloudplatform.github.io/google-cloud-python/latest/spanner-usage.html
+.. _Cloud Spanner: https://googlecloudplatform.github.io/google-cloud-python/latest/spanner/usage.html
 
 
 Quick Start

--- a/speech/README.rst
+++ b/speech/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud Speech
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/speech-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/speech/usage.html
 
 Quick Start
 -----------
@@ -41,7 +41,7 @@ and receive a text transcription from the Cloud Speech API service.
 See the ``google-cloud-python`` API `speech documentation`_ to learn how to
 connect to the Google Cloud Speech API using this Client Library.
 
-.. _speech documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/speech-usage.html
+.. _speech documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/speech/usage.html
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-speech.svg
    :target: https://pypi.python.org/pypi/google-cloud-speech
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-speech.svg

--- a/speech/README.rst
+++ b/speech/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/storage/README.rst
+++ b/storage/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/storage/README.rst
+++ b/storage/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud Storage
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/storage-client.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/storage/client.html
 
 Quick Start
 -----------
@@ -43,7 +43,7 @@ via direct download.
 See the ``google-cloud-python`` API `storage documentation`_ to learn how to
 connect to Cloud Storage using this Client Library.
 
-.. _storage documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/storage-client.html
+.. _storage documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/storage/client.html
 
 You need to create a Google Cloud Storage bucket to use this client library.
 Follow along with the `official Google Cloud Storage documentation`_ to learn

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -1015,7 +1015,7 @@ class Bucket(_PropertyMixin):
         credentials = client._base_connection.credentials
 
         if not isinstance(credentials, google.auth.credentials.Signing):
-            auth_uri = ('http://google-cloud-python.readthedocs.io/en/latest/'
+            auth_uri = ('https://google-cloud-python.readthedocs.io/en/latest/'
                         'core/auth.html?highlight=authentication#setting-up-'
                         'a-service-account')
             raise AttributeError(

--- a/translate/README.rst
+++ b/translate/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/videointelligence/README.rst
+++ b/videointelligence/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/videointelligence/README.rst
+++ b/videointelligence/README.rst
@@ -7,10 +7,6 @@ Python Client for Google Cloud Video Intelligence
 
 |pypi| |versions|
 
--  `Documentation`_
-
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/video-intelligence-usage.html
-
 Quick Start
 -----------
 

--- a/vision/README.rst
+++ b/vision/README.rst
@@ -26,7 +26,7 @@ possible. Check out the `Authentication section`_ in our documentation to
 learn more. You may also find the `authentication document`_ shared by all
 the ``google-cloud-*`` libraries to be helpful.
 
-.. _Authentication section: http://google-cloud-python.readthedocs.io/en/latest/google-cloud-auth.html
+.. _Authentication section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html
 .. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication
 
 Using the API

--- a/vision/README.rst
+++ b/vision/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud Vision
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/vision-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/vision/usage.html
 
 Quick Start
 -----------


### PR DESCRIPTION
Done via:

```
$ git grep -l 'google-cloud-auth.html' | \
> xargs sed -i s/'google-cloud-auth.html'/'core\/auth.html'/g
$ git grep -l 'http\:\/\/google-cloud-python.readthedocs.io' | \
> xargs sed -i s/'http\:\/\/google-cloud-python.readthedocs.io'/\
> 'https\:\/\/google-cloud-python.readthedocs.io'/g
```

Fixes #3531.