### PR TITLE
update documentation link

### DIFF
--- a/speech/README.rst
+++ b/speech/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud Speech
 
 -  `Documentation`_
 
-.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/speech-usage.html
+.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/speech/usage.html
 
 Quick Start
 -----------


### PR DESCRIPTION
since it moved to a new URL https://googlecloudplatform.github.io/google-cloud-python/stable/speech/usage.html