### PR TITLE
Changing all pypi.python.org links to warehouse links.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -402,7 +402,7 @@ instead of
 ``https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/CONTRIBUTING.rst``)
 may cause problems creating links or rendering the description.
 
-.. _description on PyPI: https://pypi.python.org/pypi/google-cloud
+.. _description on PyPI: https://pypi.org/project/google-cloud/
 
 ********************************************
 Travis Configuration and Build Optimizations

--- a/README.rst
+++ b/README.rst
@@ -57,35 +57,35 @@ Cloud Platform services:
 still a work-in-progress and is more likely to get backwards-incompatible
 updates. See `versioning`_ for more details.
 
-.. _Google Cloud Datastore: https://pypi.python.org/pypi/google-cloud-datastore
+.. _Google Cloud Datastore: https://pypi.org/project/google-cloud-datastore/
 .. _Datastore README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/datastore
-.. _Google Cloud Storage: https://pypi.python.org/pypi/google-cloud-storage
+.. _Google Cloud Storage: https://pypi.org/project/google-cloud-storage/
 .. _Storage README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/storage
-.. _Google Cloud Pub/Sub: https://pypi.python.org/pypi/google-cloud-pubsub
+.. _Google Cloud Pub/Sub: https://pypi.org/project/google-cloud-pubsub/
 .. _Pub/Sub README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/pubsub
-.. _Google BigQuery: https://pypi.python.org/pypi/google-cloud-bigquery
+.. _Google BigQuery: https://pypi.org/project/google-cloud-bigquery/
 .. _BigQuery README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/bigquery
-.. _Google Cloud Resource Manager: https://pypi.python.org/pypi/google-cloud-resource-manager
+.. _Google Cloud Resource Manager: https://pypi.org/project/google-cloud-resource-manager/
 .. _Resource Manager README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/resource_manager
-.. _Stackdriver Logging: https://pypi.python.org/pypi/google-cloud-logging
+.. _Stackdriver Logging: https://pypi.org/project/google-cloud-logging/
 .. _Logging README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/logging
-.. _Stackdriver Monitoring: https://pypi.python.org/pypi/google-cloud-monitoring
+.. _Stackdriver Monitoring: https://pypi.org/project/google-cloud-monitoring/
 .. _Monitoring README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/monitoring
-.. _Google Cloud Bigtable: https://pypi.python.org/pypi/google-cloud-bigtable
+.. _Google Cloud Bigtable: https://pypi.org/project/google-cloud-bigtable/
 .. _Bigtable README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/bigtable
-.. _Google Cloud DNS: https://pypi.python.org/pypi/google-cloud-dns
+.. _Google Cloud DNS: https://pypi.org/project/google-cloud-dns/
 .. _DNS README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/dns
-.. _Stackdriver Error Reporting: https://pypi.python.org/pypi/google-cloud-error-reporting
+.. _Stackdriver Error Reporting: https://pypi.org/project/google-cloud-error-reporting/
 .. _Error Reporting README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/error_reporting
-.. _Google Cloud Natural Language: https://pypi.python.org/pypi/google-cloud-language
+.. _Google Cloud Natural Language: https://pypi.org/project/google-cloud-language/
 .. _Natural Language README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/language
-.. _Google Cloud Translation: https://pypi.python.org/pypi/google-cloud-translate
+.. _Google Cloud Translation: https://pypi.org/project/google-cloud-translate/
 .. _Translation README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/translate
-.. _Google Cloud Speech: https://pypi.python.org/pypi/google-cloud-speech
+.. _Google Cloud Speech: https://pypi.org/project/google-cloud-speech/
 .. _Speech README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/speech
-.. _Google Cloud Vision: https://pypi.python.org/pypi/google-cloud-vision
+.. _Google Cloud Vision: https://pypi.org/project/google-cloud-vision/
 .. _Vision README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/vision
-.. _Google Cloud Bigtable - HappyBase: https://pypi.python.org/pypi/google-cloud-happybase/
+.. _Google Cloud Bigtable - HappyBase: https://pypi.org/project/google-cloud-happybase/
 .. _HappyBase README: https://github.com/GoogleCloudPlatform/google-cloud-python-happybase
 .. _Google Cloud Runtime Configuration: https://cloud.google.com/deployment-manager/runtime-configurator/
 .. _Runtime Config README: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/runtimeconfig
@@ -159,6 +159,6 @@ Apache 2.0 - See `the LICENSE`_ for more information.
 .. |coverage| image:: https://coveralls.io/repos/GoogleCloudPlatform/google-cloud-python/badge.svg?branch=master
    :target: https://coveralls.io/r/GoogleCloudPlatform/google-cloud-python?branch=master
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud.svg
-   :target: https://pypi.python.org/pypi/google-cloud
+   :target: https://pypi.org/project/google-cloud/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud.svg
-   :target: https://pypi.python.org/pypi/google-cloud
+   :target: https://pypi.org/project/google-cloud/

--- a/bigquery/README.rst
+++ b/bigquery/README.rst
@@ -89,6 +89,6 @@ to connect to BigQuery using this Client Library.
 .. _BigQuery documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigquery/usage.html
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-bigquery.svg
-   :target: https://pypi.python.org/pypi/google-cloud-bigquery
+   :target: https://pypi.org/project/google-cloud-bigquery/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery.svg
-   :target: https://pypi.python.org/pypi/google-cloud-bigquery
+   :target: https://pypi.org/project/google-cloud-bigquery/

--- a/bigtable/README.rst
+++ b/bigtable/README.rst
@@ -42,6 +42,6 @@ See the ``google-cloud-python`` API Bigtable `Documentation`_ to learn
 how to manage your data in Bigtable tables.
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-bigtable.svg
-   :target: https://pypi.python.org/pypi/google-cloud-bigtable
+   :target: https://pypi.org/project/google-cloud-bigtable/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigtable.svg
-   :target: https://pypi.python.org/pypi/google-cloud-bigtable
+   :target: https://pypi.org/project/google-cloud-bigtable/

--- a/core/README.rst
+++ b/core/README.rst
@@ -19,6 +19,6 @@ Quick Start
     $ pip install --upgrade google-cloud-core
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-core.svg
-   :target: https://pypi.python.org/pypi/google-cloud-core
+   :target: https://pypi.org/project/google-cloud-core/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-core.svg
-   :target: https://pypi.python.org/pypi/google-cloud-core
+   :target: https://pypi.org/project/google-cloud-core/

--- a/datastore/README.rst
+++ b/datastore/README.rst
@@ -67,6 +67,6 @@ how to activate Cloud Datastore for your project.
         print(result)
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg
-   :target: https://pypi.python.org/pypi/google-cloud-datastore
+   :target: https://pypi.org/project/google-cloud-datastore/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datastore.svg
-   :target: https://pypi.python.org/pypi/google-cloud-datastore
+   :target: https://pypi.org/project/google-cloud-datastore/

--- a/dns/README.rst
+++ b/dns/README.rst
@@ -42,6 +42,6 @@ See the ``google-cloud-python`` API DNS `Documentation`_ to learn
 how to manage DNS records using this Client Library.
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-dns.svg
-   :target: https://pypi.python.org/pypi/google-cloud-dns
+   :target: https://pypi.org/project/google-cloud-dns/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dns.svg
-   :target: https://pypi.python.org/pypi/google-cloud-dns
+   :target: https://pypi.org/project/google-cloud-dns/

--- a/docs/bigtable/usage.rst
+++ b/docs/bigtable/usage.rst
@@ -40,4 +40,4 @@ In the hierarchy of API concepts
 
 .. _Google Cloud Bigtable: https://cloud.google.com/bigtable/docs/
 .. _gRPC: http://www.grpc.io/
-.. _grpcio: https://pypi.python.org/pypi/grpcio
+.. _grpcio: https://pypi.org/project/grpcio/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,4 +73,4 @@ Resources
 * `GitHub <https://github.com/GoogleCloudPlatform/google-cloud-python/>`__
 * `Issues <https://github.com/GoogleCloudPlatform/google-cloud-python/issues>`__
 * `Stack Overflow <http://stackoverflow.com/questions/tagged/google-cloud-python>`__
-* `PyPI <https://pypi.python.org/pypi/google-cloud>`__
+* `PyPI <https://pypi.org/project/google-cloud/>`__

--- a/docs/spanner/usage.rst
+++ b/docs/spanner/usage.rst
@@ -40,5 +40,4 @@ In the hierarchy of API concepts
 
 .. _Cloud Spanner: https://cloud.google.com/spanner/docs/
 .. _gRPC: http://www.grpc.io/
-.. _grpcio: https://pypi.python.org/pypi/grpcio
-
+.. _grpcio: https://pypi.org/project/grpcio/

--- a/error_reporting/README.rst
+++ b/error_reporting/README.rst
@@ -47,6 +47,6 @@ See the ``google-cloud-python`` API Error Reporting `Documentation`_ to learn
 how to get started using this library.
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-error-reporting.svg
-   :target: https://pypi.python.org/pypi/google-cloud-error-reporting
+   :target: https://pypi.org/project/google-cloud-error-reporting/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-error-reporting.svg
-   :target: https://pypi.python.org/pypi/google-cloud-error-reporting
+   :target: https://pypi.org/project/google-cloud-error-reporting/

--- a/language/README.rst
+++ b/language/README.rst
@@ -46,6 +46,6 @@ See the ``google-cloud-python`` API Natural Language `Documentation`_ to learn
 how to analyze text with this API.
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-language.svg
-   :target: https://pypi.python.org/pypi/google-cloud-language
+   :target: https://pypi.org/project/google-cloud-language/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-language.svg
-   :target: https://pypi.python.org/pypi/google-cloud-language
+   :target: https://pypi.org/project/google-cloud-language/

--- a/logging/README.rst
+++ b/logging/README.rst
@@ -57,6 +57,6 @@ connect to Stackdriver Logging using this Client Library.
 .. _logging documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/logging/usage.html
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg
-   :target: https://pypi.python.org/pypi/google-cloud-logging
+   :target: https://pypi.org/project/google-cloud-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-logging.svg
-   :target: https://pypi.python.org/pypi/google-cloud-logging
+   :target: https://pypi.org/project/google-cloud-logging/

--- a/monitoring/README.rst
+++ b/monitoring/README.rst
@@ -67,6 +67,6 @@ to connect to Stackdriver Monitoring using this Client Library.
 .. _monitoring documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/monitoring/usage.html
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-monitoring.svg
-   :target: https://pypi.python.org/pypi/google-cloud-monitoring
+   :target: https://pypi.org/project/google-cloud-monitoring/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-monitoring.svg
-   :target: https://pypi.python.org/pypi/google-cloud-monitoring
+   :target: https://pypi.org/project/google-cloud-monitoring/

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -61,6 +61,6 @@ To get started with this API, you'll need to create
                   attr1='value1', attr2='value2')
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-pubsub.svg
-   :target: https://pypi.python.org/pypi/google-cloud-pubsub
+   :target: https://pypi.org/project/google-cloud-pubsub/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-pubsub.svg
-   :target: https://pypi.python.org/pypi/google-cloud-pubsub
+   :target: https://pypi.org/project/google-cloud-pubsub/

--- a/resource_manager/README.rst
+++ b/resource_manager/README.rst
@@ -45,6 +45,6 @@ how to manage projects using this Client Library.
 .. _Resource Manager documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/resource-manager/api.html
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-resource-manager.svg
-   :target: https://pypi.python.org/pypi/google-cloud-resource-manager
+   :target: https://pypi.org/project/google-cloud-resource-manager/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-resource-manager.svg
-   :target: https://pypi.python.org/pypi/google-cloud-resource-manager
+   :target: https://pypi.org/project/google-cloud-resource-manager/

--- a/runtimeconfig/README.rst
+++ b/runtimeconfig/README.rst
@@ -48,6 +48,6 @@ See the ``google-cloud-python`` API runtimeconfig `Documentation`_ to learn
 how to interact with Cloud RuntimeConfig using this Client Library.
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-runtimeconfig.svg
-   :target: https://pypi.python.org/pypi/google-cloud-runtimeconfig
+   :target: https://pypi.org/project/google-cloud-runtimeconfig/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-runtimeconfig.svg
-   :target: https://pypi.python.org/pypi/google-cloud-runtimeconfig
+   :target: https://pypi.org/project/google-cloud-runtimeconfig/

--- a/speech/README.rst
+++ b/speech/README.rst
@@ -43,6 +43,6 @@ connect to the Google Cloud Speech API using this Client Library.
 
 .. _speech documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/speech/usage.html
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-speech.svg
-   :target: https://pypi.python.org/pypi/google-cloud-speech
+   :target: https://pypi.org/project/google-cloud-speech/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-speech.svg
-   :target: https://pypi.python.org/pypi/google-cloud-speech
+   :target: https://pypi.org/project/google-cloud-speech/

--- a/storage/README.rst
+++ b/storage/README.rst
@@ -64,6 +64,6 @@ how to create a bucket.
     blob2.upload_from_filename(filename='/local/path.txt')
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-storage.svg
-   :target: https://pypi.python.org/pypi/google-cloud-storage
+   :target: https://pypi.org/project/google-cloud-storage/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storage.svg
-   :target: https://pypi.python.org/pypi/google-cloud-storage
+   :target: https://pypi.org/project/google-cloud-storage/

--- a/translate/README.rst
+++ b/translate/README.rst
@@ -42,6 +42,6 @@ See the ``google-cloud-python`` API Translation `Documentation`_ to learn
 how to translate text using this library.
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-translate.svg
-   :target: https://pypi.python.org/pypi/google-cloud-translate
+   :target: https://pypi.org/project/google-cloud-translate/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-translate.svg
-   :target: https://pypi.python.org/pypi/google-cloud-translate
+   :target: https://pypi.org/project/google-cloud-translate/

--- a/vision/README.rst
+++ b/vision/README.rst
@@ -50,6 +50,6 @@ See the ``google-cloud-python`` API `Documentation`_ to learn
 how to analyze images using this library.
 
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-vision.svg
-   :target: https://pypi.python.org/pypi/google-cloud-vision
+   :target: https://pypi.org/project/google-cloud-vision/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-vision.svg
-   :target: https://pypi.python.org/pypi/google-cloud-vision
+   :target: https://pypi.org/project/google-cloud-vision/


### PR DESCRIPTION
Done via

```
$ export OLD='https\:\/\/pypi.python.org\/pypi\/'
$ export NEW='https\:\/\/pypi.org\/project\/'
$ git grep -l ${OLD} | xargs sed -i s/${OLD}/${NEW}/g
```

Then manually going through and adding a trailing slash to all
warehouse links.

(Though I did undo changes to `docs/json/`.)