### PR TITLE
Fix url encoding of list parameters

### DIFF
--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -135,7 +135,7 @@ class JSONConnection(Connection):
 
         query_params = query_params or {}
         if query_params:
-            url += '?' + urlencode(query_params)
+            url += '?' + urlencode(query_params, doseq=True)
 
         return url
 


### PR DESCRIPTION
Issue can easily be reproduce with API using list parameters such as `testIamPermissions` in Cloud Storage.
Before the fix, using a list end up with this error:
```
bucket.test_iam_permissions(['storage.buckets.delete','storage.buckets.get'])
# Raises
# google.cloud.exceptions.BadRequest: 400 null is not a valid Google Cloud Storage permission. (GET https://www.googleapis.com/storage/v1/b/some-buckets/iam/testPermissions?permissions=%5B%27storage.buckets.delete%27%2C+%27storage.buckets.get%27%5D)
```