### PR TITLE
Re-enable flake8 for core package and tests

### DIFF
--- a/core/.flake8
+++ b/core/.flake8
@@ -1,5 +1,8 @@
 [flake8]
 import-order-style=google
+# Note: this forces all google imports to be in the third group. See
+# https://github.com/PyCQA/flake8-import-order/issues/111
+application-import-names=google
 exclude =
   __pycache__,
   .git,

--- a/core/google/cloud/_helpers.py
+++ b/core/google/cloud/_helpers.py
@@ -25,20 +25,20 @@ import os
 import re
 from threading import local as Local
 
+import google_auth_httplib2
+import httplib2
+import six
+from six.moves import http_client
+
 import google.auth
 from google.protobuf import duration_pb2
 from google.protobuf import timestamp_pb2
-import google_auth_httplib2
 
 try:
     import grpc
     import google.auth.transport.grpc
 except ImportError:  # pragma: NO COVER
     grpc = None
-
-import httplib2
-import six
-from six.moves import http_client
 
 
 _NOW = datetime.datetime.utcnow  # To be replaced by tests.

--- a/core/google/cloud/_http.py
+++ b/core/google/cloud/_http.py
@@ -16,8 +16,8 @@
 
 import json
 import platform
-from pkg_resources import get_distribution
 
+from pkg_resources import get_distribution
 import six
 from six.moves.urllib.parse import urlencode
 

--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -18,13 +18,13 @@ import io
 import json
 from pickle import PicklingError
 
-import google.auth.credentials
-from google.oauth2 import service_account
 import google_auth_httplib2
 import six
 
+import google.auth.credentials
 from google.cloud._helpers import _determine_default_project
 from google.cloud.credentials import get_credentials
+from google.oauth2 import service_account
 
 
 _GOOGLE_AUTH_CREDENTIALS_HELP = (

--- a/core/google/cloud/credentials.py
+++ b/core/google/cloud/credentials.py
@@ -16,15 +16,15 @@
 
 import base64
 import datetime
+
 import six
 from six.moves.urllib.parse import urlencode
 
 import google.auth
 import google.auth.credentials
-
-from google.cloud._helpers import UTC
-from google.cloud._helpers import _NOW
 from google.cloud._helpers import _microseconds_from_datetime
+from google.cloud._helpers import _NOW
+from google.cloud._helpers import UTC
 
 
 def get_credentials():

--- a/core/google/cloud/exceptions.py
+++ b/core/google/cloud/exceptions.py
@@ -22,16 +22,17 @@ from __future__ import absolute_import
 
 import copy
 import json
+
 import six
 
 from google.cloud._helpers import _to_bytes
-
-_HTTP_CODE_TO_EXCEPTION = {}  # populated at end of module
 
 try:
     from grpc._channel import _Rendezvous
 except ImportError:  # pragma: NO COVER
     _Rendezvous = None
+
+_HTTP_CODE_TO_EXCEPTION = {}  # populated at end of module
 
 
 # pylint: disable=invalid-name

--- a/core/google/cloud/future/operation.py
+++ b/core/google/cloud/future/operation.py
@@ -17,13 +17,12 @@
 import functools
 import threading
 
-from google.longrunning import operations_pb2
-from google.protobuf import json_format
-from google.rpc import code_pb2
-
 from google.cloud import _helpers
 from google.cloud import exceptions
 from google.cloud.future import polling
+from google.longrunning import operations_pb2
+from google.protobuf import json_format
+from google.rpc import code_pb2
 
 
 class Operation(polling.PollingFuture):

--- a/core/nox.py
+++ b/core/nox.py
@@ -53,7 +53,7 @@ def lint(session):
     session.install(
         'flake8', 'flake8-import-order', 'pylint', 'gcp-devrel-py-tools')
     session.install('.')
-    session.run('flake8', 'google/cloud/core')
+    session.run('flake8', 'google', 'tests')
     session.run(
         'gcp-devrel-py-tools', 'run-pylint',
         '--config', 'pylint.config.py',

--- a/core/tests/unit/test_credentials.py
+++ b/core/tests/unit/test_credentials.py
@@ -15,6 +15,7 @@
 import unittest
 
 import mock
+import six
 
 
 class Test_get_credentials(unittest.TestCase):
@@ -169,12 +170,10 @@ class Test__get_expiration_seconds(unittest.TestCase):
         self.assertEqual(self._call_fut(123), 123)
 
     def test_w_long(self):
-        try:
-            long
-        except NameError:  # pragma: NO COVER Py3K
-            pass
-        else:
-            self.assertEqual(self._call_fut(long(123)), 123)
+        if six.PY3:
+            raise unittest.SkipTest('No long on Python 3')
+
+        self.assertEqual(self._call_fut(long(123)), 123)  # noqa: F821
 
     def test_w_naive_datetime(self):
         import datetime

--- a/core/tests/unit/test_iam.py
+++ b/core/tests/unit/test_iam.py
@@ -200,7 +200,6 @@ class TestPolicy(unittest.TestCase):
                 {'role': VIEWER_ROLE, 'members': [VIEWER1, VIEWER2]},
             ],
         }
-        empty = frozenset()
         klass = self._get_target_class()
         policy = klass.from_api_repr(RESOURCE)
         self.assertEqual(policy.etag, 'DEADBEEF')


### PR DESCRIPTION
Note to reviewers: this is intentionally 2 commits. The first re-enables linting, the second addresses lint issues.