### PR TITLE
Prep langauge-0.26.0 release.

### DIFF
--- a/language/setup.py
+++ b/language/setup.py
@@ -61,7 +61,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name='google-cloud-language',
-    version='0.25.0',
+    version='0.26.0',
     description='Python Client for Google Cloud Natural Language',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
```bash
$ git log language-0.25.0..HEAD language/ | grep "^commit"
commit a813160b0e3de635cfba6e5f46099debcd77a08e
commit 14e570a3f435f8904ed9fa52d545a35ba5868ad1
commit 3d9461b91963fcc6e6a864f6f0eacad3d92bbf2d
commit da3a7bbe8c7770540c2149fabfc6f74db89f7ce4
commit bc7b0fdb9fd99b2c86de9830a25cfaaa295b1c45
commit b9cb6d17236528ddce982c3e802af3221de80880
commit 39feb3e23d451963ca31b383d8b395afcf7ab817
commit 6ab3e0127a1edf8b1f9f1603f3c1342473563ea7
```

All except the last (PR #3679) are internal / housekeeping / testing.  So, draft release notes:

----

## google-cloud-language 0.26.0

- Adding a (mostly) autogenerated surface side-by-side with the previously provided Client (#3679)