### PR TITLE
Appease current pylint opinions:

### DIFF
--- a/spanner/google/__init__.py
+++ b/spanner/google/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Google namespace package."""
+
 try:
     import pkg_resources
     pkg_resources.declare_namespace(__name__)

--- a/spanner/google/cloud/__init__.py
+++ b/spanner/google/cloud/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Google Cloud namespace package."""
+
 try:
     import pkg_resources
     pkg_resources.declare_namespace(__name__)

--- a/spanner/google/cloud/spanner/_helpers.py
+++ b/spanner/google/cloud/spanner/_helpers.py
@@ -38,6 +38,7 @@ class TimestampWithNanoseconds(datetime.datetime):
     """
     __slots__ = ('_nanosecond',)
 
+    # pylint: disable=arguments-differ
     def __new__(cls, *args, **kw):
         nanos = kw.pop('nanosecond', 0)
         if nanos > 0:
@@ -48,6 +49,7 @@ class TimestampWithNanoseconds(datetime.datetime):
         inst = datetime.datetime.__new__(cls, *args, **kw)
         inst._nanosecond = nanos or 0
         return inst
+    # pylint: disable=arguments-differ
 
     @property
     def nanosecond(self):
@@ -74,6 +76,7 @@ class TimestampWithNanoseconds(datetime.datetime):
 
         :rtype: :class:`TimestampWithNanoseconds`
         :returns: an instance matching the timestamp string
+        :raises ValueError: if ``stamp`` does not match the expected format
         """
         with_nanos = _RFC3339_NANOS.match(stamp)
         if with_nanos is None:
@@ -110,7 +113,7 @@ def _try_to_coerce_bytes(bytestring):
                          'base64-encoded bytes.')
 
 
-# pylint: disable=too-many-return-statements
+# pylint: disable=too-many-return-statements,too-many-branches
 def _make_value_pb(value):
     """Helper for :func:`_make_list_value_pbs`.
 
@@ -119,7 +122,7 @@ def _make_value_pb(value):
 
     :rtype: :class:`~google.protobuf.struct_pb2.Value`
     :returns: value protobufs
-    :raises: :exc:`ValueError` if value is not of a known scalar type.
+    :raises ValueError: if value is not of a known scalar type.
     """
     if value is None:
         return Value(null_value='NULL_VALUE')
@@ -150,7 +153,7 @@ def _make_value_pb(value):
     if isinstance(value, six.text_type):
         return Value(string_value=value)
     raise ValueError("Unknown type: %s" % (value,))
-# pylint: enable=too-many-return-statements
+# pylint: enable=too-many-return-statements,too-many-branches
 
 
 def _make_list_value_pb(values):
@@ -189,7 +192,7 @@ def _parse_value_pb(value_pb, field_type):
 
     :rtype: varies on field_type
     :returns: value extracted from value_pb
-    :raises: ValueError if uknown type is passed
+    :raises ValueError: if unknown type is passed
     """
     if value_pb.HasField('null_value'):
         return None

--- a/spanner/google/cloud/spanner/database.py
+++ b/spanner/google/cloud/spanner/database.py
@@ -99,9 +99,8 @@ class Database(object):
 
         :rtype: :class:`Database`
         :returns: The database parsed from the protobuf response.
-        :raises:
-            :class:`ValueError <exceptions.ValueError>` if the instance
-            name does not match the expected format
+        :raises ValueError:
+            if the instance name does not match the expected format
             or if the parsed project ID does not match the project ID
             on the instance's client, or if the parsed instance ID does
             not match the instance's ID.
@@ -175,6 +174,13 @@ class Database(object):
 
         See
         https://cloud.google.com/spanner/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.DatabaseAdmin.CreateDatabase
+
+        :rtype: :class:`~google.cloud.future.operation.Operation`
+        :returns: a future used to poll the status of the create request
+        :raises Conflict: if the database already exists
+        :raises NotFound: if the instance owning the database does not exist
+        :raises GaxError:
+            for errors other than ``ALREADY_EXISTS`` returned from the call
         """
         api = self._instance._client.database_admin_api
         options = _options_with_prefix(self.name)
@@ -205,6 +211,11 @@ class Database(object):
 
         See
         https://cloud.google.com/spanner/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDDL
+
+        :rtype: bool
+        :returns: True if the database exists, else false.
+        :raises GaxError:
+            for errors other than ``NOT_FOUND`` returned from the call
         """
         api = self._instance._client.database_admin_api
         options = _options_with_prefix(self.name)
@@ -224,6 +235,10 @@ class Database(object):
 
         See
         https://cloud.google.com/spanner/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDDL
+
+        :raises NotFound: if the database does not exist
+        :raises GaxError:
+            for errors other than ``NOT_FOUND`` returned from the call
         """
         api = self._instance._client.database_admin_api
         options = _options_with_prefix(self.name)
@@ -246,6 +261,9 @@ class Database(object):
 
         :rtype: :class:`google.cloud.future.operation.Operation`
         :returns: an operation instance
+        :raises NotFound: if the database does not exist
+        :raises GaxError:
+            for errors other than ``NOT_FOUND`` returned from the call
         """
         client = self._instance._client
         api = client.database_admin_api
@@ -474,6 +492,9 @@ def _check_ddl_statements(value):
 
     :rtype: tuple
     :returns: tuple of validated DDL statement strings.
+    :raises ValueError:
+        if elements in ``value`` are not strings, or if ``value`` contains
+        a ``CREATE DATABASE`` statement.
     """
     if not all(isinstance(line, six.string_types) for line in value):
         raise ValueError("Pass a list of strings")

--- a/spanner/google/cloud/spanner/instance.py
+++ b/spanner/google/cloud/spanner/instance.py
@@ -109,11 +109,10 @@ class Instance(object):
 
         :rtype: :class:`Instance`
         :returns: The instance parsed from the protobuf response.
-        :raises: :class:`ValueError <exceptions.ValueError>` if the instance
-                 name does not match
-                 ``projects/{project}/instances/{instance_id}``
-                 or if the parsed project ID does not match the project ID
-                 on the client.
+        :raises ValueError:
+            if the instance name does not match
+            ``projects/{project}/instances/{instance_id}`` or if the parsed
+            project ID does not match the project ID on the client.
         """
         match = _INSTANCE_NAME_RE.match(instance_pb.name)
         if match is None:
@@ -201,6 +200,9 @@ class Instance(object):
 
         :rtype: :class:`google.cloud.future.operation.Operation`
         :returns: an operation instance
+        :raises Conflict: if the instance already exists
+        :raises GaxError:
+            for errors other than ``ALREADY_EXISTS`` returned from the call
         """
         api = self._client.instance_admin_api
         instance_pb = admin_v1_pb2.Instance(
@@ -230,6 +232,11 @@ class Instance(object):
 
         See
         https://cloud.google.com/spanner/reference/rpc/google.spanner.admin.instance.v1#google.spanner.admin.instance.v1.InstanceAdmin.GetInstanceConfig
+
+        :rtype: bool
+        :returns: True if the instance exists, else false
+        :raises GaxError:
+            for errors other than ``NOT_FOUND`` returned from the call
         """
         api = self._client.instance_admin_api
         options = _options_with_prefix(self.name)
@@ -248,6 +255,9 @@ class Instance(object):
 
         See
         https://cloud.google.com/spanner/reference/rpc/google.spanner.admin.instance.v1#google.spanner.admin.instance.v1.InstanceAdmin.GetInstanceConfig
+
+        :raises NotFound: if the instance does not exist
+        :raises GaxError: for other errors returned from the call
         """
         api = self._client.instance_admin_api
         options = _options_with_prefix(self.name)
@@ -281,6 +291,8 @@ class Instance(object):
 
         :rtype: :class:`google.cloud.future.operation.Operation`
         :returns: an operation instance
+        :raises NotFound: if the instance does not exist
+        :raises GaxError: for other errors returned from the call
         """
         api = self._client.instance_admin_api
         instance_pb = admin_v1_pb2.Instance(

--- a/spanner/google/cloud/spanner/pool.py
+++ b/spanner/google/cloud/spanner/pool.py
@@ -39,6 +39,8 @@ class AbstractSessionPool(object):
 
         Concrete implementations of this method may pre-fill the pool
         using the database.
+
+        :raises NotImplementedError: abstract method
         """
         raise NotImplementedError()
 
@@ -48,6 +50,8 @@ class AbstractSessionPool(object):
         Concrete implementations of this method are allowed to raise an
         error to signal that the pool is exhausted, or to block until a
         session is available.
+
+        :raises NotImplementedError: abstract method
         """
         raise NotImplementedError()
 
@@ -60,6 +64,8 @@ class AbstractSessionPool(object):
         Concrete implementations of this method are allowed to raise an
         error to signal that the pool is full, or to block until it is
         not full.
+
+        :raises NotImplementedError: abstract method
         """
         raise NotImplementedError()
 
@@ -69,6 +75,8 @@ class AbstractSessionPool(object):
         Concrete implementations of this method are allowed to raise an
         error to signal that the pool is full, or to block until it is
         not full.
+
+        :raises NotImplementedError: abstract method
         """
         raise NotImplementedError()
 

--- a/spanner/google/cloud/spanner/session.py
+++ b/spanner/google/cloud/spanner/session.py
@@ -78,6 +78,7 @@ class Session(object):
 
         :rtype: str
         :returns: The session name.
+        :raises ValueError: if session is not yet created
         """
         if self._session_id is None:
             raise ValueError('No session ID set by back-end')
@@ -106,6 +107,8 @@ class Session(object):
 
         :rtype: bool
         :returns: True if the session exists on the back-end, else False.
+        :raises GaxError:
+            for errors other than ``NOT_FOUND`` returned from the call
         """
         if self._session_id is None:
             return False
@@ -126,7 +129,10 @@ class Session(object):
         See
         https://cloud.google.com/spanner/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.GetSession
 
-        :raises: :exc:`ValueError` if :attr:`session_id` is not already set.
+        :raises ValueError: if :attr:`session_id` is not already set.
+        :raises NotFound: if the session does not exist
+        :raises GaxError:
+            for errors other than ``NOT_FOUND`` returned from the call
         """
         if self._session_id is None:
             raise ValueError('Session ID not set by back-end')
@@ -151,7 +157,7 @@ class Session(object):
 
         :rtype: :class:`~google.cloud.spanner.snapshot.Snapshot`
         :returns: a snapshot bound to this session
-        :raises: :exc:`ValueError` if the session has not yet been created.
+        :raises ValueError: if the session has not yet been created.
         """
         if self._session_id is None:
             raise ValueError("Session has not been created.")
@@ -223,7 +229,7 @@ class Session(object):
 
         :rtype: :class:`~google.cloud.spanner.batch.Batch`
         :returns: a batch bound to this session
-        :raises: :exc:`ValueError` if the session has not yet been created.
+        :raises ValueError: if the session has not yet been created.
         """
         if self._session_id is None:
             raise ValueError("Session has not been created.")
@@ -235,7 +241,7 @@ class Session(object):
 
         :rtype: :class:`~google.cloud.spanner.transaction.Transaction`
         :returns: a transaction bound to this session
-        :raises: :exc:`ValueError` if the session has not yet been created.
+        :raises ValueError: if the session has not yet been created.
         """
         if self._session_id is None:
             raise ValueError("Session has not been created.")
@@ -264,6 +270,8 @@ class Session(object):
 
         :rtype: :class:`datetime.datetime`
         :returns: timestamp of committed transaction
+        :raises Exception:
+            reraises any non-ABORT execptions raised by ``func``.
         """
         deadline = time.time() + kw.pop(
             'timeout_secs', DEFAULT_RETRY_TIMEOUT_SECS)

--- a/spanner/google/cloud/spanner/snapshot.py
+++ b/spanner/google/cloud/spanner/snapshot.py
@@ -74,8 +74,9 @@ class _SnapshotBase(_SessionWrapper):
 
         :rtype: :class:`~google.cloud.spanner.streamed.StreamedResultSet`
         :returns: a result set instance which can be used to consume rows.
-        :raises: ValueError for reuse of single-use snapshots, or if a
-                 transaction ID is pending for multiple-use snapshots.
+        :raises ValueError:
+            for reuse of single-use snapshots, or if a transaction ID is
+            already pending for multiple-use snapshots.
         """
         if self._read_request_count > 0:
             if not self._multi_use:
@@ -126,8 +127,9 @@ class _SnapshotBase(_SessionWrapper):
 
         :rtype: :class:`~google.cloud.spanner.streamed.StreamedResultSet`
         :returns: a result set instance which can be used to consume rows.
-        :raises: ValueError for reuse of single-use snapshots, or if a
-                 transaction ID is pending for multiple-use snapshots.
+        :raises ValueError:
+            for reuse of single-use snapshots, or if a transaction ID is
+            already pending for multiple-use snapshots.
         """
         if self._read_request_count > 0:
             if not self._multi_use:
@@ -248,12 +250,12 @@ class Snapshot(_SnapshotBase):
             return TransactionSelector(single_use=options)
 
     def begin(self):
-        """Begin a transaction on the database.
+        """Begin a read-only transaction on the database.
 
         :rtype: bytes
         :returns: the ID for the newly-begun transaction.
-        :raises: ValueError if the transaction is already begun, committed,
-                 or rolled back.
+        :raises ValueError:
+            if the transaction is already begun, committed, or rolled back.
         """
         if not self._multi_use:
             raise ValueError("Cannot call 'begin' single-use snapshots")

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -163,7 +163,7 @@ class StreamedResultSet(object):
     def __iter__(self):
         iter_rows, self._rows[:] = self._rows[:], ()
         while True:
-            if len(iter_rows) == 0:
+            if not iter_rows:
                 self.consume_next()  # raises StopIteration
                 iter_rows, self._rows[:] = self._rows[:], ()
             while iter_rows:

--- a/spanner/google/cloud/spanner/transaction.py
+++ b/spanner/google/cloud/spanner/transaction.py
@@ -60,8 +60,8 @@ class Transaction(_SnapshotBase, _BatchBase):
 
         :rtype: bytes
         :returns: the ID for the newly-begun transaction.
-        :raises: ValueError if the transaction is already begun, committed,
-                 or rolled back.
+        :raises ValueError:
+            if the transaction is already begun, committed, or rolled back.
         """
         if self._transaction_id is not None:
             raise ValueError("Transaction already begun")
@@ -97,11 +97,11 @@ class Transaction(_SnapshotBase, _BatchBase):
 
         :rtype: datetime
         :returns: timestamp of the committed changes.
-        :raises: :exc:`ValueError` if there are no mutations to commit.
+        :raises ValueError: if there are no mutations to commit.
         """
         self._check_state()
 
-        if len(self._mutations) == 0:
+        if not self._mutations:
             raise ValueError("No mutations to commit")
 
         database = self._session._database


### PR DESCRIPTION
- Document missing ':raises:', ':rtype:', and ':returns:'.
- Use ':raises <exception_type>:'.
- Add pro-forma docstrings to namespace package initializers.
- Avoid using 'len(seq) == 0' (or '!=') for boolean tests.

pylint still complains about import cycles:

```
************* Module google.cloud.spanner.streamed
R:  1, 0: Cyclic import (google.cloud.spanner ->
google.cloud.spanner.client -> google.cloud.spanner.instance ->
google.cloud.spanner.database) (cyclic-import)
R:  1, 0: Cyclic import (google.cloud.spanner ->
google.cloud.spanner.client) (cyclic-import)
```