### PR TITLE
Increment BQ DB-API thread safety.

### DIFF
--- a/bigquery/google/cloud/bigquery/dbapi/__init__.py
+++ b/bigquery/google/cloud/bigquery/dbapi/__init__.py
@@ -55,8 +55,8 @@ from google.cloud.bigquery.dbapi.types import STRING
 
 apilevel = '2.0'
 
-# Threads may share the module, but not connections.
-threadsafety = 1
+# Threads may share the module and connections, but not cursors.
+threadsafety = 2
 
 paramstyle = 'pyformat'
 


### PR DESCRIPTION
Increment to 2 per https://www.python.org/dev/peps/pep-0249/#threadsafety. The cursor object includes some state for paging through results and other things which are not protected by locks.

Closes #3522.