### PR TITLE
Move 'datastore.exceptions_catch_remap_gax_error' to 'core.exceptions'.

### DIFF
--- a/core/google/cloud/exceptions.py
+++ b/core/google/cloud/exceptions.py
@@ -20,16 +20,26 @@ See https://cloud.google.com/storage/docs/json_api/v1/status-codes
 # Avoid the grpc and google.cloud.grpc collision.
 from __future__ import absolute_import
 
+import contextlib
 import copy
+import sys
 
 import six
 
-from google.cloud._helpers import _to_bytes
-
 try:
+    from google.gax.errors import GaxError
+    from google.gax.grpc import exc_to_code
+    from grpc import StatusCode
     from grpc._channel import _Rendezvous
 except ImportError:  # pragma: NO COVER
+    _HAVE_GRPC = False
     _Rendezvous = None
+else:
+    _HAVE_GRPC = True
+
+from google.cloud._helpers import _to_bytes
+
+_HTTP_CODE_TO_EXCEPTION = {}  # populated at end of module
 
 _HTTP_CODE_TO_EXCEPTION = {}  # populated at end of module
 
@@ -244,8 +254,50 @@ def _walk_subclasses(klass):
             yield subsub
 
 
+@contextlib.contextmanager
+def _catch_remap_gax_error():
+    """Remap GAX exceptions that happen in context.
+
+    .. _code.proto: https://github.com/googleapis/googleapis/blob/\
+                    master/google/rpc/code.proto
+
+    Remaps gRPC exceptions to the classes defined in
+    :mod:`~google.cloud.exceptions` (according to the description
+    in `code.proto`_).
+    """
+    try:
+        yield
+    except GaxError as exc:
+        error_code = exc_to_code(exc.cause)
+        error_class = _GRPC_ERROR_MAPPING.get(error_code)
+        if error_class is None:
+            raise
+        else:
+            new_exc = error_class(exc.cause.details())
+            six.reraise(error_class, new_exc, sys.exc_info()[2])
+
+
 # Build the code->exception class mapping.
 for _eklass in _walk_subclasses(GoogleCloudError):
     code = getattr(_eklass, 'code', None)
     if code is not None:
         _HTTP_CODE_TO_EXCEPTION[code] = _eklass
+
+if _HAVE_GRPC:
+    _GRPC_ERROR_MAPPING = {
+        StatusCode.UNKNOWN: InternalServerError,
+        StatusCode.INVALID_ARGUMENT: BadRequest,
+        StatusCode.DEADLINE_EXCEEDED: GatewayTimeout,
+        StatusCode.NOT_FOUND: NotFound,
+        StatusCode.ALREADY_EXISTS: Conflict,
+        StatusCode.PERMISSION_DENIED: Forbidden,
+        StatusCode.UNAUTHENTICATED: Unauthorized,
+        StatusCode.RESOURCE_EXHAUSTED: TooManyRequests,
+        StatusCode.FAILED_PRECONDITION: PreconditionFailed,
+        StatusCode.ABORTED: Conflict,
+        StatusCode.OUT_OF_RANGE: BadRequest,
+        StatusCode.UNIMPLEMENTED: MethodNotImplemented,
+        StatusCode.INTERNAL: InternalServerError,
+        StatusCode.UNAVAILABLE: ServiceUnavailable,
+        StatusCode.DATA_LOSS: InternalServerError,
+    }

--- a/core/google/cloud/exceptions.py
+++ b/core/google/cloud/exceptions.py
@@ -301,3 +301,5 @@ if _HAVE_GRPC:
         StatusCode.UNAVAILABLE: ServiceUnavailable,
         StatusCode.DATA_LOSS: InternalServerError,
     }
+else:  # pragma: NO COVER  (GAX/gRPC always present for testing)
+    pass

--- a/core/nox.py
+++ b/core/nox.py
@@ -35,6 +35,7 @@ def unit_tests(session, python_version):
         'pytest',
         'pytest-cov',
         'grpcio >= 1.0.2',
+        'google-gax >= 0.15, < 0.16.dev',
     )
     session.install('-e', '.')
 

--- a/core/tests/unit/test_exceptions.py
+++ b/core/tests/unit/test_exceptions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import unittest
 
 import requests
 from six.moves import http_client
@@ -125,3 +126,66 @@ def test_from_http_response_bad_json_content():
     assert isinstance(exception, exceptions.NotFound)
     assert exception.code == http_client.NOT_FOUND
     assert exception.message == 'POST https://example.com/: unknown error'
+
+
+@unittest.skipUnless(exceptions._HAVE_GRPC, 'No gRPC')
+class Test__catch_remap_gax_error(unittest.TestCase):
+
+    def _call_fut(self):
+        from google.cloud.exceptions import _catch_remap_gax_error
+
+        return _catch_remap_gax_error()
+
+    @staticmethod
+    def _fake_method(exc, result=None):
+        if exc is None:
+            return result
+        else:
+            raise exc
+
+    @staticmethod
+    def _make_rendezvous(status_code, details):
+        from grpc._channel import _RPCState
+        from google.cloud.exceptions import GrpcRendezvous
+
+        exc_state = _RPCState((), None, None, status_code, details)
+        return GrpcRendezvous(exc_state, None, None, None)
+
+    def test_success(self):
+        expected = object()
+        with self._call_fut():
+            result = self._fake_method(None, expected)
+        self.assertIs(result, expected)
+
+    def test_non_grpc_err(self):
+        exc = RuntimeError('Not a gRPC error')
+        with self.assertRaises(RuntimeError):
+            with self._call_fut():
+                self._fake_method(exc)
+
+    def test_gax_error(self):
+        from google.gax.errors import GaxError
+        from grpc import StatusCode
+        from google.cloud.exceptions import Forbidden
+
+        # First, create low-level GrpcRendezvous exception.
+        details = 'Some error details.'
+        cause = self._make_rendezvous(StatusCode.PERMISSION_DENIED, details)
+        # Then put it into a high-level GaxError.
+        msg = 'GAX Error content.'
+        exc = GaxError(msg, cause=cause)
+
+        with self.assertRaises(Forbidden):
+            with self._call_fut():
+                self._fake_method(exc)
+
+    def test_gax_error_not_mapped(self):
+        from google.gax.errors import GaxError
+        from grpc import StatusCode
+
+        cause = self._make_rendezvous(StatusCode.CANCELLED, None)
+        exc = GaxError(None, cause=cause)
+
+        with self.assertRaises(GaxError):
+            with self._call_fut():
+                self._fake_method(exc)

--- a/datastore/tests/unit/test__gax.py
+++ b/datastore/tests/unit/test__gax.py
@@ -20,69 +20,6 @@ from google.cloud.datastore.client import _HAVE_GRPC
 
 
 @unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
-class Test__catch_remap_gax_error(unittest.TestCase):
-
-    def _call_fut(self):
-        from google.cloud.datastore._gax import _catch_remap_gax_error
-
-        return _catch_remap_gax_error()
-
-    @staticmethod
-    def _fake_method(exc, result=None):
-        if exc is None:
-            return result
-        else:
-            raise exc
-
-    @staticmethod
-    def _make_rendezvous(status_code, details):
-        from grpc._channel import _RPCState
-        from google.cloud.exceptions import GrpcRendezvous
-
-        exc_state = _RPCState((), None, None, status_code, details)
-        return GrpcRendezvous(exc_state, None, None, None)
-
-    def test_success(self):
-        expected = object()
-        with self._call_fut():
-            result = self._fake_method(None, expected)
-        self.assertIs(result, expected)
-
-    def test_non_grpc_err(self):
-        exc = RuntimeError('Not a gRPC error')
-        with self.assertRaises(RuntimeError):
-            with self._call_fut():
-                self._fake_method(exc)
-
-    def test_gax_error(self):
-        from google.gax.errors import GaxError
-        from grpc import StatusCode
-        from google.cloud.exceptions import Forbidden
-
-        # First, create low-level GrpcRendezvous exception.
-        details = 'Some error details.'
-        cause = self._make_rendezvous(StatusCode.PERMISSION_DENIED, details)
-        # Then put it into a high-level GaxError.
-        msg = 'GAX Error content.'
-        exc = GaxError(msg, cause=cause)
-
-        with self.assertRaises(Forbidden):
-            with self._call_fut():
-                self._fake_method(exc)
-
-    def test_gax_error_not_mapped(self):
-        from google.gax.errors import GaxError
-        from grpc import StatusCode
-
-        cause = self._make_rendezvous(StatusCode.CANCELLED, None)
-        exc = GaxError(None, cause=cause)
-
-        with self.assertRaises(GaxError):
-            with self._call_fut():
-                self._fake_method(exc)
-
-
-@unittest.skipUnless(_HAVE_GRPC, 'No gRPC')
 class TestGAPICDatastoreAPI(unittest.TestCase):
 
     @staticmethod


### PR DESCRIPTION
Toward #3175.

Rework PR #3444 against current version of `core`.

Also, drop the unconditional dependency of `core` on `google-gax`:  we test with it, but omit the feature if it isn't present.