### PR TITLE
Streaming directly into file on storage downloads.

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -414,9 +414,8 @@ class Blob(_PropertyMixin):
         :param headers: Optional headers to be sent with the request(s).
         """
         if self.chunk_size is None:
-            download = Download(download_url, headers=headers)
-            response = download.consume(transport)
-            file_obj.write(response.content)
+            download = Download(download_url, stream=file_obj, headers=headers)
+            download.consume(transport)
         else:
             download = ChunkedDownload(
                 download_url, self.chunk_size, file_obj, headers=headers)

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -53,7 +53,7 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'google-cloud-core >= 0.25.0, < 0.26dev',
     'google-auth >= 1.0.0',
-    'google-resumable-media >= 0.2.1',
+    'google-resumable-media >= 0.2.2',
     'requests >= 2.0.0',
 ]
 


### PR DESCRIPTION
This won't work until `google-resumable-media==0.2.2` is actually out, but I did install it locally and the unit tests are passing.

Fixes #3703.