### PR TITLE
Add 'update' API wrapper for buckets/blobs.

### DIFF
--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -147,6 +147,22 @@ class _PropertyMixin(object):
             query_params={'projection': 'full'}, _target_object=self)
         self._set_properties(api_response)
 
+    def update(self, client=None):
+        """Sends all properties in a PUT request.
+
+        Updates the ``_properties`` with the response from the backend.
+
+        :type client: :class:`~google.cloud.storage.client.Client` or
+                      ``NoneType``
+        :param client: the client to use.  If not passed, falls back to the
+                       ``client`` stored on the current object.
+        """
+        client = self._require_client(client)
+        api_response = client._connection.api_request(
+            method='PUT', path=self.path, data=self._properties,
+            query_params={'projection': 'full'}, _target_object=self)
+        self._set_properties(api_response)
+
 
 def _scalar_property(fieldname):
     """Create a property descriptor around the :class:`_PropertyMixin` helpers.

--- a/storage/tests/unit/test__helpers.py
+++ b/storage/tests/unit/test__helpers.py
@@ -95,6 +95,26 @@ class Test_PropertyMixin(unittest.TestCase):
         # Make sure changes get reset by patch().
         self.assertEqual(derived._changes, set())
 
+    def test_update(self):
+        connection = _Connection({'foo': 'Foo'})
+        client = _Client(connection)
+        derived = self._derivedClass('/path')()
+        # Make sure changes is non-empty, so we can observe a change.
+        BAR = object()
+        BAZ = object()
+        derived._properties = {'bar': BAR, 'baz': BAZ}
+        derived._changes = set(['bar'])  # Update sends 'baz' anyway.
+        derived.update(client=client)
+        self.assertEqual(derived._properties, {'foo': 'Foo'})
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PUT')
+        self.assertEqual(kw[0]['path'], '/path')
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['data'], {'bar': BAR, 'baz': BAZ})
+        # Make sure changes get reset by patch().
+        self.assertEqual(derived._changes, set())
+
 
 class Test__scalar_property(unittest.TestCase):
 


### PR DESCRIPTION
Turns out some properties (i.e., `labels`, see #3711) behave differently under [patch semantics](https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance#patch), which makes `update` useful.

See #1430, which was closed as "not needed".