### PR TITLE
Reuse explicit credentials when creating 'database.spanner_api'.

### DIFF
--- a/spanner/google/cloud/spanner/database.py
+++ b/spanner/google/cloud/spanner/database.py
@@ -158,13 +158,13 @@ class Database(object):
     def spanner_api(self):
         """Helper for session-related API calls."""
         if self._spanner_api is None:
-            base_creds = self._instance._client.credentials
-            scoped = google.auth.credentials.with_scopes_if_required(
-                base_creds, (SPANNER_DATA_SCOPE,))
+            credentials = self._instance._client.credentials
+            if isinstance(credentials, google.auth.credentials.Scoped):
+                credentials = credentials.with_scopes((SPANNER_DATA_SCOPE,))
             self._spanner_api = SpannerClient(
                 lib_name='gccl',
                 lib_version=__version__,
-                credentials=scoped,
+                credentials=credentials,
             )
         return self._spanner_api
 

--- a/spanner/google/cloud/spanner/database.py
+++ b/spanner/google/cloud/spanner/database.py
@@ -159,7 +159,8 @@ class Database(object):
         """Helper for session-related API calls."""
         if self._spanner_api is None:
             base_creds = self._instance._client.credentials
-            scoped = base_creds.with_scopes((SPANNER_DATA_SCOPE,))
+            scoped = google.auth.credentials.with_scopes_if_required(
+                base_creds, (SPANNER_DATA_SCOPE,))
             self._spanner_api = SpannerClient(
                 lib_name='gccl',
                 lib_version=__version__,

--- a/spanner/google/cloud/spanner/database.py
+++ b/spanner/google/cloud/spanner/database.py
@@ -16,6 +16,7 @@
 
 import re
 
+import google.auth.credentials
 from google.gax.errors import GaxError
 from google.gax.grpc import exc_to_code
 from google.cloud.gapic.spanner.v1.spanner_client import SpannerClient
@@ -33,6 +34,9 @@ from google.cloud.spanner.pool import BurstyPool
 from google.cloud.spanner.snapshot import Snapshot
 from google.cloud.spanner.pool import SessionCheckout
 # pylint: enable=ungrouped-imports
+
+
+SPANNER_DATA_SCOPE = 'https://www.googleapis.com/auth/spanner.data'
 
 
 _DATABASE_NAME_RE = re.compile(
@@ -154,8 +158,13 @@ class Database(object):
     def spanner_api(self):
         """Helper for session-related API calls."""
         if self._spanner_api is None:
+            base_creds = self._instance._client.credentials
+            scoped = base_creds.with_scopes((SPANNER_DATA_SCOPE,))
             self._spanner_api = SpannerClient(
-                lib_name='gccl', lib_version=__version__)
+                lib_name='gccl',
+                lib_version=__version__,
+                credentials=scoped,
+            )
         return self._spanner_api
 
     def __eq__(self, other):

--- a/spanner/tests/unit/test_client.py
+++ b/spanner/tests/unit/test_client.py
@@ -145,46 +145,56 @@ class TestClient(unittest.TestCase):
                              __version__)
 
     def test_instance_admin_api(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.spanner import client as MUT
+        from google.cloud.spanner import __version__
+        from google.cloud.spanner.client import SPANNER_ADMIN_SCOPE
 
-        creds = _make_credentials()
-        client = self._make_one(project=self.PROJECT, credentials=creds)
+        credentials = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=credentials)
+        expected_scopes = (SPANNER_ADMIN_SCOPE,)
 
-        class _Client(object):
-            def __init__(self, *args, **kwargs):
-                self.args = args
-                self.kwargs = kwargs
+        patch = mock.patch('google.cloud.spanner.client.InstanceAdminClient')
 
-        with _Monkey(MUT, InstanceAdminClient=_Client):
+        with patch as instance_admin_client:
             api = client.instance_admin_api
 
-        self.assertTrue(isinstance(api, _Client))
+        self.assertIs(api, instance_admin_client.return_value)
+
+        # API instance is cached
         again = client.instance_admin_api
         self.assertIs(again, api)
-        self.assertEqual(api.kwargs['lib_name'], 'gccl')
-        self.assertIs(api.kwargs['credentials'], client.credentials)
+
+        instance_admin_client.assert_called_once_with(
+            lib_name='gccl',
+            lib_version=__version__,
+            credentials=credentials.with_scopes.return_value)
+
+        credentials.with_scopes.assert_called_once_with(expected_scopes)
 
     def test_database_admin_api(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.spanner import client as MUT
+        from google.cloud.spanner import __version__
+        from google.cloud.spanner.client import SPANNER_ADMIN_SCOPE
 
-        creds = _make_credentials()
-        client = self._make_one(project=self.PROJECT, credentials=creds)
+        credentials = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=credentials)
+        expected_scopes = (SPANNER_ADMIN_SCOPE,)
 
-        class _Client(object):
-            def __init__(self, *args, **kwargs):
-                self.args = args
-                self.kwargs = kwargs
+        patch = mock.patch('google.cloud.spanner.client.DatabaseAdminClient')
 
-        with _Monkey(MUT, DatabaseAdminClient=_Client):
+        with patch as database_admin_client:
             api = client.database_admin_api
 
-        self.assertTrue(isinstance(api, _Client))
+        self.assertIs(api, database_admin_client.return_value)
+
+        # API instance is cached
         again = client.database_admin_api
         self.assertIs(again, api)
-        self.assertEqual(api.kwargs['lib_name'], 'gccl')
-        self.assertIs(api.kwargs['credentials'], client.credentials)
+
+        database_admin_client.assert_called_once_with(
+            lib_name='gccl',
+            lib_version=__version__,
+            credentials=credentials.with_scopes.return_value)
+
+        credentials.with_scopes.assert_called_once_with(expected_scopes)
 
     def test_copy(self):
         credentials = _make_credentials()


### PR DESCRIPTION
- Preserves "custom" credentials (existing code worked only with implicit credentials from the environment).
- Add tests ensuring scopes are set for correctly for all GAX apis (client uses admin scope, which do not grant data access, while database uses data scope, which does not grant admin access).

Closes #3718.