### PR TITLE
Add a function to complain about obselete packages.

### DIFF
--- a/core/google/cloud/obselete.py
+++ b/core/google/cloud/obselete.py
@@ -1,0 +1,38 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pkg_resources
+import warnings
+
+
+def complain(package_name):
+    """Issue a warning if `package_name` is installed.
+
+    In a future release, this method will be updated to raise ImportError
+    rather than just send a warning.
+
+    Args:
+        package_name (str): The name of the obselete package.
+    """
+    try:
+        pkg_resources.get_distribution(package_name)
+        warnings.warn(
+            'The {pkg} package is now obselete. Please `pip uninstall {pkg}`. '
+            'In the future, this warning will become an ImportError.'.format(
+                pkg=package_name,
+            ),
+            DeprecationWarning,
+        )
+    except pkg_resources.DistributionNotFound:
+        pass

--- a/core/google/cloud/obselete.py
+++ b/core/google/cloud/obselete.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pkg_resources
 import warnings
+
+import pkg_resources
 
 
 def complain(distribution_name):

--- a/core/google/cloud/obselete.py
+++ b/core/google/cloud/obselete.py
@@ -16,21 +16,22 @@ import pkg_resources
 import warnings
 
 
-def complain(package_name):
-    """Issue a warning if `package_name` is installed.
+def complain(distribution_name):
+    """Issue a warning if `distribution_name` is installed.
 
     In a future release, this method will be updated to raise ImportError
     rather than just send a warning.
 
     Args:
-        package_name (str): The name of the obselete package.
+        distribution_name (str): The name of the obselete distribution.
     """
     try:
-        pkg_resources.get_distribution(package_name)
+        pkg_resources.get_distribution(distribution_name)
         warnings.warn(
-            'The {pkg} package is now obselete. Please `pip uninstall {pkg}`. '
+            'The {pkg} distribution is now obselete. '
+            'Please `pip uninstall {pkg}`. '
             'In the future, this warning will become an ImportError.'.format(
-                pkg=package_name,
+                pkg=distribution_name,
             ),
             DeprecationWarning,
         )

--- a/core/tests/unit/test_obselete.py
+++ b/core/tests/unit/test_obselete.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/tests/unit/test_obselete.py
+++ b/core/tests/unit/test_obselete.py
@@ -1,0 +1,31 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+import mock
+
+from google.cloud import obselete
+
+
+def test_complain_noop():
+    with mock.patch.object(warnings, 'warn', autospec=True) as warn:
+        obselete.complain('bogus_package')
+        assert warn.call_count == 0
+
+
+def test_complain():
+    with mock.patch.object(warnings, 'warn', autospec=True) as warn:
+        obselete.complain('google-cloud-core')
+        warn.assert_called_once_with(mock.ANY, DeprecationWarning)


### PR DESCRIPTION
This will be used to complain if `gapic-google-cloud-{api}-{version}` or `proto-google-cloud-{api}-{version}` are still installed after they are vendored (for GA libraries only).