### PR TITLE
Expanding the allowable descriptions for vision system tests.

### DIFF
--- a/vision/nox.py
+++ b/vision/nox.py
@@ -35,10 +35,16 @@ def unit_tests(session, python_version):
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
-    session.run('py.test', '--quiet',
-        '--cov=google.cloud.vision', '--cov=google.cloud.vision_v1',
-        '--cov-append', '--cov-config=.coveragerc', '--cov-report=',
-        'tests/',
+    session.run(
+        'py.test',
+        '--quiet',
+        '--cov=google.cloud.vision',
+        '--cov=google.cloud.vision_v1',
+        '--cov-append',
+        '--cov-config=.coveragerc',
+        '--cov-report=',
+        'tests',
+        *session.posargs
     )
 
 
@@ -63,7 +69,12 @@ def system_tests(session, python_version):
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
-    session.run('py.test', '--quiet', 'tests/system.py')
+    session.run(
+        'py.test',
+        '--quiet',
+        os.path.join('tests', 'system.py'),
+        *session.posargs
+    )
 
 
 @nox.session
@@ -84,7 +95,12 @@ def system_tests_manual_layer(session, python_version):
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
-    session.run('py.test', '--quiet', 'tests/system_old.py')
+    session.run(
+        'py.test',
+        '--quiet',
+        os.path.join('tests', 'system_old.py'),
+        *session.posargs
+    )
 
 
 @nox.session

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -25,7 +25,7 @@ with io.open(os.path.join(PACKAGE_ROOT, 'README.rst'), 'r') as readme_file:
     readme = readme_file.read()
 
 REQUIREMENTS = [
-    'google-cloud-core >= 0.25.0, < 0.26dev',
+    'google-cloud-core >= 0.26.0, < 0.27dev',
     'google-gax >= 0.15.13, < 0.16dev',
     'googleapis-common-protos[grpc] >= 1.5.2, < 2.0dev',
 ]

--- a/vision/tests/system_old.py
+++ b/vision/tests/system_old.py
@@ -332,17 +332,23 @@ class TestVisionClientFace(BaseVisionTestCase):
 
 
 class TestVisionClientLabel(BaseVisionTestCase):
+
     DESCRIPTIONS = (
-        'car',
-        'vehicle',
-        'land vehicle',
-        'automotive design',
-        'wheel',
         'automobile make',
-        'luxury vehicle',
-        'sports car',
-        'performance car',
+        'automotive design',
         'automotive exterior',
+        'automotive wheel system',
+        'car',
+        'land vehicle',
+        'luxury vehicle',
+        'motor vehicle',
+        'muscle car',
+        'performance car',
+        'personal luxury car',
+        'rim',
+        'sports car',
+        'vehicle',
+        'wheel',
     )
 
     def setUp(self):


### PR DESCRIPTION
Fixes #3681.

Also updating the `nox` configuration to allow posargs pass through and be a little more Windows path friendly.