### PR TITLE
Using HTTPS wikipedia links in language system tests.

### DIFF
--- a/docs/language/usage.rst
+++ b/docs/language/usage.rst
@@ -144,17 +144,17 @@ returns a :class:`~.language_v1.types.AnalyzeEntitiesResponse`.
      ====================
               name: Michelangelo Caravaggio
               type: PERSON
-          metadata: {'wikipedia_url': 'http://en.wikipedia.org/wiki/Caravaggio'}
+          metadata: {'wikipedia_url': 'https://en.wikipedia.org/wiki/Caravaggio'}
           salience: 0.7615959
      ====================
               name: Italian
               type: LOCATION
-          metadata: {'wikipedia_url': 'http://en.wikipedia.org/wiki/Caravaggio'}
+          metadata: {'wikipedia_url': 'https://en.wikipedia.org/wiki/Italy'}
           salience: 0.19960518
      ====================
               name: The Calling of Saint Matthew
               type: EVENT
-          metadata: {'wikipedia_url': 'http://en.wikipedia.org/wiki/Caravaggio'}
+          metadata: {'wikipedia_url': 'https://en.wikipedia.org/wiki/The_Calling_of_St_Matthew_(Caravaggio)'}
           salience: 0.038798928
 
 .. note::

--- a/language/tests/system.py
+++ b/language/tests/system.py
@@ -77,7 +77,7 @@ class TestLanguage(unittest.TestCase):
         # Other mentions may occur, e.g. "painter".
         self.assertIn(entity1.name, [str(i) for i in entity1.mentions])
         self.assertEqual(entity1.metadata['wikipedia_url'],
-                         'http://en.wikipedia.org/wiki/Caravaggio')
+                         'https://en.wikipedia.org/wiki/Caravaggio')
         self.assertIsInstance(entity1.metadata, dict)
         # Verify entity 2.
         self.assertEqual(entity2.name, self.NAME2)
@@ -85,7 +85,7 @@ class TestLanguage(unittest.TestCase):
         self.assertGreater(entity2.salience, 0.0)
         self.assertEqual([str(i) for i in entity2.mentions], [entity2.name])
         self.assertEqual(entity2.metadata['wikipedia_url'],
-                         'http://en.wikipedia.org/wiki/Italy')
+                         'https://en.wikipedia.org/wiki/Italy')
         self.assertIsInstance(entity2.metadata, dict)
         # Verify entity 3.
         self.assertEqual(entity3.name, self.NAME3)
@@ -93,7 +93,7 @@ class TestLanguage(unittest.TestCase):
         self.assertIn(entity3.entity_type, choices)
         self.assertGreater(entity3.salience, 0.0)
         self.assertEqual([str(i) for i in entity3.mentions], [entity3.name])
-        wiki_url = ('http://en.wikipedia.org/wiki/'
+        wiki_url = ('https://en.wikipedia.org/wiki/'
                     'The_Calling_of_St_Matthew_(Caravaggio)')
         self.assertEqual(entity3.metadata['wikipedia_url'], wiki_url)
         self.assertIsInstance(entity3.metadata, dict)
@@ -122,7 +122,7 @@ class TestLanguage(unittest.TestCase):
         positive_msg = 'Jogging is fun'
         document = Config.CLIENT.document_from_text(positive_msg)
         sentiment = document.analyze_sentiment().sentiment
-        self.assertEqual(sentiment.score, 0.5)
+        self.assertTrue(0.0 < sentiment.score < 1.0)
         self.assertTrue(0.0 < sentiment.magnitude < 1.5)
 
     def _verify_token(self, token, text_content, part_of_speech, lemma):


### PR DESCRIPTION
Fixes #3731.

Also relaxing the sentiment score expected range for "Jogging is fun" (the same backend update that changed HTTP to HTTPS changed the score from 0.5 to 0.7).

Also updating the language usage doc with the correct (and HTTPS) URLs for the 3 examples.