### PR TITLE
Storage: Track deleted labels; make Bucket.patch() send them.

### DIFF
--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -142,6 +142,8 @@ class _PropertyMixin(object):
         # to work properly w/ 'noAcl'.
         update_properties = {key: self._properties[key]
                              for key in self._changes}
+
+        # Make the API call.
         api_response = client._connection.api_request(
             method='PATCH', path=self.path, data=update_properties,
             query_params={'projection': 'full'}, _target_object=self)

--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -126,6 +126,8 @@ class _PropertyMixin(object):
         self._properties = value
         # If the values are reset, the changes must as well.
         self._changes = set()
+        if hasattr(self, '_label_removals'):
+            self._label_removals.clear()
 
     def patch(self, client=None):
         """Sends all changed properties in a PATCH request.

--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -165,22 +165,6 @@ class _PropertyMixin(object):
             query_params={'projection': 'full'}, _target_object=self)
         self._set_properties(api_response)
 
-    def update(self, client=None):
-        """Sends all properties in a PUT request.
-
-        Updates the ``_properties`` with the response from the backend.
-
-        :type client: :class:`~google.cloud.storage.client.Client` or
-                      ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current object.
-        """
-        client = self._require_client(client)
-        api_response = client._connection.api_request(
-            method='PUT', path=self.path, data=self._properties,
-            query_params={'projection': 'full'}, _target_object=self)
-        self._set_properties(api_response)
-
 
 def _scalar_property(fieldname):
     """Create a property descriptor around the :class:`_PropertyMixin` helpers.

--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -126,8 +126,6 @@ class _PropertyMixin(object):
         self._properties = value
         # If the values are reset, the changes must as well.
         self._changes = set()
-        if hasattr(self, '_label_removals'):
-            self._label_removals.clear()
 
     def patch(self, client=None):
         """Sends all changed properties in a PATCH request.

--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -163,6 +163,22 @@ class _PropertyMixin(object):
             query_params={'projection': 'full'}, _target_object=self)
         self._set_properties(api_response)
 
+    def update(self, client=None):
+        """Sends all properties in a PUT request.
+
+        Updates the ``_properties`` with the response from the backend.
+
+        :type client: :class:`~google.cloud.storage.client.Client` or
+                      ``NoneType``
+        :param client: the client to use.  If not passed, falls back to the
+                       ``client`` stored on the current object.
+        """
+        client = self._require_client(client)
+        api_response = client._connection.api_request(
+            method='PUT', path=self.path, data=self._properties,
+            query_params={'projection': 'full'}, _target_object=self)
+        self._set_properties(api_response)
+
 
 def _scalar_property(fieldname):
     """Create a property descriptor around the :class:`_PropertyMixin` helpers.

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -219,27 +219,7 @@ class Bucket(_PropertyMixin):
                 self._properties['labels'][removed_label] = None
 
         # Call the superclass method.
-        answer = super(Bucket, self).patch(client=client)
-
-        # Clear out the label removals.
-        # This comes after the superclass method to ensure that we hold on
-        # to the data in case of an error.
-        self._label_removals.clear()
-        return answer
-
-    def update(self, client=None):
-        """Sends all properties in a PUT request.
-
-        Updates the ``_properties`` with the response from the backend.
-
-        :type client: :class:`~google.cloud.storage.client.Client` or
-                      ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current object.
-        """
-        answer = super(Bucket, self).update(client=client)
-        self._label_removals.clear()
-        return answer
+        return super(Bucket, self).patch(client=client)
 
     @property
     def acl(self):

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -125,6 +125,15 @@ class Bucket(_PropertyMixin):
         """The client bound to this bucket."""
         return self._client
 
+    def _set_properties(self, value):
+        """Set the properties for the current object.
+
+        :type value: dict or :class:`google.cloud.storage.batch._FutureDict`
+        :param value: The properties to be set.
+        """
+        self._label_removals.clear()
+        return super(Bucket, self)._set_properties(value)
+
     def blob(self, blob_name, chunk_size=None, encryption_key=None):
         """Factory constructor for blob object.
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -127,7 +127,7 @@ class TestStorageBuckets(unittest.TestCase):
 
         new_labels = {'another-label': 'another-value'}
         bucket.labels = new_labels
-        bucket.update()
+        bucket.patch()
         self.assertEqual(bucket.labels, new_labels)
 
         bucket.labels = {}

--- a/storage/tests/unit/test__helpers.py
+++ b/storage/tests/unit/test__helpers.py
@@ -115,6 +115,26 @@ class Test_PropertyMixin(unittest.TestCase):
         # Make sure changes get reset by patch().
         self.assertEqual(derived._changes, set())
 
+    def test_update(self):
+        connection = _Connection({'foo': 'Foo'})
+        client = _Client(connection)
+        derived = self._derivedClass('/path')()
+        # Make sure changes is non-empty, so we can observe a change.
+        BAR = object()
+        BAZ = object()
+        derived._properties = {'bar': BAR, 'baz': BAZ}
+        derived._changes = set(['bar'])  # Update sends 'baz' anyway.
+        derived.update(client=client)
+        self.assertEqual(derived._properties, {'foo': 'Foo'})
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PUT')
+        self.assertEqual(kw[0]['path'], '/path')
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[0]['data'], {'bar': BAR, 'baz': BAZ})
+        # Make sure changes get reset by patch().
+        self.assertEqual(derived._changes, set())
+
 
 class Test__scalar_property(unittest.TestCase):
 

--- a/storage/tests/unit/test__helpers.py
+++ b/storage/tests/unit/test__helpers.py
@@ -115,26 +115,6 @@ class Test_PropertyMixin(unittest.TestCase):
         # Make sure changes get reset by patch().
         self.assertEqual(derived._changes, set())
 
-    def test_update(self):
-        connection = _Connection({'foo': 'Foo'})
-        client = _Client(connection)
-        derived = self._derivedClass('/path')()
-        # Make sure changes is non-empty, so we can observe a change.
-        BAR = object()
-        BAZ = object()
-        derived._properties = {'bar': BAR, 'baz': BAZ}
-        derived._changes = set(['bar'])  # Update sends 'baz' anyway.
-        derived.update(client=client)
-        self.assertEqual(derived._properties, {'foo': 'Foo'})
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'PUT')
-        self.assertEqual(kw[0]['path'], '/path')
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
-        self.assertEqual(kw[0]['data'], {'bar': BAR, 'baz': BAZ})
-        # Make sure changes get reset by patch().
-        self.assertEqual(derived._changes, set())
-
 
 class Test__scalar_property(unittest.TestCase):
 

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -710,16 +710,6 @@ class Test_Bucket(unittest.TestCase):
         self.assertIsNot(bucket._properties['labels'], LABELS)
         self.assertIn('labels', bucket._changes)
 
-        # Make sure that a update call correctly adds the labels.
-        client = mock.NonCallableMock(spec=('_connection',))
-        client._connection = mock.NonCallableMock(spec=('api_request',))
-        bucket.update(client=client)
-        client._connection.api_request.assert_called()
-        _, _, kwargs = client._connection.api_request.mock_calls[0]
-        self.assertEqual(len(kwargs['data']['labels']), 2)
-        self.assertEqual(kwargs['data']['labels']['color'], 'red')
-        self.assertEqual(kwargs['data']['labels']['flavor'], 'cherry')
-
     def test_labels_setter_with_removal(self):
         # Make sure the bucket labels look correct and follow the expected
         # public structure.


### PR DESCRIPTION
Uses #3715 as a base.

This PR adds tracking for deleted labels on the `Bucket` object, and causes the appropriate data to be sent when `Bucket.patch` is called.

Fixes #3711.