### PR TITLE
Update storage to 1.3.1.

### DIFF
--- a/storage/setup.py
+++ b/storage/setup.py
@@ -53,13 +53,13 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'google-cloud-core >= 0.26.0, < 0.27dev',
     'google-auth >= 1.0.0',
-    'google-resumable-media >= 0.2.2',
+    'google-resumable-media >= 0.2.3',
     'requests >= 2.0.0',
 ]
 
 setup(
     name='google-cloud-storage',
-    version='1.3.0',
+    version='1.3.1',
     description='Python Client for Google Cloud Storage',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Did this to update the google-resumable-media dependency to allow for empty files.

See #3685