### PR TITLE
session.run_in_transaction returns the callback's return value.

### DIFF
--- a/spanner/google/cloud/spanner/session.py
+++ b/spanner/google/cloud/spanner/session.py
@@ -268,8 +268,9 @@ class Session(object):
                    If passed, "timeout_secs" will be removed and used to
                    override the default timeout.
 
-        :rtype: :class:`datetime.datetime`
-        :returns: timestamp of committed transaction
+        :rtype: Any
+        :returns: The return value of ``func``.
+
         :raises Exception:
             reraises any non-ABORT execptions raised by ``func``.
         """
@@ -284,7 +285,7 @@ class Session(object):
             if txn._transaction_id is None:
                 txn.begin()
             try:
-                func(txn, *args, **kw)
+                return_value = func(txn, *args, **kw)
             except GaxError as exc:
                 _delay_until_retry(exc, deadline)
                 del self._transaction
@@ -299,8 +300,7 @@ class Session(object):
                 _delay_until_retry(exc, deadline)
                 del self._transaction
             else:
-                committed = txn.committed
-                return committed
+                return return_value
 
 
 # pylint: disable=misplaced-bare-raise

--- a/spanner/tests/unit/test_database.py
+++ b/spanner/tests/unit/test_database.py
@@ -22,7 +22,7 @@ from google.cloud._testing import _GAXBaseAPI
 from google.cloud.spanner import __version__
 
 
-def _make_credentials():
+def _make_credentials():  # pragma: NO COVER
     import google.auth.credentials
 
     class _CredentialsWithScopes(
@@ -223,7 +223,7 @@ class TestDatabase(_BaseTest):
                 self._scopes = scopes
                 self._source = source
 
-            def requires_scopes(self):
+            def requires_scopes(self): # pragma: NO COVER
                 return True
 
             def with_scopes(self, scopes):


### PR DESCRIPTION
This makes it so `session.run_in_transaction` returns the callback's return value, rather than the commit timestamp.

Fixes #3493.