### PR TITLE
Change docs link from stable/ to latest/

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
     <div class="container">
       <ul class="featuring-links">
         <li>
-          <a href="stable/" title="google-cloud-python docs" class="btn btn-docs">
+          <a href="latest/" title="google-cloud-python docs" class="btn btn-docs">
             <img src="_landing-page-static/images/icon-lang-python.svg" alt="Python icon" />
             Read the Docs
           </a>


### PR DESCRIPTION
Per https://github.com/GoogleCloudPlatform/google-cloud-python/issues/3595#issuecomment-321019971 `latest` is more frequently updated and `stable` is meaningless.