### PR TITLE
Fix __eq__ and __ne__.

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -328,9 +328,14 @@ class UDFResource(object):
         self.value = value
 
     def __eq__(self, other):
+        if not isinstance(other, UDFResource):
+            return NotImplemented
         return(
             self.udf_type == other.udf_type and
             self.value == other.value)
+
+    def __ne__(self, other):
+        return not self == other
 
 
 class UDFResourcesProperty(object):

--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -76,10 +76,15 @@ class AccessGrant(object):
         self.entity_id = entity_id
 
     def __eq__(self, other):
+        if not isinstance(other, AccessGrant):
+            return NotImplemented
         return (
             self.role == other.role and
             self.entity_type == other.entity_type and
             self.entity_id == other.entity_id)
+
+    def __ne__(self, other):
+        return not self == other
 
     def __repr__(self):
         return '<AccessGrant: role=%s, %s=%s>' % (

--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -101,16 +101,12 @@ class SchemaField(object):
         )
 
     def __eq__(self, other):
-        if isinstance(other, SchemaField):
-            return self._key() == other._key()
-        else:
+        if not isinstance(other, SchemaField):
             return NotImplemented
+        return self._key() == other._key()
 
     def __ne__(self, other):
-        if isinstance(other, SchemaField):
-            return self._key() != other._key()
-        else:
-            return NotImplemented
+        return not self == other
 
     def __hash__(self):
         return hash(self._key())

--- a/bigquery/tests/unit/test__helpers.py
+++ b/bigquery/tests/unit/test__helpers.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class Test_not_null(unittest.TestCase):
 
@@ -814,6 +816,18 @@ class Test_UDFResourcesProperty(unittest.TestCase):
         _, klass = self._descriptor_and_klass()
         instance = klass()
         self.assertEqual(instance.udf_resources, [])
+
+    def test_resource_equality(self):
+        from google.cloud.bigquery._helpers import UDFResource
+
+        resource1a = UDFResource('resourceUri', 'gs://bucket/file.js')
+        resource1b = UDFResource('resourceUri', 'gs://bucket/file.js')
+        resource2 = UDFResource('resourceUri', 'gs://bucket/other.js')
+
+        self.assertEqual(resource1a, resource1b)
+        self.assertNotEqual(resource1a, resource2)
+        self.assertNotEqual(resource1a, object())
+        self.assertEqual(resource1a, mock.ANY)
 
     def test_instance_getter_w_non_empty_list(self):
         from google.cloud.bigquery._helpers import UDFResource

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestAccessGrant(unittest.TestCase):
 
@@ -76,6 +78,11 @@ class TestAccessGrant(unittest.TestCase):
         grant = self._make_one('OWNER', 'userByEmail', 'phred@example.com')
         other = self._make_one('OWNER', 'userByEmail', 'phred@example.com')
         self.assertEqual(grant, other)
+
+    def test__eq___type_mismatch(self):
+        grant = self._make_one('OWNER', 'userByEmail', 'silly@example.com')
+        self.assertNotEqual(grant, object())
+        self.assertEqual(grant, mock.ANY)
 
 
 class TestDataset(unittest.TestCase):

--- a/bigquery/tests/unit/test_schema.py
+++ b/bigquery/tests/unit/test_schema.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestSchemaField(unittest.TestCase):
 
@@ -101,7 +103,7 @@ class TestSchemaField(unittest.TestCase):
         field = self._make_one('test', 'STRING')
         other = object()
         self.assertNotEqual(field, other)
-        self.assertIs(field.__eq__(other), NotImplemented)
+        self.assertEqual(field, mock.ANY)
 
     def test___eq___name_mismatch(self):
         field = self._make_one('test', 'STRING')
@@ -155,7 +157,7 @@ class TestSchemaField(unittest.TestCase):
         field = self._make_one('toast', 'INTEGER')
         other = object()
         self.assertNotEqual(field, other)
-        self.assertIs(field.__ne__(other), NotImplemented)
+        self.assertEqual(field, mock.ANY)
 
     def test___ne___same_value(self):
         field1 = self._make_one('test', 'TIMESTAMP', mode='REPEATED')

--- a/bigtable/google/cloud/bigtable/cluster.py
+++ b/bigtable/google/cloud/bigtable/cluster.py
@@ -159,7 +159,7 @@ class Cluster(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         # NOTE: This does not compare the configuration values, such as
         #       the serve_nodes. Instead, it only compares
         #       identifying values instance, cluster ID and client. This is
@@ -170,7 +170,7 @@ class Cluster(object):
                 other._instance == self._instance)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
     def reload(self):
         """Reload the metadata for this cluster."""

--- a/bigtable/google/cloud/bigtable/column_family.py
+++ b/bigtable/google/cloud/bigtable/column_family.py
@@ -39,9 +39,6 @@ class GarbageCollectionRule(object):
         don't support that feature and instead support via native classes.
     """
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
 
 class MaxVersionsGCRule(GarbageCollectionRule):
     """Garbage collection limiting the number of versions of a cell.
@@ -55,8 +52,11 @@ class MaxVersionsGCRule(GarbageCollectionRule):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.max_num_versions == self.max_num_versions
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_pb(self):
         """Converts the garbage collection rule to a protobuf.
@@ -79,8 +79,11 @@ class MaxAgeGCRule(GarbageCollectionRule):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.max_age == self.max_age
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_pb(self):
         """Converts the garbage collection rule to a protobuf.
@@ -104,8 +107,11 @@ class GCRuleUnion(GarbageCollectionRule):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.rules == self.rules
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_pb(self):
         """Converts the union into a single GC rule as a protobuf.
@@ -130,8 +136,11 @@ class GCRuleIntersection(GarbageCollectionRule):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.rules == self.rules
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_pb(self):
         """Converts the intersection into a single GC rule as a protobuf.
@@ -190,13 +199,13 @@ class ColumnFamily(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return (other.column_family_id == self.column_family_id and
                 other._table == self._table and
                 other.gc_rule == self.gc_rule)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
     def to_pb(self):
         """Converts the column family to a protobuf.

--- a/bigtable/google/cloud/bigtable/instance.py
+++ b/bigtable/google/cloud/bigtable/instance.py
@@ -180,7 +180,7 @@ class Instance(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         # NOTE: This does not compare the configuration values, such as
         #       the display_name. Instead, it only compares
         #       identifying values instance ID and client. This is
@@ -191,7 +191,7 @@ class Instance(object):
                 other._client == self._client)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
     def reload(self):
         """Reload the metadata for this instance."""

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -58,13 +58,13 @@ class Cell(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return (other.value == self.value and
                 other.timestamp == self.timestamp and
                 other.labels == self.labels)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
 
 class PartialCellData(object):
@@ -126,12 +126,12 @@ class PartialRowData(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return (other._row_key == self._row_key and
                 other._cells == self._cells)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
     def to_dict(self):
         """Convert the cells to a dictionary.
@@ -211,11 +211,11 @@ class PartialRowsData(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other._response_iterator == self._response_iterator
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
     @property
     def state(self):

--- a/bigtable/google/cloud/bigtable/row_filters.py
+++ b/bigtable/google/cloud/bigtable/row_filters.py
@@ -32,9 +32,6 @@ class RowFilter(object):
         This class is a do-nothing base class for all row filters.
     """
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
 
 class _BoolFilter(RowFilter):
     """Row filter that uses a boolean flag.
@@ -48,8 +45,11 @@ class _BoolFilter(RowFilter):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.flag == self.flag
+
+    def __ne__(self, other):
+        return not self == other
 
 
 class SinkFilter(_BoolFilter):
@@ -124,8 +124,11 @@ class _RegexFilter(RowFilter):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.regex == self.regex
+
+    def __ne__(self, other):
+        return not self == other
 
 
 class RowKeyRegexFilter(_RegexFilter):
@@ -173,8 +176,11 @@ class RowSampleFilter(RowFilter):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.sample == self.sample
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_pb(self):
         """Converts the row filter to a protobuf.
@@ -257,12 +263,12 @@ class TimestampRange(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return (other.start == self.start and
                 other.end == self.end)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
     def to_pb(self):
         """Converts the :class:`TimestampRange` to a protobuf.
@@ -292,8 +298,11 @@ class TimestampRangeFilter(RowFilter):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.range_ == self.range_
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_pb(self):
         """Converts the row filter to a protobuf.
@@ -367,12 +376,15 @@ class ColumnRangeFilter(RowFilter):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return (other.column_family_id == self.column_family_id and
                 other.start_column == self.start_column and
                 other.end_column == self.end_column and
                 other.inclusive_start == self.inclusive_start and
                 other.inclusive_end == self.inclusive_end)
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_pb(self):
         """Converts the row filter to a protobuf.
@@ -485,11 +497,14 @@ class ValueRangeFilter(RowFilter):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return (other.start_value == self.start_value and
                 other.end_value == self.end_value and
                 other.inclusive_start == self.inclusive_start and
                 other.inclusive_end == self.inclusive_end)
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_pb(self):
         """Converts the row filter to a protobuf.
@@ -533,8 +548,11 @@ class _CellCountFilter(RowFilter):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.num_cells == self.num_cells
+
+    def __ne__(self, other):
+        return not self == other
 
 
 class CellsRowOffsetFilter(_CellCountFilter):
@@ -631,8 +649,11 @@ class ApplyLabelFilter(RowFilter):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.label == self.label
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_pb(self):
         """Converts the row filter to a protobuf.
@@ -661,8 +682,11 @@ class _FilterCombination(RowFilter):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return other.filters == self.filters
+
+    def __ne__(self, other):
+        return not self == other
 
 
 class RowFilterChain(_FilterCombination):
@@ -748,10 +772,13 @@ class ConditionalRowFilter(RowFilter):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return (other.base_filter == self.base_filter and
                 other.true_filter == self.true_filter and
                 other.false_filter == self.false_filter)
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_pb(self):
         """Converts the row filter to a protobuf.

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -142,12 +142,12 @@ class Table(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return (other.table_id == self.table_id and
                 other._instance == self._instance)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
     def create(self, initial_split_keys=None, column_families=()):
         """Creates this table.

--- a/bigtable/tests/unit/test_column_family.py
+++ b/bigtable/tests/unit/test_column_family.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import unittest
+
+import mock
 
 
 class TestMaxVersionsGCRule(unittest.TestCase):
@@ -29,8 +30,8 @@ class TestMaxVersionsGCRule(unittest.TestCase):
 
     def test___eq__type_differ(self):
         gc_rule1 = self._make_one(10)
-        gc_rule2 = object()
-        self.assertNotEqual(gc_rule1, gc_rule2)
+        self.assertNotEqual(gc_rule1, object())
+        self.assertEqual(gc_rule1, mock.ANY)
 
     def test___eq__same_value(self):
         gc_rule1 = self._make_one(2)

--- a/datastore/google/cloud/datastore/entity.py
+++ b/datastore/google/cloud/datastore/entity.py
@@ -146,7 +146,7 @@ class Entity(dict):
         :returns: True if the entities compare equal, else False.
         """
         if not isinstance(other, Entity):
-            return False
+            return NotImplemented
 
         return (self.key == other.key and
                 self.exclude_from_indexes == other.exclude_from_indexes and
@@ -162,7 +162,7 @@ class Entity(dict):
         :rtype: bool
         :returns: False if the entities compare equal, else True.
         """
-        return not self.__eq__(other)
+        return not self == other
 
     @property
     def kind(self):

--- a/datastore/google/cloud/datastore/helpers.py
+++ b/datastore/google/cloud/datastore/helpers.py
@@ -454,7 +454,7 @@ class GeoPoint(object):
         :returns: True if the points compare equal, else False.
         """
         if not isinstance(other, GeoPoint):
-            return False
+            return NotImplemented
 
         return (self.latitude == other.latitude and
                 self.longitude == other.longitude)
@@ -465,4 +465,4 @@ class GeoPoint(object):
         :rtype: bool
         :returns: False if the points compare equal, else True.
         """
-        return not self.__eq__(other)
+        return not self == other

--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -123,7 +123,7 @@ class Key(object):
         :returns: True if the keys compare equal, else False.
         """
         if not isinstance(other, Key):
-            return False
+            return NotImplemented
 
         if self.is_partial or other.is_partial:
             return False
@@ -143,7 +143,7 @@ class Key(object):
         :rtype: bool
         :returns: False if the keys compare equal, else True.
         """
-        return not self.__eq__(other)
+        return not self == other
 
     def __hash__(self):
         """Hash a keys for use in a dictionary lookp.

--- a/monitoring/google/cloud/monitoring/label.py
+++ b/monitoring/google/cloud/monitoring/label.py
@@ -87,10 +87,12 @@ class LabelDescriptor(object):
         return info
 
     def __eq__(self, other):
+        if not isinstance(other, LabelDescriptor):
+            return NotImplemented
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):
-        return self.__dict__ != other.__dict__
+        return not self == other
 
     def __repr__(self):
         return (

--- a/monitoring/tests/unit/test_label.py
+++ b/monitoring/tests/unit/test_label.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import mock
+
 
 class TestLabelValueType(unittest.TestCase):
 
@@ -108,9 +110,13 @@ class TestLabelDescriptor(unittest.TestCase):
         KEY = 'response_code'
         VALUE_TYPE = 'INT64'
         DESCRIPTION = 'HTTP status code for the request.'
-        descriptor1 = self._make_one(key=KEY, value_type=VALUE_TYPE,
-                                     description=DESCRIPTION)
+        descriptor1a = self._make_one(key=KEY, value_type=VALUE_TYPE,
+                                      description=DESCRIPTION)
+        descriptor1b = self._make_one(key=KEY, value_type=VALUE_TYPE,
+                                      description=DESCRIPTION)
         descriptor2 = self._make_one(key=KEY, value_type=VALUE_TYPE,
-                                     description=DESCRIPTION)
-        self.assertTrue(descriptor1 == descriptor2)
-        self.assertFalse(descriptor1 != descriptor2)
+                                     description=DESCRIPTION + 'foo')
+        self.assertEqual(descriptor1a, descriptor1b)
+        self.assertNotEqual(descriptor1a, descriptor2)
+        self.assertNotEqual(descriptor1a, object())
+        self.assertEqual(descriptor1a, mock.ANY)

--- a/spanner/google/cloud/spanner/database.py
+++ b/spanner/google/cloud/spanner/database.py
@@ -170,12 +170,12 @@ class Database(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         return (other.database_id == self.database_id and
                 other._instance == self._instance)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
     def create(self):
         """Create this database within its instance

--- a/spanner/google/cloud/spanner/instance.py
+++ b/spanner/google/cloud/spanner/instance.py
@@ -148,7 +148,7 @@ class Instance(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False
+            return NotImplemented
         # NOTE: This does not compare the configuration values, such as
         #       the display_name. Instead, it only compares
         #       identifying values instance ID and client. This is
@@ -159,7 +159,7 @@ class Instance(object):
                 other._client == self._client)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
     def copy(self):
         """Make a copy of this instance.


### PR DESCRIPTION
This updates `__eq__` to do type-checking correctly on all classes (except mock classes defined in unit test modules):

```
def __eq__(self, other):
    if not isinstance(other, type(self)):
        return NotImplemented
```

It also updates `__ne__` to be _exactly_:

```
def __ne__(self, other):
    return not self == other
```

Fixes #3455.