### PR TITLE
Increase backoff to fix monitoring system test

### DIFF
--- a/monitoring/tests/system.py
+++ b/monitoring/tests/system.py
@@ -206,6 +206,7 @@ class TestMonitoring(unittest.TestCase):
 
             def _has_timeseries(result):
                 result_len = len(list(result))
+
                 if result_len > 0:
                     try:
                         query = client.query(METRIC_TYPE, minutes=5)

--- a/monitoring/tests/system.py
+++ b/monitoring/tests/system.py
@@ -202,19 +202,26 @@ class TestMonitoring(unittest.TestCase):
         retry_500(client.write_point)(metric, resource, VALUE)
 
         def _query_timeseries_with_retries():
-            MAX_RETRIES = 6
+            MAX_RETRIES = 10
 
             def _has_timeseries(result):
-                return len(list(result)) > 0
+                result_len = len(list(result))
+                if result_len > 0:
+                    try:
+                        query = client.query(METRIC_TYPE, minutes=5)
+                        list(query)
+                        iter_available = True
+                    except BadRequest:
+                        iter_available = False
+
+                return result_len > 0 and iter_available
 
             retry_result = RetryResult(
                 _has_timeseries,
-                max_tries=MAX_RETRIES,
-                backoff=3)(client.query)
+                max_tries=MAX_RETRIES)(client.query)
             return RetryErrors(
                 BadRequest,
-                max_tries=MAX_RETRIES,
-                backoff=3)(retry_result)
+                max_tries=MAX_RETRIES)(retry_result)
 
         query = _query_timeseries_with_retries()(METRIC_TYPE, minutes=5)
         timeseries_list = list(query)

--- a/monitoring/tests/system.py
+++ b/monitoring/tests/system.py
@@ -202,14 +202,19 @@ class TestMonitoring(unittest.TestCase):
         retry_500(client.write_point)(metric, resource, VALUE)
 
         def _query_timeseries_with_retries():
-            MAX_RETRIES = 10
+            MAX_RETRIES = 6
 
             def _has_timeseries(result):
                 return len(list(result)) > 0
 
-            retry_result = RetryResult(_has_timeseries,
-                                       max_tries=MAX_RETRIES)(client.query)
-            return RetryErrors(BadRequest, max_tries=MAX_RETRIES)(retry_result)
+            retry_result = RetryResult(
+                _has_timeseries,
+                max_tries=MAX_RETRIES,
+                backoff=3)(client.query)
+            return RetryErrors(
+                BadRequest,
+                max_tries=MAX_RETRIES,
+                backoff=3)(retry_result)
 
         query = _query_timeseries_with_retries()(METRIC_TYPE, minutes=5)
         timeseries_list = list(query)


### PR DESCRIPTION
Fixes #3739. The max waiting time will be 2 * (1+3+9+27+81) = 242 seconds.