### PR TITLE
nullMarker support for BigQuery Load Jobs (#3449)

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -518,6 +518,7 @@ class _LoadConfiguration(object):
     _field_delimiter = None
     _ignore_unknown_values = None
     _max_bad_records = None
+    _null_marker = None
     _quote_character = None
     _skip_leading_rows = None
     _source_format = None
@@ -672,6 +673,11 @@ class LoadTableFromStorageJob(_AsyncJob):
     https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.maxBadRecords
     """
 
+    null_marker = _TypedProperty('null_marker', six.string_types)
+    """See
+    https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.nullMarker
+    """
+
     quote_character = _TypedProperty('quote_character', six.string_types)
     """See
     https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.quote
@@ -710,6 +716,8 @@ class LoadTableFromStorageJob(_AsyncJob):
             configuration['ignoreUnknownValues'] = self.ignore_unknown_values
         if self.max_bad_records is not None:
             configuration['maxBadRecords'] = self.max_bad_records
+        if self.null_marker is not None:
+            configuration['nullMarker'] = self.null_marker
         if self.quote_character is not None:
             configuration['quote'] = self.quote_character
         if self.skip_leading_rows is not None:

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -247,6 +247,11 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
                              config['maxBadRecords'])
         else:
             self.assertIsNone(job.max_bad_records)
+        if 'nullMarker' in config:
+            self.assertEqual(job.null_marker,
+                             config['nullMarker'])
+        else:
+            self.assertIsNone(job.null_marker)
         if 'quote' in config:
             self.assertEqual(job.quote_character,
                              config['quote'])
@@ -288,6 +293,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         self.assertIsNone(job.field_delimiter)
         self.assertIsNone(job.ignore_unknown_values)
         self.assertIsNone(job.max_bad_records)
+        self.assertIsNone(job.null_marker)
         self.assertIsNone(job.quote_character)
         self.assertIsNone(job.skip_leading_rows)
         self.assertIsNone(job.source_format)
@@ -592,6 +598,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
             'fieldDelimiter': '|',
             'ignoreUnknownValues': True,
             'maxBadRecords': 100,
+            'nullMarker': r'\N',
             'quote': "'",
             'skipLeadingRows': 1,
             'sourceFormat': 'CSV',
@@ -619,6 +626,7 @@ class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
         job.field_delimiter = '|'
         job.ignore_unknown_values = True
         job.max_bad_records = 100
+        job.null_marker = r'\N'
         job.quote_character = "'"
         job.skip_leading_rows = 1
         job.source_format = 'CSV'


### PR DESCRIPTION
This provides the nullMarker config option (--null_marker option for CLI) for load jobs.