### PR TITLE
Spanner: Add a .one and .one_or_none method.

### DIFF
--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -169,6 +169,48 @@ class StreamedResultSet(object):
             while iter_rows:
                 yield iter_rows.pop(0)
 
+    def one(self):
+        """Return exactly one result, or raise an exception.
+
+        :raises: :exc:`NotFound`: If there are no results.
+        :raises: :exc:`ValueError`: If there are multiple results.
+        :raises: :exc:`RuntimeError`: If consumption has already occurred,
+            in whole or in part.
+        """
+        answer = self.one_or_none()
+        if answer is None:
+            raise NotFound('No rows matched the given query.')
+        return answer
+
+    def one_or_none(self):
+        """Return exactly one result, or None if there are no results.
+
+        :raises: :exc:`ValueError`: If there are multiple results.
+        :raises: :exc:`RuntimeError`: If consumption has already occurred,
+            in whole or in part.
+        """
+        # Sanity check: Has consumption of this query already started?
+        # If it has, then this is an exception.
+        if self._metadata is not None:
+            raise RuntimeError('Can not call `.one` or `.one_or_none` after '
+                               'stream consumption has already started.')
+
+        # Consume the first result of the stream.
+        # If there is no first result, then return None.
+        iterator = iter(self)
+        try:
+            answer = next(iterator)
+        except StopIteration:
+            return None
+
+        # Attempt to consume more. This should no-op; if we get additional
+        # rows, then this is an error case.
+        try:
+            next(iterator)
+            raise ValueError('Expected one result; got more.')
+        except StopIteration:
+            return answer
+
 
 class Unmergeable(ValueError):
     """Unable to merge two values.

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -16,6 +16,7 @@
 
 from google.protobuf.struct_pb2 import ListValue
 from google.protobuf.struct_pb2 import Value
+from google.cloud import exceptions
 from google.cloud.proto.spanner.v1 import type_pb2
 import six
 
@@ -179,7 +180,7 @@ class StreamedResultSet(object):
         """
         answer = self.one_or_none()
         if answer is None:
-            raise NotFound('No rows matched the given query.')
+            raise exceptions.NotFound('No rows matched the given query.')
         return answer
 
     def one_or_none(self):


### PR DESCRIPTION
@tseaver @jonparrott @vkedia This is a proposal that fixes #3021. I have not implemented tests yet because I want feedback on the surface first.

I basically followed the SQLAlchemy model; the iterator that comes back gets a `.one()` and `.one_or_none()` method, in lieu of a `read_row()` method on `Database` objects (although it would be easy to implement one and have it call this).

Essentially, where a developer calls `.read()` now, he or she could call `.read().one()` and get the single-result behavior.

If this is workable, then I will write tests.