### PR TITLE
Make Datastore doctests use a namespace.

### DIFF
--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -504,56 +504,64 @@ class Client(ClientWithProject):
 
         .. testsetup:: query
 
-           from google.cloud import datastore
+            import os
+            import uuid
 
-           client = datastore.Client()
-           query = client.query(kind='_Doctest')
+            from google.cloud import datastore
 
-           def do_something(entity):
-               pass
+            unique = os.getenv('CIRCLE_BUILD_NUM', str(uuid.uuid4())[0:8])
+            client = datastore.Client(namespace='ns{}'.format(unique))
+            query = client.query(kind='_Doctest')
+
+            def do_something(entity):
+                pass
 
         .. doctest:: query
 
-           >>> query = client.query(kind='MyKind')
-           >>> query.add_filter('property', '=', 'val')
+            >>> query = client.query(kind='MyKind')
+            >>> query.add_filter('property', '=', 'val')
 
         Using the query iterator
 
         .. doctest:: query
 
-           >>> query_iter = query.fetch()
-           >>> for entity in query_iter:
-           ...     do_something(entity)
+            >>> query_iter = query.fetch()
+            >>> for entity in query_iter:
+            ...     do_something(entity)
 
         or manually page through results
 
         .. testsetup:: query-page
 
-           from google.cloud import datastore
-           from tests.system.test_system import Config  # system tests
+            import os
+            import uuid
 
-           client = datastore.Client()
+            from google.cloud import datastore
+            from tests.system.test_system import Config  # system tests
 
-           key = client.key('_Doctest')
-           entity1 = datastore.Entity(key=key)
-           entity1['foo'] = 1337
-           entity2 = datastore.Entity(key=key)
-           entity2['foo'] = 42
-           Config.TO_DELETE.extend([entity1, entity2])
-           client.put_multi([entity1, entity2])
+            unique = os.getenv('CIRCLE_BUILD_NUM', str(uuid.uuid4())[0:8])
+            client = datastore.Client(namespace='ns{}'.format(unique))
 
-           query = client.query(kind='_Doctest')
-           cursor = None
+            key = client.key('_Doctest')
+            entity1 = datastore.Entity(key=key)
+            entity1['foo'] = 1337
+            entity2 = datastore.Entity(key=key)
+            entity2['foo'] = 42
+            Config.TO_DELETE.extend([entity1, entity2])
+            client.put_multi([entity1, entity2])
+
+            query = client.query(kind='_Doctest')
+            cursor = None
 
         .. doctest:: query-page
 
-           >>> query_iter = query.fetch(start_cursor=cursor)
-           >>> pages = query_iter.pages
-           >>>
-           >>> first_page = next(pages)
-           >>> first_page_entities = list(first_page)
-           >>> query_iter.next_page_token
-           b'...'
+            >>> query_iter = query.fetch(start_cursor=cursor)
+            >>> pages = query_iter.pages
+            >>>
+            >>> first_page = next(pages)
+            >>> first_page_entities = list(first_page)
+            >>> query_iter.next_page_token
+            b'...'
 
         :type kwargs: dict
         :param kwargs: Parameters for initializing and instance of

--- a/datastore/google/cloud/datastore/entity.py
+++ b/datastore/google/cloud/datastore/entity.py
@@ -42,29 +42,33 @@ class Entity(dict):
 
     .. testsetup:: entity-ctor
 
-       from google.cloud import datastore
-       from tests.system.test_system import Config  # system tests
+        import os
+        import uuid
 
-       client = datastore.Client()
-       key = client.key('EntityKind', 1234, namespace='_Doctest')
-       entity = datastore.Entity(key=key)
-       entity['property'] = 'value'
-       Config.TO_DELETE.append(entity)
+        from google.cloud import datastore
+        from tests.system.test_system import Config  # system tests
 
-       client.put(entity)
+        unique = os.getenv('CIRCLE_BUILD_NUM', str(uuid.uuid4())[0:8])
+        client = datastore.Client(namespace='ns{}'.format(unique))
+        key = client.key('EntityKind', 1234, namespace='_Doctest')
+        entity = datastore.Entity(key=key)
+        entity['property'] = 'value'
+        Config.TO_DELETE.append(entity)
+
+        client.put(entity)
 
     .. doctest:: entity-ctor
 
-       >>> client.get(key)
-       <Entity('EntityKind', 1234) {'property': 'value'}>
+        >>> client.get(key)
+        <Entity('EntityKind', 1234) {'property': 'value'}>
 
     You can the set values on the entity just like you would on any
     other dictionary.
 
     .. doctest:: entity-ctor
 
-       >>> entity['age'] = 20
-       >>> entity['name'] = 'JJ'
+        >>> entity['age'] = 20
+        >>> entity['name'] = 'JJ'
 
     However, not all types are allowed as a value for a Google Cloud Datastore
     entity. The following basic types are supported by the API:


### PR DESCRIPTION
Fixes #3232.

Running `nox -s doctests` passes locally (I expect CI will not check it until post-merge):

```
$ nox -s doctests
nox > Running session doctests
nox > The virtualenv name was hashed to avoid being too long.
nox > virtualenv /usr/local/google/home/lukesneeringer/Code/Google/google-cloud-python/datastore/.nox/765eb60c -p python3.6
nox > chdir /usr/local/google/home/lukesneeringer/Code/Google/google-cloud-python/datastore
nox > pip install --upgrade mock pytest sphinx ../core/
nox > pip install --upgrade ../test_utils/
nox > pip install --upgrade .
nox > py.test --quiet tests/doctests.py
.
1 passed in 12.24 seconds
nox > Session doctests successful. :)
```