### PR TITLE
Rename job classes

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -19,7 +19,7 @@ from google.cloud.client import ClientWithProject
 from google.cloud.bigquery._http import Connection
 from google.cloud.bigquery.dataset import Dataset
 from google.cloud.bigquery.job import CopyJob
-from google.cloud.bigquery.job import ExtractTableToStorageJob
+from google.cloud.bigquery.job import ExtractJob
 from google.cloud.bigquery.job import LoadJob
 from google.cloud.bigquery.job import QueryJob
 from google.cloud.bigquery.query import QueryResults
@@ -171,7 +171,7 @@ class Client(ClientWithProject):
         :rtype: One of:
                 :class:`google.cloud.bigquery.job.LoadJob`,
                 :class:`google.cloud.bigquery.job.CopyJob`,
-                :class:`google.cloud.bigquery.job.ExtractTableToStorageJob`,
+                :class:`google.cloud.bigquery.job.ExtractJob`,
                 :class:`google.cloud.bigquery.job.QueryJob`,
                 :class:`google.cloud.bigquery.job.RunSyncQueryJob`
         :returns: the job instance, constructed via the resource
@@ -182,7 +182,7 @@ class Client(ClientWithProject):
         elif 'copy' in config:
             return CopyJob.from_api_repr(resource, self)
         elif 'extract' in config:
-            return ExtractTableToStorageJob.from_api_repr(resource, self)
+            return ExtractJob.from_api_repr(resource, self)
         elif 'query' in config:
             return QueryJob.from_api_repr(resource, self)
         raise ValueError('Cannot parse job resource')
@@ -295,11 +295,10 @@ class Client(ClientWithProject):
                                  table data is to be extracted; in format
                                  ``gs://<bucket_name>/<object_name_or_glob>``.
 
-        :rtype: :class:`google.cloud.bigquery.job.ExtractTableToStorageJob`
-        :returns: a new ``ExtractTableToStorageJob`` instance
+        :rtype: :class:`google.cloud.bigquery.job.ExtractJob`
+        :returns: a new ``ExtractJob`` instance
         """
-        return ExtractTableToStorageJob(job_name, source, destination_uris,
-                                        client=self)
+        return ExtractJob(job_name, source, destination_uris, client=self)
 
     def run_async_query(self, job_name, query,
                         udf_resources=(), query_parameters=()):

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -20,7 +20,7 @@ from google.cloud.bigquery._http import Connection
 from google.cloud.bigquery.dataset import Dataset
 from google.cloud.bigquery.job import CopyJob
 from google.cloud.bigquery.job import ExtractTableToStorageJob
-from google.cloud.bigquery.job import LoadTableFromStorageJob
+from google.cloud.bigquery.job import LoadJob
 from google.cloud.bigquery.job import QueryJob
 from google.cloud.bigquery.query import QueryResults
 
@@ -169,7 +169,7 @@ class Client(ClientWithProject):
         :param resource: one job resource from API response
 
         :rtype: One of:
-                :class:`google.cloud.bigquery.job.LoadTableFromStorageJob`,
+                :class:`google.cloud.bigquery.job.LoadJob`,
                 :class:`google.cloud.bigquery.job.CopyJob`,
                 :class:`google.cloud.bigquery.job.ExtractTableToStorageJob`,
                 :class:`google.cloud.bigquery.job.QueryJob`,
@@ -178,7 +178,7 @@ class Client(ClientWithProject):
         """
         config = resource['configuration']
         if 'load' in config:
-            return LoadTableFromStorageJob.from_api_repr(resource, self)
+            return LoadJob.from_api_repr(resource, self)
         elif 'copy' in config:
             return CopyJob.from_api_repr(resource, self)
         elif 'extract' in config:
@@ -253,11 +253,10 @@ class Client(ClientWithProject):
         :param source_uris: URIs of data files to be loaded; in format
                             ``gs://<bucket_name>/<object_name_or_glob>``.
 
-        :rtype: :class:`google.cloud.bigquery.job.LoadTableFromStorageJob`
-        :returns: a new ``LoadTableFromStorageJob`` instance
+        :rtype: :class:`google.cloud.bigquery.job.LoadJob`
+        :returns: a new ``LoadJob`` instance
         """
-        return LoadTableFromStorageJob(job_name, destination, source_uris,
-                                       client=self)
+        return LoadJob(job_name, destination, source_uris, client=self)
 
     def copy_table(self, job_name, destination, *sources):
         """Construct a job for copying one or more tables into another table.

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -525,8 +525,8 @@ class _LoadConfiguration(object):
     _write_disposition = None
 
 
-class LoadTableFromStorageJob(_AsyncJob):
-    """Asynchronous job for loading data into a table from CloudStorage.
+class LoadJob(_AsyncJob):
+    """Asynchronous job for loading data into a table from remote URI.
 
     :type name: str
     :param name: the name of the job
@@ -535,8 +535,10 @@ class LoadTableFromStorageJob(_AsyncJob):
     :param destination: Table into which data is to be loaded.
 
     :type source_uris: sequence of string
-    :param source_uris: URIs of one or more data files to be loaded, in
-                        format ``gs://<bucket_name>/<object_name_or_glob>``.
+    :param source_uris:
+        URIs of one or more data files to be loaded.  See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.sourceUris
+        for supported URI formats.
 
     :type client: :class:`google.cloud.bigquery.client.Client`
     :param client: A client which holds credentials and project configuration
@@ -550,7 +552,7 @@ class LoadTableFromStorageJob(_AsyncJob):
     _JOB_TYPE = 'load'
 
     def __init__(self, name, destination, source_uris, client, schema=()):
-        super(LoadTableFromStorageJob, self).__init__(name, client)
+        super(LoadJob, self).__init__(name, client)
         self.destination = destination
         self.source_uris = source_uris
         self._configuration = _LoadConfiguration()
@@ -775,7 +777,7 @@ class LoadTableFromStorageJob(_AsyncJob):
         :param client: Client which holds credentials and project
                        configuration for the dataset.
 
-        :rtype: :class:`google.cloud.bigquery.job.LoadTableFromStorageJob`
+        :rtype: :class:`google.cloud.bigquery.job.LoadJob`
         :returns: Job parsed from ``resource``.
         """
         name, config = cls._get_resource_config(resource)

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -921,7 +921,7 @@ class _ExtractConfiguration(object):
     _print_header = None
 
 
-class ExtractTableToStorageJob(_AsyncJob):
+class ExtractJob(_AsyncJob):
     """Asynchronous job: extract data from a table into Cloud Storage.
 
     :type name: str
@@ -942,7 +942,7 @@ class ExtractTableToStorageJob(_AsyncJob):
     _JOB_TYPE = 'extract'
 
     def __init__(self, name, source, destination_uris, client):
-        super(ExtractTableToStorageJob, self).__init__(name, client)
+        super(ExtractJob, self).__init__(name, client)
         self.source = source
         self.destination_uris = destination_uris
         self._configuration = _ExtractConfiguration()
@@ -1020,7 +1020,7 @@ class ExtractTableToStorageJob(_AsyncJob):
         :param client: Client which holds credentials and project
                        configuration for the dataset.
 
-        :rtype: :class:`google.cloud.bigquery.job.ExtractTableToStorageJob`
+        :rtype: :class:`google.cloud.bigquery.job.ExtractJob`
         :returns: Job parsed from ``resource``.
         """
         name, config = cls._get_resource_config(resource)

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1120,7 +1120,7 @@ class Table(object):
         :type null_marker: str
         :param null_marker: Optional. A custom null marker (example: "\\N")
 
-        :rtype: :class:`~google.cloud.bigquery.jobs.LoadTableFromStorageJob`
+        :rtype: :class:`~google.cloud.bigquery.jobs.LoadJob`
 
         :returns: the job instance used to load the data (e.g., for
                   querying status). Note that the job is already started:

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -212,7 +212,7 @@ class TestClient(unittest.TestCase):
         import six
         from google.cloud.bigquery.job import LoadJob
         from google.cloud.bigquery.job import CopyJob
-        from google.cloud.bigquery.job import ExtractTableToStorageJob
+        from google.cloud.bigquery.job import ExtractJob
         from google.cloud.bigquery.job import QueryJob
 
         PROJECT = 'PROJECT'
@@ -225,7 +225,7 @@ class TestClient(unittest.TestCase):
         JOB_TYPES = {
             'load_job': LoadJob,
             'copy_job': CopyJob,
-            'extract_job': ExtractTableToStorageJob,
+            'extract_job': ExtractJob,
             'query_job': QueryJob,
         }
         PATH = 'projects/%s/jobs' % PROJECT
@@ -470,7 +470,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(job.destination, destination)
 
     def test_extract_table_to_storage(self):
-        from google.cloud.bigquery.job import ExtractTableToStorageJob
+        from google.cloud.bigquery.job import ExtractJob
 
         PROJECT = 'PROJECT'
         JOB = 'job_name'
@@ -483,7 +483,7 @@ class TestClient(unittest.TestCase):
         dataset = client.dataset(DATASET)
         source = dataset.table(SOURCE)
         job = client.extract_table_to_storage(JOB, source, DESTINATION)
-        self.assertIsInstance(job, ExtractTableToStorageJob)
+        self.assertIsInstance(job, ExtractJob)
         self.assertIs(job._client, client)
         self.assertEqual(job.name, JOB)
         self.assertEqual(job.source, source)

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -210,7 +210,7 @@ class TestClient(unittest.TestCase):
 
     def test_list_jobs_defaults(self):
         import six
-        from google.cloud.bigquery.job import LoadTableFromStorageJob
+        from google.cloud.bigquery.job import LoadJob
         from google.cloud.bigquery.job import CopyJob
         from google.cloud.bigquery.job import ExtractTableToStorageJob
         from google.cloud.bigquery.job import QueryJob
@@ -223,7 +223,7 @@ class TestClient(unittest.TestCase):
         SOURCE_URI = 'gs://test_bucket/src_object*'
         DESTINATION_URI = 'gs://test_bucket/dst_object*'
         JOB_TYPES = {
-            'load_job': LoadTableFromStorageJob,
+            'load_job': LoadJob,
             'copy_job': CopyJob,
             'extract_job': ExtractTableToStorageJob,
             'query_job': QueryJob,
@@ -342,13 +342,13 @@ class TestClient(unittest.TestCase):
 
     def test_list_jobs_load_job_wo_sourceUris(self):
         import six
-        from google.cloud.bigquery.job import LoadTableFromStorageJob
+        from google.cloud.bigquery.job import LoadJob
 
         PROJECT = 'PROJECT'
         DATASET = 'test_dataset'
         SOURCE_TABLE = 'source_table'
         JOB_TYPES = {
-            'load_job': LoadTableFromStorageJob,
+            'load_job': LoadJob,
         }
         PATH = 'projects/%s/jobs' % PROJECT
         TOKEN = 'TOKEN'
@@ -429,7 +429,7 @@ class TestClient(unittest.TestCase):
                           'stateFilter': 'done'})
 
     def test_load_table_from_storage(self):
-        from google.cloud.bigquery.job import LoadTableFromStorageJob
+        from google.cloud.bigquery.job import LoadJob
 
         PROJECT = 'PROJECT'
         JOB = 'job_name'
@@ -442,7 +442,7 @@ class TestClient(unittest.TestCase):
         dataset = client.dataset(DATASET)
         destination = dataset.table(DESTINATION)
         job = client.load_table_from_storage(JOB, destination, SOURCE_URI)
-        self.assertIsInstance(job, LoadTableFromStorageJob)
+        self.assertIsInstance(job, LoadJob)
         self.assertIs(job._client, client)
         self.assertEqual(job.name, JOB)
         self.assertEqual(list(job.source_uris), [SOURCE_URI])

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -143,24 +143,24 @@ class _Base(object):
             self.assertIsNone(job.user_email)
 
 
-class TestLoadTableFromStorageJob(unittest.TestCase, _Base):
+class TestLoadJob(unittest.TestCase, _Base):
     JOB_TYPE = 'load'
 
     @staticmethod
     def _get_target_class():
-        from google.cloud.bigquery.job import LoadTableFromStorageJob
+        from google.cloud.bigquery.job import LoadJob
 
-        return LoadTableFromStorageJob
+        return LoadJob
 
     def _setUpConstants(self):
-        super(TestLoadTableFromStorageJob, self)._setUpConstants()
+        super(TestLoadJob, self)._setUpConstants()
         self.INPUT_FILES = 2
         self.INPUT_BYTES = 12345
         self.OUTPUT_BYTES = 23456
         self.OUTPUT_ROWS = 345
 
     def _makeResource(self, started=False, ended=False):
-        resource = super(TestLoadTableFromStorageJob, self)._makeResource(
+        resource = super(TestLoadJob, self)._makeResource(
             started, ended)
         config = resource['configuration']['load']
         config['sourceUris'] = [self.SOURCE1]
@@ -2098,15 +2098,15 @@ class _Table(object):
     def name(self):
         if self._name is not None:
             return self._name
-        return TestLoadTableFromStorageJob.TABLE_NAME
+        return TestLoadJob.TABLE_NAME
 
     @property
     def project(self):
-        return TestLoadTableFromStorageJob.PROJECT
+        return TestLoadJob.PROJECT
 
     @property
     def dataset_name(self):
-        return TestLoadTableFromStorageJob.DS_NAME
+        return TestLoadJob.DS_NAME
 
 
 class _Connection(object):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1110,19 +1110,19 @@ class TestCopyJob(unittest.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
 
-class TestExtractTableToStorageJob(unittest.TestCase, _Base):
+class TestExtractJob(unittest.TestCase, _Base):
     JOB_TYPE = 'extract'
     SOURCE_TABLE = 'source_table'
     DESTINATION_URI = 'gs://bucket_name/object_name'
 
     @staticmethod
     def _get_target_class():
-        from google.cloud.bigquery.job import ExtractTableToStorageJob
+        from google.cloud.bigquery.job import ExtractJob
 
-        return ExtractTableToStorageJob
+        return ExtractJob
 
     def _makeResource(self, started=False, ended=False):
-        resource = super(TestExtractTableToStorageJob, self)._makeResource(
+        resource = super(TestExtractJob, self)._makeResource(
             started, ended)
         config = resource['configuration']['extract']
         config['sourceTable'] = {


### PR DESCRIPTION
- Rename class: `jobs.LoadTableFromStorageJob` -> `jobs.LoadJob`.
- Rename class: `jobs.ExtractTableToStorageJob` -> `jobs.ExtractJob`.

