### PR TITLE
Add new scalar statistics properties to 'QueryJob'

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1299,6 +1299,19 @@ class QueryJob(_AsyncJob):
         plan_entries = self._job_statistics().get('queryPlan', ())
         return [QueryPlanEntry.from_api_repr(entry) for entry in plan_entries]
 
+    @property
+    def total_bytes_processed(self):
+        """Return total bytes processed from job statistics, if present.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#statistics.query.totalBytesProcessed
+
+        :rtype: int or None
+        :returns: total bytes processed by the job, or None if job is not
+                  yet complete.
+        """
+        return self._job_statistics().get('totalBytesProcessed')
+
     def query_results(self):
         """Construct a QueryResults instance, bound to this job.
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1364,6 +1364,19 @@ class QueryJob(_AsyncJob):
         """
         return self._job_statistics().get('numDmlAffectedRows')
 
+    @property
+    def statement_type(self):
+        """Return statement type from job statistics, if present.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#statistics.query.statementType
+
+        :rtype: str or None
+        :returns: type of statement used by the job, or None if job is not
+                  yet complete.
+        """
+        return self._job_statistics().get('statementType')
+
     def query_results(self):
         """Construct a QueryResults instance, bound to this job.
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1310,7 +1310,10 @@ class QueryJob(_AsyncJob):
         :returns: total bytes processed by the job, or None if job is not
                   yet complete.
         """
-        return self._job_statistics().get('totalBytesProcessed')
+        result = self._job_statistics().get('totalBytesProcessed')
+        if result is not None:
+            result = int(result)
+        return result
 
     @property
     def total_bytes_billed(self):
@@ -1323,7 +1326,10 @@ class QueryJob(_AsyncJob):
         :returns: total bytes processed by the job, or None if job is not
                   yet complete.
         """
-        return self._job_statistics().get('totalBytesBilled')
+        result = self._job_statistics().get('totalBytesBilled')
+        if result is not None:
+            result = int(result)
+        return result
 
     @property
     def billing_tier(self):
@@ -1362,7 +1368,10 @@ class QueryJob(_AsyncJob):
         :returns: number of DML rows affectd by the job, or None if job is not
                   yet complete.
         """
-        return self._job_statistics().get('numDmlAffectedRows')
+        result = self._job_statistics().get('numDmlAffectedRows')
+        if result is not None:
+            result = int(result)
+        return result
 
     @property
     def statement_type(self):

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1338,6 +1338,19 @@ class QueryJob(_AsyncJob):
         """
         return self._job_statistics().get('billingTier')
 
+    @property
+    def cache_hit(self):
+        """Return billing tier from job statistics, if present.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#statistics.query.cacheHit
+
+        :rtype: bool or None
+        :returns: whether the query results were returned from cache, or None
+                  if job is not yet complete.
+        """
+        return self._job_statistics().get('cacheHit')
+
     def query_results(self):
         """Construct a QueryResults instance, bound to this job.
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1325,6 +1325,19 @@ class QueryJob(_AsyncJob):
         """
         return self._job_statistics().get('totalBytesBilled')
 
+    @property
+    def billing_tier(self):
+        """Return billing tier from job statistics, if present.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#statistics.query.billingTier
+
+        :rtype: int or None
+        :returns: billing tier used by the job, or None if job is not
+                  yet complete.
+        """
+        return self._job_statistics().get('billingTier')
+
     def query_results(self):
         """Construct a QueryResults instance, bound to this job.
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1312,6 +1312,19 @@ class QueryJob(_AsyncJob):
         """
         return self._job_statistics().get('totalBytesProcessed')
 
+    @property
+    def total_bytes_billed(self):
+        """Return total bytes billed from job statistics, if present.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#statistics.query.totalBytesBilled
+
+        :rtype: int or None
+        :returns: total bytes processed by the job, or None if job is not
+                  yet complete.
+        """
+        return self._job_statistics().get('totalBytesBilled')
+
     def query_results(self):
         """Construct a QueryResults instance, bound to this job.
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1351,6 +1351,19 @@ class QueryJob(_AsyncJob):
         """
         return self._job_statistics().get('cacheHit')
 
+    @property
+    def num_dml_affected_rows(self):
+        """Return total bytes billed from job statistics, if present.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#statistics.query.numDmlAffectedRows
+
+        :rtype: int or None
+        :returns: number of DML rows affectd by the job, or None if job is not
+                  yet complete.
+        """
+        return self._job_statistics().get('numDmlAffectedRows')
+
     def query_results(self):
         """Construct a QueryResults instance, bound to this job.
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1775,7 +1775,22 @@ class TestQueryJob(unittest.TestCase, _Base):
 
         query_stats['numDmlAffectedRows'] = num_rows
         self.assertEqual(job.num_dml_affected_rows, num_rows)
-    
+
+    def test_statement_type(self):
+        statement_type = 'SELECT'
+        client = _Client(self.PROJECT)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client)
+        self.assertIsNone(job.statement_type)
+
+        statistics = job._properties['statistics'] = {}
+        self.assertIsNone(job.statement_type)
+
+        query_stats = statistics['query'] = {}
+        self.assertIsNone(job.statement_type)
+
+        query_stats['statementType'] = statement_type
+        self.assertEqual(job.statement_type, statement_type)
+
     def test_query_results(self):
         from google.cloud.bigquery.query import QueryResults
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1747,6 +1747,20 @@ class TestQueryJob(unittest.TestCase, _Base):
         query_stats['billingTier'] = billing_tier
         self.assertEqual(job.billing_tier, billing_tier)
 
+    def test_cache_hit(self):
+        client = _Client(self.PROJECT)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client)
+        self.assertIsNone(job.cache_hit)
+
+        statistics = job._properties['statistics'] = {}
+        self.assertIsNone(job.cache_hit)
+
+        query_stats = statistics['query'] = {}
+        self.assertIsNone(job.cache_hit)
+
+        query_stats['cacheHit'] = True
+        self.assertTrue(job.cache_hit)
+
     def test_query_results(self):
         from google.cloud.bigquery.query import QueryResults
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1714,7 +1714,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         query_stats = statistics['query'] = {}
         self.assertIsNone(job.total_bytes_processed)
 
-        query_stats['totalBytesProcessed'] = total_bytes
+        query_stats['totalBytesProcessed'] = str(total_bytes)
         self.assertEqual(job.total_bytes_processed, total_bytes)
 
     def test_total_bytes_billed(self):
@@ -1729,7 +1729,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         query_stats = statistics['query'] = {}
         self.assertIsNone(job.total_bytes_billed)
 
-        query_stats['totalBytesBilled'] = total_bytes
+        query_stats['totalBytesBilled'] = str(total_bytes)
         self.assertEqual(job.total_bytes_billed, total_bytes)
 
     def test_billing_tier(self):
@@ -1773,7 +1773,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         query_stats = statistics['query'] = {}
         self.assertIsNone(job.num_dml_affected_rows)
 
-        query_stats['numDmlAffectedRows'] = num_rows
+        query_stats['numDmlAffectedRows'] = str(num_rows)
         self.assertEqual(job.num_dml_affected_rows, num_rows)
 
     def test_statement_type(self):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1761,6 +1761,21 @@ class TestQueryJob(unittest.TestCase, _Base):
         query_stats['cacheHit'] = True
         self.assertTrue(job.cache_hit)
 
+    def test_num_dml_affected_rows(self):
+        num_rows = 1234
+        client = _Client(self.PROJECT)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client)
+        self.assertIsNone(job.num_dml_affected_rows)
+
+        statistics = job._properties['statistics'] = {}
+        self.assertIsNone(job.num_dml_affected_rows)
+
+        query_stats = statistics['query'] = {}
+        self.assertIsNone(job.num_dml_affected_rows)
+
+        query_stats['numDmlAffectedRows'] = num_rows
+        self.assertEqual(job.num_dml_affected_rows, num_rows)
+    
     def test_query_results(self):
         from google.cloud.bigquery.query import QueryResults
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1732,6 +1732,21 @@ class TestQueryJob(unittest.TestCase, _Base):
         query_stats['totalBytesBilled'] = total_bytes
         self.assertEqual(job.total_bytes_billed, total_bytes)
 
+    def test_billing_tier(self):
+        billing_tier = 1
+        client = _Client(self.PROJECT)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client)
+        self.assertIsNone(job.billing_tier)
+
+        statistics = job._properties['statistics'] = {}
+        self.assertIsNone(job.billing_tier)
+
+        query_stats = statistics['query'] = {}
+        self.assertIsNone(job.billing_tier)
+
+        query_stats['billingTier'] = billing_tier
+        self.assertEqual(job.billing_tier, billing_tier)
+
     def test_query_results(self):
         from google.cloud.bigquery.query import QueryResults
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1702,6 +1702,21 @@ class TestQueryJob(unittest.TestCase, _Base):
                 self.assertEqual(f_step.kind, e_step['kind'])
                 self.assertEqual(f_step.substeps, e_step['substeps'])
 
+    def test_total_bytes_processed(self):
+        total_bytes = 1234
+        client = _Client(self.PROJECT)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client)
+        self.assertIsNone(job.total_bytes_processed)
+
+        statistics = job._properties['statistics'] = {}
+        self.assertIsNone(job.total_bytes_processed)
+
+        query_stats = statistics['query'] = {}
+        self.assertIsNone(job.total_bytes_processed)
+
+        query_stats['totalBytesProcessed'] = total_bytes
+        self.assertEqual(job.total_bytes_processed, total_bytes)
+
     def test_query_results(self):
         from google.cloud.bigquery.query import QueryResults
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1717,6 +1717,21 @@ class TestQueryJob(unittest.TestCase, _Base):
         query_stats['totalBytesProcessed'] = total_bytes
         self.assertEqual(job.total_bytes_processed, total_bytes)
 
+    def test_total_bytes_billed(self):
+        total_bytes = 1234
+        client = _Client(self.PROJECT)
+        job = self._make_one(self.JOB_NAME, self.QUERY, client)
+        self.assertIsNone(job.total_bytes_billed)
+
+        statistics = job._properties['statistics'] = {}
+        self.assertIsNone(job.total_bytes_billed)
+
+        query_stats = statistics['query'] = {}
+        self.assertIsNone(job.total_bytes_billed)
+
+        query_stats['totalBytesBilled'] = total_bytes
+        self.assertEqual(job.total_bytes_billed, total_bytes)
+
     def test_query_results(self):
         from google.cloud.bigquery.query import QueryResults
 


### PR DESCRIPTION
- `total_bytes_processed`
- `total_bytes_billed`
- `billing_tier`
- `cache_hit`
- `num_dml_affected_rows`
- `statement_type`

~~Uses #3799 as a base.~~

Cherry-picked / fixed up from PR #3721.
