### PR TITLE
Add 'Client.get_job' API wrapper.

### DIFF
--- a/bigquery/.coveragerc
+++ b/bigquery/.coveragerc
@@ -9,3 +9,5 @@ exclude_lines =
     pragma: NO COVER
     # Ignore debug-only repr
     def __repr__
+    # Ignore abstract methods
+    raise NotImplementedError

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -662,6 +662,18 @@ class StructQueryParameter(AbstractQueryParameter):
         return resource
 
 
+def _query_param_from_api_repr(resource):
+    """Helper:  construct concrete query parameter from JSON resource."""
+    qp_type = resource['parameterType']
+    if 'arrayType' in qp_type:
+        klass = ArrayQueryParameter
+    elif 'structTypes' in qp_type:
+        klass = StructQueryParameter
+    else:
+        klass = ScalarQueryParameter
+    return klass.from_api_repr(resource)
+
+
 class QueryParametersProperty(object):
     """Custom property type, holding query parameter instances."""
 

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -299,6 +299,8 @@ class _TypedProperty(_ConfigurationProperty):
 
         :raises: ValueError on a type mismatch.
         """
+        if value is None:
+            return
         if not isinstance(value, self.property_type):
             raise ValueError('Required type: %s' % (self.property_type,))
 
@@ -396,6 +398,14 @@ class ScalarQueryParameter(AbstractQueryParameter):
         self.type_ = type_
         self.value = value
 
+    def __eq__(self, other):
+        if not isinstance(other, ScalarQueryParameter):
+            return NotImplemented
+        return(
+            self.name == other.name and
+            self.type_ == other.type_ and
+            self.value == other.value)
+
     @classmethod
     def positional(cls, type_, value):
         """Factory for positional paramater.
@@ -472,6 +482,14 @@ class ArrayQueryParameter(AbstractQueryParameter):
         self.name = name
         self.array_type = array_type
         self.values = values
+
+    def __eq__(self, other):
+        if not isinstance(other, ArrayQueryParameter):
+            return NotImplemented
+        return(
+            self.name == other.name and
+            self.array_type == other.array_type and
+            self.values == other.values)
 
     @classmethod
     def positional(cls, array_type, values):
@@ -565,6 +583,14 @@ class StructQueryParameter(AbstractQueryParameter):
             else:
                 types[sub.name] = sub.type_
                 values[sub.name] = sub.value
+
+    def __eq__(self, other):
+        if not isinstance(other, StructQueryParameter):
+            return NotImplemented
+        return(
+            self.name == other.name and
+            self.struct_types == other.struct_types and
+            self.struct_values == other.struct_values)
 
     @classmethod
     def positional(cls, *sub_params):

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -187,6 +187,35 @@ class Client(ClientWithProject):
             return QueryJob.from_api_repr(resource, self)
         raise ValueError('Cannot parse job resource')
 
+    def get_job(self, job_name, project=None):
+        """Fetch a job for the project associated with this client.
+
+        See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/get
+
+        :type job_name: str
+        :param job_name: Name of the job.
+
+        :type project: str
+        :param project:
+            project ID owning the job (defaults to the client's project)
+
+        :rtype: :class:`~google.cloud.bigquery.job._AsyncJob`
+        :returns:
+            Concrete job instance, based on the resource returned by the API.
+        """
+        extra_params = {'projection': 'full'}
+
+        if project is None:
+            project = self.project
+
+        path = '/projects/{}/jobs/{}'.format(project, job_name)
+
+        resource = self._connection.api_request(
+            method='GET', path=path, query_params=extra_params)
+
+        return self.job_from_resource(resource)
+
     def list_jobs(self, max_results=None, page_token=None, all_users=None,
                   state_filter=None):
         """List jobs for the project associated with this client.

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -187,14 +187,14 @@ class Client(ClientWithProject):
             return QueryJob.from_api_repr(resource, self)
         raise ValueError('Cannot parse job resource')
 
-    def get_job(self, job_name, project=None):
+    def get_job(self, job_id, project=None):
         """Fetch a job for the project associated with this client.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/get
 
-        :type job_name: str
-        :param job_name: Name of the job.
+        :type job_id: str
+        :param job_id: Name of the job.
 
         :type project: str
         :param project:
@@ -209,7 +209,7 @@ class Client(ClientWithProject):
         if project is None:
             project = self.project
 
-        path = '/projects/{}/jobs/{}'.format(project, job_name)
+        path = '/projects/{}/jobs/{}'.format(project, job_id)
 
         resource = self._connection.api_request(
             method='GET', path=path, query_params=extra_params)
@@ -266,14 +266,14 @@ class Client(ClientWithProject):
             max_results=max_results,
             extra_params=extra_params)
 
-    def load_table_from_storage(self, job_name, destination, *source_uris):
+    def load_table_from_storage(self, job_id, destination, *source_uris):
         """Construct a job for loading data into a table from CloudStorage.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
 
-        :type job_name: str
-        :param job_name: Name of the job.
+        :type job_id: str
+        :param job_id: Name of the job.
 
         :type destination: :class:`google.cloud.bigquery.table.Table`
         :param destination: Table into which data is to be loaded.
@@ -285,16 +285,16 @@ class Client(ClientWithProject):
         :rtype: :class:`google.cloud.bigquery.job.LoadJob`
         :returns: a new ``LoadJob`` instance
         """
-        return LoadJob(job_name, destination, source_uris, client=self)
+        return LoadJob(job_id, destination, source_uris, client=self)
 
-    def copy_table(self, job_name, destination, *sources):
+    def copy_table(self, job_id, destination, *sources):
         """Construct a job for copying one or more tables into another table.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy
 
-        :type job_name: str
-        :param job_name: Name of the job.
+        :type job_id: str
+        :param job_id: Name of the job.
 
         :type destination: :class:`google.cloud.bigquery.table.Table`
         :param destination: Table into which data is to be copied.
@@ -305,16 +305,16 @@ class Client(ClientWithProject):
         :rtype: :class:`google.cloud.bigquery.job.CopyJob`
         :returns: a new ``CopyJob`` instance
         """
-        return CopyJob(job_name, destination, sources, client=self)
+        return CopyJob(job_id, destination, sources, client=self)
 
-    def extract_table_to_storage(self, job_name, source, *destination_uris):
+    def extract_table_to_storage(self, job_id, source, *destination_uris):
         """Construct a job for extracting a table into Cloud Storage files.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.extract
 
-        :type job_name: str
-        :param job_name: Name of the job.
+        :type job_id: str
+        :param job_id: Name of the job.
 
         :type source: :class:`google.cloud.bigquery.table.Table`
         :param source: table to be extracted.
@@ -327,17 +327,17 @@ class Client(ClientWithProject):
         :rtype: :class:`google.cloud.bigquery.job.ExtractJob`
         :returns: a new ``ExtractJob`` instance
         """
-        return ExtractJob(job_name, source, destination_uris, client=self)
+        return ExtractJob(job_id, source, destination_uris, client=self)
 
-    def run_async_query(self, job_name, query,
+    def run_async_query(self, job_id, query,
                         udf_resources=(), query_parameters=()):
         """Construct a job for running a SQL query asynchronously.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query
 
-        :type job_name: str
-        :param job_name: Name of the job.
+        :type job_id: str
+        :param job_id: Name of the job.
 
         :type query: str
         :param query: SQL query to be executed
@@ -356,7 +356,7 @@ class Client(ClientWithProject):
         :rtype: :class:`google.cloud.bigquery.job.QueryJob`
         :returns: a new ``QueryJob`` instance
         """
-        return QueryJob(job_name, query, client=self,
+        return QueryJob(job_id, query, client=self,
                         udf_resources=udf_resources,
                         query_parameters=query_parameters)
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -755,7 +755,7 @@ class LoadJob(_AsyncJob):
         if self.quote_character is not None:
             configuration['quote'] = self.quote_character
         if self.skip_leading_rows is not None:
-            configuration['skipLeadingRows'] = self.skip_leading_rows
+            configuration['skipLeadingRows'] = str(self.skip_leading_rows)
         if self.source_format is not None:
             configuration['sourceFormat'] = self.source_format
         if self.write_disposition is not None:

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -28,7 +28,10 @@ from google.cloud.bigquery.schema import SchemaField
 from google.cloud.bigquery.table import Table
 from google.cloud.bigquery.table import _build_schema_resource
 from google.cloud.bigquery.table import _parse_schema_resource
+from google.cloud.bigquery._helpers import ArrayQueryParameter
 from google.cloud.bigquery._helpers import QueryParametersProperty
+from google.cloud.bigquery._helpers import ScalarQueryParameter
+from google.cloud.bigquery._helpers import StructQueryParameter
 from google.cloud.bigquery._helpers import UDFResource
 from google.cloud.bigquery._helpers import UDFResourcesProperty
 from google.cloud.bigquery._helpers import _EnumProperty

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -28,10 +28,7 @@ from google.cloud.bigquery.schema import SchemaField
 from google.cloud.bigquery.table import Table
 from google.cloud.bigquery.table import _build_schema_resource
 from google.cloud.bigquery.table import _parse_schema_resource
-from google.cloud.bigquery._helpers import ArrayQueryParameter
 from google.cloud.bigquery._helpers import QueryParametersProperty
-from google.cloud.bigquery._helpers import ScalarQueryParameter
-from google.cloud.bigquery._helpers import StructQueryParameter
 from google.cloud.bigquery._helpers import UDFResource
 from google.cloud.bigquery._helpers import UDFResourcesProperty
 from google.cloud.bigquery._helpers import _EnumProperty

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1266,7 +1266,8 @@ class QueryJob(_AsyncJob):
         if self.maximum_billing_tier is not None:
             configuration['maximumBillingTier'] = self.maximum_billing_tier
         if self.maximum_bytes_billed is not None:
-            configuration['maximumBytesBilled'] = self.maximum_bytes_billed
+            configuration['maximumBytesBilled'] = str(
+                self.maximum_bytes_billed)
         if len(self._udf_resources) > 0:
             configuration[self._UDF_KEY] = [
                 {udf_resource.udf_type: udf_resource.value}
@@ -1332,7 +1333,8 @@ class QueryJob(_AsyncJob):
         self.priority = configuration.get('priority')
         self.write_disposition = configuration.get('writeDisposition')
         self.maximum_billing_tier = configuration.get('maximumBillingTier')
-        self.maximum_bytes_billed = configuration.get('maximumBytesBilled')
+        self.maximum_bytes_billed = _int_or_none(
+            configuration.get('maximumBytesBilled'))
 
         dest_remote = configuration.get('destinationTable')
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -32,8 +32,10 @@ from google.cloud.bigquery._helpers import ArrayQueryParameter
 from google.cloud.bigquery._helpers import QueryParametersProperty
 from google.cloud.bigquery._helpers import ScalarQueryParameter
 from google.cloud.bigquery._helpers import StructQueryParameter
+from google.cloud.bigquery._helpers import UDFResource
 from google.cloud.bigquery._helpers import UDFResourcesProperty
 from google.cloud.bigquery._helpers import _EnumProperty
+from google.cloud.bigquery._helpers import _query_param_from_api_repr
 from google.cloud.bigquery._helpers import _TypedProperty
 
 _DONE_STATE = 'DONE'
@@ -59,6 +61,22 @@ _ERROR_REASON_TO_EXCEPTION = {
     'stopped': http_client.OK,
     'tableUnavailable': http_client.BAD_REQUEST,
 }
+
+
+def _bool_or_none(value):
+    """Helper: deserialize boolean value from JSON string."""
+    if isinstance(value, bool):
+        return value
+    if value is not None:
+        return value.lower() in ['t', 'true', '1']
+
+
+def _int_or_none(value):
+    """Helper: deserialize int value from JSON string."""
+    if isinstance(value, int):
+        return value
+    if value is not None:
+        return int(value)
 
 
 def _error_result_to_exception(error_result):
@@ -311,6 +329,10 @@ class _AsyncJob(google.api.core.future.polling.PollingFuture):
         """Helper:  handle subclass properties in cleaned."""
         pass
 
+    def _copy_configuration_properties(self, configuration):
+        """Helper:  assign subclass configuration properties in cleaned."""
+        raise NotImplementedError("Abstract")
+
     def _set_properties(self, api_response):
         """Update properties from resource in body of ``api_response``
 
@@ -330,6 +352,8 @@ class _AsyncJob(google.api.core.future.polling.PollingFuture):
 
         self._properties.clear()
         self._properties.update(cleaned)
+        configuration = cleaned['configuration'][self._JOB_TYPE]
+        self._copy_configuration_properties(configuration)
 
         # For Future interface
         self._set_future_result()
@@ -769,6 +793,28 @@ class LoadJob(_AsyncJob):
         schema = cleaned.pop('schema', {'fields': ()})
         self.schema = _parse_schema_resource(schema)
 
+    def _copy_configuration_properties(self, configuration):
+        """Helper:  assign subclass configuration properties in cleaned."""
+        self.allow_jagged_rows = _bool_or_none(
+            configuration.get('allowJaggedRows'))
+        self.allow_quoted_newlines = _bool_or_none(
+            configuration.get('allowQuotedNewlines'))
+        self.autodetect = _bool_or_none(
+            configuration.get('autodetect'))
+        self.create_disposition = configuration.get('createDisposition')
+        self.encoding = configuration.get('encoding')
+        self.field_delimiter = configuration.get('fieldDelimiter')
+        self.ignore_unknown_values = _bool_or_none(
+            configuration.get('ignoreUnknownValues'))
+        self.max_bad_records = _int_or_none(
+            configuration.get('maxBadRecords'))
+        self.null_marker = configuration.get('nullMarker')
+        self.quote_character = configuration.get('quote')
+        self.skip_leading_rows = _int_or_none(
+            configuration.get('skipLeadingRows'))
+        self.source_format = configuration.get('sourceFormat')
+        self.write_disposition = configuration.get('writeDisposition')
+
     @classmethod
     def from_api_repr(cls, resource, client):
         """Factory:  construct a job given its API representation
@@ -878,6 +924,11 @@ class CopyJob(_AsyncJob):
         self._populate_config_resource(configuration)
 
         return resource
+
+    def _copy_configuration_properties(self, configuration):
+        """Helper:  assign subclass configuration properties in cleaned."""
+        self.create_disposition = configuration.get('createDisposition')
+        self.write_disposition = configuration.get('writeDisposition')
 
     @classmethod
     def from_api_repr(cls, resource, client):
@@ -1011,6 +1062,14 @@ class ExtractJob(_AsyncJob):
         self._populate_config_resource(configuration)
 
         return resource
+
+    def _copy_configuration_properties(self, configuration):
+        """Helper:  assign subclass configuration properties in cleaned."""
+        self.compression = configuration.get('compression')
+        self.destination_format = configuration.get('destinationFormat')
+        self.field_delimiter = configuration.get('fieldDelimiter')
+        self.print_header = _bool_or_none(
+            configuration.get('printHeader'))
 
     @classmethod
     def from_api_repr(cls, resource, client):
@@ -1257,6 +1316,24 @@ class QueryJob(_AsyncJob):
         configuration = cleaned['configuration']['query']
 
         self.query = configuration['query']
+
+    def _copy_configuration_properties(self, configuration):
+        """Helper:  assign subclass configuration properties in cleaned."""
+        self.allow_large_results = _bool_or_none(
+            configuration.get('allowLargeResults'))
+        self.flatten_results = _bool_or_none(
+            configuration.get('flattenResults'))
+        self.use_query_cache = _bool_or_none(
+            configuration.get('useQueryCache'))
+        self.use_legacy_sql = _bool_or_none(
+            configuration.get('useLegacySql'))
+
+        self.create_disposition = configuration.get('createDisposition')
+        self.priority = configuration.get('priority')
+        self.write_disposition = configuration.get('writeDisposition')
+        self.maximum_billing_tier = configuration.get('maximumBillingTier')
+        self.maximum_bytes_billed = configuration.get('maximumBytesBilled')
+
         dest_remote = configuration.get('destinationTable')
 
         if dest_remote is None:
@@ -1265,8 +1342,29 @@ class QueryJob(_AsyncJob):
         else:
             dest_local = self._destination_table_resource()
             if dest_remote != dest_local:
-                dataset = self._client.dataset(dest_remote['datasetId'])
+                project = dest_remote['projectId']
+                dataset = self._client.dataset(
+                    dest_remote['datasetId'], project=project)
                 self.destination = dataset.table(dest_remote['tableId'])
+
+        def_ds = configuration.get('defaultDataset')
+        if def_ds is None:
+            if self.default_dataset is not None:
+                del self.default_dataset
+        else:
+            project = def_ds['projectId']
+            self.default_dataset = self._client.dataset(def_ds['datasetId'])
+
+        udf_resources = []
+        for udf_mapping in configuration.get(self._UDF_KEY, ()):
+            key_val, = udf_mapping.items()
+            udf_resources.append(UDFResource(key_val[0], key_val[1]))
+        self._udf_resources = udf_resources
+
+        self._query_parameters = [
+            _query_param_from_api_repr(mapping)
+            for mapping in configuration.get(self._QUERY_PARAMETERS_KEY, ())
+        ]
 
     @classmethod
     def from_api_repr(cls, resource, client):

--- a/bigquery/tests/unit/test__helpers.py
+++ b/bigquery/tests/unit/test__helpers.py
@@ -1528,6 +1528,82 @@ class Test_StructQueryParameter(unittest.TestCase):
         self.assertEqual(param.to_api_repr(), EXPECTED)
 
 
+class Test__query_param_from_api_repr(unittest.TestCase):
+
+    @staticmethod
+    def _call_fut(resource):
+        from google.cloud.bigquery._helpers import _query_param_from_api_repr
+
+        return _query_param_from_api_repr(resource)
+
+    def test_w_scalar(self):
+        from google.cloud.bigquery._helpers import ScalarQueryParameter
+
+        RESOURCE = {
+            'name': 'foo',
+            'parameterType': {'type': 'INT64'},
+            'parameterValue': {'value': '123'},
+        }
+
+        parameter = self._call_fut(RESOURCE)
+
+        self.assertIsInstance(parameter, ScalarQueryParameter)
+        self.assertEqual(parameter.name, 'foo')
+        self.assertEqual(parameter.type_, 'INT64')
+        self.assertEqual(parameter.value, 123)
+
+    def test_w_array(self):
+        from google.cloud.bigquery._helpers import ArrayQueryParameter
+
+        RESOURCE = {
+            'name': 'foo',
+            'parameterType': {
+                'type': 'ARRAY',
+                'arrayType': {'type': 'INT64'},
+            },
+            'parameterValue': {
+                'arrayValues': [
+                    {'value': '123'},
+                ]},
+        }
+
+        parameter = self._call_fut(RESOURCE)
+
+        self.assertIsInstance(parameter, ArrayQueryParameter)
+        self.assertEqual(parameter.name, 'foo')
+        self.assertEqual(parameter.array_type, 'INT64')
+        self.assertEqual(parameter.values, [123])
+
+    def test_w_struct(self):
+        from google.cloud.bigquery._helpers import StructQueryParameter
+
+        RESOURCE = {
+            'name': 'foo',
+            'parameterType': {
+                'type': 'STRUCT',
+                'structTypes': [
+                    {'name': 'foo', 'type': {'type': 'STRING'}},
+                    {'name': 'bar', 'type': {'type': 'INT64'}},
+                ],
+            },
+            'parameterValue': {
+                'structValues': {
+                    'foo': {'value': 'Foo'},
+                    'bar': {'value': '123'},
+                }
+            },
+        }
+
+        parameter = self._call_fut(RESOURCE)
+
+        self.assertIsInstance(parameter, StructQueryParameter)
+        self.assertEqual(parameter.name, 'foo')
+        self.assertEqual(
+            parameter.struct_types, {'foo': 'STRING', 'bar': 'INT64'})
+        self.assertEqual(parameter.struct_values, {'foo': 'Foo', 'bar': 123})
+
+
+
 class Test_QueryParametersProperty(unittest.TestCase):
 
     @staticmethod

--- a/bigquery/tests/unit/test__helpers.py
+++ b/bigquery/tests/unit/test__helpers.py
@@ -751,6 +751,14 @@ class Test_TypedProperty(unittest.TestCase):
         self.assertEqual(wrapper.attr, 42)
         self.assertEqual(wrapper._configuration._attr, 42)
 
+        wrapper.attr = None
+        self.assertIsNone(wrapper.attr)
+        self.assertIsNone(wrapper._configuration._attr)
+
+        wrapper.attr = 23
+        self.assertEqual(wrapper.attr, 23)
+        self.assertEqual(wrapper._configuration._attr, 23)
+
         del wrapper.attr
         self.assertIsNone(wrapper.attr)
         self.assertIsNone(wrapper._configuration._attr)
@@ -913,6 +921,17 @@ class Test_ScalarQueryParameter(unittest.TestCase):
         self.assertEqual(param.name, 'foo')
         self.assertEqual(param.type_, 'INT64')
         self.assertEqual(param.value, 123)
+
+    def test___eq__(self):
+        param = self._make_one(name='foo', type_='INT64', value=123)
+        self.assertEqual(param, param)
+        self.assertNotEqual(param, object())
+        alias = self._make_one(name='bar', type_='INT64', value=123)
+        self.assertNotEqual(param, alias)
+        wrong_type = self._make_one(name='foo', type_='FLOAT64', value=123.0)
+        self.assertNotEqual(param, wrong_type)
+        wrong_val = self._make_one(name='foo', type_='INT64', value=234)
+        self.assertNotEqual(param, wrong_val)
 
     def test_positional(self):
         klass = self._get_target_class()
@@ -1145,6 +1164,19 @@ class Test_ArrayQueryParameter(unittest.TestCase):
         self.assertEqual(param.array_type, 'INT64')
         self.assertEqual(param.values, [1, 2])
 
+    def test___eq__(self):
+        param = self._make_one(name='foo', array_type='INT64', values=[123])
+        self.assertEqual(param, param)
+        self.assertNotEqual(param, object())
+        alias = self._make_one(name='bar', array_type='INT64', values=[123])
+        self.assertNotEqual(param, alias)
+        wrong_type = self._make_one(
+            name='foo', array_type='FLOAT64', values=[123.0])
+        self.assertNotEqual(param, wrong_type)
+        wrong_val = self._make_one(
+            name='foo', array_type='INT64', values=[234])
+        self.assertNotEqual(param, wrong_val)
+
     def test_positional(self):
         klass = self._get_target_class()
         param = klass.positional(array_type='INT64', values=[1, 2])
@@ -1318,6 +1350,21 @@ class Test_StructQueryParameter(unittest.TestCase):
         self.assertEqual(param.name, 'foo')
         self.assertEqual(param.struct_types, {'bar': 'INT64', 'baz': 'STRING'})
         self.assertEqual(param.struct_values, {'bar': 123, 'baz': 'abc'})
+
+    def test___eq__(self):
+        sub_1 = _make_subparam('bar', 'INT64', 123)
+        sub_2 = _make_subparam('baz', 'STRING', 'abc')
+        sub_3 = _make_subparam('baz', 'STRING', 'def')
+        sub_1_float = _make_subparam('bar', 'FLOAT64', 123.0)
+        param = self._make_one('foo', sub_1, sub_2)
+        self.assertEqual(param, param)
+        self.assertNotEqual(param, object())
+        alias = self._make_one('bar', sub_1, sub_2)
+        self.assertNotEqual(param, alias)
+        wrong_type = self._make_one( 'foo', sub_1_float, sub_2)
+        self.assertNotEqual(param, wrong_type)
+        wrong_val = self._make_one('foo', sub_2, sub_3)
+        self.assertNotEqual(param, wrong_val)
 
     def test_positional(self):
         sub_1 = _make_subparam('bar', 'INT64', 123)

--- a/bigquery/tests/unit/test__helpers.py
+++ b/bigquery/tests/unit/test__helpers.py
@@ -1361,7 +1361,7 @@ class Test_StructQueryParameter(unittest.TestCase):
         self.assertNotEqual(param, object())
         alias = self._make_one('bar', sub_1, sub_2)
         self.assertNotEqual(param, alias)
-        wrong_type = self._make_one( 'foo', sub_1_float, sub_2)
+        wrong_type = self._make_one('foo', sub_1_float, sub_2)
         self.assertNotEqual(param, wrong_type)
         wrong_val = self._make_one('foo', sub_2, sub_3)
         self.assertNotEqual(param, wrong_val)
@@ -1601,7 +1601,6 @@ class Test__query_param_from_api_repr(unittest.TestCase):
         self.assertEqual(
             parameter.struct_types, {'foo': 'STRING', 'bar': 'INT64'})
         self.assertEqual(parameter.struct_values, {'foo': 'Foo', 'bar': 123})
-
 
 
 class Test_QueryParametersProperty(unittest.TestCase):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -298,7 +298,7 @@ class TestLoadJob(unittest.TestCase, _Base):
         else:
             self.assertIsNone(job.quote_character)
         if 'skipLeadingRows' in config:
-            self.assertEqual(job.skip_leading_rows,
+            self.assertEqual(str(job.skip_leading_rows),
                              config['skipLeadingRows'])
         else:
             self.assertIsNone(job.skip_leading_rows)
@@ -642,7 +642,7 @@ class TestLoadJob(unittest.TestCase, _Base):
             'maxBadRecords': 100,
             'nullMarker': r'\N',
             'quote': "'",
-            'skipLeadingRows': 1,
+            'skipLeadingRows': '1',
             'sourceFormat': 'CSV',
             'writeDisposition': 'WRITE_TRUNCATE',
             'schema': {'fields': [

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1494,13 +1494,14 @@ class TestQueryJob(unittest.TestCase, _Base):
 
     def _verifyIntegerResourceProperties(self, job, config):
         if 'maximumBillingTier' in config:
-            self.assertEqual(job.maximum_billing_tier,
-                             config['maximumBillingTier'])
+            self.assertEqual(
+                job.maximum_billing_tier, config['maximumBillingTier'])
         else:
             self.assertIsNone(job.maximum_billing_tier)
         if 'maximumBytesBilled' in config:
-            self.assertEqual(job.maximum_bytes_billed,
-                             config['maximumBytesBilled'])
+            self.assertEqual(
+                str(job.maximum_bytes_billed), config['maximumBytesBilled'])
+            self.assertIsInstance(job.maximum_bytes_billed, int)
         else:
             self.assertIsNone(job.maximum_bytes_billed)
 
@@ -2099,7 +2100,7 @@ class TestQueryJob(unittest.TestCase, _Base):
             'useLegacySql': True,
             'writeDisposition': 'WRITE_TRUNCATE',
             'maximumBillingTier': 4,
-            'maximumBytesBilled': 123456
+            'maximumBytesBilled': '123456'
         }
         RESOURCE['configuration']['query'] = QUERY_CONFIGURATION
         conn1 = _Connection()


### PR DESCRIPTION
Note that 177caa5 fixes a longstanding bug:  `Job` configuration properties were not replaced when loading a job from the server.  Unfortunately,  I can't find the bug after the huge pile of issue closures this week.

The helper for constructing concrete query params added in cc4ba04 is a more general form of the one I did in-place in #3802, and should replace that version.



