### PR TITLE
Update storage to 1.3.2.

### DIFF
--- a/storage/setup.py
+++ b/storage/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-storage',
-    version='1.3.1',
+    version='1.3.2',
     description='Python Client for Google Cloud Storage',
     long_description=README,
     namespace_packages=[

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -54,7 +54,7 @@ REQUIREMENTS = [
     'google-cloud-core >= 0.26.0, < 0.27dev',
     'google-auth >= 1.0.0',
     'google-resumable-media >= 0.2.3',
-    'requests >= 2.0.0',
+    'requests >= 2.18.0',
 ]
 
 setup(


### PR DESCRIPTION
Did this to update the lower bound on the `requests` dependency (see #3736).

This PR is an alternative to #3812. Note the diffbase is `GoogleCloudPlatform:storage-1.3.2`, which is at the same point as the `storage-1.3.1` branch:

https://github.com/GoogleCloudPlatform/google-cloud-python/commits/storage-1.3.1
https://github.com/GoogleCloudPlatform/google-cloud-python/commits/storage-1.3.2