### PR TITLE
BigQuery: Poll via getQueryResults method.

### DIFF
--- a/bigquery/google/cloud/bigquery/dbapi/cursor.py
+++ b/bigquery/google/cloud/bigquery/dbapi/cursor.py
@@ -154,20 +154,13 @@ class Cursor(object):
             query_parameters=query_parameters)
         query_job.use_legacy_sql = False
 
+        # Wait for the query to finish.
         try:
-            query_results = query_job.result()
+            query_job = query_job.result()
         except google.cloud.exceptions.GoogleCloudError:
             raise exceptions.DatabaseError(query_job.errors)
 
-        # Force the iterator to run because the query_results doesn't
-        # have the total_rows populated. See:
-        # https://github.com/GoogleCloudPlatform/google-cloud-python/issues/3506
-        query_iterator = query_results.fetch_data()
-        try:
-            six.next(iter(query_iterator))
-        except StopIteration:
-            pass
-
+        query_results = query_job.query_results()
         self._query_data = iter(
             query_results.fetch_data(max_results=self.arraysize))
         self._set_rowcount(query_results)

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -1093,7 +1093,8 @@ class TestBigQuery(unittest.TestCase):
             str(uuid.uuid4()), 'SELECT 1')
         query_job.use_legacy_sql = False
 
-        iterator = query_job.result(timeout=JOB_TIMEOUT).fetch_data()
+        query_job = query_job.result(timeout=JOB_TIMEOUT)
+        iterator = query_job.query_results().fetch_data()
         rows = list(iterator)
         self.assertEqual(rows, [(1,)])
 

--- a/bigquery/tests/unit/test_dbapi_cursor.py
+++ b/bigquery/tests/unit/test_dbapi_cursor.py
@@ -42,7 +42,8 @@ class TestCursor(unittest.TestCase):
         mock_job = mock.create_autospec(job.QueryJob)
         mock_job.error_result = None
         mock_job.state = 'DONE'
-        mock_job.result.return_value = self._mock_results(
+        mock_job.result.return_value = mock_job
+        mock_job.query_results.return_value = self._mock_results(
             rows=rows, schema=schema,
             num_dml_affected_rows=num_dml_affected_rows)
         return mock_job


### PR DESCRIPTION
This modifies the QueryJob's Futures interface implementation to poll
using getQueryResults instead of jobs.get. This was recommended by
BigQuery engineers because getQueryResults does HTTP long-polling for
closer to realtime results.

Follow-up to https://github.com/GoogleCloudPlatform/google-cloud-python/issues/3556.