### PR TITLE
Use metadata server to detect GKE environment

### DIFF
--- a/logging/google/cloud/logging/_helpers.py
+++ b/logging/google/cloud/logging/_helpers.py
@@ -15,6 +15,7 @@
 """Common logging helpers."""
 
 import requests
+from requests import exceptions
 
 from google.cloud.logging.entries import ProtobufEntry
 from google.cloud.logging.entries import StructEntry
@@ -70,11 +71,12 @@ def retrieve_metadata_server(metadata_key):
     try:
         response = requests.get(url, headers=METADATA_HEADERS)
 
-        if response.status_code == requests.codes.ok:
-            return response.text
-        else:
-            return None
-    except requests.exceptions.RequestException:
+        # Exception will raise if the HTTP request returned an unsuccessful
+        # status code.
+        response.raise_for_status()
+
+        return response.text
+    except (exceptions.RequestException, exceptions.HTTPError):
         # Ignore the exception, connection failed means the attribute does not
         # exist in the metadata server.
         pass

--- a/logging/google/cloud/logging/_helpers.py
+++ b/logging/google/cloud/logging/_helpers.py
@@ -14,10 +14,16 @@
 
 """Common logging helpers."""
 
+import requests
 
 from google.cloud.logging.entries import ProtobufEntry
 from google.cloud.logging.entries import StructEntry
 from google.cloud.logging.entries import TextEntry
+
+METADATA_URL = 'http://metadata/computeMetadata/v1/'
+METADATA_HEADERS = {
+    'Metadata-Flavor': 'Google'
+}
 
 
 def entry_from_resource(resource, client, loggers):
@@ -46,3 +52,31 @@ def entry_from_resource(resource, client, loggers):
         return ProtobufEntry.from_api_repr(resource, client, loggers)
 
     raise ValueError('Cannot parse log entry resource.')
+
+
+def retrieve_metadata_server(metadata_key):
+    """Retrieve the metadata key in the metadata server.
+
+    See: https://cloud.google.com/compute/docs/storing-retrieving-metadata
+
+    :type metadata_key: str
+    :param metadata_key: Key of the metadata which will form the url.
+
+    :rtype: str
+    :returns: The value of the metadata key returned by the metadata server.
+    """
+    url = METADATA_URL + metadata_key
+
+    try:
+        response = requests.get(url, headers=METADATA_HEADERS)
+
+        if response.status_code == requests.codes.ok:
+            return response.text
+        else:
+            return None
+    except requests.exceptions.RequestException:
+        # Ignore the exception, connection failed means the attribute does not
+        # exist in the metadata server.
+        pass
+
+    return None

--- a/logging/google/cloud/logging/_helpers.py
+++ b/logging/google/cloud/logging/_helpers.py
@@ -60,7 +60,9 @@ def retrieve_metadata_server(metadata_key):
     See: https://cloud.google.com/compute/docs/storing-retrieving-metadata
 
     :type metadata_key: str
-    :param metadata_key: Key of the metadata which will form the url.
+    :param metadata_key: Key of the metadata which will form the url. You can
+                         also supply query parameters after the metadata key.
+                         e.g. "tags?alt=json"
 
     :rtype: str
     :returns: The value of the metadata key returned by the metadata server.

--- a/logging/google/cloud/logging/_helpers.py
+++ b/logging/google/cloud/logging/_helpers.py
@@ -15,7 +15,6 @@
 """Common logging helpers."""
 
 import requests
-from requests import exceptions
 
 from google.cloud.logging.entries import ProtobufEntry
 from google.cloud.logging.entries import StructEntry
@@ -76,9 +75,7 @@ def retrieve_metadata_server(metadata_key):
         if response.status_code == requests.codes.ok:
             return response.text
 
-        response.raise_for_status()
-
-    except (exceptions.RequestException, exceptions.HTTPError):
+    except requests.exceptions.RequestException:
         # Ignore the exception, connection failed means the attribute does not
         # exist in the metadata server.
         pass

--- a/logging/google/cloud/logging/_helpers.py
+++ b/logging/google/cloud/logging/_helpers.py
@@ -73,9 +73,11 @@ def retrieve_metadata_server(metadata_key):
 
         # Exception will raise if the HTTP request returned an unsuccessful
         # status code.
+        if response.status_code == requests.codes.ok:
+            return response.text
+
         response.raise_for_status()
 
-        return response.text
     except (exceptions.RequestException, exceptions.HTTPError):
         # Ignore the exception, connection failed means the attribute does not
         # exist in the metadata server.

--- a/logging/google/cloud/logging/_helpers.py
+++ b/logging/google/cloud/logging/_helpers.py
@@ -70,8 +70,6 @@ def retrieve_metadata_server(metadata_key):
     try:
         response = requests.get(url, headers=METADATA_HEADERS)
 
-        # Exception will raise if the HTTP request returned an unsuccessful
-        # status code.
         if response.status_code == requests.codes.ok:
             return response.text
 

--- a/logging/tests/unit/test__helpers.py
+++ b/logging/tests/unit/test__helpers.py
@@ -73,6 +73,7 @@ class Test_retrieve_metadata_server(unittest.TestCase):
 
         requests_mock = mock.Mock()
         requests_mock.get.return_value = response_mock
+        requests_mock.codes.ok = status_code_ok
 
         patch = mock.patch(
             'google.cloud.logging._helpers.requests',
@@ -84,6 +85,7 @@ class Test_retrieve_metadata_server(unittest.TestCase):
         self.assertEqual(metadata, response_text)
 
     def test_metadata_does_not_exist(self):
+        status_code_ok = 200
         status_code_not_found = 404
         metadata_key = 'test_key'
 
@@ -91,6 +93,7 @@ class Test_retrieve_metadata_server(unittest.TestCase):
 
         requests_mock = mock.Mock()
         requests_mock.get.return_value = response_mock
+        requests_mock.codes.ok = status_code_ok
 
         patch = mock.patch(
             'google.cloud.logging._helpers.requests',

--- a/logging/tests/unit/test__helpers.py
+++ b/logging/tests/unit/test__helpers.py
@@ -134,9 +134,3 @@ class ResponseMock(object):
     def __init__(self, status_code, text='test_response_text'):
         self.status_code = status_code
         self.text = text
-
-    def raise_for_status(self):
-        from requests.exceptions import HTTPError
-
-        if self.status_code >= 400:
-            raise HTTPError('test_error_msg', response=self)

--- a/logging/tests/unit/test__helpers.py
+++ b/logging/tests/unit/test__helpers.py
@@ -15,6 +15,8 @@
 
 import unittest
 
+import mock
+
 
 class Test_entry_from_resource(unittest.TestCase):
 
@@ -51,6 +53,71 @@ class Test_entry_from_resource(unittest.TestCase):
 
     def test_proto_payload(self):
         self._payload_helper('protoPayload', 'ProtobufEntry')
+
+
+class Test_retrieve_metadata_server(unittest.TestCase):
+
+    @staticmethod
+    def _call_fut(metadata_key):
+        from google.cloud.logging._helpers import retrieve_metadata_server
+
+        return retrieve_metadata_server(metadata_key)
+
+    def test_metadata_exists(self):
+        status_code_ok = 200
+        response_text = 'my-gke-cluster'
+        metadata_key = 'test_key'
+
+        response_mock = mock.Mock()
+        response_mock.status_code = status_code_ok
+        response_mock.text = response_text
+
+        requests_mock = mock.Mock()
+        requests_mock.get.return_value = response_mock
+        requests_mock.codes.ok = status_code_ok
+
+        patch = mock.patch(
+            'google.cloud.logging._helpers.requests',
+            requests_mock)
+
+        with patch:
+            metadata = self._call_fut(metadata_key)
+
+        self.assertEqual(metadata, response_text)
+
+    def test_metadata_does_not_exist(self):
+        status_code_ok = 200
+        status_code_not_found = 404
+        metadata_key = 'test_key'
+
+        response_mock = mock.Mock()
+        response_mock.status_code = status_code_not_found
+
+        requests_mock = mock.Mock()
+        requests_mock.get.return_value = response_mock
+        requests_mock.codes.ok = status_code_ok
+
+        patch = mock.patch(
+            'google.cloud.logging._helpers.requests',
+            requests_mock)
+
+        with patch:
+            metadata = self._call_fut(metadata_key)
+
+        self.assertIsNone(metadata)
+
+    def test_request_exception(self):
+        metadata_key = 'test_url_cannot_connect'
+        metadata_url = 'invalid_url'
+
+        patch = mock.patch(
+            'google.cloud.logging._helpers.METADATA_URL',
+            new=metadata_url)
+
+        with patch:
+            metadata = self._call_fut(metadata_key)
+
+        self.assertIsNone(metadata)
 
 
 class EntryMock(object):

--- a/logging/tests/unit/test__helpers.py
+++ b/logging/tests/unit/test__helpers.py
@@ -106,7 +106,7 @@ class Test_retrieve_metadata_server(unittest.TestCase):
 
     def test_request_exception(self):
         metadata_key = 'test_url_cannot_connect'
-        metadata_url = 'invalid_url'
+        metadata_url = 'http://metadata.invalid/'
 
         patch = mock.patch(
             'google.cloud.logging._helpers.METADATA_URL',

--- a/logging/tests/unit/test_client.py
+++ b/logging/tests/unit/test_client.py
@@ -581,16 +581,18 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(handler, AppEngineHandler)
 
     def test_get_default_handler_container_engine(self):
-        import os
-        from google.cloud._testing import _Monkey
-        from google.cloud.logging.client import _CONTAINER_ENGINE_ENV
         from google.cloud.logging.handlers import ContainerEngineHandler
 
-        client = self._make_one(project=self.PROJECT,
-                                credentials=_make_credentials(),
-                                _use_grpc=False)
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=_make_credentials(),
+            _use_grpc=False)
 
-        with _Monkey(os, environ={_CONTAINER_ENGINE_ENV: 'True'}):
+        patch = mock.patch(
+            'google.cloud.logging.client.retrieve_metadata_server',
+            return_value='test-gke-cluster')
+
+        with patch:
             handler = client.get_default_handler()
 
         self.assertIsInstance(handler, ContainerEngineHandler)


### PR DESCRIPTION
For #3622. This fixes the `get_default_handler()` method to let it return the `ContainerEngineHandler` when in GKE environment using the `cluster_name` attribute from the metadata server. If this attribute exists, it should be in GKE environment.