### PR TITLE
Updating 10 packages after google-cloud-core==0.27.0

### DIFF
--- a/dns/setup.py
+++ b/dns/setup.py
@@ -56,7 +56,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-dns',
-    version='0.26.0',
+    version='0.27.0',
     description='Python Client for Google Cloud DNS',
     long_description=README,
     namespace_packages=[

--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -52,13 +52,13 @@ SETUP_BASE = {
 
 REQUIREMENTS = [
     'google-cloud-core >= 0.27.0, < 0.28dev',
-    'google-cloud-logging >= 1.2.0, < 1.3dev',
+    'google-cloud-logging >= 1.3.0, < 1.4dev',
     'gapic-google-cloud-error-reporting-v1beta1 >= 0.15.0, < 0.16dev'
 ]
 
 setup(
     name='google-cloud-error-reporting',
-    version='0.26.0',
+    version='0.27.0',
     description='Python Client for Stackdriver Error Reporting',
     long_description=README,
     namespace_packages=[

--- a/language/setup.py
+++ b/language/setup.py
@@ -61,7 +61,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name='google-cloud-language',
-    version='0.27.0',
+    version='0.28.0',
     description='Python Client for Google Cloud Natural Language',
     long_description=README,
     namespace_packages=[

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -58,7 +58,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-logging',
-    version='1.2.0',
+    version='1.3.0',
     description='Python Client for Stackdriver Logging',
     long_description=README,
     namespace_packages=[

--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -56,7 +56,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-monitoring',
-    version='0.26.0',
+    version='0.27.0',
     description='Python Client for Stackdriver Monitoring',
     long_description=README,
     namespace_packages=[

--- a/resource_manager/setup.py
+++ b/resource_manager/setup.py
@@ -56,7 +56,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-resource-manager',
-    version='0.26.0',
+    version='0.27.0',
     description='Python Client for Google Cloud Resource Manager',
     long_description=README,
     namespace_packages=[

--- a/runtimeconfig/setup.py
+++ b/runtimeconfig/setup.py
@@ -56,7 +56,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-runtimeconfig',
-    version='0.26.0',
+    version='0.27.0',
     description='Python Client for Google Cloud RuntimeConfig',
     long_description=README,
     namespace_packages=[

--- a/setup.py
+++ b/setup.py
@@ -48,26 +48,25 @@ SETUP_BASE = {
     ],
 }
 
-
 REQUIREMENTS = [
     'google-cloud-bigquery >= 0.26.0, < 0.27dev',
     'google-cloud-bigtable >= 0.26.0, < 0.27dev',
     'google-cloud-core >= 0.27.0, < 0.28dev',
     'google-cloud-datastore >= 1.2.0, < 1.3dev',
-    'google-cloud-dns >= 0.26.0, < 0.27dev',
-    'google-cloud-error-reporting >= 0.26.0, < 0.27dev',
-    'google-cloud-language >= 0.27.0, < 0.28dev',
-    'google-cloud-logging >= 1.2.0, < 1.3dev',
-    'google-cloud-monitoring >= 0.26.0, < 0.27dev',
+    'google-cloud-dns >= 0.27.0, < 0.28dev',
+    'google-cloud-error-reporting >= 0.27.0, < 0.28dev',
+    'google-cloud-language >= 0.28.0, < 0.29dev',
+    'google-cloud-logging >= 1.3.0, < 1.4dev',
+    'google-cloud-monitoring >= 0.27.0, < 0.28dev',
     'google-cloud-pubsub >= 0.27.0, < 0.28dev',
-    'google-cloud-resource-manager >= 0.26.0, < 0.27dev',
-    'google-cloud-runtimeconfig >= 0.26.0, < 0.27dev',
+    'google-cloud-resource-manager >= 0.27.0, < 0.28dev',
+    'google-cloud-runtimeconfig >= 0.27.0, < 0.28dev',
     'google-cloud-spanner >= 0.26.0, < 0.27dev',
-    'google-cloud-speech >= 0.28.0, < 0.29dev',
+    'google-cloud-speech >= 0.29.0, < 0.30dev',
     'google-cloud-storage >= 1.3.0, < 1.4dev',
-    'google-cloud-translate >= 1.1.0, < 1.2dev',
+    'google-cloud-translate >= 1.2.0, < 1.3dev',
     'google-cloud-videointelligence >= 0.25.0, < 0.26dev',
-    'google-cloud-vision >= 0.26.0, < 0.27dev',
+    'google-cloud-vision >= 0.27.0, < 0.28dev',
 ]
 
 setup(

--- a/speech/setup.py
+++ b/speech/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-speech',
-    version='0.28.0',
+    version='0.29.0',
     description='Python Client for Google Cloud Speech',
     long_description=README,
     namespace_packages=[

--- a/translate/setup.py
+++ b/translate/setup.py
@@ -56,7 +56,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-translate',
-    version='1.1.0',
+    version='1.2.0',
     description='Python Client for Google Cloud Translation API',
     long_description=README,
     namespace_packages=[

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -37,7 +37,7 @@ setup(
     author='Google Cloud Platform',
     author_email='googleapis-publisher@google.com',
     name='google-cloud-vision',
-    version='0.26.0',
+    version='0.27.0',
     description='Python Client for Google Cloud Vision',
     long_description=readme,
     namespace_packages=[


### PR DESCRIPTION
- dns
- error_reporting
- language
- logging
- monitoring
- resource_manager
- runtimeconfig
- speech
- translate
- vision

Also updating bounds on these in `google-cloud` uber-package.

Release notes will be forthcoming as comments on this PR.