### PR TITLE
Bigtable 0.27.0

### DIFF
--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-bigtable',
-    version='0.26.0',
+    version='0.27.0',
     description='Python Client for Google Cloud Bigtable',
     long_description=README,
     namespace_packages=[

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ SETUP_BASE = {
 
 REQUIREMENTS = [
     'google-cloud-bigquery >= 0.26.0, < 0.27dev',
-    'google-cloud-bigtable >= 0.26.0, < 0.27dev',
+    'google-cloud-bigtable >= 0.27.0, < 0.28dev',
     'google-cloud-core >= 0.27.0, < 0.28dev',
     'google-cloud-datastore >= 1.2.0, < 1.3dev',
     'google-cloud-dns >= 0.26.0, < 0.27dev',


### PR DESCRIPTION
Release notes:

  * @lukesneeringer Allow `Table.read_rows` to take an inclusive end key. (#3744)
  * @jonparrott Move `google.cloud.future` to `google.api.core` (#3764)
  * @tswast Use `latest/` directory for docs instead of `stable/` (#3766)
  * @lukesneeringer Fix `__eq__` and `__ne__`. (#3765)
  * @lukesneeringer Bump core version number (#3864)