### PR TITLE
Update video intelligence to 0.26.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ REQUIREMENTS = [
     'google-cloud-speech >= 0.28.0, < 0.29dev',
     'google-cloud-storage >= 1.3.0, < 1.4dev',
     'google-cloud-translate >= 1.1.0, < 1.2dev',
-    'google-cloud-videointelligence >= 0.25.0, < 0.26dev',
+    'google-cloud-videointelligence >= 0.26.0, < 0.27dev',
     'google-cloud-vision >= 0.26.0, < 0.27dev',
 ]
 

--- a/videointelligence/setup.py
+++ b/videointelligence/setup.py
@@ -29,7 +29,7 @@ setup(
     author='Google Cloud Platform',
     author_email='googleapis-publisher@google.com',
     name='google-cloud-videointelligence',
-    version='0.25.0',
+    version='0.26.0',
     description='Python Client for Google Cloud Video Intelligence',
     long_description=readme,
     namespace_packages=[


### PR DESCRIPTION
Release notes:

  * Fixed incorrect import from `google.cloud.gapic.videointelligence_v1beta1` (should omit `.gapic.`) (#3447)
  * Missed an `.items()` on an iteration over a dict. (#3447)
  * Fixed references to "dead" docs links. (#3631)
  * Tests are now included in `manifest.in` (#3552)
  * Update broken links to video intelligence docs in package README (#3458)