### PR TITLE
Bump BigQuery to 0.27.0

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-bigquery',
-    version='0.26.0',
+    version='0.27.0',
     description='Python Client for Google BigQuery',
     long_description=README,
     namespace_packages=[

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ SETUP_BASE = {
 }
 
 REQUIREMENTS = [
-    'google-cloud-bigquery >= 0.26.0, < 0.27dev',
+    'google-cloud-bigquery >= 0.27.0, < 0.28dev',
     'google-cloud-bigtable >= 0.27.0, < 0.28dev',
     'google-cloud-core >= 0.27.0, < 0.28dev',
     'google-cloud-datastore >= 1.3.0, < 1.4dev',


### PR DESCRIPTION
## Implementation

  * Remove client-side enum validation. (#3735)
  * Add `Table.row_from_mapping` helper. (#3425)
  * Move `google.cloud.future` to `google.api.core` (#3764)
  * Fix `__eq__` and `__ne__`. (#3765)
  * Move `google.cloud.iterator` to `google.api.core.page_iterator` (#3770)
  * `nullMarker` support for BigQuery Load Jobs (#3777), h/t @leondealmeida
  * Allow `job_id` to be explicitly specified. (#3779)
  * Add support for a custom null marker. (#3776)
  * Add `SchemaField` serialization and deserialization. (#3786)
  * Add `get_query_results` method. (#3838)
  * Poll via `getQueryResults` method. (#3844)
  * Allow fetching more than the first page when `max_results` is set. (#3845)


## Dependencies

  * Bump `requests` minimum bound to 2.18.0 (#3748)

## Documentation

  * Reference valid input formats in API docs. (#3758)
  * Use `latest/` directory for docs instead of `stable/` (#3766)
  * Fix documentation link. (#3825)

OMITTED: 
  * Wait for load jobs to complete in system tests. (#3782)