### PR TITLE
BigQuery: make get_query_results private. Return rows for QueryJob.result()

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -162,7 +162,7 @@ class Client(ClientWithProject):
         """
         return Dataset(dataset_name, client=self, project=project)
 
-    def get_query_results(self, job_id, project=None, timeout_ms=None):
+    def _get_query_results(self, job_id, project=None, timeout_ms=None):
         """Get the query results object for a query job.
 
         :type job_id: str

--- a/bigquery/google/cloud/bigquery/dbapi/cursor.py
+++ b/bigquery/google/cloud/bigquery/dbapi/cursor.py
@@ -154,7 +154,7 @@ class Cursor(object):
 
         # Wait for the query to finish.
         try:
-            query_job = query_job.result()
+            query_job.result()
         except google.cloud.exceptions.GoogleCloudError:
             raise exceptions.DatabaseError(query_job.errors)
 

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -599,13 +599,6 @@ class TestBigQuery(unittest.TestCase):
         # raise an error, and that the job completed (in the `retry()`
         # above).
 
-    def test_get_query_results(self):
-        job_id = 'test-get-query-results-' + str(uuid.uuid4())
-        query_job = Config.CLIENT.run_async_query(job_id, 'SELECT 1')
-        query_job.begin()
-        results = Config.CLIENT.get_query_results(job_id)
-        self.assertEqual(results.total_rows, 1)
-
     def test_sync_query_w_legacy_sql_types(self):
         naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
         stamp = '%s %s' % (naive.date().isoformat(), naive.time().isoformat())
@@ -1103,8 +1096,7 @@ class TestBigQuery(unittest.TestCase):
             str(uuid.uuid4()), 'SELECT 1')
         query_job.use_legacy_sql = False
 
-        query_job = query_job.result(timeout=JOB_TIMEOUT)
-        iterator = query_job.query_results().fetch_data()
+        iterator = query_job.result(timeout=JOB_TIMEOUT)
         rows = list(iterator)
         self.assertEqual(rows, [(1,)])
 

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -45,7 +45,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(client._connection.credentials, creds)
         self.assertIs(client._connection.http, http)
 
-    def test_get_job_miss_w_explicit_project_and_timeout(self):
+    def test__get_query_results_miss_w_explicit_project_and_timeout(self):
         from google.cloud.exceptions import NotFound
 
         project = 'PROJECT'
@@ -54,7 +54,7 @@ class TestClient(unittest.TestCase):
         conn = client._connection = _Connection()
 
         with self.assertRaises(NotFound):
-            client.get_query_results(
+            client._get_query_results(
                 'nothere', project='other-project', timeout_ms=500)
 
         self.assertEqual(len(conn._requested), 1)
@@ -65,7 +65,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(
             req['query_params'], {'maxResults': 0, 'timeoutMs': 500})
 
-    def test_get_query_results_hit(self):
+    def test__get_query_results_hit(self):
         project = 'PROJECT'
         job_id = 'query_job'
         data = {
@@ -98,7 +98,7 @@ class TestClient(unittest.TestCase):
         creds = _make_credentials()
         client = self._make_one(project, creds)
         client._connection = _Connection(data)
-        query_results = client.get_query_results(job_id)
+        query_results = client._get_query_results(job_id)
 
         self.assertEqual(query_results.total_rows, 10)
         self.assertTrue(query_results.complete)


### PR DESCRIPTION
Based on feedback from others in the redesign plan.

The `get_query_results()` function is too low level to expose directly to users.

The result() object should just return the rows as an iterator. This simplifies the proposed query interface to:

    job = client.query('MY QUERY')
    rows = job.result()

No need for separate fetch_data() call after calling result().