### PR TITLE
Prep core-0.27.1 release.

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -65,7 +65,7 @@ EXTRAS_REQUIREMENTS = {
 
 setup(
     name='google-cloud-core',
-    version='0.27.0',
+    version='0.27.1',
     description='API Client library for Google Cloud: Core Helpers',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Draft release notes

## google-cloud-core 0.27.1

- Pin dependency: `six >= 0.10.1`. (issue #3880, PR #3881)
- Add optional `on_error` support to `google.api.core.retry.retry_target`, and the `Retry` wrapper class. (PR #3891)