### PR TITLE
Use queue if provided in kwargs

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -61,7 +61,7 @@ class Policy(base.BasePolicy):
         # Create a queue for keeping track of shared state.
         if queue is None:
             queue = Queue()
-        self._request_queue = Queue()
+        self._request_queue = queue
 
         # Call the superclass constructor.
         super(Policy, self).__init__(


### PR DESCRIPTION
Bugfix

Fix for a new Queue being instantiated regardless of whether a queue is passed in or not.