### PR TITLE
BigQuery: Add system tests for microsecond-level precision datetimes

### DIFF
--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -685,7 +685,8 @@ class TestBigQuery(unittest.TestCase):
                 'expected': naive,
             },
             {
-                'sql': 'SELECT DATETIME(TIMESTAMP "%s")' % (stamp_microseconds,),
+                'sql': 'SELECT DATETIME(TIMESTAMP "%s")' % (
+                    stamp_microseconds,),
                 'expected': naive_microseconds,
             },
             {

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -648,6 +648,7 @@ class TestBigQuery(unittest.TestCase):
         naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
         naive_microseconds = datetime.datetime(2016, 12, 5, 12, 41, 9, 250000)
         stamp = '%s %s' % (naive.date().isoformat(), naive.time().isoformat())
+        stamp_microseconds = stamp + '.250000'
         zoned = naive.replace(tzinfo=UTC)
         zoned_microseconds = naive_microseconds.replace(tzinfo=UTC)
         return [
@@ -676,7 +677,7 @@ class TestBigQuery(unittest.TestCase):
                 'expected': zoned,
             },
             {
-                'sql': 'SELECT TIMESTAMP "%s"' % (stamp,),
+                'sql': 'SELECT TIMESTAMP "%s"' % (stamp_microseconds,),
                 'expected': zoned_microseconds,
             },
             {
@@ -684,7 +685,7 @@ class TestBigQuery(unittest.TestCase):
                 'expected': naive,
             },
             {
-                'sql': 'SELECT DATETIME(TIMESTAMP "%s")' % (stamp,),
+                'sql': 'SELECT DATETIME(TIMESTAMP "%s")' % (stamp_microseconds,),
                 'expected': naive_microseconds,
             },
             {

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -646,8 +646,10 @@ class TestBigQuery(unittest.TestCase):
 
     def _generate_standard_sql_types_examples(self):
         naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
+        naive_microseconds = datetime.datetime(2016, 12, 5, 12, 41, 9, 250000)
         stamp = '%s %s' % (naive.date().isoformat(), naive.time().isoformat())
         zoned = naive.replace(tzinfo=UTC)
+        zoned_microseconds = naive_microseconds.replace(tzinfo=UTC)
         return [
             {
                 'sql': 'SELECT 1',
@@ -674,8 +676,16 @@ class TestBigQuery(unittest.TestCase):
                 'expected': zoned,
             },
             {
+                'sql': 'SELECT TIMESTAMP "%s"' % (stamp,),
+                'expected': zoned_microseconds,
+            },
+            {
                 'sql': 'SELECT DATETIME(TIMESTAMP "%s")' % (stamp,),
                 'expected': naive,
+            },
+            {
+                'sql': 'SELECT DATETIME(TIMESTAMP "%s")' % (stamp,),
+                'expected': naive_microseconds,
             },
             {
                 'sql': 'SELECT DATE(TIMESTAMP "%s")' % (stamp,),


### PR DESCRIPTION
Follow-up to #3901.

Closes #3870.