### PR TITLE
Allowing `dict` (as an `Entity`) for property values.

### DIFF
--- a/datastore/google/cloud/datastore/entity.py
+++ b/datastore/google/cloud/datastore/entity.py
@@ -83,10 +83,12 @@ class Entity(dict):
     * :class:`~google.cloud.datastore.helpers.GeoPoint`
     * :data:`None`
 
-    In addition, two container types are supported:
+    In addition, three container types are supported:
 
     * :class:`list`
     * :class:`~google.cloud.datastore.entity.Entity`
+    * :class:`dict` (will just be treated like an ``Entity`` without
+      a key or ``exclude_from_indexes``)
 
     Each entry in a list must be one of the value types (basic or
     container) and each value in an

--- a/datastore/google/cloud/datastore/helpers.py
+++ b/datastore/google/cloud/datastore/helpers.py
@@ -290,8 +290,11 @@ def _pb_attr_value(val):
     >>> _pb_attr_value('my_string')
     ('string_value', 'my_string')
 
-    :type val: `datetime.datetime`, :class:`google.cloud.datastore.key.Key`,
-               bool, float, integer, string
+    :type val:
+        :class:`datetime.datetime`, :class:`google.cloud.datastore.key.Key`,
+        bool, float, integer, bytes, str, unicode,
+        :class:`google.cloud.datastore.entity.Entity`, dict, list,
+        :class:`google.cloud.datastore.helpers.GeoPoint`, NoneType
     :param val: The value to be scrutinized.
 
     :rtype: tuple
@@ -315,6 +318,10 @@ def _pb_attr_value(val):
         name, value = 'blob', val
     elif isinstance(val, Entity):
         name, value = 'entity', val
+    elif isinstance(val, dict):
+        entity_val = Entity(key=None)
+        entity_val.update(val)
+        name, value = 'entity', entity_val
     elif isinstance(val, list):
         name, value = 'array', val
     elif isinstance(val, GeoPoint):
@@ -322,7 +329,7 @@ def _pb_attr_value(val):
     elif val is None:
         name, value = 'null', struct_pb2.NULL_VALUE
     else:
-        raise ValueError("Unknown protobuf attr type %s" % type(val))
+        raise ValueError('Unknown protobuf attr type', type(val))
 
     return name + '_value', value
 

--- a/datastore/tests/unit/test_helpers.py
+++ b/datastore/tests/unit/test_helpers.py
@@ -376,7 +376,7 @@ class Test_entity_to_protobuf(unittest.TestCase):
         from google.cloud.datastore.entity import Entity
 
         entity = Entity()
-        entity['a'] = {'b': 'c'}
+        entity['a'] = {'b': u'c'}
         entity_pb = self._call_fut(entity)
 
         expected_pb = entity_pb2.Entity(
@@ -590,7 +590,7 @@ class Test__pb_attr_value(unittest.TestCase):
     def test_dict(self):
         from google.cloud.datastore.entity import Entity
 
-        orig_value = {'richard': 'feynman'}
+        orig_value = {'richard': b'feynman'}
         name, value = self._call_fut(orig_value)
         self.assertEqual(name, 'entity_value')
         self.assertIsInstance(value, Entity)


### PR DESCRIPTION
Fixes #3923.