### PR TITLE
Retry streaming exceptions (redux)

### DIFF
--- a/docs/spanner/snapshot-usage.rst
+++ b/docs/spanner/snapshot-usage.rst
@@ -62,26 +62,6 @@ fails if the result set is too large,
    manually, perform all iteration within the context of  the
    ``with database.snapshot()`` block.
 
-.. note::
-
-   If streaming a chunk raises an exception, the application can
-   retry the ``read``, passing the ``resume_token`` from ``StreamingResultSet``
-   which raised the error.  E.g.:
-
-   .. code:: python
-
-      result = snapshot.read(table, columns, keys)
-      while True:
-          try:
-              for row in result.rows:
-                  print row
-          except Exception:
-               result = snapshot.read(
-                  table, columns, keys, resume_token=result.resume_token)
-               continue
-          else:
-              break
-
 
 
 Execute a SQL Select Statement
@@ -111,26 +91,6 @@ fails if the result set is too large,
    session pool.  Therefore, unless your application creates sessions
    manually, perform all iteration within the context of  the
    ``with database.snapshot()`` block.
-
-.. note::
-
-   If streaming a chunk raises an exception, the application can
-   retry the query, passing the ``resume_token`` from ``StreamingResultSet``
-   which raised the error.  E.g.:
-
-   .. code:: python
-
-      result = snapshot.execute_sql(QUERY)
-      while True:
-          try:
-              for row in result.rows:
-                  print row
-          except Exception:
-               result = snapshot.execute_sql(
-                  QUERY, resume_token=result.resume_token)
-               continue
-          else:
-              break
 
 
 Next Step

--- a/docs/spanner/transaction-usage.rst
+++ b/docs/spanner/transaction-usage.rst
@@ -32,12 +32,6 @@ fails if the result set is too large,
     for row in result.rows:
         print(row)
 
-.. note::
-
-   If streaming a chunk fails due to a "resumable" error,
-   :meth:`Session.read` retries the ``StreamingRead`` API reqeust,
-   passing the ``resume_token`` from the last partial result streamed.
-
 
 Execute a SQL Select Statement
 ------------------------------

--- a/spanner/google/cloud/spanner/session.py
+++ b/spanner/google/cloud/spanner/session.py
@@ -165,8 +165,7 @@ class Session(object):
 
         return Snapshot(self, **kw)
 
-    def read(self, table, columns, keyset, index='', limit=0,
-             resume_token=b''):
+    def read(self, table, columns, keyset, index='', limit=0):
         """Perform a ``StreamingRead`` API request for rows in a table.
 
         :type table: str
@@ -185,17 +184,12 @@ class Session(object):
         :type limit: int
         :param limit: (Optional) maxiumn number of rows to return
 
-        :type resume_token: bytes
-        :param resume_token: token for resuming previously-interrupted read
-
         :rtype: :class:`~google.cloud.spanner.streamed.StreamedResultSet`
         :returns: a result set instance which can be used to consume rows.
         """
-        return self.snapshot().read(
-            table, columns, keyset, index, limit, resume_token)
+        return self.snapshot().read(table, columns, keyset, index, limit)
 
-    def execute_sql(self, sql, params=None, param_types=None, query_mode=None,
-                    resume_token=b''):
+    def execute_sql(self, sql, params=None, param_types=None, query_mode=None):
         """Perform an ``ExecuteStreamingSql`` API request.
 
         :type sql: str
@@ -216,14 +210,11 @@ class Session(object):
         :param query_mode: Mode governing return of results / query plan. See
             https://cloud.google.com/spanner/reference/rpc/google.spanner.v1#google.spanner.v1.ExecuteSqlRequest.QueryMode1
 
-        :type resume_token: bytes
-        :param resume_token: token for resuming previously-interrupted query
-
         :rtype: :class:`~google.cloud.spanner.streamed.StreamedResultSet`
         :returns: a result set instance which can be used to consume rows.
         """
         return self.snapshot().execute_sql(
-            sql, params, param_types, query_mode, resume_token)
+            sql, params, param_types, query_mode)
 
     def batch(self):
         """Factory to create a batch for this session.

--- a/spanner/google/cloud/spanner/snapshot.py
+++ b/spanner/google/cloud/spanner/snapshot.py
@@ -89,14 +89,15 @@ class _SnapshotBase(_SessionWrapper):
 
         iterator = api.streaming_read(
             self._session.name, table, columns, keyset.to_pb(),
-            transaction=transaction, index=index, limit=limit,
-            options=options)
+            index=index, limit=limit,
+            transaction=transaction, options=options)
 
         self._read_request_count += 1
 
         restart = functools.partial(
             api.streaming_read, self._session.name, table, columns, keyset,
-            index=index, limit=limit)
+            index=index, limit=limit,
+            transaction=transaction, options=options)
 
         if self._multi_use:
             return StreamedResultSet(iterator, restart, source=self)
@@ -150,14 +151,15 @@ class _SnapshotBase(_SessionWrapper):
         api = database.spanner_api
         iterator = api.execute_streaming_sql(
             self._session.name, sql,
-            transaction=transaction, params=params_pb, param_types=param_types,
-            query_mode=query_mode, options=options)
+            params=params_pb, param_types=param_types, query_mode=query_mode,
+            transaction=transaction, options=options)
 
         self._read_request_count += 1
 
         restart = functools.partial(
             api.execute_streaming_sql, self._session.name, sql,
-            params=params, param_types=param_types, query_mode=query_mode)
+            params=params, param_types=param_types, query_mode=query_mode,
+            transaction=transaction, options=options)
 
         if self._multi_use:
             return StreamedResultSet(iterator, restart, source=self)

--- a/spanner/google/cloud/spanner/snapshot.py
+++ b/spanner/google/cloud/spanner/snapshot.py
@@ -51,8 +51,7 @@ class _SnapshotBase(_SessionWrapper):
         """
         raise NotImplementedError
 
-    def read(self, table, columns, keyset, index='', limit=0,
-             resume_token=b''):
+    def read(self, table, columns, keyset, index='', limit=0):
         """Perform a ``StreamingRead`` API request for rows in a table.
 
         :type table: str
@@ -70,9 +69,6 @@ class _SnapshotBase(_SessionWrapper):
 
         :type limit: int
         :param limit: (Optional) maxiumn number of rows to return
-
-        :type resume_token: bytes
-        :param resume_token: token for resuming previously-interrupted read
 
         :rtype: :class:`~google.cloud.spanner.streamed.StreamedResultSet`
         :returns: a result set instance which can be used to consume rows.
@@ -94,21 +90,20 @@ class _SnapshotBase(_SessionWrapper):
         iterator = api.streaming_read(
             self._session.name, table, columns, keyset.to_pb(),
             transaction=transaction, index=index, limit=limit,
-            resume_token=resume_token, options=options)
+            options=options)
 
         self._read_request_count += 1
 
         retry = functools.partial(
             api.streaming_read, self._session.name, table, columns, keyset,
-            index=index, limit=limit, resume_token=resume_token)
+            index=index, limit=limit)
 
         if self._multi_use:
             return StreamedResultSet(iterator, retry, source=self)
         else:
             return StreamedResultSet(iterator, retry)
 
-    def execute_sql(self, sql, params=None, param_types=None, query_mode=None,
-                    resume_token=b''):
+    def execute_sql(self, sql, params=None, param_types=None, query_mode=None):
         """Perform an ``ExecuteStreamingSql`` API request for rows in a table.
 
         :type sql: str
@@ -127,9 +122,6 @@ class _SnapshotBase(_SessionWrapper):
             :class:`google.cloud.proto.spanner.v1.ExecuteSqlRequest.QueryMode`
         :param query_mode: Mode governing return of results / query plan. See
             https://cloud.google.com/spanner/reference/rpc/google.spanner.v1#google.spanner.v1.ExecuteSqlRequest.QueryMode1
-
-        :type resume_token: bytes
-        :param resume_token: token for resuming previously-interrupted query
 
         :rtype: :class:`~google.cloud.spanner.streamed.StreamedResultSet`
         :returns: a result set instance which can be used to consume rows.
@@ -159,14 +151,13 @@ class _SnapshotBase(_SessionWrapper):
         iterator = api.execute_streaming_sql(
             self._session.name, sql,
             transaction=transaction, params=params_pb, param_types=param_types,
-            query_mode=query_mode, resume_token=resume_token, options=options)
+            query_mode=query_mode, options=options)
 
         self._read_request_count += 1
 
         retry = functools.partial(
             api.execute_streaming_sql, self._session.name, sql,
-            params=params, param_types=param_types, query_mode=query_mode,
-            resume_token=resume_token)
+            params=params, param_types=param_types, query_mode=query_mode)
 
         if self._multi_use:
             return StreamedResultSet(iterator, retry, source=self)

--- a/spanner/google/cloud/spanner/snapshot.py
+++ b/spanner/google/cloud/spanner/snapshot.py
@@ -94,14 +94,14 @@ class _SnapshotBase(_SessionWrapper):
 
         self._read_request_count += 1
 
-        retry = functools.partial(
+        restart = functools.partial(
             api.streaming_read, self._session.name, table, columns, keyset,
             index=index, limit=limit)
 
         if self._multi_use:
-            return StreamedResultSet(iterator, retry, source=self)
+            return StreamedResultSet(iterator, restart, source=self)
         else:
-            return StreamedResultSet(iterator, retry)
+            return StreamedResultSet(iterator, restart)
 
     def execute_sql(self, sql, params=None, param_types=None, query_mode=None):
         """Perform an ``ExecuteStreamingSql`` API request for rows in a table.
@@ -155,14 +155,14 @@ class _SnapshotBase(_SessionWrapper):
 
         self._read_request_count += 1
 
-        retry = functools.partial(
+        restart = functools.partial(
             api.execute_streaming_sql, self._session.name, sql,
             params=params, param_types=param_types, query_mode=query_mode)
 
         if self._multi_use:
-            return StreamedResultSet(iterator, retry, source=self)
+            return StreamedResultSet(iterator, restart, source=self)
         else:
-            return StreamedResultSet(iterator, retry)
+            return StreamedResultSet(iterator, restart)
 
 
 class Snapshot(_SnapshotBase):

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -139,6 +139,16 @@ class StreamedResultSet(object):
         self._pending_rows[:] = ()
         self._complete_rows.extend(flushed)
 
+    def _do_restart(self):
+        """Helper for :meth:`consume_next`."""
+        if not self._resume_token:
+            raise ValueError("No resume token")
+
+        self._pending_chunk = None
+        self._pending_rows[:] = ()
+        self._current_row[:] = ()
+        self._response_iterator = self._restart(self._resume_token)
+
     def consume_next(self):
         """Consume the next partial result set from the stream.
 

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -154,12 +154,13 @@ class StreamedResultSet(object):
 
         Parse the result set into new/existing rows in :attr:`_complete_rows`
 
-        :raises :class:`~google.api.core.exceptions.ServiceUnavailable`:
-            if the iterator must be restarted.
         :raises StopIteration: if the iterator is empty.
         """
         try:
             response = six.next(self._response_iterator)
+        except exceptions.ServiceUnavailable:
+            self._do_restart()
+            return
         except StopIteration:
             self._flush_pending_rows()
             raise

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -142,7 +142,8 @@ class StreamedResultSet(object):
         """
         response = six.next(self._response_iterator)
         self._counter += 1
-        self._resume_token = response.resume_token
+        if response.resume_token:
+            self._resume_token = response.resume_token
 
         if self._metadata is None:  # first response
             metadata = self._metadata = response.metadata

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -136,6 +136,9 @@ class StreamedResultSet(object):
         """Consume the next partial result set from the stream.
 
         Parse the result set into new/existing rows in :attr:`_rows`
+
+        :raises :class:`~google.api.core.exceptions.ServiceUnavailable`:
+            if the iterator must be restarted.
         """
         response = six.next(self._response_iterator)
         self._counter += 1

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -141,13 +141,14 @@ class StreamedResultSet(object):
 
     def _do_restart(self):
         """Helper for :meth:`consume_next`."""
-        if not self._resume_token:
-            raise ValueError("No resume token")
-
         self._pending_chunk = None
         self._pending_rows[:] = ()
         self._current_row[:] = ()
-        self._response_iterator = self._restart(self._resume_token)
+
+        if self._resume_token:
+            self._response_iterator = self._restart(self._resume_token)
+        else:
+            self._response_iterator = self._restart()
 
     def consume_next(self):
         """Consume the next partial result set from the stream.

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -46,7 +46,8 @@ class StreamedResultSet(object):
     def __init__(self, response_iterator, restart, source=None):
         self._response_iterator = response_iterator
         self._restart = restart
-        self._rows = []             # Fully-processed rows
+        self._pending_rows = []     # Rows pending new token / EOT
+        self._complete_rows = []    # Fully-processed rows
         self._counter = 0           # Counter for processed responses
         self._metadata = None       # Until set from first PRS
         self._stats = None          # Until set from last PRS
@@ -62,7 +63,7 @@ class StreamedResultSet(object):
         :rtype: list of row-data lists.
         :returns: list of completed row data, from proceesd PRS responses.
         """
-        return self._rows
+        return self._complete_rows
 
     @property
     def fields(self):
@@ -129,21 +130,38 @@ class StreamedResultSet(object):
             field = self.fields[index]
             self._current_row.append(_parse_value_pb(value, field.type))
             if len(self._current_row) == width:
-                self._rows.append(self._current_row)
+                self._pending_rows.append(self._current_row)
                 self._current_row = []
+
+    def _flush_pending_rows(self):
+        """Helper for :meth:`consume_next`."""
+        flushed = self._pending_rows[:]
+        self._pending_rows[:] = ()
+        self._complete_rows.extend(flushed)
 
     def consume_next(self):
         """Consume the next partial result set from the stream.
 
-        Parse the result set into new/existing rows in :attr:`_rows`
+        Parse the result set into new/existing rows in :attr:`_complete_rows`
 
         :raises :class:`~google.api.core.exceptions.ServiceUnavailable`:
             if the iterator must be restarted.
+        :raises StopIteration: if the iterator is empty.
         """
-        response = six.next(self._response_iterator)
+        try:
+            response = six.next(self._response_iterator)
+        except StopIteration:
+            self._flush_pending_rows()
+            raise
+
         self._counter += 1
         if response.resume_token:
+            self._flush_pending_rows()
             self._resume_token = response.resume_token
+
+        if response.HasField('stats'):  # last response
+            self._flush_pending_rows()
+            self._stats = response.stats
 
         if self._metadata is None:  # first response
             metadata = self._metadata = response.metadata
@@ -151,9 +169,6 @@ class StreamedResultSet(object):
             source = self._source
             if source is not None and source._transaction_id is None:
                 source._transaction_id = metadata.transaction.id
-
-        if response.HasField('stats'):  # last response
-            self._stats = response.stats
 
         values = list(response.values)
         if self._pending_chunk is not None:
@@ -173,11 +188,15 @@ class StreamedResultSet(object):
                 break
 
     def __iter__(self):
-        iter_rows, self._rows[:] = self._rows[:], ()
+        iter_rows, self._complete_rows[:] = self._complete_rows[:], ()
         while True:
             if not iter_rows:
-                self.consume_next()  # raises StopIteration
-                iter_rows, self._rows[:] = self._rows[:], ()
+                try:
+                    self.consume_next()  # raises StopIteration
+                except StopIteration:
+                    if not self._complete_rows:
+                        raise
+                iter_rows, self._complete_rows[:] = self._complete_rows[:], ()
             while iter_rows:
                 yield iter_rows.pop(0)
 
@@ -210,11 +229,11 @@ class StreamedResultSet(object):
 
         self.consume_all()
 
-        if len(self._rows) > 1:
+        if len(self._complete_rows) > 1:
             raise ValueError('Expected one result; got more.')
 
-        if self._rows:
-            return self._rows[0]
+        if self._complete_rows:
+            return self._complete_rows[0]
 
 
 class Unmergeable(ValueError):

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -34,18 +34,18 @@ class StreamedResultSet(object):
         :class:`google.cloud.proto.spanner.v1.result_set_pb2.PartialResultSet`
         instances.
 
-    :type retry: callable
-    :param retry:
+    :type restart: callable
+    :param restart:
         Function (typically curried via :func:`functools.partial`) used to
-        retry the initial request if a retriable error is raised during
+        restart the initial request if a retriable error is raised during
         streaming.
 
     :type source: :class:`~google.cloud.spanner.snapshot.Snapshot`
     :param source: Snapshot from which the result set was fetched.
     """
-    def __init__(self, response_iterator, retry, source=None):
+    def __init__(self, response_iterator, restart, source=None):
         self._response_iterator = response_iterator
-        self._retry = retry
+        self._restart = restart
         self._rows = []             # Fully-processed rows
         self._counter = 0           # Counter for processed responses
         self._metadata = None       # Until set from first PRS

--- a/spanner/google/cloud/spanner/streamed.py
+++ b/spanner/google/cloud/spanner/streamed.py
@@ -34,11 +34,18 @@ class StreamedResultSet(object):
         :class:`google.cloud.proto.spanner.v1.result_set_pb2.PartialResultSet`
         instances.
 
+    :type retry: callable
+    :param retry:
+        Function (typically curried via :func:`functools.partial`) used to
+        retry the initial request if a retriable error is raised during
+        streaming.
+
     :type source: :class:`~google.cloud.spanner.snapshot.Snapshot`
     :param source: Snapshot from which the result set was fetched.
     """
-    def __init__(self, response_iterator, source=None):
+    def __init__(self, response_iterator, retry, source=None):
         self._response_iterator = response_iterator
+        self._retry = retry
         self._rows = []             # Fully-processed rows
         self._counter = 0           # Counter for processed responses
         self._metadata = None       # Until set from first PRS

--- a/spanner/tests/unit/test_session.py
+++ b/spanner/tests/unit/test_session.py
@@ -265,7 +265,6 @@ class TestSession(unittest.TestCase):
         KEYSET = KeySet(keys=KEYS)
         INDEX = 'email-address-index'
         LIMIT = 20
-        TOKEN = b'DEADBEEF'
         database = _Database(self.DATABASE_NAME)
         session = self._make_one(database)
         session._session_id = 'DEADBEEF'
@@ -279,28 +278,26 @@ class TestSession(unittest.TestCase):
                 self._session = session
                 self._kwargs = kwargs.copy()
 
-            def read(self, table, columns, keyset, index='', limit=0,
-                     resume_token=b''):
+            def read(self, table, columns, keyset, index='', limit=0):
                 _read_with.append(
-                    (table, columns, keyset, index, limit, resume_token))
+                    (table, columns, keyset, index, limit))
                 return expected
 
         with _Monkey(MUT, Snapshot=_Snapshot):
             found = session.read(
                 TABLE_NAME, COLUMNS, KEYSET,
-                index=INDEX, limit=LIMIT, resume_token=TOKEN)
+                index=INDEX, limit=LIMIT)
 
         self.assertIs(found, expected)
 
         self.assertEqual(len(_read_with), 1)
-        (table, columns, key_set, index, limit, resume_token) = _read_with[0]
+        (table, columns, key_set, index, limit) = _read_with[0]
 
         self.assertEqual(table, TABLE_NAME)
         self.assertEqual(columns, COLUMNS)
         self.assertEqual(key_set, KEYSET)
         self.assertEqual(index, INDEX)
         self.assertEqual(limit, LIMIT)
-        self.assertEqual(resume_token, TOKEN)
 
     def test_execute_sql_not_created(self):
         SQL = 'SELECT first_name, age FROM citizens'
@@ -315,7 +312,6 @@ class TestSession(unittest.TestCase):
         from google.cloud._testing import _Monkey
 
         SQL = 'SELECT first_name, age FROM citizens'
-        TOKEN = b'DEADBEEF'
         database = _Database(self.DATABASE_NAME)
         session = self._make_one(database)
         session._session_id = 'DEADBEEF'
@@ -330,25 +326,23 @@ class TestSession(unittest.TestCase):
                 self._kwargs = kwargs.copy()
 
             def execute_sql(
-                    self, sql, params=None, param_types=None, query_mode=None,
-                    resume_token=None):
+                    self, sql, params=None, param_types=None, query_mode=None):
                 _executed_sql_with.append(
-                    (sql, params, param_types, query_mode, resume_token))
+                    (sql, params, param_types, query_mode))
                 return expected
 
         with _Monkey(MUT, Snapshot=_Snapshot):
-            found = session.execute_sql(SQL, resume_token=TOKEN)
+            found = session.execute_sql(SQL)
 
         self.assertIs(found, expected)
 
         self.assertEqual(len(_executed_sql_with), 1)
-        sql, params, param_types, query_mode, token = _executed_sql_with[0]
+        sql, params, param_types, query_mode = _executed_sql_with[0]
 
         self.assertEqual(sql, SQL)
         self.assertEqual(params, None)
         self.assertEqual(param_types, None)
         self.assertEqual(query_mode, None)
-        self.assertEqual(token, TOKEN)
 
     def test_batch_not_created(self):
         database = _Database(self.DATABASE_NAME)

--- a/spanner/tests/unit/test_snapshot.py
+++ b/spanner/tests/unit/test_snapshot.py
@@ -360,8 +360,6 @@ class Test_SnapshotBase(unittest.TestCase):
 
 class _MockCancellableIterator(object):
 
-    cancel_calls = 0
-
     def __init__(self, *values):
         self.iter_values = iter(values)
 

--- a/spanner/tests/unit/test_snapshot.py
+++ b/spanner/tests/unit/test_snapshot.py
@@ -168,7 +168,7 @@ class Test_SnapshotBase(unittest.TestCase):
                 TABLE_NAME, COLUMNS, KEYSET,
                 index=INDEX, limit=LIMIT)
 
-            self.assertIs(result_set._retry, patch.return_value)
+            self.assertIs(result_set._restart, patch.return_value)
             patch.assert_called_once_with(
                 api.streaming_read, session.name, TABLE_NAME, COLUMNS, KEYSET,
                 index=INDEX, limit=LIMIT)
@@ -314,7 +314,7 @@ class Test_SnapshotBase(unittest.TestCase):
                 SQL_QUERY_WITH_PARAM, PARAMS, PARAM_TYPES,
                 query_mode=MODE)
 
-            self.assertIs(result_set._retry, patch.return_value)
+            self.assertIs(result_set._restart, patch.return_value)
             patch.assert_called_once_with(
                 api.execute_streaming_sql, session.name, SQL_QUERY_WITH_PARAM,
                 params=PARAMS, param_types=PARAM_TYPES, query_mode=MODE)

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -900,8 +900,6 @@ class TestStreamedResultSet(unittest.TestCase):
 
 class _MockCancellableIterator(object):
 
-    cancel_calls = 0
-
     def __init__(self, *values):
         self.iter_values = iter(values)
 

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -608,48 +608,6 @@ class TestStreamedResultSet(unittest.TestCase):
         self.assertEqual(streamed.rows, [VALUES[0:3], VALUES[3:6]])
         self.assertEqual(streamed._current_row, VALUES[6:])
 
-    def test_one_or_none_no_value(self):
-        streamed = self._make_one(_MockCancellableIterator())
-        with mock.patch.object(streamed, 'consume_next') as consume_next:
-            consume_next.side_effect = StopIteration
-            self.assertIsNone(streamed.one_or_none())
-
-    def test_one_or_none_single_value(self):
-        streamed = self._make_one(_MockCancellableIterator())
-        streamed._rows = ['foo']
-        with mock.patch.object(streamed, 'consume_next') as consume_next:
-            consume_next.side_effect = StopIteration
-            self.assertEqual(streamed.one_or_none(), 'foo')
-
-    def test_one_or_none_multiple_values(self):
-        streamed = self._make_one(_MockCancellableIterator())
-        streamed._rows = ['foo', 'bar']
-        with self.assertRaises(ValueError):
-            streamed.one_or_none()
-
-    def test_one_or_none_consumed_stream(self):
-        streamed = self._make_one(_MockCancellableIterator())
-        streamed._metadata = object()
-        with self.assertRaises(RuntimeError):
-            streamed.one_or_none()
-
-    def test_one_single_value(self):
-        streamed = self._make_one(_MockCancellableIterator())
-        streamed._rows = ['foo']
-        with mock.patch.object(streamed, 'consume_next') as consume_next:
-            consume_next.side_effect = StopIteration
-            self.assertEqual(streamed.one(), 'foo')
-
-    def test_one_no_value(self):
-        from google.cloud import exceptions
-
-        iterator = _MockCancellableIterator(['foo'])
-        streamed = self._make_one(iterator)
-        with mock.patch.object(streamed, 'consume_next') as consume_next:
-            consume_next.side_effect = StopIteration
-            with self.assertRaises(exceptions.NotFound):
-                streamed.one()
-
     def test_consume_next_empty(self):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
@@ -902,6 +860,48 @@ class TestStreamedResultSet(unittest.TestCase):
         self.assertEqual(streamed.rows, [])
         self.assertEqual(streamed._current_row, [])
         self.assertIsNone(streamed._pending_chunk)
+
+    def test_one_single_value(self):
+        streamed = self._make_one(_MockCancellableIterator())
+        streamed._rows = ['foo']
+        with mock.patch.object(streamed, 'consume_next') as consume_next:
+            consume_next.side_effect = StopIteration
+            self.assertEqual(streamed.one(), 'foo')
+
+    def test_one_no_value(self):
+        from google.cloud import exceptions
+
+        iterator = _MockCancellableIterator(['foo'])
+        streamed = self._make_one(iterator)
+        with mock.patch.object(streamed, 'consume_next') as consume_next:
+            consume_next.side_effect = StopIteration
+            with self.assertRaises(exceptions.NotFound):
+                streamed.one()
+
+    def test_one_or_none_no_value(self):
+        streamed = self._make_one(_MockCancellableIterator())
+        with mock.patch.object(streamed, 'consume_next') as consume_next:
+            consume_next.side_effect = StopIteration
+            self.assertIsNone(streamed.one_or_none())
+
+    def test_one_or_none_single_value(self):
+        streamed = self._make_one(_MockCancellableIterator())
+        streamed._rows = ['foo']
+        with mock.patch.object(streamed, 'consume_next') as consume_next:
+            consume_next.side_effect = StopIteration
+            self.assertEqual(streamed.one_or_none(), 'foo')
+
+    def test_one_or_none_multiple_values(self):
+        streamed = self._make_one(_MockCancellableIterator())
+        streamed._rows = ['foo', 'bar']
+        with self.assertRaises(ValueError):
+            streamed.one_or_none()
+
+    def test_one_or_none_consumed_stream(self):
+        streamed = self._make_one(_MockCancellableIterator())
+        streamed._metadata = object()
+        with self.assertRaises(RuntimeError):
+            streamed.one_or_none()
 
 
 class _MockCancellableIterator(object):

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -25,15 +25,16 @@ class TestStreamedResultSet(unittest.TestCase):
 
         return StreamedResultSet
 
-    def _make_one(self, response_iterator, retry=object(), source=None):
-        return self._getTargetClass()(response_iterator, retry, source=source)
+    def _make_one(self, response_iterator, restart=object(), source=None):
+        return self._getTargetClass()(
+            response_iterator, restart, source=source)
 
     def test_ctor_defaults(self):
         iterator = _MockCancellableIterator()
-        retry = object()
-        streamed = self._make_one(iterator, retry)
+        restart = object()
+        streamed = self._make_one(iterator, restart)
         self.assertIs(streamed._response_iterator, iterator)
-        self.assertIs(streamed._retry, retry)
+        self.assertIs(streamed._restart, restart)
         self.assertIsNone(streamed._source)
         self.assertEqual(streamed.rows, [])
         self.assertIsNone(streamed.metadata)
@@ -43,11 +44,11 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test_ctor_w_source(self):
         iterator = _MockCancellableIterator()
-        retry = object()
+        restart = object()
         source = object()
-        streamed = self._make_one(iterator, retry, source=source)
+        streamed = self._make_one(iterator, restart, source=source)
         self.assertIs(streamed._response_iterator, iterator)
-        self.assertIs(streamed._retry, retry)
+        self.assertIs(streamed._restart, restart)
         self.assertIs(streamed._source, source)
         self.assertEqual(streamed.rows, [])
         self.assertIsNone(streamed.metadata)
@@ -924,8 +925,9 @@ class TestStreamedResultSet_JSON_acceptance_tests(unittest.TestCase):
 
         return StreamedResultSet
 
-    def _make_one(self, response_iterator, retry=object(), source=None):
-        return self._getTargetClass()(response_iterator, retry, source=source)
+    def _make_one(self, response_iterator, restart=object(), source=None):
+        return self._getTargetClass()(
+            response_iterator, restart, source=source)
 
     def _load_json_test(self, test_name):
         import os

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -25,24 +25,29 @@ class TestStreamedResultSet(unittest.TestCase):
 
         return StreamedResultSet
 
-    def _make_one(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+    def _make_one(self, response_iterator, retry=object(), source=None):
+        return self._getTargetClass()(response_iterator, retry, source=source)
 
     def test_ctor_defaults(self):
         iterator = _MockCancellableIterator()
-        streamed = self._make_one(iterator)
+        retry = object()
+        streamed = self._make_one(iterator, retry)
         self.assertIs(streamed._response_iterator, iterator)
+        self.assertIs(streamed._retry, retry)
         self.assertIsNone(streamed._source)
         self.assertEqual(streamed.rows, [])
         self.assertIsNone(streamed.metadata)
         self.assertIsNone(streamed.stats)
         self.assertIsNone(streamed.resume_token)
+        self.assertIsNone(streamed.resume_token)
 
     def test_ctor_w_source(self):
         iterator = _MockCancellableIterator()
+        retry = object()
         source = object()
-        streamed = self._make_one(iterator, source=source)
+        streamed = self._make_one(iterator, retry, source=source)
         self.assertIs(streamed._response_iterator, iterator)
+        self.assertIs(streamed._retry, retry)
         self.assertIs(streamed._source, source)
         self.assertEqual(streamed.rows, [])
         self.assertIsNone(streamed.metadata)
@@ -919,8 +924,8 @@ class TestStreamedResultSet_JSON_acceptance_tests(unittest.TestCase):
 
         return StreamedResultSet
 
-    def _make_one(self, *args, **kwargs):
-        return self._getTargetClass()(*args, **kwargs)
+    def _make_one(self, response_iterator, retry=object(), source=None):
+        return self._getTargetClass()(response_iterator, retry, source=source)
 
     def _load_json_test(self, test_name):
         import os

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -649,10 +649,9 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator, restart=restart)
 
-        with self.assertRaises(ValueError):
-            streamed._do_restart()
+        streamed._do_restart()
 
-        restart.assert_not_called()
+        restart.assert_called_once_with()
 
     def test__do_restart_empty(self):
         TOKEN = b'DEADBEEF'
@@ -687,6 +686,16 @@ class TestStreamedResultSet(unittest.TestCase):
         self.assertEqual(streamed._pending_rows, [])
         self.assertEqual(streamed._current_row, [])
         restart.assert_called_once_with(TOKEN)
+
+    def test_consume_next_w_service_no_token_yet(self):
+        restart = mock.Mock()
+        iterator = _ServiceUnavailableIterator()
+        streamed = self._make_one(iterator, restart=restart)
+
+        streamed.consume_next()
+
+        self.assertIs(streamed._response_iterator, restart.return_value)
+        restart.assert_called_once_with()
 
     def test_consume_next_w_service_unavailable(self):
         TOKEN = b'DEADBEEF'


### PR DESCRIPTION
Handle double-buffering required by possibly-missing `resumeToken`.

Closes #3775.