### PR TITLE
docs/bigquery/usage.rst: Remove incorrect note about UUIDs

### DIFF
--- a/docs/bigquery/usage.rst
+++ b/docs/bigquery/usage.rst
@@ -273,7 +273,6 @@ Background a query, loading the results into a table:
 
 .. note::
 
-   - ``google.cloud.bigquery`` generates a UUID for each job.
    - The ``created`` and ``state`` fields are not set until the job
      is submitted to the BigQuery back-end.
 


### PR DESCRIPTION
The following note was listed under "Inserting data (asynchronous)":

* google.cloud.bigquery generates a UUID for each job.

This is incorrect: run_async_query requires a name, which gets passed
as the jobId field to the REST API. For the synchronous case,
run_sync_query calls the query REST API which does not require an ID.

The BigQuery API currently makes no use of UUIDs, so remove the note.