### PR TITLE
Suppress instance creation tests by default on CI

### DIFF
--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -46,8 +46,7 @@ from test_utils.system import unique_resource_id
 from tests._fixtures import DDL_STATEMENTS
 
 
-IS_CIRCLE = os.getenv('CIRCLECI') == 'true'
-CREATE_INSTANCE = IS_CIRCLE or os.getenv(
+CREATE_INSTANCE = os.getenv(
     'GOOGLE_CLOUD_TESTS_CREATE_SPANNER_INSTANCE') is not None
 
 if CREATE_INSTANCE:

--- a/spanner/tests/system/utils/populate_streaming.py
+++ b/spanner/tests/system/utils/populate_streaming.py
@@ -84,8 +84,9 @@ def ensure_database(client):
 def populate_table(database, table_desc):
     all_ = KeySet(all_=True)
     columns = ('pkey', 'chunk_me')
-    rows = list(database.execute_sql(
-        'SELECT COUNT(*) FROM {}'.format(table_desc.table)))
+    with database.snapshot() as snapshot:
+        rows = list(snapshot.execute_sql(
+            'SELECT COUNT(*) FROM {}'.format(table_desc.table)))
     assert len(rows) == 1
     count = rows[0][0]
     if count != table_desc.row_count:
@@ -102,8 +103,9 @@ def populate_table(database, table_desc):
 def populate_table_2_columns(database, table_desc):
     all_ = KeySet(all_=True)
     columns = ('pkey', 'chunk_me', 'chunk_me_2')
-    rows = list(database.execute_sql(
-        'SELECT COUNT(*) FROM {}'.format(table_desc.table)))
+    with database.snapshot() as snapshot:
+        rows = list(snapshot.execute_sql(
+            'SELECT COUNT(*) FROM {}'.format(table_desc.table)))
     assert len(rows) == 1
     count = rows[0][0]
     if count != table_desc.row_count:

--- a/spanner/tests/system/utils/scrub_instances.py
+++ b/spanner/tests/system/utils/scrub_instances.py
@@ -1,0 +1,24 @@
+from google.cloud.spanner import Client
+from .streaming_utils import INSTANCE_NAME as STREAMING_INSTANCE
+
+STANDARD_INSTANCE = 'google-cloud-python-systest'
+
+
+def scrub_instances(client):
+
+    for instance in client.list_instances():
+        if instance.name == STREAMING_INSTANCE:
+            print('Not deleting streaming instance: {}'.format(
+                STREAMING_INSTANCE))
+            continue
+        elif instance.name == STANDARD_INSTANCE:
+            print('Not deleting standard instance: {}'.format(
+                STANDARD_INSTANCE))
+        else:
+            print("deleting instance: {}".format(instance.name))
+            instance.delete()
+
+
+if __name__ == '__main__':
+    client = Client()
+    scrub_instances(client)

--- a/spanner/tests/system/utils/scrub_instances.py
+++ b/spanner/tests/system/utils/scrub_instances.py
@@ -1,3 +1,17 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from google.cloud.spanner import Client
 from .streaming_utils import INSTANCE_NAME as STREAMING_INSTANCE
 
@@ -5,7 +19,6 @@ STANDARD_INSTANCE = 'google-cloud-python-systest'
 
 
 def scrub_instances(client):
-
     for instance in client.list_instances():
         if instance.name == STREAMING_INSTANCE:
             print('Not deleting streaming instance: {}'.format(


### PR DESCRIPTION
We don't have enough quota to risk orphans.

- Fix `tests/system/utils/populate_streaming` script after PR #3787.

- Add utility for scrubbing orphaned instances.