### PR TITLE
bigquery: rename TableReference.dataset_ref

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -66,7 +66,7 @@ class TableReference(object):
         self._table_id = table_id
 
     @property
-    def dataset_ref(self):
+    def dataset(self):
         """Pointer to the dataset.
 
         :rtype: :class:`google.cloud.bigquery.dataset.DatasetReference`

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -104,7 +104,7 @@ class TestDatasetReference(unittest.TestCase):
     def test_table(self):
         dataset_ref = self._make_one('some-project-1', 'dataset_1')
         table_ref = dataset_ref.table('table_1')
-        self.assertIs(table_ref.dataset_ref, dataset_ref)
+        self.assertIs(table_ref.dataset, dataset_ref)
         self.assertEqual(table_ref.table_id, 'table_1')
 
 

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -53,7 +53,7 @@ class TestTableReference(unittest.TestCase):
         dataset_ref = DatasetReference('project_1', 'dataset_1')
 
         table_ref = self._make_one(dataset_ref, 'table_1')
-        self.assertIs(table_ref.dataset_ref, dataset_ref)
+        self.assertIs(table_ref.dataset, dataset_ref)
         self.assertEqual(table_ref.table_id, 'table_1')
 
 


### PR DESCRIPTION
Rename to dataset to be consistent with Client.dataset. Both
methods actually return a DatasetReference.