### PR TITLE
Remove deepcopy of client._http

### DIFF
--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -20,7 +20,6 @@ Uses a background worker to log to Stackdriver Logging asynchronously.
 from __future__ import print_function
 
 import atexit
-import copy
 import logging
 import threading
 

--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -254,9 +254,7 @@ class BackgroundThreadTransport(Transport):
 
     def __init__(self, client, name, grace_period=_DEFAULT_GRACE_PERIOD,
                  batch_size=_DEFAULT_MAX_BATCH_SIZE):
-        http = copy.deepcopy(client._http)
-        self.client = client.__class__(
-            client.project, client._credentials, http)
+        self.client = client
         logger = self.client.logger(name)
         self.worker = _Worker(logger)
         self.worker.start()

--- a/logging/tests/system.py
+++ b/logging/tests/system.py
@@ -414,30 +414,32 @@ class TestLogging(unittest.TestCase):
         self.assertTrue(sink.exists())
 
     def test_create_sink_pubsub_topic(self):
-        from google.cloud.iam import OWNER_ROLE
-        from google.cloud.pubsub import client as pubsub_client
+        import uuid
+
+        from google.cloud import pubsub_v1
 
         SINK_NAME = 'test-create-sink-topic%s' % (_RESOURCE_ID,)
-        TOPIC_NAME = 'logging-test-sink%s' % (_RESOURCE_ID,)
+        TOPIC_NAME = '%s-%s' % ('systest', str(uuid.uuid4())[0:8])
 
         # Create the destination topic, and set up the IAM policy to allow
         # Stackdriver Logging to write into it.
-        pubsub_client = pubsub_client.Client()
-        topic = pubsub_client.topic(TOPIC_NAME)
-        topic.create()
-        self.to_delete.append(topic)
-        policy = topic.get_iam_policy()
-        new_owners = set([policy.group('cloud-logs@google.com')])
-        new_owners.update(policy.owners)
-        policy[OWNER_ROLE] = new_owners
-        topic.set_iam_policy(policy)
+        publisher = pubsub_v1.PublisherClient()
+        topic_path = publisher.topic_path(Config.CLIENT.project, TOPIC_NAME)
+        publisher.create_topic(topic_path)
 
-        TOPIC_URI = 'pubsub.googleapis.com/%s' % (topic.full_name,)
+        policy = publisher.get_iam_policy(topic_path)
+        policy.bindings.add(
+            role='roles/owner',
+            members=['group:cloud-logs@google.com']
+        )
+        publisher.set_iam_policy(topic_path, policy)
+
+        TOPIC_URI = 'pubsub.googleapis.com/%s' % (topic_path,)
 
         sink = Config.CLIENT.sink(SINK_NAME, DEFAULT_FILTER, TOPIC_URI)
         self.assertFalse(sink.exists())
         sink.create()
-        self.to_delete.append(sink)
+        publisher.delete_topic(topic_path)
         self.assertTrue(sink.exists())
 
     def _init_bigquery_dataset(self):

--- a/logging/tests/unit/test_client.py
+++ b/logging/tests/unit/test_client.py
@@ -560,23 +560,18 @@ class TestClient(unittest.TestCase):
         })
 
     def test_get_default_handler_app_engine(self):
-        import requests
         import os
         from google.cloud._testing import _Monkey
         from google.cloud.logging.client import _APPENGINE_FLEXIBLE_ENV_VM
         from google.cloud.logging.handlers import AppEngineHandler
 
-        http_mock = mock.Mock(spec=requests.Session)
         credentials = _make_credentials()
-        deepcopy = mock.Mock(return_value=http_mock)
 
         with _Monkey(os, environ={_APPENGINE_FLEXIBLE_ENV_VM: 'True'}):
-            with mock.patch('copy.deepcopy', new=deepcopy):
-                client = self._make_one(project=self.PROJECT,
-                                        credentials=credentials,
-                                        _use_grpc=False)
-                handler = client.get_default_handler()
-                deepcopy.assert_called_once_with(client._http)
+            client = self._make_one(project=self.PROJECT,
+                                    credentials=credentials,
+                                    _use_grpc=False)
+            handler = client.get_default_handler()
 
         self.assertIsInstance(handler, AppEngineHandler)
 
@@ -598,39 +593,28 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(handler, ContainerEngineHandler)
 
     def test_get_default_handler_general(self):
-        import requests
         from google.cloud.logging.handlers import CloudLoggingHandler
 
-        http_mock = mock.Mock(spec=requests.Session)
         credentials = _make_credentials()
-        deepcopy = mock.Mock(return_value=http_mock)
 
-        with mock.patch('copy.deepcopy', new=deepcopy):
-            client = self._make_one(project=self.PROJECT,
-                                    credentials=credentials,
-                                    _use_grpc=False)
-            handler = client.get_default_handler()
-            deepcopy.assert_called_once_with(client._http)
+        client = self._make_one(project=self.PROJECT,
+                                credentials=credentials,
+                                _use_grpc=False)
+        handler = client.get_default_handler()
 
         self.assertIsInstance(handler, CloudLoggingHandler)
 
     def test_setup_logging(self):
-        import requests
-
-        http_mock = mock.Mock(spec=requests.Session)
-        deepcopy = mock.Mock(return_value=http_mock)
         setup_logging = mock.Mock(spec=[])
 
         credentials = _make_credentials()
 
-        with mock.patch('copy.deepcopy', new=deepcopy):
-            with mock.patch('google.cloud.logging.client.setup_logging',
-                            new=setup_logging):
-                client = self._make_one(project=self.PROJECT,
-                                        credentials=credentials,
-                                        _use_grpc=False)
-                client.setup_logging()
-                deepcopy.assert_called_once_with(client._http)
+        with mock.patch('google.cloud.logging.client.setup_logging',
+                        new=setup_logging):
+            client = self._make_one(project=self.PROJECT,
+                                    credentials=credentials,
+                                    _use_grpc=False)
+            client.setup_logging()
 
         setup_logging.assert_called()
 


### PR DESCRIPTION
Fixes #3931.
When GOOGLE_CLOUD_DISABLE_GRPC=true, the logging will have `'AuthorizedSession' object has no attribute 'credentials'` exception.
The line `http = copy.deepcopy(client._http)` is a relic when httplib2 was used. Removing it and directly use the `client` passed in instead of re-initialize with the deepcopied http object solved the problem.