### PR TITLE
Video Intelligence: Bump version to 0.27.0

### DIFF
--- a/videointelligence/setup.py
+++ b/videointelligence/setup.py
@@ -29,7 +29,7 @@ setup(
     author='Google Cloud Platform',
     author_email='googleapis-publisher@google.com',
     name='google-cloud-videointelligence',
-    version='0.26.0',
+    version='0.27.0',
     description='Python Client for Google Cloud Video Intelligence',
     long_description=readme,
     namespace_packages=[


### PR DESCRIPTION
Uses #3977 as a base.