### PR TITLE
Pass service address to OperationsClient.

### DIFF
--- a/videointelligence/google/cloud/videointelligence_v1beta1/gapic/video_intelligence_service_client.py
+++ b/videointelligence/google/cloud/videointelligence_v1beta1/gapic/video_intelligence_service_client.py
@@ -130,6 +130,7 @@ class VideoIntelligenceServiceClient(object):
             ssl_credentials=ssl_credentials)
 
         self.operations_client = operations_client.OperationsClient(
+            service_path=self.SERVICE_ADDRESS,
             channel=channel,
             credentials=credentials,
             ssl_credentials=ssl_credentials,

--- a/videointelligence/google/cloud/videointelligence_v1beta2/gapic/video_intelligence_service_client.py
+++ b/videointelligence/google/cloud/videointelligence_v1beta2/gapic/video_intelligence_service_client.py
@@ -130,6 +130,7 @@ class VideoIntelligenceServiceClient(object):
             ssl_credentials=ssl_credentials)
 
         self.operations_client = operations_client.OperationsClient(
+            service_path=self.SERVICE_ADDRESS,
             channel=channel,
             credentials=credentials,
             ssl_credentials=ssl_credentials,


### PR DESCRIPTION
This fixes an issue where the wrong service address was passed to the LRO client, so `operation.result()` would return a 404.