### PR TITLE
bigquery: remove dataset.exists

### DIFF
--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -17,7 +17,6 @@ import six
 
 from google.api.core import page_iterator
 from google.cloud._helpers import _datetime_from_microseconds
-from google.cloud.exceptions import NotFound
 from google.cloud.bigquery.table import Table
 from google.cloud.bigquery.table import TableReference
 

--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -486,30 +486,6 @@ class Dataset(object):
 
         return resource
 
-    def exists(self, client=None):
-        """API call:  test for the existence of the dataset via a GET request
-
-        See
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/get
-
-        :type client: :class:`~google.cloud.bigquery.client.Client` or
-                      ``NoneType``
-        :param client: the client to use.  If not passed, falls back to the
-                       ``client`` stored on the current dataset.
-
-        :rtype: bool
-        :returns: Boolean indicating existence of the dataset.
-        """
-        client = self._require_client(client)
-
-        try:
-            client._connection.api_request(method='GET', path=self.path,
-                                           query_params={'fields': 'id'})
-        except NotFound:
-            return False
-        else:
-            return True
-
     def patch(self, client=None, **kw):
         """API call:  update individual dataset properties via a PATCH request.
 

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -1196,10 +1196,10 @@ class TestBigQuery(unittest.TestCase):
 def _job_done(instance):
     return instance.state.lower() == 'done'
 
+
 def _dataset_exists(ds):
     try:
         Config.CLIENT.get_dataset(DatasetReference(ds.project, ds.dataset_id))
         return True
     except NotFound:
         return False
-    

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -386,37 +386,6 @@ class TestDataset(unittest.TestCase):
         with self.assertRaises(ValueError):
             dataset._parse_access_entries(ACCESS)
 
-    def test_exists_miss_w_bound_client(self):
-        PATH = 'projects/%s/datasets/%s' % (self.PROJECT, self.DS_ID)
-        conn = _Connection()
-        client = _Client(project=self.PROJECT, connection=conn)
-        dataset = self._make_one(self.DS_ID, client=client)
-
-        self.assertFalse(dataset.exists())
-
-        self.assertEqual(len(conn._requested), 1)
-        req = conn._requested[0]
-        self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], '/%s' % PATH)
-        self.assertEqual(req['query_params'], {'fields': 'id'})
-
-    def test_exists_hit_w_alternate_client(self):
-        PATH = 'projects/%s/datasets/%s' % (self.PROJECT, self.DS_ID)
-        conn1 = _Connection()
-        CLIENT1 = _Client(project=self.PROJECT, connection=conn1)
-        conn2 = _Connection({})
-        CLIENT2 = _Client(project=self.PROJECT, connection=conn2)
-        dataset = self._make_one(self.DS_ID, client=CLIENT1)
-
-        self.assertTrue(dataset.exists(client=CLIENT2))
-
-        self.assertEqual(len(conn1._requested), 0)
-        self.assertEqual(len(conn2._requested), 1)
-        req = conn2._requested[0]
-        self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['path'], '/%s' % PATH)
-        self.assertEqual(req['query_params'], {'fields': 'id'})
-
     def test_patch_w_invalid_expiration(self):
         RESOURCE = self._makeResource()
         conn = _Connection(RESOURCE)

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -696,9 +696,6 @@ class _Connection(object):
         self._requested = []
 
     def api_request(self, **kw):
-        from google.cloud.exceptions import NotFound
-
         self._requested.append(kw)
-
         response, self._responses = self._responses[0], self._responses[1:]
         return response

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -700,9 +700,5 @@ class _Connection(object):
 
         self._requested.append(kw)
 
-        try:
-            response, self._responses = self._responses[0], self._responses[1:]
-        except IndexError:
-            raise NotFound('miss')
-        else:
-            return response
+        response, self._responses = self._responses[0], self._responses[1:]
+        return response


### PR DESCRIPTION
Dataset won't be able to support this method when we remove its client.  

Don't add `Client.dataset_exists`; the user can use `Client.get_dataset` and catch NotFound.


