### PR TITLE
BigQuery: Remove dataset property from TableReference and add project/dataset_id properties

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1119,8 +1119,8 @@ class ExtractJob(_AsyncJob):
         """Generate a resource for :meth:`begin`."""
 
         source_ref = {
-            'projectId': self.source.dataset.project,
-            'datasetId': self.source.dataset.dataset_id,
+            'projectId': self.source.project,
+            'datasetId': self.source.dataset_id,
             'tableId': self.source.table_id,
         }
 

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -68,6 +68,15 @@ class TableReference(object):
         self._table_id = table_id
 
     @property
+    def project(self):
+        """Project bound to the table.
+
+        :rtype: str
+        :returns: the project (derived from the dataset reference).
+        """
+        return self._dataset_ref.project
+
+    @property
     def dataset(self):
         """Pointer to the dataset.
 
@@ -75,6 +84,15 @@ class TableReference(object):
         :returns: a pointer to the dataset.
         """
         return self._dataset_ref
+
+    @property
+    def dataset_id(self):
+        """ID of dataset containing the table.
+
+        :rtype: str
+        :returns: the ID (derived from the dataset reference).
+        """
+        return self._dataset_ref.dataset_id
 
     @property
     def table_id(self):

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -581,7 +581,7 @@ class TestBigQuery(unittest.TestCase):
         self.to_delete.insert(0, blob)
 
         dataset = retry_403(Config.CLIENT.create_dataset)(
-            Dataset(table.dataset.dataset_id))
+            Dataset(table.dataset_id))
         self.to_delete.append(dataset)
         table = dataset.table(table.table_id)
         self.to_delete.insert(0, table)

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -104,7 +104,8 @@ class TestDatasetReference(unittest.TestCase):
     def test_table(self):
         dataset_ref = self._make_one('some-project-1', 'dataset_1')
         table_ref = dataset_ref.table('table_1')
-        self.assertIs(table_ref.dataset, dataset_ref)
+        self.assertEqual(table_ref.dataset_id, 'dataset_1')
+        self.assertEqual(table_ref.project, 'some-project-1')
         self.assertEqual(table_ref.table_id, 'table_1')
 
 
@@ -663,7 +664,8 @@ class TestDataset(unittest.TestCase):
         table = dataset.table('table_id')
         self.assertIsInstance(table, Table)
         self.assertEqual(table.table_id, 'table_id')
-        self.assertIs(table._dataset, dataset)
+        self.assertEqual(table.dataset_id, self.DS_ID)
+        self.assertEqual(table.project, self.PROJECT)
         self.assertEqual(table.schema, [])
 
     def test_table_w_schema(self):
@@ -678,7 +680,8 @@ class TestDataset(unittest.TestCase):
         table = dataset.table('table_id', schema=[full_name, age])
         self.assertIsInstance(table, Table)
         self.assertEqual(table.table_id, 'table_id')
-        self.assertIs(table._dataset, dataset)
+        self.assertEqual(table.dataset_id, self.DS_ID)
+        self.assertEqual(table.project, self.PROJECT)
         self.assertEqual(table.schema, [full_name, age])
 
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1220,8 +1220,8 @@ class TestExtractJob(unittest.TestCase, _Base):
         self.assertEqual(job.destination_uris, config['destinationUris'])
 
         table_ref = config['sourceTable']
-        self.assertEqual(job.source.dataset.project, table_ref['projectId'])
-        self.assertEqual(job.source.dataset.dataset_id, table_ref['datasetId'])
+        self.assertEqual(job.source.project, table_ref['projectId'])
+        self.assertEqual(job.source.dataset_id, table_ref['datasetId'])
         self.assertEqual(job.source.table_id, table_ref['tableId'])
 
         if 'compression' in config:
@@ -1908,7 +1908,6 @@ class TestQueryJob(unittest.TestCase, _Base):
         self.assertEqual(job.statement_type, statement_type)
 
     def test_referenced_tables(self):
-        from google.cloud.bigquery.dataset import Dataset
         from google.cloud.bigquery.table import Table
 
         ref_tables_resource = [{
@@ -1942,24 +1941,21 @@ class TestQueryJob(unittest.TestCase, _Base):
 
         self.assertIsInstance(local1, Table)
         self.assertEqual(local1.table_id, 'local1')
-        self.assertIsInstance(local1._dataset, Dataset)
         self.assertEqual(local1.dataset_id, 'dataset')
         self.assertEqual(local1.project, self.PROJECT)
-        self.assertIs(local1._dataset._client, client)
+        self.assertIs(local1._client, client)
 
         self.assertIsInstance(local2, Table)
         self.assertEqual(local2.table_id, 'local2')
-        self.assertIsInstance(local2._dataset, Dataset)
         self.assertEqual(local2.dataset_id, 'dataset')
         self.assertEqual(local2.project, self.PROJECT)
-        self.assertIs(local2._dataset._client, client)
+        self.assertIs(local2._client, client)
 
         self.assertIsInstance(remote, Table)
         self.assertEqual(remote.table_id, 'other-table')
-        self.assertIsInstance(remote._dataset, Dataset)
         self.assertEqual(remote.dataset_id, 'other-dataset')
         self.assertEqual(remote.project, 'other-project-123')
-        self.assertIs(remote._dataset._client, client)
+        self.assertIs(remote._client, client)
 
     def test_undeclared_query_paramters(self):
         from google.cloud.bigquery._helpers import ArrayQueryParameter


### PR DESCRIPTION
The dataset property (of type DatasetReference) in the TableReference class was primarily being used for the dataset_id and project properties. This change replaces the dataset property with dataset_id and project properties to make TableReference consistent with the Table class.