### PR TITLE
Bump release to 0.27.1.

### DIFF
--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -61,7 +61,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-spanner',
-    version='0.27.0',
+    version='0.27.1',
     description='Python Client for Cloud Spanner',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Draft release notes:

## google-cloud-spanner 0.27.1

- Pin dependency  `google-auth >= 1.1.0` to fix use of `google.cloud.spanner` on GCE. (PR #3950, issue #3933)
- Fix merge of partial timestamp and date field values. (PR #4015, issue #3981, #3998)
- Restart streaming iterators from `read` / `execute_sql` operations after resumable error (PR #4016, issue #3775).

---

Internal housekeeping not included in release notes:

- Suppress instance creation tests by default on CI (PR #3951)