### PR TITLE
Fix up the documentation nav for Spanner.

### DIFF
--- a/docs/spanner/api-reference.rst
+++ b/docs/spanner/api-reference.rst
@@ -1,8 +1,11 @@
 API Reference
 =============
 
+The following classes and methods constitute the Spanner client.
+Most likely, you will be interacting almost exclusively with these:
+
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     client-api
     instance-api
@@ -13,6 +16,14 @@ API Reference
     batch-api
     transaction-api
     streamed-api
+
+
+The classes and methods above depend on the following, lower-level
+classes and methods. Documentation for these is provided for completion,
+and some advanced use cases may wish to interact with these directly:
+
+.. toctree::
+    :maxdepth: 1
 
     gapic/v1/api
     gapic/v1/types

--- a/docs/spanner/api-reference.rst
+++ b/docs/spanner/api-reference.rst
@@ -1,0 +1,22 @@
+API Reference
+=============
+
+.. toctree::
+    :maxdepth: 2
+
+    client-api
+    instance-api
+    database-api
+    session-api
+    keyset-api
+    snapshot-api
+    batch-api
+    transaction-api
+    streamed-api
+
+    gapic/v1/api
+    gapic/v1/types
+    gapic/v1/admin_database_api
+    gapic/v1/admin_database_types
+    gapic/v1/admin_instance_api
+    gapic/v1/admin_instance_types

--- a/docs/spanner/database-usage.rst
+++ b/docs/spanner/database-usage.rst
@@ -1,5 +1,5 @@
-Database Admin API
-==================
+Database Admin
+==============
 
 After creating a :class:`~google.cloud.spanner.instance.Instance`, you can
 interact with individual databases for that instance.

--- a/docs/spanner/instance-usage.rst
+++ b/docs/spanner/instance-usage.rst
@@ -1,5 +1,5 @@
-Instance Admin API
-==================
+Instance Admin
+==============
 
 After creating a :class:`~google.cloud.spanner.client.Client`, you can
 interact with individual instances for a project.

--- a/docs/spanner/usage.rst
+++ b/docs/spanner/usage.rst
@@ -12,23 +12,7 @@ Spanner
   snapshot-usage
   transaction-usage
   advanced-session-pool-topics
-
-  client-api
-  instance-api
-  database-api
-  session-api
-  keyset-api
-  snapshot-api
-  batch-api
-  transaction-api
-  streamed-api
-
-  gapic/v1/api
-  gapic/v1/types
-  gapic/v1/admin_database_api
-  gapic/v1/admin_database_types
-  gapic/v1/admin_instance_api
-  gapic/v1/admin_instance_types
+  api-reference
 
 API requests are sent to the `Cloud Spanner`_ API via RPC over
 HTTP/2.  In order to support this, we'll rely on `gRPC`_.


### PR DESCRIPTION
Uses #4028 as a base.

This improves the left nav for Spanner and generally makes it make more sense.
Fixes the sixth item on @jonparrott's documentation hotlist.