### PR TITLE
Re-enable 'Bucket.requester_pays' feature

### DIFF
--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -67,6 +67,11 @@ class _PropertyMixin(object):
         """Abstract getter for the object client."""
         raise NotImplementedError
 
+    @property
+    def user_project(self):
+        """Abstract getter for the object user_project."""
+        raise NotImplementedError
+
     def _require_client(self, client):
         """Check client or verify over-ride.
 
@@ -94,6 +99,8 @@ class _PropertyMixin(object):
         # Pass only '?projection=noAcl' here because 'acl' and related
         # are handled via custom endpoints.
         query_params = {'projection': 'noAcl'}
+        if self.user_project is not None:
+            query_params['userProject'] = self.user_project
         api_response = client._connection.api_request(
             method='GET', path=self.path, query_params=query_params,
             _target_object=self)
@@ -140,13 +147,16 @@ class _PropertyMixin(object):
         client = self._require_client(client)
         # Pass '?projection=full' here because 'PATCH' documented not
         # to work properly w/ 'noAcl'.
+        query_params = {'projection': 'full'}
+        if self.user_project is not None:
+            query_params['userProject'] = self.user_project
         update_properties = {key: self._properties[key]
                              for key in self._changes}
 
         # Make the API call.
         api_response = client._connection.api_request(
             method='PATCH', path=self.path, data=update_properties,
-            query_params={'projection': 'full'}, _target_object=self)
+            query_params=query_params, _target_object=self)
         self._set_properties(api_response)
 
     def update(self, client=None):

--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -170,9 +170,12 @@ class _PropertyMixin(object):
                        ``client`` stored on the current object.
         """
         client = self._require_client(client)
+        query_params = {'projection': 'full'}
+        if self.user_project is not None:
+            query_params['userProject'] = self.user_project
         api_response = client._connection.api_request(
             method='PUT', path=self.path, data=self._properties,
-            query_params={'projection': 'full'}, _target_object=self)
+            query_params=query_params, _target_object=self)
         self._set_properties(api_response)
 
 

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -221,6 +221,16 @@ class Blob(_PropertyMixin):
         return self.bucket.client
 
     @property
+    def user_project(self):
+        """Project ID used for API requests made via this blob.
+
+        Derived from bucket's value.
+
+        :rtype: str
+        """
+        return self.bucket.user_project
+
+    @property
     def public_url(self):
         """The public URL for this blob's object.
 

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -34,7 +34,11 @@ import os
 import time
 import warnings
 
+from six.moves.urllib.parse import parse_qsl
 from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib.parse import urlsplit
+from six.moves.urllib.parse import urlunsplit
 
 from google import resumable_media
 from google.resumable_media.requests import ChunkedDownload
@@ -399,15 +403,19 @@ class Blob(_PropertyMixin):
         :rtype: str
         :returns: The download URL for the current blob.
         """
+        name_value_pairs = []
         if self.media_link is None:
-            download_url = _DOWNLOAD_URL_TEMPLATE.format(path=self.path)
+            base_url = _DOWNLOAD_URL_TEMPLATE.format(path=self.path)
             if self.generation is not None:
-                download_url += u'&generation={:d}'.format(self.generation)
-            if self.user_project is not None:
-                download_url += u'&userProject={}'.format(self.user_project)
-            return download_url
+                name_value_pairs.append(
+                    ('generation', '{:d}'.format(self.generation)))
         else:
-            return self.media_link
+            base_url = self.media_link
+
+        if self.user_project is not None:
+            name_value_pairs.append(('userProject', self.user_project))
+
+        return _add_query_parameters(base_url, name_value_pairs)
 
     def _do_download(self, transport, file_obj, download_url, headers):
         """Perform a download without any error handling.
@@ -653,12 +661,14 @@ class Blob(_PropertyMixin):
         info = self._get_upload_arguments(content_type)
         headers, object_metadata, content_type = info
 
-        upload_url = _MULTIPART_URL_TEMPLATE.format(
+        base_url = _MULTIPART_URL_TEMPLATE.format(
             bucket_path=self.bucket.path)
+        name_value_pairs = []
 
         if self.user_project is not None:
-            upload_url += '&userProject={}'.format(self.user_project)
+            name_value_pairs.append(('userProject', self.user_project))
 
+        upload_url = _add_query_parameters(base_url, name_value_pairs)
         upload = MultipartUpload(upload_url, headers=headers)
 
         if num_retries is not None:
@@ -729,12 +739,14 @@ class Blob(_PropertyMixin):
         if extra_headers is not None:
             headers.update(extra_headers)
 
-        upload_url = _RESUMABLE_URL_TEMPLATE.format(
+        base_url = _RESUMABLE_URL_TEMPLATE.format(
             bucket_path=self.bucket.path)
+        name_value_pairs = []
 
         if self.user_project is not None:
-            upload_url += '&userProject={}'.format(self.user_project)
+            name_value_pairs.append(('userProject', self.user_project))
 
+        upload_url = _add_query_parameters(base_url, name_value_pairs)
         upload = ResumableUpload(upload_url, chunk_size, headers=headers)
 
         if num_retries is not None:
@@ -1670,3 +1682,24 @@ def _raise_from_invalid_response(error):
              to the failed status code
     """
     raise exceptions.from_http_response(error.response)
+
+
+def _add_query_parameters(base_url, name_value_pairs):
+    """Add one query parameter to a base URL.
+
+    :type base_url: string
+    :param base_url: Base URL (may already contain query parameters)
+
+    :type name_value_pairs: list of (string, string) tuples.
+    :param name_value_pairs: Names and values of the query parameters to add
+
+    :rtype: string
+    :returns: URL with additional query strings appended.
+    """
+    if len(name_value_pairs) == 0:
+        return base_url
+
+    scheme, netloc, path, query, frag = urlsplit(base_url)
+    query = parse_qsl(query)
+    query.extend(name_value_pairs)
+    return urlunsplit((scheme, netloc, path, urlencode(query), frag))

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -108,6 +108,10 @@ class Bucket(_PropertyMixin):
     :type name: str
     :param name: The name of the bucket. Bucket names must start and end with a
                  number or letter.
+
+    :type user_project: str
+    :param user_project: (Optional) the project ID to be billed for API
+                         requests made via this instance.
     """
 
     _MAX_OBJECTS_FOR_ITERATION = 256
@@ -131,13 +135,14 @@ class Bucket(_PropertyMixin):
     https://cloud.google.com/storage/docs/storage-classes
     """
 
-    def __init__(self, client, name=None):
+    def __init__(self, client, name=None, user_project=None):
         name = _validate_name(name)
         super(Bucket, self).__init__(name=name)
         self._client = client
         self._acl = BucketACL(self)
         self._default_object_acl = DefaultObjectACL(self)
         self._label_removals = set()
+        self._user_project = user_project
 
     def __repr__(self):
         return '<Bucket: %s>' % (self.name,)
@@ -155,6 +160,16 @@ class Bucket(_PropertyMixin):
         """
         self._label_removals.clear()
         return super(Bucket, self)._set_properties(value)
+
+    @property
+    def user_project(self):
+        """Project ID to be billed for API requests made via this bucket.
+
+        If unset, API requests are billed to the bucket owner.
+
+        :rtype: str
+        """
+        return self._user_project
 
     def blob(self, blob_name, chunk_size=None, encryption_key=None):
         """Factory constructor for blob object.

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -964,9 +964,39 @@ class Bucket(_PropertyMixin):
         details.
 
         :type value: convertible to boolean
-        :param value: should versioning be anabled for the bucket?
+        :param value: should versioning be enabled for the bucket?
         """
         self._patch_property('versioning', {'enabled': bool(value)})
+
+    @property
+    def requester_pays(self):
+        """Does the requester pay for API requests for this bucket?
+
+        .. note::
+
+           No public docs exist yet for the "requester pays" feature.
+
+        :setter: Update whether requester pays for this bucket.
+        :getter: Query whether requester pays for this bucket.
+
+        :rtype: bool
+        :returns: True if requester pays for API requests for the bucket,
+                  else False.
+        """
+        versioning = self._properties.get('billing', {})
+        return versioning.get('requesterPays', False)
+
+    @requester_pays.setter
+    def requester_pays(self, value):
+        """Update whether requester pays for API requests for this bucket.
+
+        See  https://cloud.google.com/storage/docs/<DOCS-MISSING> for
+        details.
+
+        :type value: convertible to boolean
+        :param value: should requester pay for API requests for the bucket?
+        """
+        self._patch_property('billing', {'requesterPays': bool(value)})
 
     def configure_website(self, main_page_suffix=None, not_found_page=None):
         """Configure website-related properties.

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -121,7 +121,7 @@ class Client(ClientWithProject):
         """
         return self._batch_stack.top
 
-    def bucket(self, bucket_name):
+    def bucket(self, bucket_name, user_project=None):
         """Factory constructor for bucket object.
 
         .. note::
@@ -131,10 +131,14 @@ class Client(ClientWithProject):
         :type bucket_name: str
         :param bucket_name: The name of the bucket to be instantiated.
 
+        :type user_project: str
+        :param user_project: (Optional) the project ID to be billed for API
+                             requests made via this instance.
+
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
         :returns: The bucket object created.
         """
-        return Bucket(client=self, name=bucket_name)
+        return Bucket(client=self, name=bucket_name, user_project=user_project)
 
     def batch(self):
         """Factory constructor for batch object.

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -194,7 +194,7 @@ class Client(ClientWithProject):
         except NotFound:
             return None
 
-    def create_bucket(self, bucket_name):
+    def create_bucket(self, bucket_name, requester_pays=None):
         """Create a new bucket.
 
         For example:
@@ -211,10 +211,17 @@ class Client(ClientWithProject):
         :type bucket_name: str
         :param bucket_name: The bucket name to create.
 
+        :type requester_pays: bool
+        :param requester_pays:
+            (Optional) Whether requester pays for API requests for this
+            bucket and its blobs.
+
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
         :returns: The newly created bucket.
         """
         bucket = Bucket(self, name=bucket_name)
+        if requester_pays is not None:
+            bucket.requester_pays = requester_pays
         bucket.create(client=self)
         return bucket
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -28,9 +28,6 @@ from test_utils.retry import RetryErrors
 from test_utils.system import unique_resource_id
 
 
-REQUESTER_PAYS_ENABLED = False  # query from environment?
-
-
 def _bad_copy(bad_request):
     """Predicate: pass only exceptions for a failed copyTo."""
     err_msg = bad_request.message
@@ -98,7 +95,6 @@ class TestStorageBuckets(unittest.TestCase):
         self.case_buckets_to_delete.append(new_bucket_name)
         self.assertEqual(created.name, new_bucket_name)
 
-    @unittest.skipUnless(REQUESTER_PAYS_ENABLED, "requesterPays not enabled")
     def test_create_bucket_with_requester_pays(self):
         new_bucket_name = 'w-requester-pays' + unique_resource_id('-')
         created = Config.CLIENT.create_bucket(

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -215,6 +215,34 @@ class TestStorageBuckets(unittest.TestCase):
         viewers.add(policy.all_users())
         with_user_project.set_iam_policy(policy)
 
+    @unittest.skipUnless(USER_PROJECT, 'USER_PROJECT not set in environment.')
+    def test_copy_existing_file_with_user_project(self):
+        new_bucket_name = 'copy-w-requester-pays' + unique_resource_id('-')
+        created = Config.CLIENT.create_bucket(
+            new_bucket_name, requester_pays=True)
+        self.case_buckets_to_delete.append(new_bucket_name)
+        self.assertEqual(created.name, new_bucket_name)
+        self.assertTrue(created.requester_pays)
+
+        to_delete = []
+        blob = storage.Blob('simple', bucket=created)
+        blob.upload_from_string(b'DEADBEEF')
+        to_delete.append(blob)
+        try:
+            with_user_project = Config.CLIENT.bucket(
+                new_bucket_name, user_project=USER_PROJECT)
+
+            new_blob = retry_bad_copy(with_user_project.copy_blob)(
+                blob, with_user_project, 'simple-copy')
+            to_delete.append(new_blob)
+
+            base_contents = blob.download_as_string()
+            copied_contents = new_blob.download_as_string()
+            self.assertEqual(base_contents, copied_contents)
+        finally:
+            for blob in to_delete:
+                retry_429(blob.delete)()
+
 
 class TestStorageFiles(unittest.TestCase):
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -28,6 +28,9 @@ from test_utils.retry import RetryErrors
 from test_utils.system import unique_resource_id
 
 
+USER_PROJECT = os.environ.get('GOOGLE_CLOUD_TESTS_USER_PROJECT')
+
+
 def _bad_copy(bad_request):
     """Predicate: pass only exceptions for a failed copyTo."""
     err_msg = bad_request.message
@@ -95,14 +98,6 @@ class TestStorageBuckets(unittest.TestCase):
         self.case_buckets_to_delete.append(new_bucket_name)
         self.assertEqual(created.name, new_bucket_name)
 
-    def test_create_bucket_with_requester_pays(self):
-        new_bucket_name = 'w-requester-pays' + unique_resource_id('-')
-        created = Config.CLIENT.create_bucket(
-            new_bucket_name, requester_pays=True)
-        self.case_buckets_to_delete.append(new_bucket_name)
-        self.assertEqual(created.name, new_bucket_name)
-        self.assertTrue(created.requester_pays)
-
     def test_list_buckets(self):
         buckets_to_create = [
             'new' + unique_resource_id(),
@@ -140,6 +135,47 @@ class TestStorageBuckets(unittest.TestCase):
         bucket.labels = {}
         bucket.update()
         self.assertEqual(bucket.labels, {})
+
+    @unittest.skipUnless(USER_PROJECT, 'USER_PROJECT not set in environment.')
+    def test_crud_bucket_with_requester_pays(self):
+        new_bucket_name = 'w-requester-pays' + unique_resource_id('-')
+        created = Config.CLIENT.create_bucket(
+            new_bucket_name, requester_pays=True)
+        self.case_buckets_to_delete.append(new_bucket_name)
+        self.assertEqual(created.name, new_bucket_name)
+        self.assertTrue(created.requester_pays)
+
+        with_up = Config.CLIENT.bucket(
+            new_bucket_name, user_project=USER_PROJECT)
+
+        # Bucket will be deleted in-line below.
+        self.case_buckets_to_delete.remove(new_bucket_name)
+
+        try:
+            # Exercise 'buckets.get' w/ userProject.
+            self.assertTrue(with_up.exists())
+            with_up.reload()
+            self.assertTrue(with_up.requester_pays)
+
+            # Exercise 'buckets.patch' w/ userProject.
+            with_up.configure_website(
+                main_page_suffix='index.html', not_found_page='404.html')
+            with_up.patch()
+            self.assertEqual(
+                with_up._properties['website'], {
+                    'mainPageSuffix': 'index.html',
+                    'notFoundPage': '404.html',
+                })
+
+            # Exercise 'buckets.update' w/ userProject.
+            new_labels = {'another-label': 'another-value'}
+            with_up.labels = new_labels
+            with_up.update()
+            self.assertEqual(with_up.labels, new_labels)
+
+        finally:
+            # Exercise 'buckets.delete' w/ userProject.
+            with_up.delete()
 
 
 class TestStorageFiles(unittest.TestCase):

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -28,6 +28,9 @@ from test_utils.retry import RetryErrors
 from test_utils.system import unique_resource_id
 
 
+REQUESTER_PAYS_ENABLED = False  # query from environment?
+
+
 def _bad_copy(bad_request):
     """Predicate: pass only exceptions for a failed copyTo."""
     err_msg = bad_request.message
@@ -94,6 +97,15 @@ class TestStorageBuckets(unittest.TestCase):
         created = Config.CLIENT.create_bucket(new_bucket_name)
         self.case_buckets_to_delete.append(new_bucket_name)
         self.assertEqual(created.name, new_bucket_name)
+
+    @unittest.skipUnless(REQUESTER_PAYS_ENABLED, "requesterPays not enabled")
+    def test_create_bucket_with_requester_pays(self):
+        new_bucket_name = 'w-requester-pays' + unique_resource_id('-')
+        created = Config.CLIENT.create_bucket(
+            new_bucket_name, requester_pays=True)
+        self.case_buckets_to_delete.append(new_bucket_name)
+        self.assertEqual(created.name, new_bucket_name)
+        self.assertTrue(created.requester_pays)
 
     def test_list_buckets(self):
         buckets_to_create = [

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -506,6 +506,15 @@ class TestStorageListFiles(TestStorageFiles):
         self.assertEqual(sorted(blob.name for blob in all_blobs),
                          sorted(self.FILENAMES))
 
+    @unittest.skipUnless(USER_PROJECT, 'USER_PROJECT not set in environment.')
+    @RetryErrors(unittest.TestCase.failureException)
+    def test_list_files_with_user_project(self):
+        with_user_project = Config.CLIENT.bucket(
+            self.bucket.name, user_project=USER_PROJECT)
+        all_blobs = list(with_user_project.list_blobs())
+        self.assertEqual(sorted(blob.name for blob in all_blobs),
+                         sorted(self.FILENAMES))
+
     @RetryErrors(unittest.TestCase.failureException)
     def test_paginate_files(self):
         truncation_size = 1

--- a/storage/tests/unit/test__helpers.py
+++ b/storage/tests/unit/test__helpers.py
@@ -26,7 +26,7 @@ class Test_PropertyMixin(unittest.TestCase):
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
-    def _derivedClass(self, path=None):
+    def _derivedClass(self, path=None, user_project=None):
 
         class Derived(self._get_target_class()):
 
@@ -36,30 +36,67 @@ class Test_PropertyMixin(unittest.TestCase):
             def path(self):
                 return path
 
+            @property
+            def user_project(self):
+                return user_project
+
         return Derived
 
     def test_path_is_abstract(self):
         mixin = self._make_one()
-        self.assertRaises(NotImplementedError, lambda: mixin.path)
+        with self.assertRaises(NotImplementedError):
+            mixin.path
 
     def test_client_is_abstract(self):
         mixin = self._make_one()
-        self.assertRaises(NotImplementedError, lambda: mixin.client)
+        with self.assertRaises(NotImplementedError):
+            mixin.client
+
+    def test_user_project_is_abstract(self):
+        mixin = self._make_one()
+        with self.assertRaises(NotImplementedError):
+            mixin.user_project
 
     def test_reload(self):
         connection = _Connection({'foo': 'Foo'})
         client = _Client(connection)
         derived = self._derivedClass('/path')()
-        # Make sure changes is not a set, so we can observe a change.
+        # Make sure changes is not a set instance before calling reload
+        # (which will clear / replace it with an empty set), checked below.
         derived._changes = object()
         derived.reload(client=client)
         self.assertEqual(derived._properties, {'foo': 'Foo'})
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'GET')
-        self.assertEqual(kw[0]['path'], '/path')
-        self.assertEqual(kw[0]['query_params'], {'projection': 'noAcl'})
-        # Make sure changes get reset by reload.
+        self.assertEqual(kw[0], {
+            'method': 'GET',
+            'path': '/path',
+            'query_params': {'projection': 'noAcl'},
+            '_target_object': derived,
+        })
+        self.assertEqual(derived._changes, set())
+
+    def test_reload_w_user_project(self):
+        user_project = 'user-project-123'
+        connection = _Connection({'foo': 'Foo'})
+        client = _Client(connection)
+        derived = self._derivedClass('/path', user_project)()
+        # Make sure changes is not a set instance before calling reload
+        # (which will clear / replace it with an empty set), checked below.
+        derived._changes = object()
+        derived.reload(client=client)
+        self.assertEqual(derived._properties, {'foo': 'Foo'})
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0], {
+            'method': 'GET',
+            'path': '/path',
+            'query_params': {
+                'projection': 'noAcl',
+                'userProject': user_project,
+            },
+            '_target_object': derived,
+        })
         self.assertEqual(derived._changes, set())
 
     def test__set_properties(self):
@@ -87,11 +124,42 @@ class Test_PropertyMixin(unittest.TestCase):
         self.assertEqual(derived._properties, {'foo': 'Foo'})
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'PATCH')
-        self.assertEqual(kw[0]['path'], '/path')
-        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
-        # Since changes does not include `baz`, we don't see it sent.
-        self.assertEqual(kw[0]['data'], {'bar': BAR})
+        self.assertEqual(kw[0], {
+            'method': 'PATCH',
+            'path': '/path',
+            'query_params': {'projection': 'full'},
+            # Since changes does not include `baz`, we don't see it sent.
+            'data': {'bar': BAR},
+            '_target_object': derived,
+        })
+        # Make sure changes get reset by patch().
+        self.assertEqual(derived._changes, set())
+
+    def test_patch_w_user_project(self):
+        user_project = 'user-project-123'
+        connection = _Connection({'foo': 'Foo'})
+        client = _Client(connection)
+        derived = self._derivedClass('/path', user_project)()
+        # Make sure changes is non-empty, so we can observe a change.
+        BAR = object()
+        BAZ = object()
+        derived._properties = {'bar': BAR, 'baz': BAZ}
+        derived._changes = set(['bar'])  # Ignore baz.
+        derived.patch(client=client)
+        self.assertEqual(derived._properties, {'foo': 'Foo'})
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0], {
+            'method': 'PATCH',
+            'path': '/path',
+            'query_params': {
+                'projection': 'full',
+                'userProject': user_project,
+            },
+            # Since changes does not include `baz`, we don't see it sent.
+            'data': {'bar': BAR},
+            '_target_object': derived,
+        })
         # Make sure changes get reset by patch().
         self.assertEqual(derived._changes, set())
 

--- a/storage/tests/unit/test__helpers.py
+++ b/storage/tests/unit/test__helpers.py
@@ -183,6 +183,31 @@ class Test_PropertyMixin(unittest.TestCase):
         # Make sure changes get reset by patch().
         self.assertEqual(derived._changes, set())
 
+    def test_update_w_user_project(self):
+        user_project = 'user-project-123'
+        connection = _Connection({'foo': 'Foo'})
+        client = _Client(connection)
+        derived = self._derivedClass('/path', user_project)()
+        # Make sure changes is non-empty, so we can observe a change.
+        BAR = object()
+        BAZ = object()
+        derived._properties = {'bar': BAR, 'baz': BAZ}
+        derived._changes = set(['bar'])  # Update sends 'baz' anyway.
+        derived.update(client=client)
+        self.assertEqual(derived._properties, {'foo': 'Foo'})
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PUT')
+        self.assertEqual(kw[0]['path'], '/path')
+        self.assertEqual(
+            kw[0]['query_params'], {
+                'projection': 'full',
+                'userProject': user_project,
+            })
+        self.assertEqual(kw[0]['data'], {'bar': BAR, 'baz': BAZ})
+        # Make sure changes get reset by patch().
+        self.assertEqual(derived._changes, set())
+
 
 class Test__scalar_property(unittest.TestCase):
 

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -317,16 +317,31 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket(client)
         blob = self._make_one(NONESUCH, bucket=bucket)
         self.assertFalse(blob.exists())
+        self.assertEqual(len(connection._requested), 1)
+        self.assertEqual(connection._requested[0], {
+            'method': 'GET',
+            'path': '/b/name/o/{}'.format(NONESUCH),
+            'query_params': {'fields': 'name'},
+            '_target_object': None,
+        })
 
-    def test_exists_hit(self):
+    def test_exists_hit_w_user_project(self):
         BLOB_NAME = 'blob-name'
+        USER_PROJECT = 'user-project-123'
         found_response = ({'status': http_client.OK}, b'')
         connection = _Connection(found_response)
         client = _Client(connection)
-        bucket = _Bucket(client)
+        bucket = _Bucket(client, user_project=USER_PROJECT)
         blob = self._make_one(BLOB_NAME, bucket=bucket)
         bucket._blobs[BLOB_NAME] = 1
         self.assertTrue(blob.exists())
+        self.assertEqual(len(connection._requested), 1)
+        self.assertEqual(connection._requested[0], {
+            'method': 'GET',
+            'path': '/b/name/o/{}'.format(BLOB_NAME),
+            'query_params': {'fields': 'name', 'userProject': USER_PROJECT},
+            '_target_object': None,
+        })
 
     def test_delete(self):
         BLOB_NAME = 'blob-name'
@@ -362,7 +377,7 @@ class Test_Blob(unittest.TestCase):
 
     def test__get_download_url_on_the_fly(self):
         blob_name = 'bzzz-fly.txt'
-        bucket = mock.Mock(path='/b/buhkit', spec=['path'])
+        bucket = _Bucket(name='buhkit')
         blob = self._make_one(blob_name, bucket=bucket)
 
         self.assertIsNone(blob.media_link)
@@ -374,7 +389,7 @@ class Test_Blob(unittest.TestCase):
 
     def test__get_download_url_on_the_fly_with_generation(self):
         blob_name = 'pretend.txt'
-        bucket = mock.Mock(path='/b/fictional', spec=['path'])
+        bucket = _Bucket(name='fictional')
         blob = self._make_one(blob_name, bucket=bucket)
         generation = 1493058489532987
         # Set the media link on the blob
@@ -385,6 +400,20 @@ class Test_Blob(unittest.TestCase):
         expected_url = (
             'https://www.googleapis.com/download/storage/v1/b/'
             'fictional/o/pretend.txt?alt=media&generation=1493058489532987')
+        self.assertEqual(download_url, expected_url)
+
+    def test__get_download_url_on_the_fly_with_user_project(self):
+        blob_name = 'pretend.txt'
+        user_project = 'user-project-123'
+        bucket = _Bucket(name='fictional', user_project=user_project)
+        blob = self._make_one(blob_name, bucket=bucket)
+
+        self.assertIsNone(blob.media_link)
+        download_url = blob._get_download_url()
+        expected_url = (
+            'https://www.googleapis.com/download/storage/v1/b/'
+            'fictional/o/pretend.txt?alt=media&userProject={}'.format(
+                user_project))
         self.assertEqual(download_url, expected_url)
 
     @staticmethod
@@ -772,8 +801,8 @@ class Test_Blob(unittest.TestCase):
         return fake_transport
 
     def _do_multipart_success(self, mock_get_boundary, size=None,
-                              num_retries=None):
-        bucket = mock.Mock(path='/b/w00t', spec=[u'path'])
+                              num_retries=None, user_project=None):
+        bucket = _Bucket(name='w00t', user_project=user_project)
         blob = self._make_one(u'blob-name', bucket=bucket)
         self.assertIsNone(blob.chunk_size)
 
@@ -803,6 +832,8 @@ class Test_Blob(unittest.TestCase):
             'https://www.googleapis.com/upload/storage/v1' +
             bucket.path +
             '/o?uploadType=multipart')
+        if user_project is not None:
+            upload_url += '&userProject={}'.format(user_project)
         payload = (
             b'--==0==\r\n' +
             b'content-type: application/json; charset=UTF-8\r\n\r\n' +
@@ -827,6 +858,13 @@ class Test_Blob(unittest.TestCase):
 
     @mock.patch(u'google.resumable_media._upload.get_boundary',
                 return_value=b'==0==')
+    def test__do_multipart_upload_with_user_project(self, mock_get_boundary):
+        user_project = 'user-project-123'
+        self._do_multipart_success(
+            mock_get_boundary, user_project=user_project)
+
+    @mock.patch(u'google.resumable_media._upload.get_boundary',
+                return_value=b'==0==')
     def test__do_multipart_upload_with_retry(self, mock_get_boundary):
         self._do_multipart_success(mock_get_boundary, num_retries=8)
 
@@ -846,11 +884,12 @@ class Test_Blob(unittest.TestCase):
             'was specified but the file-like object only had', exc_contents)
         self.assertEqual(stream.tell(), len(data))
 
-    def _initiate_resumable_helper(self, size=None, extra_headers=None,
-                                   chunk_size=None, num_retries=None):
+    def _initiate_resumable_helper(
+            self, size=None, extra_headers=None, chunk_size=None,
+            num_retries=None, user_project=None):
         from google.resumable_media.requests import ResumableUpload
 
-        bucket = mock.Mock(path='/b/whammy', spec=[u'path'])
+        bucket = _Bucket(name='whammy', user_project=user_project)
         blob = self._make_one(u'blob-name', bucket=bucket)
         blob.metadata = {'rook': 'takes knight'}
         blob.chunk_size = 3 * blob._CHUNK_SIZE_MULTIPLE
@@ -882,6 +921,8 @@ class Test_Blob(unittest.TestCase):
             'https://www.googleapis.com/upload/storage/v1' +
             bucket.path +
             '/o?uploadType=resumable')
+        if user_project is not None:
+            upload_url += '&userProject={}'.format(user_project)
         self.assertEqual(upload.upload_url, upload_url)
         if extra_headers is None:
             self.assertEqual(upload._headers, {})
@@ -932,6 +973,10 @@ class Test_Blob(unittest.TestCase):
 
     def test__initiate_resumable_upload_with_size(self):
         self._initiate_resumable_helper(size=10000)
+
+    def test__initiate_resumable_upload_with_user_project(self):
+        user_project = 'user-project-123'
+        self._initiate_resumable_helper(user_project=user_project)
 
     def test__initiate_resumable_upload_with_chunk_size(self):
         one_mb = 1048576
@@ -1013,7 +1058,7 @@ class Test_Blob(unittest.TestCase):
             'PUT', resumable_url, data=payload, headers=expected_headers)
 
     def _do_resumable_helper(self, use_size=False, num_retries=None):
-        bucket = mock.Mock(path='/b/yesterday', spec=[u'path'])
+        bucket = _Bucket(name='yesterday')
         blob = self._make_one(u'blob-name', bucket=bucket)
         blob.chunk_size = blob._CHUNK_SIZE_MULTIPLE
         self.assertIsNotNone(blob.chunk_size)
@@ -1258,7 +1303,7 @@ class Test_Blob(unittest.TestCase):
 
     def _create_resumable_upload_session_helper(self, origin=None,
                                                 side_effect=None):
-        bucket = mock.Mock(path='/b/alex-trebek', spec=[u'path'])
+        bucket = _Bucket(name='alex-trebek')
         blob = self._make_one('blob-name', bucket=bucket)
         chunk_size = 99 * blob._CHUNK_SIZE_MULTIPLE
         blob.chunk_size = chunk_size
@@ -1367,8 +1412,49 @@ class Test_Blob(unittest.TestCase):
 
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'GET')
-        self.assertEqual(kw[0]['path'], '%s/iam' % (PATH,))
+        self.assertEqual(kw[0], {
+            'method': 'GET',
+            'path': '%s/iam' % (PATH,),
+            'query_params': {},
+            '_target_object': None,
+        })
+
+    def test_get_iam_policy_w_user_project(self):
+        from google.cloud.iam import Policy
+
+        BLOB_NAME = 'blob-name'
+        USER_PROJECT = 'user-project-123'
+        PATH = '/b/name/o/%s' % (BLOB_NAME,)
+        ETAG = 'DEADBEEF'
+        VERSION = 17
+        RETURNED = {
+            'resourceId': PATH,
+            'etag': ETAG,
+            'version': VERSION,
+            'bindings': [],
+        }
+        after = ({'status': http_client.OK}, RETURNED)
+        EXPECTED = {}
+        connection = _Connection(after)
+        client = _Client(connection)
+        bucket = _Bucket(client=client, user_project=USER_PROJECT)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
+
+        policy = blob.get_iam_policy()
+
+        self.assertIsInstance(policy, Policy)
+        self.assertEqual(policy.etag, RETURNED['etag'])
+        self.assertEqual(policy.version, RETURNED['version'])
+        self.assertEqual(dict(policy), EXPECTED)
+
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0], {
+            'method': 'GET',
+            'path': '%s/iam' % (PATH,),
+            'query_params': {'userProject': USER_PROJECT},
+            '_target_object': None,
+        })
 
     def test_set_iam_policy(self):
         import operator
@@ -1417,6 +1503,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PUT')
         self.assertEqual(kw[0]['path'], '%s/iam' % (PATH,))
+        self.assertEqual(kw[0]['query_params'], {})
         sent = kw[0]['data']
         self.assertEqual(sent['resourceId'], PATH)
         self.assertEqual(len(sent['bindings']), len(BINDINGS))
@@ -1427,6 +1514,41 @@ class Test_Blob(unittest.TestCase):
             self.assertEqual(found['role'], expected['role'])
             self.assertEqual(
                 sorted(found['members']), sorted(expected['members']))
+
+    def test_set_iam_policy_w_user_project(self):
+        from google.cloud.iam import Policy
+
+        BLOB_NAME = 'blob-name'
+        USER_PROJECT = 'user-project-123'
+        PATH = '/b/name/o/%s' % (BLOB_NAME,)
+        ETAG = 'DEADBEEF'
+        VERSION = 17
+        BINDINGS = []
+        RETURNED = {
+            'etag': ETAG,
+            'version': VERSION,
+            'bindings': BINDINGS,
+        }
+        after = ({'status': http_client.OK}, RETURNED)
+        policy = Policy()
+
+        connection = _Connection(after)
+        client = _Client(connection)
+        bucket = _Bucket(client=client, user_project=USER_PROJECT)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
+
+        returned = blob.set_iam_policy(policy)
+
+        self.assertEqual(returned.etag, ETAG)
+        self.assertEqual(returned.version, VERSION)
+        self.assertEqual(dict(returned), dict(policy))
+
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PUT')
+        self.assertEqual(kw[0]['path'], '%s/iam' % (PATH,))
+        self.assertEqual(kw[0]['query_params'], {'userProject': USER_PROJECT})
+        self.assertEqual(kw[0]['data'], {'resourceId': PATH})
 
     def test_test_iam_permissions(self):
         from google.cloud.storage.iam import STORAGE_OBJECTS_LIST
@@ -1457,6 +1579,39 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['method'], 'GET')
         self.assertEqual(kw[0]['path'], '%s/iam/testPermissions' % (PATH,))
         self.assertEqual(kw[0]['query_params'], {'permissions': PERMISSIONS})
+
+    def test_test_iam_permissions_w_user_project(self):
+        from google.cloud.storage.iam import STORAGE_OBJECTS_LIST
+        from google.cloud.storage.iam import STORAGE_BUCKETS_GET
+        from google.cloud.storage.iam import STORAGE_BUCKETS_UPDATE
+
+        BLOB_NAME = 'blob-name'
+        USER_PROJECT = 'user-project-123'
+        PATH = '/b/name/o/%s' % (BLOB_NAME,)
+        PERMISSIONS = [
+            STORAGE_OBJECTS_LIST,
+            STORAGE_BUCKETS_GET,
+            STORAGE_BUCKETS_UPDATE,
+        ]
+        ALLOWED = PERMISSIONS[1:]
+        RETURNED = {'permissions': ALLOWED}
+        after = ({'status': http_client.OK}, RETURNED)
+        connection = _Connection(after)
+        client = _Client(connection)
+        bucket = _Bucket(client=client, user_project=USER_PROJECT)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
+
+        allowed = blob.test_iam_permissions(PERMISSIONS)
+
+        self.assertEqual(allowed, ALLOWED)
+
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'GET')
+        self.assertEqual(kw[0]['path'], '%s/iam/testPermissions' % (PATH,))
+        self.assertEqual(
+            kw[0]['query_params'],
+            {'permissions': PERMISSIONS, 'userProject': USER_PROJECT})
 
     def test_make_public(self):
         from google.cloud.storage.acl import _ACLEntity
@@ -1492,17 +1647,18 @@ class Test_Blob(unittest.TestCase):
         with self.assertRaises(ValueError):
             destination.compose(sources=[source_1, source_2])
 
-    def test_compose_minimal(self):
+    def test_compose_minimal_w_user_project(self):
         SOURCE_1 = 'source-1'
         SOURCE_2 = 'source-2'
         DESTINATION = 'destinaton'
         RESOURCE = {
             'etag': 'DEADBEEF'
         }
+        USER_PROJECT = 'user-project-123'
         after = ({'status': http_client.OK}, RESOURCE)
         connection = _Connection(after)
         client = _Client(connection)
-        bucket = _Bucket(client=client)
+        bucket = _Bucket(client=client, user_project=USER_PROJECT)
         source_1 = self._make_one(SOURCE_1, bucket=bucket)
         source_2 = self._make_one(SOURCE_2, bucket=bucket)
         destination = self._make_one(DESTINATION, bucket=bucket)
@@ -1512,20 +1668,23 @@ class Test_Blob(unittest.TestCase):
 
         self.assertEqual(destination.etag, 'DEADBEEF')
 
-        SENT = {
-            'sourceObjects': [
-                {'name': source_1.name},
-                {'name': source_2.name},
-            ],
-            'destination': {
-                'contentType': 'text/plain',
-            },
-        }
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'POST')
-        self.assertEqual(kw[0]['path'], '/b/name/o/%s/compose' % DESTINATION)
-        self.assertEqual(kw[0]['data'], SENT)
+        self.assertEqual(kw[0], {
+            'method': 'POST',
+            'path': '/b/name/o/%s/compose' % DESTINATION,
+            'query_params': {'userProject': USER_PROJECT},
+            'data':  {
+                'sourceObjects': [
+                    {'name': source_1.name},
+                    {'name': source_2.name},
+                ],
+                'destination': {
+                    'contentType': 'text/plain',
+                },
+            },
+            '_target_object': destination,
+        })
 
     def test_compose_w_additional_property_changes(self):
         SOURCE_1 = 'source-1'
@@ -1549,24 +1708,27 @@ class Test_Blob(unittest.TestCase):
 
         self.assertEqual(destination.etag, 'DEADBEEF')
 
-        SENT = {
-            'sourceObjects': [
-                {'name': source_1.name},
-                {'name': source_2.name},
-            ],
-            'destination': {
-                'contentType': 'text/plain',
-                'contentLanguage': 'en-US',
-                'metadata': {
-                    'my-key': 'my-value',
-                }
-            },
-        }
         kw = connection._requested
         self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]['method'], 'POST')
-        self.assertEqual(kw[0]['path'], '/b/name/o/%s/compose' % DESTINATION)
-        self.assertEqual(kw[0]['data'], SENT)
+        self.assertEqual(kw[0], {
+            'method': 'POST',
+            'path': '/b/name/o/%s/compose' % DESTINATION,
+            'query_params': {},
+            'data':  {
+                'sourceObjects': [
+                    {'name': source_1.name},
+                    {'name': source_2.name},
+                ],
+                'destination': {
+                    'contentType': 'text/plain',
+                    'contentLanguage': 'en-US',
+                    'metadata': {
+                        'my-key': 'my-value',
+                    }
+                },
+            },
+            '_target_object': destination,
+        })
 
     def test_rewrite_response_without_resource(self):
         SOURCE_BLOB = 'source'
@@ -1638,7 +1800,7 @@ class Test_Blob(unittest.TestCase):
         self.assertNotIn('X-Goog-Encryption-Key', headers)
         self.assertNotIn('X-Goog-Encryption-Key-Sha256', headers)
 
-    def test_rewrite_same_name_no_old_key_new_key_done(self):
+    def test_rewrite_same_name_no_old_key_new_key_done_w_user_project(self):
         import base64
         import hashlib
 
@@ -1647,6 +1809,7 @@ class Test_Blob(unittest.TestCase):
         KEY_HASH = hashlib.sha256(KEY).digest()
         KEY_HASH_B64 = base64.b64encode(KEY_HASH).rstrip().decode('ascii')
         BLOB_NAME = 'blob'
+        USER_PROJECT = 'user-project-123'
         RESPONSE = {
             'totalBytesRewritten': 42,
             'objectSize': 42,
@@ -1656,7 +1819,7 @@ class Test_Blob(unittest.TestCase):
         response = ({'status': http_client.OK}, RESPONSE)
         connection = _Connection(response)
         client = _Client(connection)
-        bucket = _Bucket(client=client)
+        bucket = _Bucket(client=client, user_project=USER_PROJECT)
         plain = self._make_one(BLOB_NAME, bucket=bucket)
         encrypted = self._make_one(BLOB_NAME, bucket=bucket,
                                    encryption_key=KEY)
@@ -1672,7 +1835,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['method'], 'POST')
         PATH = '/b/name/o/%s/rewriteTo/b/name/o/%s' % (BLOB_NAME, BLOB_NAME)
         self.assertEqual(kw[0]['path'], PATH)
-        self.assertEqual(kw[0]['query_params'], {})
+        self.assertEqual(kw[0]['query_params'], {'userProject': USER_PROJECT})
         SENT = {}
         self.assertEqual(kw[0]['data'], SENT)
 
@@ -1775,7 +1938,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['method'], 'POST')
         PATH = '/b/name/o/%s/rewriteTo/b/name/o/%s' % (BLOB_NAME, BLOB_NAME)
         self.assertEqual(kw[0]['path'], PATH)
-        self.assertNotIn('query_params', kw[0])
+        self.assertEqual(kw[0]['query_params'], {})
         SENT = {'storageClass': STORAGE_CLASS}
         self.assertEqual(kw[0]['data'], SENT)
 
@@ -1789,7 +1952,7 @@ class Test_Blob(unittest.TestCase):
         self.assertNotIn('X-Goog-Encryption-Key', headers)
         self.assertNotIn('X-Goog-Encryption-Key-Sha256', headers)
 
-    def test_update_storage_class_w_encryption_key(self):
+    def test_update_storage_class_w_encryption_key_w_user_project(self):
         import base64
         import hashlib
 
@@ -1800,13 +1963,14 @@ class Test_Blob(unittest.TestCase):
         BLOB_KEY_HASH_B64 = base64.b64encode(
             BLOB_KEY_HASH).rstrip().decode('ascii')
         STORAGE_CLASS = u'NEARLINE'
+        USER_PROJECT = 'user-project-123'
         RESPONSE = {
             'resource': {'storageClass': STORAGE_CLASS},
         }
         response = ({'status': http_client.OK}, RESPONSE)
         connection = _Connection(response)
         client = _Client(connection)
-        bucket = _Bucket(client=client)
+        bucket = _Bucket(client=client, user_project=USER_PROJECT)
         blob = self._make_one(
             BLOB_NAME, bucket=bucket, encryption_key=BLOB_KEY)
 
@@ -1819,7 +1983,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['method'], 'POST')
         PATH = '/b/name/o/%s/rewriteTo/b/name/o/%s' % (BLOB_NAME, BLOB_NAME)
         self.assertEqual(kw[0]['path'], PATH)
-        self.assertNotIn('query_params', kw[0])
+        self.assertEqual(kw[0]['query_params'], {'userProject': USER_PROJECT})
         SENT = {'storageClass': STORAGE_CLASS}
         self.assertEqual(kw[0]['data'], SENT)
 

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -141,6 +141,19 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(blob_name, bucket=bucket)
         self.assertEqual(blob.path, '/b/name/o/Caf%C3%A9')
 
+    def test_client(self):
+        blob_name = 'BLOB'
+        bucket = _Bucket()
+        blob = self._make_one(blob_name, bucket=bucket)
+        self.assertIs(blob.client, bucket.client)
+
+    def test_user_project(self):
+        user_project = 'user-project-123'
+        blob_name = 'BLOB'
+        bucket = _Bucket(user_project=user_project)
+        blob = self._make_one(blob_name, bucket=bucket)
+        self.assertEqual(blob.user_project, user_project)
+
     def test_public_url(self):
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
@@ -2267,7 +2280,7 @@ class _Connection(object):
 
 class _Bucket(object):
 
-    def __init__(self, client=None, name='name'):
+    def __init__(self, client=None, name='name', user_project=None):
         if client is None:
             connection = _Connection()
             client = _Client(connection)
@@ -2277,6 +2290,7 @@ class _Bucket(object):
         self._deleted = []
         self.name = name
         self.path = '/b/' + name
+        self.user_project = user_project
 
     def delete_blob(self, blob_name, client=None):
         del self._blobs[blob_name]

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -234,6 +234,7 @@ class Test_Bucket(unittest.TestCase):
             'location': LOCATION,
             'storageClass': STORAGE_CLASS,
             'versioning': {'enabled': True},
+            'billing': {'requesterPays': True},
             'labels': LABELS,
         }
         connection = _Connection(DATA)
@@ -244,6 +245,7 @@ class Test_Bucket(unittest.TestCase):
         bucket.location = LOCATION
         bucket.storage_class = STORAGE_CLASS
         bucket.versioning_enabled = True
+        bucket.requester_pays = True
         bucket.labels = LABELS
         bucket.create()
 
@@ -1025,6 +1027,24 @@ class Test_Bucket(unittest.TestCase):
         self.assertFalse(bucket.versioning_enabled)
         bucket.versioning_enabled = True
         self.assertTrue(bucket.versioning_enabled)
+
+    def test_requester_pays_getter_missing(self):
+        NAME = 'name'
+        bucket = self._make_one(name=NAME)
+        self.assertEqual(bucket.requester_pays, False)
+
+    def test_requester_pays_getter(self):
+        NAME = 'name'
+        before = {'billing': {'requesterPays': True}}
+        bucket = self._make_one(name=NAME, properties=before)
+        self.assertEqual(bucket.requester_pays, True)
+
+    def test_requester_pays_setter(self):
+        NAME = 'name'
+        bucket = self._make_one(name=NAME)
+        self.assertFalse(bucket.requester_pays)
+        bucket.requester_pays = True
+        self.assertTrue(bucket.requester_pays)
 
     def test_configure_website_defaults(self):
         NAME = 'name'

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -38,11 +38,16 @@ class Test_Bucket(unittest.TestCase):
         from google.cloud.storage.bucket import Bucket
         return Bucket
 
-    def _make_one(self, client=None, name=None, properties=None):
+    def _make_one(
+            self, client=None, name=None, properties=None, user_project=None):
         if client is None:
             connection = _Connection()
             client = _Client(connection)
-        bucket = self._get_target_class()(client, name=name)
+        if user_project is None:
+            bucket = self._get_target_class()(client, name=name)
+        else:
+            bucket = self._get_target_class()(
+                client, name=name, user_project=user_project)
         bucket._properties = properties or {}
         return bucket
 
@@ -63,8 +68,7 @@ class Test_Bucket(unittest.TestCase):
         USER_PROJECT = 'user-project-123'
         connection = _Connection()
         client = _Client(connection)
-        klass = self._get_target_class()
-        bucket = klass(client, name=NAME, user_project=USER_PROJECT)
+        bucket = self._make_one(client, name=NAME, user_project=USER_PROJECT)
         self.assertEqual(bucket.name, NAME)
         self.assertEqual(bucket._properties, {})
         self.assertEqual(bucket.user_project, USER_PROJECT)
@@ -195,7 +199,9 @@ class Test_Bucket(unittest.TestCase):
         expected_cw = [((), expected_called_kwargs)]
         self.assertEqual(_FakeConnection._called_with, expected_cw)
 
-    def test_exists_hit(self):
+    def test_exists_hit_w_user_project(self):
+        USER_PROJECT = 'user-project-123'
+
         class _FakeConnection(object):
 
             _called_with = []
@@ -207,7 +213,7 @@ class Test_Bucket(unittest.TestCase):
                 return object()
 
         BUCKET_NAME = 'bucket-name'
-        bucket = self._make_one(name=BUCKET_NAME)
+        bucket = self._make_one(name=BUCKET_NAME, user_project=USER_PROJECT)
         client = _Client(_FakeConnection)
         self.assertTrue(bucket.exists(client=client))
         expected_called_kwargs = {
@@ -215,17 +221,29 @@ class Test_Bucket(unittest.TestCase):
             'path': bucket.path,
             'query_params': {
                 'fields': 'name',
+                'userProject': USER_PROJECT,
             },
             '_target_object': None,
         }
         expected_cw = [((), expected_called_kwargs)]
         self.assertEqual(_FakeConnection._called_with, expected_cw)
 
+    def test_create_w_user_project(self):
+        PROJECT = 'PROJECT'
+        BUCKET_NAME = 'bucket-name'
+        USER_PROJECT = 'user-project-123'
+        connection = _Connection()
+        client = _Client(connection, project=PROJECT)
+        bucket = self._make_one(client, BUCKET_NAME, user_project=USER_PROJECT)
+
+        with self.assertRaises(ValueError):
+            bucket.create()
+
     def test_create_hit(self):
+        PROJECT = 'PROJECT'
         BUCKET_NAME = 'bucket-name'
         DATA = {'name': BUCKET_NAME}
         connection = _Connection(DATA)
-        PROJECT = 'PROJECT'
         client = _Client(connection, project=PROJECT)
         bucket = self._make_one(client=client, name=BUCKET_NAME)
         bucket.create()
@@ -317,18 +335,20 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw['method'], 'GET')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, NONESUCH))
 
-    def test_get_blob_hit(self):
+    def test_get_blob_hit_w_user_project(self):
         NAME = 'name'
         BLOB_NAME = 'blob-name'
+        USER_PROJECT = 'user-project-123'
         connection = _Connection({'name': BLOB_NAME})
         client = _Client(connection)
-        bucket = self._make_one(name=NAME)
+        bucket = self._make_one(name=NAME, user_project=USER_PROJECT)
         blob = bucket.get_blob(BLOB_NAME, client=client)
         self.assertIs(blob.bucket, bucket)
         self.assertEqual(blob.name, BLOB_NAME)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'GET')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, BLOB_NAME))
+        self.assertEqual(kw['query_params'], {'userProject': USER_PROJECT})
 
     def test_get_blob_hit_with_kwargs(self):
         from google.cloud.storage.blob import _get_encryption_headers
@@ -366,8 +386,9 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw['path'], '/b/%s/o' % NAME)
         self.assertEqual(kw['query_params'], {'projection': 'noAcl'})
 
-    def test_list_blobs_w_all_arguments(self):
+    def test_list_blobs_w_all_arguments_and_user_project(self):
         NAME = 'name'
+        USER_PROJECT = 'user-project-123'
         MAX_RESULTS = 10
         PAGE_TOKEN = 'ABCD'
         PREFIX = 'subfolder'
@@ -383,10 +404,11 @@ class Test_Bucket(unittest.TestCase):
             'versions': VERSIONS,
             'projection': PROJECTION,
             'fields': FIELDS,
+            'userProject': USER_PROJECT,
         }
         connection = _Connection({'items': []})
         client = _Client(connection)
-        bucket = self._make_one(name=NAME)
+        bucket = self._make_one(name=NAME, user_project=USER_PROJECT)
         iterator = bucket.list_blobs(
             max_results=MAX_RESULTS,
             page_token=PAGE_TOKEN,
@@ -480,23 +502,27 @@ class Test_Bucket(unittest.TestCase):
         expected_cw = [{
             'method': 'DELETE',
             'path': bucket.path,
+            'query_params': {},
             '_target_object': None,
         }]
         self.assertEqual(connection._deleted_buckets, expected_cw)
 
-    def test_delete_hit(self):
+    def test_delete_hit_with_user_project(self):
         NAME = 'name'
+        USER_PROJECT = 'user-project-123'
         GET_BLOBS_RESP = {'items': []}
         connection = _Connection(GET_BLOBS_RESP)
         connection._delete_bucket = True
         client = _Client(connection)
-        bucket = self._make_one(client=client, name=NAME)
+        bucket = self._make_one(
+            client=client, name=NAME, user_project=USER_PROJECT)
         result = bucket.delete(force=True)
         self.assertIsNone(result)
         expected_cw = [{
             'method': 'DELETE',
             'path': bucket.path,
             '_target_object': None,
+            'query_params': {'userProject': USER_PROJECT},
         }]
         self.assertEqual(connection._deleted_buckets, expected_cw)
 
@@ -521,6 +547,7 @@ class Test_Bucket(unittest.TestCase):
         expected_cw = [{
             'method': 'DELETE',
             'path': bucket.path,
+            'query_params': {},
             '_target_object': None,
         }]
         self.assertEqual(connection._deleted_buckets, expected_cw)
@@ -539,6 +566,7 @@ class Test_Bucket(unittest.TestCase):
         expected_cw = [{
             'method': 'DELETE',
             'path': bucket.path,
+            'query_params': {},
             '_target_object': None,
         }]
         self.assertEqual(connection._deleted_buckets, expected_cw)
@@ -575,18 +603,22 @@ class Test_Bucket(unittest.TestCase):
         kw, = connection._requested
         self.assertEqual(kw['method'], 'DELETE')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, NONESUCH))
+        self.assertEqual(kw['query_params'], {})
 
-    def test_delete_blob_hit(self):
+    def test_delete_blob_hit_with_user_project(self):
         NAME = 'name'
         BLOB_NAME = 'blob-name'
+        USER_PROJECT = 'user-project-123'
         connection = _Connection({})
         client = _Client(connection)
-        bucket = self._make_one(client=client, name=NAME)
+        bucket = self._make_one(
+            client=client, name=NAME, user_project=USER_PROJECT)
         result = bucket.delete_blob(BLOB_NAME)
         self.assertIsNone(result)
         kw, = connection._requested
         self.assertEqual(kw['method'], 'DELETE')
         self.assertEqual(kw['path'], '/b/%s/o/%s' % (NAME, BLOB_NAME))
+        self.assertEqual(kw['query_params'], {'userProject': USER_PROJECT})
 
     def test_delete_blobs_empty(self):
         NAME = 'name'
@@ -596,17 +628,20 @@ class Test_Bucket(unittest.TestCase):
         bucket.delete_blobs([])
         self.assertEqual(connection._requested, [])
 
-    def test_delete_blobs_hit(self):
+    def test_delete_blobs_hit_w_user_project(self):
         NAME = 'name'
         BLOB_NAME = 'blob-name'
+        USER_PROJECT = 'user-project-123'
         connection = _Connection({})
         client = _Client(connection)
-        bucket = self._make_one(client=client, name=NAME)
+        bucket = self._make_one(
+            client=client, name=NAME, user_project=USER_PROJECT)
         bucket.delete_blobs([BLOB_NAME])
         kw = connection._requested
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'DELETE')
         self.assertEqual(kw[0]['path'], '/b/%s/o/%s' % (NAME, BLOB_NAME))
+        self.assertEqual(kw[0]['query_params'], {'userProject': USER_PROJECT})
 
     def test_delete_blobs_miss_no_on_error(self):
         from google.cloud.exceptions import NotFound
@@ -664,6 +699,7 @@ class Test_Bucket(unittest.TestCase):
                                                      DEST, BLOB_NAME)
         self.assertEqual(kw['method'], 'POST')
         self.assertEqual(kw['path'], COPY_PATH)
+        self.assertEqual(kw['query_params'], {})
 
     def test_copy_blobs_preserve_acl(self):
         from google.cloud.storage.acl import ObjectACL
@@ -695,14 +731,17 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(len(kw), 2)
         self.assertEqual(kw[0]['method'], 'POST')
         self.assertEqual(kw[0]['path'], COPY_PATH)
+        self.assertEqual(kw[0]['query_params'], {})
         self.assertEqual(kw[1]['method'], 'PATCH')
         self.assertEqual(kw[1]['path'], NEW_BLOB_PATH)
+        self.assertEqual(kw[1]['query_params'], {'projection': 'full'})
 
-    def test_copy_blobs_w_name(self):
+    def test_copy_blobs_w_name_and_user_project(self):
         SOURCE = 'source'
         DEST = 'dest'
         BLOB_NAME = 'blob-name'
         NEW_NAME = 'new_name'
+        USER_PROJECT = 'user-project-123'
 
         class _Blob(object):
             name = BLOB_NAME
@@ -710,7 +749,8 @@ class Test_Bucket(unittest.TestCase):
 
         connection = _Connection({})
         client = _Client(connection)
-        source = self._make_one(client=client, name=SOURCE)
+        source = self._make_one(
+            client=client, name=SOURCE, user_project=USER_PROJECT)
         dest = self._make_one(client=client, name=DEST)
         blob = _Blob()
         new_blob = source.copy_blob(blob, dest, NEW_NAME)
@@ -721,6 +761,7 @@ class Test_Bucket(unittest.TestCase):
                                                      DEST, NEW_NAME)
         self.assertEqual(kw['method'], 'POST')
         self.assertEqual(kw['path'], COPY_PATH)
+        self.assertEqual(kw['query_params'], {'userProject': USER_PROJECT})
 
     def test_rename_blob(self):
         BUCKET_NAME = 'BUCKET_NAME'
@@ -1139,6 +1180,40 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'GET')
         self.assertEqual(kw[0]['path'], '%s/iam' % (PATH,))
+        self.assertEqual(kw[0]['query_params'], {})
+
+    def test_get_iam_policy_w_user_project(self):
+        from google.cloud.iam import Policy
+
+        NAME = 'name'
+        USER_PROJECT = 'user-project-123'
+        PATH = '/b/%s' % (NAME,)
+        ETAG = 'DEADBEEF'
+        VERSION = 17
+        RETURNED = {
+            'resourceId': PATH,
+            'etag': ETAG,
+            'version': VERSION,
+            'bindings': [],
+        }
+        EXPECTED = {}
+        connection = _Connection(RETURNED)
+        client = _Client(connection, None)
+        bucket = self._make_one(
+            client=client, name=NAME, user_project=USER_PROJECT)
+
+        policy = bucket.get_iam_policy()
+
+        self.assertIsInstance(policy, Policy)
+        self.assertEqual(policy.etag, RETURNED['etag'])
+        self.assertEqual(policy.version, RETURNED['version'])
+        self.assertEqual(dict(policy), EXPECTED)
+
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'GET')
+        self.assertEqual(kw[0]['path'], '%s/iam' % (PATH,))
+        self.assertEqual(kw[0]['query_params'], {'userProject': USER_PROJECT})
 
     def test_set_iam_policy(self):
         import operator
@@ -1185,6 +1260,66 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(len(kw), 1)
         self.assertEqual(kw[0]['method'], 'PUT')
         self.assertEqual(kw[0]['path'], '%s/iam' % (PATH,))
+        self.assertEqual(kw[0]['query_params'], {})
+        sent = kw[0]['data']
+        self.assertEqual(sent['resourceId'], PATH)
+        self.assertEqual(len(sent['bindings']), len(BINDINGS))
+        key = operator.itemgetter('role')
+        for found, expected in zip(
+            sorted(sent['bindings'], key=key),
+            sorted(BINDINGS, key=key)):
+            self.assertEqual(found['role'], expected['role'])
+            self.assertEqual(
+                sorted(found['members']), sorted(expected['members']))
+
+    def test_set_iam_policy_w_user_project(self):
+        import operator
+        from google.cloud.storage.iam import STORAGE_OWNER_ROLE
+        from google.cloud.storage.iam import STORAGE_EDITOR_ROLE
+        from google.cloud.storage.iam import STORAGE_VIEWER_ROLE
+        from google.cloud.iam import Policy
+
+        NAME = 'name'
+        USER_PROJECT = 'user-project-123'
+        PATH = '/b/%s' % (NAME,)
+        ETAG = 'DEADBEEF'
+        VERSION = 17
+        OWNER1 = 'user:phred@example.com'
+        OWNER2 = 'group:cloud-logs@google.com'
+        EDITOR1 = 'domain:google.com'
+        EDITOR2 = 'user:phred@example.com'
+        VIEWER1 = 'serviceAccount:1234-abcdef@service.example.com'
+        VIEWER2 = 'user:phred@example.com'
+        BINDINGS = [
+            {'role': STORAGE_OWNER_ROLE, 'members': [OWNER1, OWNER2]},
+            {'role': STORAGE_EDITOR_ROLE, 'members': [EDITOR1, EDITOR2]},
+            {'role': STORAGE_VIEWER_ROLE, 'members': [VIEWER1, VIEWER2]},
+        ]
+        RETURNED = {
+            'etag': ETAG,
+            'version': VERSION,
+            'bindings': BINDINGS,
+        }
+        policy = Policy()
+        for binding in BINDINGS:
+            policy[binding['role']] = binding['members']
+
+        connection = _Connection(RETURNED)
+        client = _Client(connection, None)
+        bucket = self._make_one(
+            client=client, name=NAME, user_project=USER_PROJECT)
+
+        returned = bucket.set_iam_policy(policy)
+
+        self.assertEqual(returned.etag, ETAG)
+        self.assertEqual(returned.version, VERSION)
+        self.assertEqual(dict(returned), dict(policy))
+
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PUT')
+        self.assertEqual(kw[0]['path'], '%s/iam' % (PATH,))
+        self.assertEqual(kw[0]['query_params'], {'userProject': USER_PROJECT})
         sent = kw[0]['data']
         self.assertEqual(sent['resourceId'], PATH)
         self.assertEqual(len(sent['bindings']), len(BINDINGS))
@@ -1223,6 +1358,38 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw[0]['method'], 'GET')
         self.assertEqual(kw[0]['path'], '%s/iam/testPermissions' % (PATH,))
         self.assertEqual(kw[0]['query_params'], {'permissions': PERMISSIONS})
+
+    def test_test_iam_permissions_w_user_project(self):
+        from google.cloud.storage.iam import STORAGE_OBJECTS_LIST
+        from google.cloud.storage.iam import STORAGE_BUCKETS_GET
+        from google.cloud.storage.iam import STORAGE_BUCKETS_UPDATE
+
+        NAME = 'name'
+        USER_PROJECT = 'user-project-123'
+        PATH = '/b/%s' % (NAME,)
+        PERMISSIONS = [
+            STORAGE_OBJECTS_LIST,
+            STORAGE_BUCKETS_GET,
+            STORAGE_BUCKETS_UPDATE,
+        ]
+        ALLOWED = PERMISSIONS[1:]
+        RETURNED = {'permissions': ALLOWED}
+        connection = _Connection(RETURNED)
+        client = _Client(connection, None)
+        bucket = self._make_one(
+            client=client, name=NAME, user_project=USER_PROJECT)
+
+        allowed = bucket.test_iam_permissions(PERMISSIONS)
+
+        self.assertEqual(allowed, ALLOWED)
+
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'GET')
+        self.assertEqual(kw[0]['path'], '%s/iam/testPermissions' % (PATH,))
+        self.assertEqual(
+            kw[0]['query_params'],
+            {'permissions': PERMISSIONS, 'userProject': USER_PROJECT})
 
     def test_make_public_defaults(self):
         from google.cloud.storage.acl import _ACLEntity

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -140,6 +140,22 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(bucket, Bucket)
         self.assertIs(bucket.client, client)
         self.assertEqual(bucket.name, BUCKET_NAME)
+        self.assertIsNone(bucket.user_project)
+
+    def test_bucket_w_user_project(self):
+        from google.cloud.storage.bucket import Bucket
+
+        PROJECT = 'PROJECT'
+        USER_PROJECT = 'USER_PROJECT'
+        CREDENTIALS = _make_credentials()
+        BUCKET_NAME = 'BUCKET_NAME'
+
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+        bucket = client.bucket(BUCKET_NAME, user_project=USER_PROJECT)
+        self.assertIsInstance(bucket, Bucket)
+        self.assertIs(bucket.client, client)
+        self.assertEqual(bucket.name, BUCKET_NAME)
+        self.assertEqual(bucket.user_project, USER_PROJECT)
 
     def test_batch(self):
         from google.cloud.storage.batch import Batch

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -184,23 +184,23 @@ class TestClient(unittest.TestCase):
         CREDENTIALS = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
-        BLOB_NAME = 'blob-name'
+        BUCKET_NAME = 'bucket-name'
         URI = '/'.join([
             client._connection.API_BASE_URL,
             'storage',
             client._connection.API_VERSION,
             'b',
-            '%s?projection=noAcl' % (BLOB_NAME,),
+            '%s?projection=noAcl' % (BUCKET_NAME,),
         ])
 
-        data = {'name': BLOB_NAME}
+        data = {'name': BUCKET_NAME}
         http = _make_requests_session([_make_json_response(data)])
         client._http_internal = http
 
-        bucket = client.get_bucket(BLOB_NAME)
+        bucket = client.get_bucket(BUCKET_NAME)
 
         self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BLOB_NAME)
+        self.assertEqual(bucket.name, BUCKET_NAME)
         http.request.assert_called_once_with(
             method='GET', url=URI, data=mock.ANY, headers=mock.ANY)
 
@@ -234,22 +234,22 @@ class TestClient(unittest.TestCase):
         CREDENTIALS = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
-        BLOB_NAME = 'blob-name'
+        BUCKET_NAME = 'bucket-name'
         URI = '/'.join([
             client._connection.API_BASE_URL,
             'storage',
             client._connection.API_VERSION,
             'b',
-            '%s?projection=noAcl' % (BLOB_NAME,),
+            '%s?projection=noAcl' % (BUCKET_NAME,),
         ])
-        data = {'name': BLOB_NAME}
+        data = {'name': BUCKET_NAME}
         http = _make_requests_session([_make_json_response(data)])
         client._http_internal = http
 
-        bucket = client.lookup_bucket(BLOB_NAME)
+        bucket = client.lookup_bucket(BUCKET_NAME)
 
         self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BLOB_NAME)
+        self.assertEqual(bucket.name, BUCKET_NAME)
         http.request.assert_called_once_with(
             method='GET', url=URI, data=mock.ANY, headers=mock.ANY)
 
@@ -260,7 +260,7 @@ class TestClient(unittest.TestCase):
         CREDENTIALS = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
-        BLOB_NAME = 'blob-name'
+        BUCKET_NAME = 'bucket-name'
         URI = '/'.join([
             client._connection.API_BASE_URL,
             'storage',
@@ -268,13 +268,16 @@ class TestClient(unittest.TestCase):
             'b?project=%s' % (PROJECT,),
         ])
         data = {'error': {'message': 'Conflict'}}
+        sent = {'name': BUCKET_NAME}
         http = _make_requests_session([
             _make_json_response(data, status=http_client.CONFLICT)])
         client._http_internal = http
 
-        self.assertRaises(Conflict, client.create_bucket, BLOB_NAME)
+        self.assertRaises(Conflict, client.create_bucket, BUCKET_NAME)
         http.request.assert_called_once_with(
             method='POST', url=URI, data=mock.ANY, headers=mock.ANY)
+        json_sent = http.request.call_args_list[0][1]['data']
+        self.assertEqual(sent, json.loads(json_sent))
 
     def test_create_bucket_success(self):
         from google.cloud.storage.bucket import Bucket
@@ -283,23 +286,27 @@ class TestClient(unittest.TestCase):
         CREDENTIALS = _make_credentials()
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
-        BLOB_NAME = 'blob-name'
+        BUCKET_NAME = 'bucket-name'
         URI = '/'.join([
             client._connection.API_BASE_URL,
             'storage',
             client._connection.API_VERSION,
             'b?project=%s' % (PROJECT,),
         ])
-        data = {'name': BLOB_NAME}
+        sent = {'name': BUCKET_NAME, 'billing': {'requesterPays': True}}
+        data = sent
         http = _make_requests_session([_make_json_response(data)])
         client._http_internal = http
 
-        bucket = client.create_bucket(BLOB_NAME)
+        bucket = client.create_bucket(BUCKET_NAME, requester_pays=True)
 
         self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BLOB_NAME)
+        self.assertEqual(bucket.name, BUCKET_NAME)
+        self.assertTrue(bucket.requester_pays)
         http.request.assert_called_once_with(
             method='POST', url=URI, data=mock.ANY, headers=mock.ANY)
+        json_sent = http.request.call_args_list[0][1]['data']
+        self.assertEqual(sent, json.loads(json_sent))
 
     def test_list_buckets_empty(self):
         from six.moves.urllib.parse import parse_qs
@@ -422,7 +429,7 @@ class TestClient(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
 
-        blob_name = 'blob-name'
+        blob_name = 'bucket-name'
         response = {'items': [{'name': blob_name}]}
 
         def dummy_response():


### PR DESCRIPTION
Closes #3474.

Needs extra system tests which pass `user_project` to the various APIs which take it, in the context of a bucket which is created with `requester_pays` enabled.