### PR TITLE
Support 'user_project' in '{Bucket,Blob}.update'

### DIFF
--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -170,9 +170,12 @@ class _PropertyMixin(object):
                        ``client`` stored on the current object.
         """
         client = self._require_client(client)
+        query_params = {'projection': 'full'}
+        if self.user_project is not None:
+            query_params['userProject'] = self.user_project
         api_response = client._connection.api_request(
             method='PUT', path=self.path, data=self._properties,
-            query_params={'projection': 'full'}, _target_object=self)
+            query_params=query_params, _target_object=self)
         self._set_properties(api_response)
 
 

--- a/storage/tests/unit/test__helpers.py
+++ b/storage/tests/unit/test__helpers.py
@@ -183,6 +183,31 @@ class Test_PropertyMixin(unittest.TestCase):
         # Make sure changes get reset by patch().
         self.assertEqual(derived._changes, set())
 
+    def test_update_w_user_project(self):
+        user_project = 'user-project-123'
+        connection = _Connection({'foo': 'Foo'})
+        client = _Client(connection)
+        derived = self._derivedClass('/path', user_project)()
+        # Make sure changes is non-empty, so we can observe a change.
+        BAR = object()
+        BAZ = object()
+        derived._properties = {'bar': BAR, 'baz': BAZ}
+        derived._changes = set(['bar'])  # Update sends 'baz' anyway.
+        derived.update(client=client)
+        self.assertEqual(derived._properties, {'foo': 'Foo'})
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PUT')
+        self.assertEqual(kw[0]['path'], '/path')
+        self.assertEqual(
+            kw[0]['query_params'], {
+                'projection': 'full',
+                'userProject': user_project,
+            })
+        self.assertEqual(kw[0]['data'], {'bar': BAR, 'baz': BAZ})
+        # Make sure changes get reset by patch().
+        self.assertEqual(derived._changes, set())
+
 
 class Test__scalar_property(unittest.TestCase):
 


### PR DESCRIPTION
Closes #4074.