### PR TITLE
Add DEFAULT sentinel for gapic_v1.method

### DIFF
--- a/core/google/api/core/gapic_v1/__init__.py
+++ b/core/google/api/core/gapic_v1/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.api.core.gapic_v1 import config
+from google.api.core.gapic_v1 import method
+
+__all__ = [
+    'config',
+    'method',
+]

--- a/core/google/api/core/gapic_v1/method.py
+++ b/core/google/api/core/gapic_v1/method.py
@@ -34,6 +34,8 @@ _API_CORE_VERSION = pkg_resources.get_distribution('google-cloud-core').version
 METRICS_METADATA_KEY = 'x-goog-api-client'
 USE_DEFAULT_METADATA = object()
 DEFAULT = object()
+"""Sentinel value indicating that a retry or timeout argument was unspecified,
+so the default should be used."""
 
 
 def _is_not_none_or_false(value):
@@ -83,7 +85,8 @@ def _determine_timeout(default_timeout, specified_timeout, retry):
         default_timeout (Optional[Timeout]): The default timeout specified
             at method creation time.
         specified_timeout (Optional[Timeout]): The timeout specified at
-            invocation time.
+            invocation time. If :attr:`DEFAULT`, this will be set to
+            the ``default_timeout``.
         retry (Optional[Retry]): The retry specified at invocation time.
 
     Returns:

--- a/core/tests/unit/api_core/gapic/test_method.py
+++ b/core/tests/unit/api_core/gapic/test_method.py
@@ -97,6 +97,26 @@ def test_wrap_method_with_default_retry_and_timeout(unusued_sleep):
 
 
 @mock.patch('time.sleep')
+def test_wrap_method_with_default_retry_and_timeout_using_sentinel(
+        unusued_sleep):
+    method = mock.Mock(spec=['__call__'], side_effect=[
+        exceptions.InternalServerError(None),
+        42])
+    default_retry = retry.Retry()
+    default_timeout = timeout.ConstantTimeout(60)
+    wrapped_method = google.api.core.gapic_v1.method.wrap_method(
+        method, default_retry, default_timeout)
+
+    result = wrapped_method(
+        retry=google.api.core.gapic_v1.method.DEFAULT,
+        timeout=google.api.core.gapic_v1.method.DEFAULT)
+
+    assert result == 42
+    assert method.call_count == 2
+    method.assert_called_with(timeout=60, metadata=mock.ANY)
+
+
+@mock.patch('time.sleep')
 def test_wrap_method_with_overriding_retry_and_timeout(unusued_sleep):
     method = mock.Mock(spec=['__call__'], side_effect=[
         exceptions.NotFound(None),

--- a/core/tests/unit/api_core/gapic/test_method.py
+++ b/core/tests/unit/api_core/gapic/test_method.py
@@ -81,9 +81,10 @@ def test_wrap_method_with_merged_metadata():
 
 @mock.patch('time.sleep')
 def test_wrap_method_with_default_retry_and_timeout(unusued_sleep):
-    method = mock.Mock(spec=['__call__'], side_effect=[
-        exceptions.InternalServerError(None),
-        42])
+    method = mock.Mock(
+        spec=['__call__'],
+        side_effect=[exceptions.InternalServerError(None), 42]
+    )
     default_retry = retry.Retry()
     default_timeout = timeout.ConstantTimeout(60)
     wrapped_method = google.api.core.gapic_v1.method.wrap_method(
@@ -99,9 +100,10 @@ def test_wrap_method_with_default_retry_and_timeout(unusued_sleep):
 @mock.patch('time.sleep')
 def test_wrap_method_with_default_retry_and_timeout_using_sentinel(
         unusued_sleep):
-    method = mock.Mock(spec=['__call__'], side_effect=[
-        exceptions.InternalServerError(None),
-        42])
+    method = mock.Mock(
+        spec=['__call__'],
+        side_effect=[exceptions.InternalServerError(None), 42]
+    )
     default_retry = retry.Retry()
     default_timeout = timeout.ConstantTimeout(60)
     wrapped_method = google.api.core.gapic_v1.method.wrap_method(
@@ -118,9 +120,10 @@ def test_wrap_method_with_default_retry_and_timeout_using_sentinel(
 
 @mock.patch('time.sleep')
 def test_wrap_method_with_overriding_retry_and_timeout(unusued_sleep):
-    method = mock.Mock(spec=['__call__'], side_effect=[
-        exceptions.NotFound(None),
-        42])
+    method = mock.Mock(
+        spec=['__call__'],
+        side_effect=[exceptions.NotFound(None), 42]
+    )
     default_retry = retry.Retry()
     default_timeout = timeout.ConstantTimeout(60)
     wrapped_method = google.api.core.gapic_v1.method.wrap_method(
@@ -137,8 +140,10 @@ def test_wrap_method_with_overriding_retry_and_timeout(unusued_sleep):
 
 @mock.patch('time.sleep')
 def test_wrap_method_with_overriding_retry_deadline(unusued_sleep):
-    method = mock.Mock(spec=['__call__'], side_effect=([
-        exceptions.InternalServerError(None)] * 3) + [42])
+    method = mock.Mock(
+        spec=['__call__'],
+        side_effect=([exceptions.InternalServerError(None)] * 3) + [42]
+    )
     default_retry = retry.Retry()
     default_timeout = timeout.ExponentialTimeout(deadline=60)
     wrapped_method = google.api.core.gapic_v1.method.wrap_method(


### PR DESCRIPTION
This is needed because the wrapped gapic methods can't discern between "unspecified" and "None" because the gapic clients will *always* specify retry and timeout, e.g.:

```python
def get_operation(name, retry=None, timeout=None):
     request = operations_pb2.GetOperationRequest(name=name)
     return self._get_operation(request, retry=retry, timeout=timeout)
```

gapic methods will use this sentinel to indicate unspecified:

```python
def get_operation(name, retry=gapic_v1.method.DEFAULT, timeout=gapic_v1.method.DEFAULT):
     request = operations_pb2.GetOperationRequest(name=name)
     return self._get_operation(request, retry=retry, timeout=timeout)
```