### PR TITLE
Avoiding `grpcio==1.6.0` in deps.

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -51,7 +51,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'googleapis-common-protos >= 1.3.4',
+    'googleapis-common-protos[grpc] >= 1.5.3, < 2.0dev',
     'protobuf >= 3.0.0',
     'google-auth >= 0.4.0, < 2.0.0dev',
     'requests >= 2.18.0, < 3.0.0dev',

--- a/language/setup.py
+++ b/language/setup.py
@@ -53,7 +53,7 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'google-cloud-core >= 0.27.0, < 0.28dev',
     'google-gax >= 0.15.14, < 0.16dev',
-    'googleapis-common-protos[grpc] >= 1.5.2, < 2.0dev',
+    'googleapis-common-protos[grpc] >= 1.5.3, < 2.0dev',
 ]
 EXTRAS_REQUIRE = {
     ':python_version<"3.4"': ['enum34'],

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -52,7 +52,7 @@ SETUP_BASE = {
 
 REQUIREMENTS = [
     'google-cloud-core >= 0.27.0, < 0.28dev',
-    'grpcio >= 1.2.0, < 2.0dev',
+    'grpcio >= 1.2.0, < 1.6dev',
     'gapic-google-cloud-logging-v2 >= 0.91.0, < 0.92dev',
 ]
 

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -53,9 +53,9 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'google-cloud-core >= 0.27.0, < 0.28dev',
     'google-gax >= 0.15.13, < 0.16dev',
-    'googleapis-common-protos[grpc] >= 1.5.2, < 2.0dev',
+    'googleapis-common-protos[grpc] >= 1.5.3, < 2.0dev',
     'grpc-google-iam-v1 >= 0.11.1, < 0.12dev',
-    'grpcio >= 1.0.2, < 2.0dev',
+    'grpcio >= 1.2.0, < 1.6dev',
     'psutil >= 5.2.2, < 6.0dev',
 ]
 

--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -54,7 +54,7 @@ REQUIREMENTS = [
     'google-auth >= 1.1.0',
     'google-cloud-core >= 0.27.0, < 0.28dev',
     'google-gax>=0.15.15, <0.16dev',
-    'googleapis-common-protos[grpc]>=1.5.2, <2.0dev',
+    'googleapis-common-protos[grpc]>=1.5.3, <2.0dev',
     'grpc-google-iam-v1>=0.11.4, <0.12dev',
     'requests>=2.18.4, <3.0dev',
 ]

--- a/speech/setup.py
+++ b/speech/setup.py
@@ -54,7 +54,7 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'google-cloud-core >= 0.27.0, < 0.28dev',
     'google-gax >= 0.15.14, < 0.16dev',
-    'googleapis-common-protos[grpc] >= 1.5.2, < 2.0dev',
+    'googleapis-common-protos[grpc] >= 1.5.3, < 2.0dev',
 ]
 
 setup(

--- a/trace/setup.py
+++ b/trace/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'google-gax>=0.15.7, <0.16dev',
-    'googleapis-common-protos[grpc]>=1.5.2, <2.0dev',
+    'googleapis-common-protos[grpc]>=1.5.3, <2.0dev',
     'google-cloud-core >= 0.27.0, < 0.28dev',
 ]
 

--- a/videointelligence/setup.py
+++ b/videointelligence/setup.py
@@ -38,7 +38,7 @@ setup(
     ],
     packages=find_packages(exclude=('tests*',)),
     install_requires=(
-        'googleapis-common-protos >= 1.5.2, < 2.0dev',
+        'googleapis-common-protos >= 1.5.3, < 2.0dev',
         'google-gax >= 0.15.14, < 0.16dev',
         'six >= 1.10.0',
     ),

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -27,7 +27,7 @@ with io.open(os.path.join(PACKAGE_ROOT, 'README.rst'), 'r') as readme_file:
 REQUIREMENTS = [
     'google-cloud-core >= 0.27.0, < 0.28dev',
     'google-gax >= 0.15.14, < 0.16dev',
-    'googleapis-common-protos[grpc] >= 1.5.2, < 2.0dev',
+    'googleapis-common-protos[grpc] >= 1.5.3, < 2.0dev',
 ]
 EXTRAS_REQUIRE = {
     ':python_version<"3.4"': ['enum34'],


### PR DESCRIPTION
This is due to `google-gax` doing the same, which has broken
RTD builds:

https://readthedocs.org/projects/google-cloud-python/builds/6063446/

The motivation for avoiding `grpcio==1.6.0` is:

https://github.com/grpc/grpc/issues/12455

----

@lukesneeringer I'm unclear, but it's possible that `googleapis-common-protos` will need to have the strict upper bound set as well (it currently has `>= 1.0.0`).