### PR TITLE
Do not use easily-misread glyphs in Firestore auto-IDs.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/collection.py
+++ b/firestore/google/cloud/firestore_v1beta1/collection.py
@@ -24,8 +24,7 @@ from google.cloud.firestore_v1beta1 import query as query_mod
 from google.cloud.firestore_v1beta1.proto import document_pb2
 
 
-_AUTO_ID_CHARS = (
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789')
+_AUTO_ID_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789'
 
 
 class CollectionReference(object):

--- a/firestore/google/cloud/firestore_v1beta1/collection.py
+++ b/firestore/google/cloud/firestore_v1beta1/collection.py
@@ -92,7 +92,7 @@ class CollectionReference(object):
         Args:
             document_id (Optional[str]): The document identifier
                 within the current collection. If not provided, will default
-                to a random 20 character string composed of digits,
+                to a random 21 character string composed of digits,
                 uppercase and lowercase and letters.
 
         Returns:
@@ -138,7 +138,7 @@ class CollectionReference(object):
             document_id (Optional[str]): The document identifier within the
                 current collection. If not provided, an ID will be
                 automatically assigned by the server (the assigned ID will be
-                a random 20 character string composed of digits,
+                a random 21 character string composed of digits,
                 uppercase and lowercase letters).
 
         Returns:
@@ -375,8 +375,8 @@ def _auto_id():
     """Generate a "random" automatically generated ID.
 
     Returns:
-        str: A 20 character string composed of digits, uppercase and
+        str: A 21 character string composed of digits, uppercase and
         lowercase and letters.
     """
     return ''.join(
-        random.choice(_AUTO_ID_CHARS) for _ in six.moves.xrange(20))
+        random.choice(_AUTO_ID_CHARS) for _ in six.moves.xrange(21))

--- a/firestore/tests/unit/test_collection.py
+++ b/firestore/tests/unit/test_collection.py
@@ -427,12 +427,12 @@ class Test__auto_id(unittest.TestCase):
     def test_it(self, mock_rand_choice):
         from google.cloud.firestore_v1beta1.collection import _AUTO_ID_CHARS
 
-        mock_result = '0123456789abcdefghij'
+        mock_result = '23456789abcdefghjkmnp'
         mock_rand_choice.side_effect = list(mock_result)
         result = self._call_fut()
         self.assertEqual(result, mock_result)
 
-        mock_calls = [mock.call(_AUTO_ID_CHARS)] * 20
+        mock_calls = [mock.call(_AUTO_ID_CHARS)] * 21
         self.assertEqual(mock_rand_choice.mock_calls, mock_calls)
 
 


### PR DESCRIPTION
This PR removes `{'i', 'I', 'l', 'o', 'O', '0', '1'}` from the set of characters used in automatically-generated IDs, because it is easy to mis-read them if you are in a situation where you need to do that.

Exact set of blacklisted characters is loaned from Django's [`make_random_password`](https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#django.contrib.auth.models.BaseUserManager.make_random_password).

/cc @schmidt-sebastian