### PR TITLE
bigquery: retry idempotent RPCs

### DIFF
--- a/bigquery/google/cloud/bigquery/__init__.py
+++ b/bigquery/google/cloud/bigquery/__init__.py
@@ -27,6 +27,7 @@ from pkg_resources import get_distribution
 __version__ = get_distribution('google-cloud-bigquery').version
 
 from google.cloud.bigquery._helpers import Row
+from google.cloud.bigquery._helpers import DEFAULT_RETRY
 from google.cloud.bigquery.client import Client
 from google.cloud.bigquery.dataset import AccessEntry
 from google.cloud.bigquery.dataset import Dataset
@@ -61,4 +62,5 @@ __all__ = [
     'Table',
     'TableReference',
     'UDFResource',
+    'DEFAULT_RETRY',
 ]


### PR DESCRIPTION
Add retry logic to every RPC for which it makes sense.

Following the BigQuery team, we ignore the error code and
use the "reason" field of the error to determine whether
to retry.