### PR TITLE
Add scope for trace client

### DIFF
--- a/trace/google/cloud/trace/__init__.py
+++ b/trace/google/cloud/trace/__init__.py
@@ -15,4 +15,7 @@
 from google.cloud.trace.client import Client
 
 
-__all__ = ['Client']
+__all__ = ['Client', 'SCOPE']
+
+
+SCOPE = Client.SCOPE

--- a/trace/google/cloud/trace/client.py
+++ b/trace/google/cloud/trace/client.py
@@ -32,6 +32,10 @@ class Client(ClientWithProject):
                         client. If not passed, falls back to the default
                         inferred from the environment.
     """
+    SCOPE = ('https://www.googleapis.com/auth/cloud-platform',
+             'https://www.googleapis.com/auth/trace.append',)
+    """The scopes required for authenticating as a Trace consumer."""
+
     _trace_api = None
 
     def __init__(self, project=None, credentials=None):


### PR DESCRIPTION
Adding the scope needed when setting credentials file via `$GOOGLE_APPLICATION_CREDENTIALS`.