### PR TITLE
bigquery: generate row IDs in create_rows

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -860,7 +860,7 @@ class Client(ClientWithProject):
 
         :type row_ids: list of string
         :param row_ids: (Optional)  Unique ids, one per row being inserted.
-                        If not passed, no de-duplication occurs.
+                        If omitted, unique IDs are created.
 
         :type selected_fields: list of :class:`SchemaField`
         :param selected_fields:
@@ -923,7 +923,8 @@ class Client(ClientWithProject):
             info = {'json': row_info}
             if row_ids is not None:
                 info['insertId'] = row_ids[index]
-
+            else:
+                info['insertId'] = str(uuid.uuid4())
             rows_info.append(info)
 
         if skip_invalid_rows is not None:
@@ -935,6 +936,7 @@ class Client(ClientWithProject):
         if template_suffix is not None:
             data['templateSuffix'] = template_suffix
 
+        # TODO(jba): use self._call_api here after #4148 is merged.
         response = self._connection.api_request(
             method='POST',
             path='%s/insertAll' % table.path,

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -1889,10 +1889,14 @@ class TestClient(unittest.TestCase):
                     'joined': joined}
 
         SENT = {
-            'rows': [{'json': _row_data(row)} for row in ROWS],
+            'rows': [{
+                'json': _row_data(row),
+                'insertId': str(i),
+            } for i, row in enumerate(ROWS)],
         }
 
-        errors = client.create_rows(table, ROWS)
+        with mock.patch('uuid.uuid4', side_effect=map(str, range(len(ROWS)))):
+            errors = client.create_rows(table, ROWS)
 
         self.assertEqual(len(errors), 0)
         self.assertEqual(len(conn._requested), 1)
@@ -1950,10 +1954,14 @@ class TestClient(unittest.TestCase):
             return row
 
         SENT = {
-            'rows': [{'json': _row_data(row)} for row in ROWS],
+            'rows': [{
+                'json': _row_data(row),
+                'insertId': str(i),
+            } for i, row in enumerate(ROWS)],
         }
 
-        errors = client.create_rows(table, ROWS)
+        with mock.patch('uuid.uuid4', side_effect=map(str, range(len(ROWS)))):
+            errors = client.create_rows(table, ROWS)
 
         self.assertEqual(len(errors), 0)
         self.assertEqual(len(conn._requested), 1)
@@ -1990,10 +1998,14 @@ class TestClient(unittest.TestCase):
             return {'full_name': row[0], 'age': str(row[1])}
 
         SENT = {
-            'rows': [{'json': _row_data(row)} for row in ROWS],
+            'rows': [{
+                'json': _row_data(row),
+                'insertId': str(i),
+            } for i, row in enumerate(ROWS)],
         }
 
-        errors = client.create_rows(table, ROWS)
+        with mock.patch('uuid.uuid4', side_effect=map(str, range(len(ROWS)))):
+            errors = client.create_rows(table, ROWS)
 
         self.assertEqual(len(errors), 0)
         self.assertEqual(len(conn._requested), 1)
@@ -2095,10 +2107,14 @@ class TestClient(unittest.TestCase):
                     'struct': row[1]}
 
         SENT = {
-            'rows': [{'json': _row_data(row)} for row in ROWS],
+            'rows': [{
+                'json': _row_data(row),
+                'insertId': str(i),
+            } for i, row in enumerate(ROWS)],
         }
 
-        errors = client.create_rows(table, ROWS)
+        with mock.patch('uuid.uuid4', side_effect=map(str, range(len(ROWS)))):
+            errors = client.create_rows(table, ROWS)
 
         self.assertEqual(len(errors), 0)
         self.assertEqual(len(conn._requested), 1)
@@ -2138,11 +2154,15 @@ class TestClient(unittest.TestCase):
                     'phone': row[1]}
 
         SENT = {
-            'rows': [{'json': _row_data(row)} for row in ROWS],
+            'rows': [{
+                'json': _row_data(row),
+                'insertId': str(i),
+            } for i, row in enumerate(ROWS)],
         }
 
-        errors = client.create_rows(self.TABLE_REF, ROWS,
-                                    selected_fields=[full_name, phone])
+        with mock.patch('uuid.uuid4', side_effect=map(str, range(len(ROWS)))):
+            errors = client.create_rows(self.TABLE_REF, ROWS,
+                                        selected_fields=[full_name, phone])
 
         self.assertEqual(len(errors), 0)
         self.assertEqual(len(conn._requested), 1)


### PR DESCRIPTION
If the user doesn't provide row IDs, create unique IDs for them.