### PR TITLE
Pub/Sub version bump: 0.28.4

### DIFF
--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-pubsub',
-    version='0.28.3',
+    version='0.28.4',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Release notes will be:

### Bugfixes

  * Fix a bug with debug logging causing unintentional blocking behavior (#4174, h/t @jeffkpayne)
  * Fix a bug where explicitly-provided queues were ignored (#3924, h/t @garykrige)

### Dependencies

  * Remove of `grpcio` as an explicit dependency; now a transitive dependency of `google-gax` only (#4098)

### Documentation

  * Update `gcloud-common` nomenclature to `google-cloud-common` (#4180)