### PR TITLE
Clear 'session._transaction' before calling '_delay_unitl_retry'. 

### DIFF
--- a/spanner/google/cloud/spanner_v1/session.py
+++ b/spanner/google/cloud/spanner_v1/session.py
@@ -280,8 +280,8 @@ class Session(object):
             try:
                 return_value = func(txn, *args, **kw)
             except (GaxError, GrpcRendezvous) as exc:
-                _delay_until_retry(exc, deadline)
                 del self._transaction
+                _delay_until_retry(exc, deadline)
                 continue
             except Exception:
                 txn.rollback()
@@ -290,8 +290,8 @@ class Session(object):
             try:
                 txn.commit()
             except GaxError as exc:
-                _delay_until_retry(exc, deadline)
                 del self._transaction
+                _delay_until_retry(exc, deadline)
             else:
                 return return_value
 

--- a/spanner/nox.py
+++ b/spanner/nox.py
@@ -72,10 +72,10 @@ def system_tests(session, python_version):
     # virtualenv's dist-packages.
     session.install('mock', 'pytest', *LOCAL_DEPS)
     session.install('../test_utils/')
-    session.install('.')
+    session.install('-e', '.')
 
     # Run py.test against the system tests.
-    session.run('py.test', '--quiet', 'tests/system')
+    session.run('py.test', '--quiet', 'tests/system', *session.posargs)
 
 
 @nox.session


### PR DESCRIPTION
That helper raises non-`ABORTED` exceptions, which makes reusing the session impossible if the transaction is not cleared.

Closes #4181.

/cc @vkedia