### PR TITLE
Add Links to Python Setup Guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Example Applications
 --------------------
 

--- a/bigquery/README.rst
+++ b/bigquery/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-bigquery
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/bigtable/README.rst
+++ b/bigtable/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-bigtable
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/core/README.rst
+++ b/core/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-core
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-core.svg
    :target: https://pypi.org/project/google-cloud-core/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-core.svg

--- a/datastore/README.rst
+++ b/datastore/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-datastore
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/dns/README.rst
+++ b/dns/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-dns
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,10 @@ The ``google-cloud`` library is ``pip`` install-able:
 
     $ pip install google-cloud
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Cloud Datastore
 ~~~~~~~~~~~~~~~
 

--- a/error_reporting/README.rst
+++ b/error_reporting/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-error-reporting
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/firestore/README.rst
+++ b/firestore/README.rst
@@ -16,6 +16,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-firestore
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/language/README.rst
+++ b/language/README.rst
@@ -20,6 +20,10 @@ Quick Start
     $ # OR
     $ pip install --upgrade google-cloud-natural-language
 
+ Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/logging/README.rst
+++ b/logging/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-logging
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/monitoring/README.rst
+++ b/monitoring/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-monitoring
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-pubsub
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/resource_manager/README.rst
+++ b/resource_manager/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-resource-manager
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/runtimeconfig/README.rst
+++ b/runtimeconfig/README.rst
@@ -22,6 +22,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-runtimeconfig
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/spanner/README.rst
+++ b/spanner/README.rst
@@ -13,6 +13,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-spanner
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 
 Authentication
 --------------

--- a/speech/README.rst
+++ b/speech/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-speech
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/storage/README.rst
+++ b/storage/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-storage
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/trace/README.rst
+++ b/trace/README.rst
@@ -59,6 +59,10 @@ Windows
     <your-env>\Scripts\activate
     <your-env>\Scripts\pip.exe install gapic-google-cloud-trace-v1
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` and ``virtualenv`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Preview
 ~~~~~~~
 

--- a/translate/README.rst
+++ b/translate/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-translate
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/videointelligence/README.rst
+++ b/videointelligence/README.rst
@@ -14,6 +14,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-videointelligence
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 

--- a/vision/README.rst
+++ b/vision/README.rst
@@ -18,6 +18,10 @@ Quick Start
 
     $ pip install --upgrade google-cloud-vision
 
+Fore more information on setting up your Python development environment, such as installing ``pip`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
+
 Authentication
 --------------
 


### PR DESCRIPTION
As requested in b/64770713.

Considering the structure of documentation it makes more sense to add the setup guide here as well as in the documentation.