### PR TITLE
Clarify 'user_project' semantics for API wrapper methods.

### DIFF
--- a/storage/google/cloud/storage/_helpers.py
+++ b/storage/google/cloud/storage/_helpers.py
@@ -90,6 +90,8 @@ class _PropertyMixin(object):
     def reload(self, client=None):
         """Reload properties from Cloud Storage.
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -139,6 +141,8 @@ class _PropertyMixin(object):
 
         Updates the ``_properties`` with the response from the backend.
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
@@ -163,6 +167,8 @@ class _PropertyMixin(object):
         """Sends all properties in a PUT request.
 
         Updates the ``_properties`` with the response from the backend.
+
+        If :attr:`user_project` is set, bills the API request to that project.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``

--- a/storage/google/cloud/storage/acl.py
+++ b/storage/google/cloud/storage/acl.py
@@ -399,6 +399,8 @@ class ACL(object):
     def reload(self, client=None):
         """Reload the ACL data from Cloud Storage.
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
@@ -463,6 +465,8 @@ class ACL(object):
     def save(self, acl=None, client=None):
         """Save this ACL for the current bucket.
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type acl: :class:`google.cloud.storage.acl.ACL`, or a compatible list.
         :param acl: The ACL object to save.  If left blank, this will save
                     current entries.
@@ -483,6 +487,8 @@ class ACL(object):
 
     def save_predefined(self, predefined, client=None):
         """Save this ACL for the current bucket using a predefined ACL.
+
+        If :attr:`user_project` is set, bills the API request to that project.
 
         :type predefined: str
         :param predefined: An identifier for a predefined ACL.  Must be one
@@ -505,6 +511,8 @@ class ACL(object):
 
     def clear(self, client=None):
         """Remove all ACL entries.
+
+        If :attr:`user_project` is set, bills the API request to that project.
 
         Note that this won't actually remove *ALL* the rules, but it
         will remove all the non-default rules.  In short, you'll still

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -226,7 +226,7 @@ class Blob(_PropertyMixin):
 
     @property
     def user_project(self):
-        """Project ID used for API requests made via this blob.
+        """Project ID billed for API requests made via this blob.
 
         Derived from bucket's value.
 
@@ -333,6 +333,9 @@ class Blob(_PropertyMixin):
     def exists(self, client=None):
         """Determines whether or not this blob exists.
 
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
@@ -364,6 +367,9 @@ class Blob(_PropertyMixin):
 
     def delete(self, client=None):
         """Deletes a blob from Cloud Storage.
+
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
@@ -470,6 +476,9 @@ class Blob(_PropertyMixin):
         `google-resumable-media`_. For example, this library allows
         downloading **parts** of a blob rather than the whole thing.
 
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
+
         :type file_obj: file
         :param file_obj: A file handle to which to write the blob's data.
 
@@ -492,6 +501,9 @@ class Blob(_PropertyMixin):
 
     def download_to_filename(self, filename, client=None):
         """Download the contents of this blob into a named file.
+
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
 
         :type filename: str
         :param filename: A filename to be passed to ``open``.
@@ -518,6 +530,9 @@ class Blob(_PropertyMixin):
 
     def download_as_string(self, client=None):
         """Download the contents of this blob as a string.
+
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
@@ -889,6 +904,9 @@ class Blob(_PropertyMixin):
         For more fine-grained over the upload process, check out
         `google-resumable-media`_.
 
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
+
         :type file_obj: file
         :param file_obj: A file handle open for reading.
 
@@ -952,6 +970,9 @@ class Blob(_PropertyMixin):
            `lifecycle <https://cloud.google.com/storage/docs/lifecycle>`_
            API documents for details.
 
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
+
         :type filename: str
         :param filename: The path to the file.
 
@@ -983,6 +1004,9 @@ class Blob(_PropertyMixin):
            <https://cloud.google.com/storage/docs/object-versioning>`_ and
            `lifecycle <https://cloud.google.com/storage/docs/lifecycle>`_
            API documents for details.
+
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
 
         :type data: bytes or str
         :param data: The data to store in this blob.  If the value is
@@ -1045,6 +1069,9 @@ class Blob(_PropertyMixin):
         If :attr:`encryption_key` is set, the blob will be encrypted with
         a `customer-supplied`_ encryption key.
 
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
+
         :type size: int
         :param size: (Optional). The maximum number of bytes that can be
                      uploaded using this session. If the size is not known
@@ -1096,6 +1123,9 @@ class Blob(_PropertyMixin):
         See
         https://cloud.google.com/storage/docs/json_api/v1/objects/getIamPolicy
 
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
@@ -1124,6 +1154,9 @@ class Blob(_PropertyMixin):
 
         See
         https://cloud.google.com/storage/docs/json_api/v1/objects/setIamPolicy
+
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
 
         :type policy: :class:`google.cloud.iam.Policy`
         :param policy: policy instance used to update bucket's IAM policy.
@@ -1159,6 +1192,9 @@ class Blob(_PropertyMixin):
 
         See
         https://cloud.google.com/storage/docs/json_api/v1/objects/testIamPermissions
+
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
 
         :type permissions: list of string
         :param permissions: the permissions to check
@@ -1200,6 +1236,9 @@ class Blob(_PropertyMixin):
     def compose(self, sources, client=None):
         """Concatenate source blobs into this one.
 
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
+
         :type sources: list of :class:`Blob`
         :param sources: blobs whose contents will be composed into this blob.
 
@@ -1234,6 +1273,9 @@ class Blob(_PropertyMixin):
 
     def rewrite(self, source, token=None, client=None):
         """Rewrite source blob into this one.
+
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
 
         :type source: :class:`Blob`
         :param source: blob whose contents will be rewritten into this blob.
@@ -1292,6 +1334,9 @@ class Blob(_PropertyMixin):
 
         See
         https://cloud.google.com/storage/docs/per-object-storage-class
+
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
 
         :type new_class: str
         :param new_class: new storage class for the object

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -220,6 +220,8 @@ class Bucket(_PropertyMixin):
     def exists(self, client=None):
         """Determines whether or not this bucket exists.
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
@@ -257,6 +259,8 @@ class Bucket(_PropertyMixin):
 
         This implements "storage.buckets.insert".
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
@@ -278,6 +282,8 @@ class Bucket(_PropertyMixin):
         """Sends all changed properties in a PATCH request.
 
         Updates the ``_properties`` with the response from the backend.
+
+        If :attr:`user_project` is set, bills the API request to that project.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
@@ -334,6 +340,8 @@ class Bucket(_PropertyMixin):
           :start-after: [START get_blob]
           :end-before: [END get_blob]
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type blob_name: str
         :param blob_name: The name of the blob to retrieve.
 
@@ -384,6 +392,8 @@ class Bucket(_PropertyMixin):
                    delimiter=None, versions=None,
                    projection='noAcl', fields=None, client=None):
         """Return an iterator used to find blobs in the bucket.
+
+        If :attr:`user_project` is set, bills the API request to that project.
 
         :type max_results: int
         :param max_results: (Optional) Maximum number of blobs to return.
@@ -462,6 +472,8 @@ class Bucket(_PropertyMixin):
         See:
         https://cloud.google.com/storage/docs/json_api/v1/notifications/list
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
@@ -496,6 +508,8 @@ class Bucket(_PropertyMixin):
         this will cowardly refuse to delete the objects (or the bucket). This
         is to prevent accidental bucket deletion and to prevent extremely long
         runtime of this method.
+
+        If :attr:`user_project` is set, bills the API request to that project.
 
         :type force: bool
         :param force: If True, empties the bucket's objects then deletes it.
@@ -552,6 +566,8 @@ class Bucket(_PropertyMixin):
           :start-after: [START delete_blob]
           :end-before: [END delete_blob]
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type blob_name: str
         :param blob_name: A blob name to delete.
 
@@ -590,6 +606,8 @@ class Bucket(_PropertyMixin):
 
         Uses :meth:`delete_blob` to delete each individual blob.
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type blobs: list
         :param blobs: A list of :class:`~google.cloud.storage.blob.Blob`-s or
                       blob names to delete.
@@ -622,6 +640,8 @@ class Bucket(_PropertyMixin):
     def copy_blob(self, blob, destination_bucket, new_name=None,
                   client=None, preserve_acl=True):
         """Copy the given blob to the given bucket, optionally with a new name.
+
+        If :attr:`user_project` is set, bills the API request to that project.
 
         :type blob: :class:`google.cloud.storage.blob.Blob`
         :param blob: The blob to be copied.
@@ -671,6 +691,8 @@ class Bucket(_PropertyMixin):
 
     def rename_blob(self, blob, new_name, client=None):
         """Rename the given blob using copy and delete operations.
+
+        If :attr:`user_project` is set, bills the API request to that project.
 
         Effectively, copies blob to the same bucket with a new name, then
         deletes the blob.
@@ -1112,6 +1134,8 @@ class Bucket(_PropertyMixin):
         See
         https://cloud.google.com/storage/docs/json_api/v1/buckets/getIamPolicy
 
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
@@ -1139,6 +1163,8 @@ class Bucket(_PropertyMixin):
 
         See
         https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy
+
+        If :attr:`user_project` is set, bills the API request to that project.
 
         :type policy: :class:`google.cloud.iam.Policy`
         :param policy: policy instance used to update bucket's IAM policy.
@@ -1173,6 +1199,8 @@ class Bucket(_PropertyMixin):
 
         See
         https://cloud.google.com/storage/docs/json_api/v1/buckets/testIamPermissions
+
+        If :attr:`user_project` is set, bills the API request to that project.
 
         :type permissions: list of string
         :param permissions: the permissions to check

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -133,7 +133,7 @@ class Client(ClientWithProject):
 
         :type user_project: str
         :param user_project: (Optional) the project ID to be billed for API
-                             requests made via this instance.
+                             requests made via the bucket.
 
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
         :returns: The bucket object created.

--- a/storage/google/cloud/storage/notification.py
+++ b/storage/google/cloud/storage/notification.py
@@ -223,6 +223,9 @@ class BucketNotification(object):
         See:
         https://cloud.google.com/storage/docs/json_api/v1/notifications/insert
 
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client`
         :param client: (Optional) the client to use.  If not passed, falls back
                        to the ``client`` stored on the notification's bucket.
@@ -253,6 +256,9 @@ class BucketNotification(object):
 
         See:
         https://cloud.google.com/storage/docs/json_api/v1/notifications/get
+
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
@@ -289,6 +295,9 @@ class BucketNotification(object):
         See:
         https://cloud.google.com/storage/docs/json_api/v1/notifications/get
 
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
@@ -319,6 +328,9 @@ class BucketNotification(object):
 
         See:
         https://cloud.google.com/storage/docs/json_api/v1/notifications/delete
+
+        If :attr:`user_project` is set on the bucket, bills the API request
+        to that project.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``


### PR DESCRIPTION
Closes #4142.

[ci skip]