### PR TITLE
BigQuery: removes LoadJob error for autodetect=True and schema set

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -143,9 +143,6 @@ class AutoDetectSchema(_TypedApiResourceProperty):
     """
     def __set__(self, instance, value):
         self._validate(value)
-        if instance.schema:
-            raise ValueError('A schema should not be already defined '
-                             'when using schema auto-detection')
         instance._properties[self.resource_name] = value
 
 
@@ -638,9 +635,6 @@ class LoadJobConfig(object):
     def schema(self, value):
         if not all(isinstance(field, SchemaField) for field in value):
             raise ValueError('Schema items must be fields')
-        if self.autodetect:
-            raise ValueError(
-                'Schema can not be set if `autodetect` property is True')
         self._schema = tuple(value)
 
     def to_api_repr(self):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -426,32 +426,6 @@ class TestLoadJob(unittest.TestCase, _Base):
         config.schema = [full_name, age]
         self.assertEqual(config.schema, [full_name, age])
 
-    def test_schema_setter_w_autodetect(self):
-        from google.cloud.bigquery.schema import SchemaField
-
-        config = LoadJobConfig()
-        schema = [SchemaField('full_name', 'STRING')]
-        config.autodetect = False
-        config.schema = schema
-        self.assertEqual(config.schema, schema)
-
-        config.schema = []
-        config.autodetect = True
-        with self.assertRaises(ValueError):
-            config.schema = schema
-
-    def test_autodetect_setter_w_schema(self):
-        from google.cloud.bigquery.schema import SchemaField
-
-        config = LoadJobConfig()
-
-        config.autodetect = False
-        config.schema = [SchemaField('full_name', 'STRING')]
-        self.assertEqual(config.autodetect, False)
-
-        with self.assertRaises(ValueError):
-            config.autodetect = True
-
     def test_props_set_by_server(self):
         import datetime
         from google.cloud._helpers import UTC


### PR DESCRIPTION
Validations in the `LoadJob` class were set to disallow a schema to be set while autodetect is True. This raised an error when running `client.get_job()` and `client.list_jobs()` for LoadJobs that were created with `autodetect=True` because the jobs came back with the schema having been set. The additional code added in system tests shows how to reproduce the bug.