### PR TITLE
[DO NOT MERGE] Demonstrate changes needed to move video gapic to api_core

### DIFF
--- a/videointelligence/google/cloud/videointelligence_v1beta2/gapic/video_intelligence_service_client.py
+++ b/videointelligence/google/cloud/videointelligence_v1beta2/gapic/video_intelligence_service_client.py
@@ -22,125 +22,98 @@
 # merge preserves those additions if the generated source changes.
 """Accesses the google.cloud.videointelligence.v1beta2 VideoIntelligenceService API."""
 
-import collections
-import json
-import os
 import pkg_resources
-import platform
 
-from google.gapic.longrunning import operations_client
-from google.gax import api_callable
-from google.gax import config
-from google.gax import path_template
 import google.gax
 
+import google.api_core.grpc_helpers
+import google.api_core.gapic_v1.client_info
+import google.api_core.gapic_v1.config
+import google.api_core.gapic_v1.method
+import google.api_core.operations_v1
+import google.api_core.operation
+
 from google.cloud.videointelligence_v1beta2.gapic import enums
-from google.cloud.videointelligence_v1beta2.gapic import video_intelligence_service_client_config
+from google.cloud.videointelligence_v1beta2.gapic import (
+    video_intelligence_service_client_config)
 from google.cloud.videointelligence_v1beta2.proto import video_intelligence_pb2
+
+_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
+    'google-cloud-videointelligence').version
 
 
 class VideoIntelligenceServiceClient(object):
     """Service that implements Google Cloud Video Intelligence API."""
 
-    SERVICE_ADDRESS = 'videointelligence.googleapis.com'
+    SERVICE_ADDRESS = 'videointelligence.googleapis.com:443'
     """The default address of the service."""
-
-    DEFAULT_SERVICE_PORT = 443
-    """The default port of the service."""
 
     # The scopes needed to make gRPC calls to all of the methods defined in
     # this service
-    _ALL_SCOPES = ('https://www.googleapis.com/auth/cloud-platform', )
+    _DEFAULT_SCOPES = ('https://www.googleapis.com/auth/cloud-platform', )
+
+    # The name of the interface for this client. This is the key used to find
+    # method configuration in the client_config dictionary
+    _INTERFACE_NAME = (
+        'google.cloud.videointelligence.v1beta2.VideoIntelligenceService')
 
     def __init__(self,
                  channel=None,
                  credentials=None,
-                 ssl_credentials=None,
-                 scopes=None,
-                 client_config=None,
-                 lib_name=None,
-                 lib_version='',
-                 metrics_headers=()):
+                 client_config=video_intelligence_service_client_config.config,
+                 library_identifier=None):
         """Constructor.
 
         Args:
-            channel (~grpc.Channel): A ``Channel`` instance through
-                which to make calls.
-            credentials (~google.auth.credentials.Credentials): The authorization
-                credentials to attach to requests. These credentials identify this
-                application to the service.
-            ssl_credentials (~grpc.ChannelCredentials): A
-                ``ChannelCredentials`` instance for use with an SSL-enabled
-                channel.
-            scopes (Sequence[str]): A list of OAuth2 scopes to attach to requests.
+            channel (grpc.Channel): A ``Channel`` instance through
+                which to make calls. If specified, then the ``credentials``
+                argument is ignored.
+            credentials (google.auth.credentials.Credentials): The
+                authorization credentials to attach to requests. These
+                credentials identify this application to the service. If none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
             client_config (dict):
-                A dictionary for call options for each method. See
-                :func:`google.gax.construct_settings` for the structure of
-                this data. Falls back to the default config if not specified
-                or the specified config is missing data points.
-            lib_name (str): The API library software used for calling
-                the service. (Unless you are writing an API client itself,
-                leave this as default.)
-            lib_version (str): The API library software version used
-                for calling the service. (Unless you are writing an API client
-                itself, leave this as default.)
-            metrics_headers (dict): A dictionary of values for tracking
-                client library metrics. Ultimately serializes to a string
-                (e.g. 'foo/1.2.3 bar/3.14.1'). This argument should be
-                considered private.
+                A dictionary of call options for each method. If not specified
+                the default configuration is used.
         """
-        # Unless the calling application specifically requested
-        # OAuth scopes, request everything.
-        if scopes is None:
-            scopes = self._ALL_SCOPES
 
-        # Initialize an empty client config, if none is set.
-        if client_config is None:
-            client_config = {}
+        # gRPC channel & client stub initialization.
+        if channel is not None and credentials is not None:
+            raise ValueError(
+                'channel and credentials arguments to {} are mutually '
+                'exclusive.'.format(self.__class__.__name___))
 
-        # Initialize metrics_headers as an ordered dictionary
-        # (cuts down on cardinality of the resulting string slightly).
-        metrics_headers = collections.OrderedDict(metrics_headers)
-        metrics_headers['gl-python'] = platform.python_version()
+        if channel is None:
+            channel = google.api_core.grpc_helpers.create_channel(
+                self.SERVICE_ADDRESS,
+                credentials=credentials,
+                scopes=self._DEFAULT_SCOPES)
 
-        # The library may or may not be set, depending on what is
-        # calling this client. Newer client libraries set the library name
-        # and version.
-        if lib_name:
-            metrics_headers[lib_name] = lib_version
+        self.video_intelligence_service_stub = (
+            video_intelligence_pb2.VideoIntelligenceServiceStub(channel))
 
-        # Finally, track the GAPIC package version.
-        metrics_headers['gapic'] = pkg_resources.get_distribution(
-            'google-cloud-videointelligence', ).version
+        # Operations client for methods that return long-running operations
+        # futures.
+        self.operations_client = (
+            google.api_core.operations_v1.OperationsClient(channel))
 
-        # Load the configuration defaults.
-        defaults = api_callable.construct_settings(
-            'google.cloud.videointelligence.v1beta2.VideoIntelligenceService',
-            video_intelligence_service_client_config.config,
-            client_config,
-            config.STATUS_CODE_NAMES,
-            metrics_headers=metrics_headers, )
-        self.video_intelligence_service_stub = config.create_stub(
-            video_intelligence_pb2.VideoIntelligenceServiceStub,
-            channel=channel,
-            service_path=self.SERVICE_ADDRESS,
-            service_port=self.DEFAULT_SERVICE_PORT,
-            credentials=credentials,
-            scopes=scopes,
-            ssl_credentials=ssl_credentials)
+        # Client information initialization.
+        client_info = google.api_core.gapic_v1.client_info.ClientInfo(
+            gapic_version=_GAPIC_LIBRARY_VERSION)
 
-        self.operations_client = operations_client.OperationsClient(
-            service_path=self.SERVICE_ADDRESS,
-            channel=channel,
-            credentials=credentials,
-            ssl_credentials=ssl_credentials,
-            scopes=scopes,
-            client_config=client_config,
-            metrics_headers=metrics_headers, )
+        # The interface config contains all of the default settings for retry
+        # and timeout for each RPC method.
+        interface_config = client_config['interfaces'][self._INTERFACE_NAME]
+        method_configs = google.api_core.gapic_v1.config.parse_method_configs(
+            interface_config)
 
-        self._annotate_video = api_callable.create_api_call(
+        # Create the wrapped gRPC methods for each RPC method.
+        self._annotate_video = google.api_core.gapic_v1.method.wrap_method(
             self.video_intelligence_service_stub.AnnotateVideo,
-            settings=defaults['annotate_video'])
+            default_retry=method_configs['AnnotateVideo'].retry,
+            default_timeout=method_configs['AnnotateVideo'].timeout,
+            client_info=client_info)
 
     # Service calls
     def annotate_video(self,
@@ -150,7 +123,8 @@ class VideoIntelligenceServiceClient(object):
                        video_context=None,
                        output_uri=None,
                        location_id=None,
-                       options=None):
+                       retry=None,
+                       timeout=None):
         """
         Performs asynchronous video annotation. Progress and results can be
         retrieved through the ``google.longrunning.Operations`` interface.
@@ -168,13 +142,7 @@ class VideoIntelligenceServiceClient(object):
             >>>
             >>> response = client.annotate_video(input_uri, features)
             >>>
-            >>> def callback(operation_future):
-            ...     # Handle result.
-            ...     result = operation_future.result()
-            >>>
-            >>> response.add_done_callback(callback)
-            >>>
-            >>> # Handle metadata.
+            >>> result = response.result()
             >>> metadata = response.metadata()
 
         Args:
@@ -203,15 +171,22 @@ class VideoIntelligenceServiceClient(object):
             location_id (str): Optional cloud region where annotation should take place. Supported cloud
                 regions: ``us-east1``, ``us-west1``, ``europe-west1``, ``asia-east1``. If no region
                 is specified, a region will be determined based on video file location.
-            options (~google.gax.CallOptions): Overrides the default
-                settings for this call, e.g, timeout, retries etc.
+            retry (Optional[google.api_core.retry.Retry]): A retry object used
+                to retry requests. If ``None`` is specified, requests will not
+                be retried.
+            timeout (Optional[float]): The amount of time, in seconds, to wait
+                for the request to complete. Note that if ``retry`` is
+                specified, the timeout applies to each individual attempt.
 
         Returns:
             A :class:`~google.cloud.videointelligence_v1beta2.types._OperationFuture` instance.
 
         Raises:
-            :exc:`google.gax.errors.GaxError` if the RPC is aborted.
-            :exc:`ValueError` if the parameters are invalid.
+            google.api_core.exceptions.GoogleAPICallError: If the request
+                failed for any reason.
+            google.api_core.exceptions.RetryError: If the request failed due
+                to a retryable error and retry attempts failed.
+            ValueError: If the parameters are invalid.
         """
         request = video_intelligence_pb2.AnnotateVideoRequest(
             input_uri=input_uri,
@@ -220,7 +195,9 @@ class VideoIntelligenceServiceClient(object):
             video_context=video_context,
             output_uri=output_uri,
             location_id=location_id)
-        return google.gax._OperationFuture(
-            self._annotate_video(request, options), self.operations_client,
+        operation = self._annotate_video(request, retry=retry, timeout=timeout)
+        return google.api_core.operation.from_gapic(
+            operation,
+            self.operations_client,
             video_intelligence_pb2.AnnotateVideoResponse,
-            video_intelligence_pb2.AnnotateVideoProgress, options)
+            metadata_type=video_intelligence_pb2.AnnotateVideoProgress)

--- a/videointelligence/google/cloud/videointelligence_v1beta2/gapic/video_intelligence_service_client.py
+++ b/videointelligence/google/cloud/videointelligence_v1beta2/gapic/video_intelligence_service_client.py
@@ -132,8 +132,8 @@ class VideoIntelligenceServiceClient(object):
                        video_context=None,
                        output_uri=None,
                        location_id=None,
-                       retry=None,
-                       timeout=None):
+                       retry=google.api_core.gapic_v1.method.DEFAULT,
+                       timeout=google.api_core.gapic_v1.method.DEFAULT):
         """
         Performs asynchronous video annotation. Progress and results can be
         retrieved through the ``google.longrunning.Operations`` interface.

--- a/videointelligence/google/cloud/videointelligence_v1beta2/gapic/video_intelligence_service_client.py
+++ b/videointelligence/google/cloud/videointelligence_v1beta2/gapic/video_intelligence_service_client.py
@@ -61,7 +61,7 @@ class VideoIntelligenceServiceClient(object):
                  channel=None,
                  credentials=None,
                  client_config=video_intelligence_service_client_config.config,
-                 library_identifier=None):
+                 client_info=None):
         """Constructor.
 
         Args:
@@ -75,7 +75,13 @@ class VideoIntelligenceServiceClient(object):
                 credentials from the environment.
             client_config (dict):
                 A dictionary of call options for each method. If not specified
-                the default configuration is used.
+                the default configuration is used. Generally, you only need
+                to set this if you're developing your own client library.
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
+                your own client library.
         """
 
         # gRPC channel & client stub initialization.
@@ -99,8 +105,11 @@ class VideoIntelligenceServiceClient(object):
             google.api_core.operations_v1.OperationsClient(channel))
 
         # Client information initialization.
-        client_info = google.api_core.gapic_v1.client_info.ClientInfo(
-            gapic_version=_GAPIC_LIBRARY_VERSION)
+        if client_info is None:
+            client_info = (
+                google.api_core.gapic_v1.client_info.DEFAULT_CLIENT_INFO)
+
+        client_info.gapic_version = _GAPIC_LIBRARY_VERSION
 
         # The interface config contains all of the default settings for retry
         # and timeout for each RPC method.

--- a/videointelligence/google/cloud/videointelligence_v1beta2/types.py
+++ b/videointelligence/google/cloud/videointelligence_v1beta2/types.py
@@ -31,7 +31,7 @@ names = []
 for module in (
         http_pb2,
         video_intelligence_pb2,
-        operations_pb2,
+        #operations_pb2,
         any_pb2,
         descriptor_pb2,
         duration_pb2,

--- a/videointelligence/nox.py
+++ b/videointelligence/nox.py
@@ -29,11 +29,12 @@ def unit_tests(session, python_version):
     session.virtualenv_dirname = 'unit-' + python_version
 
     # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('mock', 'pytest', 'pytest-cov', '../api_core')
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
     session.run('py.test', '--quiet', 'tests/')
+
 
 @nox.session
 def lint_setup_py(session):

--- a/videointelligence/setup.py
+++ b/videointelligence/setup.py
@@ -39,7 +39,9 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     install_requires=(
         'googleapis-common-protos >= 1.5.3, < 2.0dev',
+        # GAX remains for the time being for the v1beta1 interface.
         'google-gax >= 0.15.14, < 0.16dev',
+        'google-api-core >= 0.1.0, < 0.2.0dev',
         'grpcio >= 1.2.0, < 1.6dev',
         'six >= 1.10.0',
     ),

--- a/videointelligence/tests/unit/gapic/v1beta2/test_video_intelligence_service_client_v1beta2.py
+++ b/videointelligence/tests/unit/gapic/v1beta2/test_video_intelligence_service_client_v1beta2.py
@@ -11,12 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests."""
 
-import mock
-import unittest
-
-from google.gax import errors
 from google.rpc import status_pb2
 
 from google.cloud import videointelligence_v1beta2
@@ -24,54 +19,63 @@ from google.cloud.videointelligence_v1beta2.proto import video_intelligence_pb2
 from google.longrunning import operations_pb2
 
 
-class CustomException(Exception):
-    pass
+class UnaryUnaryMultiCallableStub(object):
+    """Stub for the grpc.UnaryUnaryMultiCallable interface."""
+    def __init__(self, method, channel_stub):
+        self.method = method
+        self.channel_stub = channel_stub
+
+    def __call__(self, request, timeout=None, metadata=None, credentials=None):
+        self.channel_stub.requests.append((self.method, request))
+        return self.channel_stub.responses.pop()
 
 
-class TestVideoIntelligenceServiceClient(unittest.TestCase):
-    @mock.patch('google.gax.config.create_stub', spec=True)
-    def test_annotate_video(self, mock_create_stub):
-        # Mock gRPC layer
-        grpc_stub = mock.Mock()
-        mock_create_stub.return_value = grpc_stub
+class ChannelStub(object):
+    """Stub for the grpc.Channel interface."""
+    def __init__(self, responses):
+        self.responses = responses
+        self.requests = []
 
-        client = videointelligence_v1beta2.VideoIntelligenceServiceClient()
+    def unary_unary(
+            self, method, request_serializer=None, response_deserializer=None):
+        return UnaryUnaryMultiCallableStub(method, self)
 
-        # Mock request
+
+class TestVideoIntelligenceServiceClient(object):
+    def test_annotate_video(self):
+        # Request
         input_uri = 'inputUri1707300727'
         features = []
 
-        # Mock response
-        expected_response = {}
-        expected_response = video_intelligence_pb2.AnnotateVideoResponse(
-            **expected_response)
+        # Response
+        expected_response = video_intelligence_pb2.AnnotateVideoResponse()
         operation = operations_pb2.Operation(
             name='operations/test_annotate_video', done=True)
         operation.response.Pack(expected_response)
-        grpc_stub.AnnotateVideo.return_value = operation
 
+        # gRPC Channel
+        channel = ChannelStub(responses=[operation])
+
+        # Client
+        client = videointelligence_v1beta2.VideoIntelligenceServiceClient(
+            channel=channel)
+
+        # Make the request and check the result.
         response = client.annotate_video(input_uri, features)
-        self.assertEqual(expected_response, response.result())
+        result = response.result()
 
-        grpc_stub.AnnotateVideo.assert_called_once()
-        args, kwargs = grpc_stub.AnnotateVideo.call_args
-        self.assertEqual(len(args), 2)
-        self.assertEqual(len(kwargs), 1)
-        self.assertIn('metadata', kwargs)
-        actual_request = args[0]
+        assert expected_response == result
+
+        # Verify the state of the stubs
+        assert len(channel.requests) == 1
 
         expected_request = video_intelligence_pb2.AnnotateVideoRequest(
             input_uri=input_uri, features=features)
-        self.assertEqual(expected_request, actual_request)
+        actual_request = channel.requests[0][1]
 
-    @mock.patch('google.gax.config.create_stub', spec=True)
-    def test_annotate_video_exception(self, mock_create_stub):
-        # Mock gRPC layer
-        grpc_stub = mock.Mock()
-        mock_create_stub.return_value = grpc_stub
+        assert actual_request == expected_request
 
-        client = videointelligence_v1beta2.VideoIntelligenceServiceClient()
-
+    def test_annotate_video_exception(self):
         # Mock request
         input_uri = 'inputUri1707300727'
         features = []
@@ -81,7 +85,15 @@ class TestVideoIntelligenceServiceClient(unittest.TestCase):
         operation = operations_pb2.Operation(
             name='operations/test_annotate_video_exception', done=True)
         operation.error.CopyFrom(error)
-        grpc_stub.AnnotateVideo.return_value = operation
+
+        # gRPC Channel
+        channel = ChannelStub(responses=[operation])
+
+        # Make the request and check the result.
+        client = videointelligence_v1beta2.VideoIntelligenceServiceClient(
+            channel=channel)
 
         response = client.annotate_video(input_uri, features)
-        self.assertEqual(error, response.exception())
+        exception = response.exception()
+
+        assert exception.errors[0] == error


### PR DESCRIPTION
* This change will pass unit tests once #4231 is in and merged.
* LRO is broken right now because the old protos barf when timeout and metadata arguments are passed to RPC methods. Re-generating the copy of `google.longrunning` in `googleapis-common-protos` will fix this (alternatively we could place our own copy in `google.api_core.operations_v`).