### PR TITLE
BigQuery: Renames client.load_table_from_storage() to client.load_table_from_uri()

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -606,9 +606,9 @@ class Client(ClientWithProject):
             max_results=max_results,
             extra_params=extra_params)
 
-    def load_table_from_storage(self, source_uris, destination,
-                                job_id=None, job_id_prefix=None,
-                                job_config=None, retry=DEFAULT_RETRY):
+    def load_table_from_uri(self, source_uris, destination,
+                            job_id=None, job_id_prefix=None,
+                            job_config=None, retry=DEFAULT_RETRY):
         """Starts a job for loading data into a table from CloudStorage.
 
         See
@@ -654,7 +654,7 @@ class Client(ClientWithProject):
                              job_id=None, job_id_prefix=None, job_config=None):
         """Upload the contents of this table from a file-like object.
 
-        Like load_table_from_storage, this creates, starts and returns
+        Like load_table_from_uri, this creates, starts and returns
         a ``LoadJob``.
 
         :type file_obj: file

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -434,7 +434,7 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(sorted(row_tuples, key=by_wavelength),
                          sorted(ROWS, key=by_wavelength))
 
-    def test_load_table_from_storage_then_dump_table(self):
+    def test_load_table_from_uri_then_dump_table(self):
         TABLE_ID = 'test_table'
         GS_URL = self._write_csv_to_storage(
             'bq_load_test' + unique_resource_id(), 'person_ages.csv',
@@ -451,7 +451,7 @@ class TestBigQuery(unittest.TestCase):
         config.skip_leading_rows = 1
         config.source_format = 'CSV'
         config.write_disposition = 'WRITE_EMPTY'
-        job = Config.CLIENT.load_table_from_storage(
+        job = Config.CLIENT.load_table_from_uri(
             GS_URL, dataset.table(TABLE_ID), job_config=config)
 
         # Allow for 90 seconds of "warm up" before rows visible.  See
@@ -466,7 +466,7 @@ class TestBigQuery(unittest.TestCase):
         self.assertEqual(sorted(row_tuples, key=by_age),
                          sorted(ROWS, key=by_age))
 
-    def test_load_table_from_storage_w_autodetect_schema_then_get_job(self):
+    def test_load_table_from_uri_w_autodetect_schema_then_get_job(self):
         from google.cloud.bigquery import SchemaField
         from google.cloud.bigquery.job import LoadJob
 
@@ -482,7 +482,7 @@ class TestBigQuery(unittest.TestCase):
 
         config = bigquery.LoadJobConfig()
         config.autodetect = True
-        job = Config.CLIENT.load_table_from_storage(
+        job = Config.CLIENT.load_table_from_uri(
             gs_url, table_ref, job_config=config, job_id=JOB_ID)
 
         # Allow for 90 seconds of "warm up" before rows visible.  See
@@ -563,8 +563,8 @@ class TestBigQuery(unittest.TestCase):
         table_ref = dataset.table(table.table_id)
         config = bigquery.LoadJobConfig()
         config.autodetect = True
-        job = Config.CLIENT.load_table_from_storage(gs_url, table_ref,
-                                                    job_config=config)
+        job = Config.CLIENT.load_table_from_uri(gs_url, table_ref,
+                                                job_config=config)
         # TODO(jba): do we need this retry now that we have job.result()?
         # Allow for 90 seconds of "warm up" before rows visible.  See
         # https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataavailability

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -1425,7 +1425,7 @@ class TestClient(unittest.TestCase):
                           'allUsers': True,
                           'stateFilter': 'done'})
 
-    def test_load_table_from_storage(self):
+    def test_load_table_from_uri(self):
         from google.cloud.bigquery.job import LoadJob
 
         JOB = 'job_name'
@@ -1454,10 +1454,9 @@ class TestClient(unittest.TestCase):
         conn = client._connection = _Connection(RESOURCE)
         destination = client.dataset(self.DS_ID).table(DESTINATION)
 
-        job = client.load_table_from_storage(SOURCE_URI, destination,
-                                             job_id=JOB)
+        job = client.load_table_from_uri(SOURCE_URI, destination, job_id=JOB)
 
-        # Check that load_table_from_storage actually starts the job.
+        # Check that load_table_from_uri actually starts the job.
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
         self.assertEqual(req['method'], 'POST')
@@ -1471,8 +1470,7 @@ class TestClient(unittest.TestCase):
 
         conn = client._connection = _Connection(RESOURCE)
 
-        job = client.load_table_from_storage([SOURCE_URI], destination,
-                                             job_id=JOB)
+        job = client.load_table_from_uri([SOURCE_URI], destination, job_id=JOB)
         self.assertIsInstance(job, LoadJob)
         self.assertIs(job._client, client)
         self.assertEqual(job.job_id, JOB)


### PR DESCRIPTION
Renamed so we can add functionality to use URIs that point to [Bigtable instances](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.sourceUris)