### PR TITLE
BigQuery: make docstrings use bigquery module, like the samples do.

### DIFF
--- a/bigquery/google/cloud/bigquery/__init__.py
+++ b/bigquery/google/cloud/bigquery/__init__.py
@@ -26,15 +26,18 @@ The main concepts with this API are:
 from pkg_resources import get_distribution
 __version__ = get_distribution('google-cloud-bigquery').version
 
-from google.cloud.bigquery._helpers import Row
 from google.cloud.bigquery._helpers import DEFAULT_RETRY
 from google.cloud.bigquery.client import Client
 from google.cloud.bigquery.dataset import AccessEntry
 from google.cloud.bigquery.dataset import Dataset
 from google.cloud.bigquery.dataset import DatasetReference
+from google.cloud.bigquery.job import CopyJob
 from google.cloud.bigquery.job import CopyJobConfig
+from google.cloud.bigquery.job import ExtractJob
 from google.cloud.bigquery.job import ExtractJobConfig
+from google.cloud.bigquery.job import QueryJob
 from google.cloud.bigquery.job import QueryJobConfig
+from google.cloud.bigquery.job import LoadJob
 from google.cloud.bigquery.job import LoadJobConfig
 from google.cloud.bigquery.query import ArrayQueryParameter
 from google.cloud.bigquery.query import ScalarQueryParameter
@@ -52,27 +55,34 @@ from google.cloud.bigquery.external_config import GoogleSheetsOptions
 
 __all__ = [
     '__version__',
-    'AccessEntry',
-    'ArrayQueryParameter',
     'Client',
+    # Queries
+    'QueryJob',
+    'QueryJobConfig',
+    'ArrayQueryParameter',
+    'ScalarQueryParameter',
+    'StructQueryParameter',
+    # Datasets
     'Dataset',
     'DatasetReference',
-    'CopyJobConfig',
-    'ExtractJobConfig',
-    'QueryJobConfig',
-    'Row',
-    'LoadJobConfig',
-    'ScalarQueryParameter',
-    'SchemaField',
-    'StructQueryParameter',
+    'AccessEntry',
+    # Tables
     'Table',
     'TableReference',
+    'CopyJob',
+    'CopyJobConfig',
+    'ExtractJob',
+    'ExtractJobConfig',
+    'LoadJob',
+    'LoadJobConfig',
+    # Shared helpers
+    'SchemaField',
     'UDFResource',
-    'DEFAULT_RETRY',
     'ExternalConfig',
     'BigtableOptions',
     'BigtableColumnFamily',
     'BigtableColumn',
     'CSVOptions',
     'GoogleSheetsOptions',
+    'DEFAULT_RETRY',
 ]

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -502,7 +502,7 @@ def _item_to_row(iterator, resource):
     :type resource: dict
     :param resource: An item to be converted to a row.
 
-    :rtype: :class:`Row`
+    :rtype: :class:`~google.cloud.bigquery.Row`
     :returns: The next row in the page.
     """
     return Row(_row_tuple_from_json(resource, iterator.schema),

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -181,7 +181,7 @@ class Client(ClientWithProject):
         :param retry: (Optional) How to retry the RPC.
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
-        :returns: Iterator of :class:`~google.cloud.bigquery.dataset.Dataset`.
+        :returns: Iterator of :class:`~google.cloud.bigquery.Dataset`.
                   accessible to the current client.
         """
         extra_params = {}
@@ -212,7 +212,7 @@ class Client(ClientWithProject):
         :param project: (Optional) project ID for the dataset (defaults to
                         the project of the client).
 
-        :rtype: :class:`google.cloud.bigquery.dataset.DatasetReference`
+        :rtype: :class:`google.cloud.bigquery.DatasetReference`
         :returns: a new ``DatasetReference`` instance
         """
         if project is None:
@@ -226,12 +226,12 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert
 
-        :type dataset: :class:`~google.cloud.bigquery.dataset.Dataset`
+        :type dataset: :class:`~google.cloud.bigquery.Dataset`
         :param dataset: A ``Dataset`` populated with the desired initial state.
                         If project is missing, it defaults to the project of
                         the client.
 
-        :rtype: ":class:`~google.cloud.bigquery.dataset.Dataset`"
+        :rtype: ":class:`~google.cloud.bigquery.Dataset`"
         :returns: a new ``Dataset`` returned from the service.
         """
         path = '/projects/%s/datasets' % (dataset.project,)
@@ -245,10 +245,10 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert
 
-        :type table: :class:`~google.cloud.bigquery.table.Table`
+        :type table: :class:`~google.cloud.bigquery.Table`
         :param table: A ``Table`` populated with the desired initial state.
 
-        :rtype: ":class:`~google.cloud.bigquery.table.Table`"
+        :rtype: ":class:`~google.cloud.bigquery.Table`"
         :returns: a new ``Table`` returned from the service.
         """
         path = '/projects/%s/datasets/%s/tables' % (
@@ -271,13 +271,13 @@ class Client(ClientWithProject):
         """Fetch the dataset referenced by ``dataset_ref``
 
         :type dataset_ref:
-            :class:`google.cloud.bigquery.dataset.DatasetReference`
+            :class:`google.cloud.bigquery.DatasetReference`
         :param dataset_ref: the dataset to use.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.dataset.Dataset`
+        :rtype: :class:`google.cloud.bigquery.Dataset`
         :returns: a ``Dataset`` instance
         """
         api_response = self._call_api(retry,
@@ -289,13 +289,13 @@ class Client(ClientWithProject):
         """Fetch the table referenced by ``table_ref``
 
         :type table_ref:
-            :class:`google.cloud.bigquery.table.TableReference`
+            :class:`google.cloud.bigquery.TableReference`
         :param table_ref: the table to use.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.table.Table`
+        :rtype: :class:`google.cloud.bigquery.Table`
         :returns: a ``Table`` instance
         """
         api_response = self._call_api(retry, method='GET', path=table_ref.path)
@@ -315,7 +315,7 @@ class Client(ClientWithProject):
         will only be saved if no modifications to the dataset occurred
         since the read.
 
-        :type dataset: :class:`google.cloud.bigquery.dataset.Dataset`
+        :type dataset: :class:`google.cloud.bigquery.Dataset`
         :param dataset: the dataset to update.
 
         :type fields: sequence of string
@@ -325,7 +325,7 @@ class Client(ClientWithProject):
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.dataset.Dataset`
+        :rtype: :class:`google.cloud.bigquery.Dataset`
         :returns: the modified ``Dataset`` instance
         """
         path = '/projects/%s/datasets/%s' % (dataset.project,
@@ -358,13 +358,13 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/update
 
         :type table:
-            :class:`google.cloud.bigquery.table.Table`
+            :class:`google.cloud.bigquery.Table`
         :param table_ref: the table to update.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.table.Table`
+        :rtype: :class:`google.cloud.bigquery.Table`
         :returns: a ``Table`` instance
         """
         partial = table._build_resource(properties)
@@ -385,8 +385,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list
 
         :type dataset: One of:
-                       :class:`~google.cloud.bigquery.dataset.Dataset`
-                       :class:`~google.cloud.bigquery.dataset.DatasetReference`
+                       :class:`~google.cloud.bigquery.Dataset`
+                       :class:`~google.cloud.bigquery.DatasetReference`
         :param dataset: the dataset whose tables to list, or a reference to it.
 
         :type max_results: int
@@ -402,7 +402,7 @@ class Client(ClientWithProject):
         :param retry: (Optional) How to retry the RPC.
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
-        :returns: Iterator of :class:`~google.cloud.bigquery.table.Table`
+        :returns: Iterator of :class:`~google.cloud.bigquery.Table`
                   contained within the current dataset.
         """
         if not isinstance(dataset, (Dataset, DatasetReference)):
@@ -426,8 +426,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/delete
 
         :type dataset: One of:
-                       :class:`~google.cloud.bigquery.dataset.Dataset`
-                       :class:`~google.cloud.bigquery.dataset.DatasetReference`
+                       :class:`~google.cloud.bigquery.Dataset`
+                       :class:`~google.cloud.bigquery.DatasetReference`
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
@@ -445,8 +445,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/delete
 
         :type table: One of:
-                     :class:`~google.cloud.bigquery.table.Table`
-                     :class:`~google.cloud.bigquery.table.TableReference`
+                     :class:`~google.cloud.bigquery.Table`
+                     :class:`~google.cloud.bigquery.TableReference`
         :param table: the table to delete, or a reference to it.
 
         :type retry: :class:`google.api_core.retry.Retry`
@@ -475,7 +475,7 @@ class Client(ClientWithProject):
             (Optional) number of milliseconds the the API call should wait for
             the query to complete before the request times out.
 
-        :rtype: :class:`google.cloud.bigquery.query.QueryResults`
+        :rtype: :class:`google.cloud.bigquery.QueryResults`
         :returns: a new ``QueryResults`` instance
         """
 
@@ -503,11 +503,10 @@ class Client(ClientWithProject):
         :param resource: one job resource from API response
 
         :rtype: One of:
-                :class:`google.cloud.bigquery.job.LoadJob`,
-                :class:`google.cloud.bigquery.job.CopyJob`,
-                :class:`google.cloud.bigquery.job.ExtractJob`,
-                :class:`google.cloud.bigquery.job.QueryJob`,
-                :class:`google.cloud.bigquery.job.RunSyncQueryJob`
+                :class:`google.cloud.bigquery.LoadJob`,
+                :class:`google.cloud.bigquery.CopyJob`,
+                :class:`google.cloud.bigquery.ExtractJob`,
+                :class:`google.cloud.bigquery.QueryJob`
         :returns: the job instance, constructed via the resource
         """
         config = resource['configuration']
@@ -537,7 +536,11 @@ class Client(ClientWithProject):
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`~google.cloud.bigquery.job._AsyncJob`
+        :rtype: One of:
+                :class:`google.cloud.bigquery.LoadJob`,
+                :class:`google.cloud.bigquery.CopyJob`,
+                :class:`google.cloud.bigquery.ExtractJob`,
+                :class:`google.cloud.bigquery.QueryJob`
         :returns:
             Concrete job instance, based on the resource returned by the API.
         """
@@ -631,13 +634,13 @@ class Client(ClientWithProject):
                               randomly generated job ID. This parameter will be
                               ignored if a ``job_id`` is also given.
 
-        :type job_config: :class:`google.cloud.bigquery.job.LoadJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.LoadJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.job.LoadJob`
+        :rtype: :class:`google.cloud.bigquery.LoadJob`
         :returns: a new ``LoadJob`` instance
         """
         job_id = _make_job_id(job_id, job_id_prefix)
@@ -683,10 +686,10 @@ class Client(ClientWithProject):
                               randomly generated job ID. This parameter will be
                               ignored if a ``job_id`` is also given.
 
-        :type job_config: :class:`google.cloud.bigquery.job.LoadJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.LoadJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
-        :rtype: :class:`~google.cloud.bigquery.jobs.LoadJob`
+        :rtype: :class:`~google.cloud.bigquery.LoadJob`
 
         :returns: the job instance used to load the data (e.g., for
                   querying status). Note that the job is already started:
@@ -827,9 +830,9 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy
 
         :type sources: One of:
-                       :class:`~google.cloud.bigquery.table.TableReference`
+                       :class:`~google.cloud.bigquery.TableReference`
                        sequence of
-                       :class:`~google.cloud.bigquery.table.TableReference`
+                       :class:`~google.cloud.bigquery.TableReference`
         :param sources: Table or tables to be copied.
 
 
@@ -844,13 +847,13 @@ class Client(ClientWithProject):
                               randomly generated job ID. This parameter will be
                               ignored if a ``job_id`` is also given.
 
-        :type job_config: :class:`google.cloud.bigquery.job.CopyJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.CopyJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.job.CopyJob`
+        :rtype: :class:`google.cloud.bigquery.CopyJob`
         :returns: a new ``CopyJob`` instance
         """
         job_id = _make_job_id(job_id, job_id_prefix)
@@ -870,7 +873,7 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.extract
 
-        :type source: :class:`google.cloud.bigquery.table.TableReference`
+        :type source: :class:`google.cloud.bigquery.TableReference`
         :param source: table to be extracted.
 
         :type destination_uris: One of:
@@ -891,13 +894,13 @@ class Client(ClientWithProject):
                               randomly generated job ID. This parameter will be
                               ignored if a ``job_id`` is also given.
 
-        :type job_config: :class:`google.cloud.bigquery.job.ExtractJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.ExtractJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.job.ExtractJob`
+        :rtype: :class:`google.cloud.bigquery.ExtractJob`
         :returns: a new ``ExtractJob`` instance
         """
         job_id = _make_job_id(job_id, job_id_prefix)
@@ -923,7 +926,7 @@ class Client(ClientWithProject):
             SQL query to be executed. Defaults to the standard SQL dialect.
             Use the ``job_config`` parameter to change dialects.
 
-        :type job_config: :class:`google.cloud.bigquery.job.QueryJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.QueryJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
         :type job_id: str
@@ -937,7 +940,7 @@ class Client(ClientWithProject):
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.job.QueryJob`
+        :rtype: :class:`google.cloud.bigquery.QueryJob`
         :returns: a new ``QueryJob`` instance
         """
         job_id = _make_job_id(job_id, job_id_prefix)
@@ -952,8 +955,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
 
         :type table: One of:
-                     :class:`~google.cloud.bigquery.table.Table`
-                     :class:`~google.cloud.bigquery.table.TableReference`
+                     :class:`~google.cloud.bigquery.Table`
+                     :class:`~google.cloud.bigquery.TableReference`
         :param table: the destination table for the row data, or a reference
                       to it.
 
@@ -967,14 +970,15 @@ class Client(ClientWithProject):
                      include all required fields in the schema.  Keys which do
                      not correspond to a field in the schema are ignored.
 
-        :type selected_fields: list of :class:`SchemaField`
+        :type selected_fields:
+            list of :class:`~google.cloud.bigquery.SchemaField`
         :param selected_fields:
             The fields to return. Required if ``table`` is a
-            :class:`~google.cloud.bigquery.table.TableReference`.
+            :class:`~google.cloud.bigquery.TableReference`.
 
         :type kwargs: dict
         :param kwargs: Keyword arguments to
-                       `~google.cloud.bigquery.client.Client.create_rows_json`
+                       `~google.cloud.bigquery.Client.create_rows_json`
 
         :rtype: list of mappings
         :returns: One mapping per row with insert errors:  the "index" key
@@ -1020,8 +1024,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
 
         :type table: One of:
-                     :class:`~google.cloud.bigquery.table.Table`
-                     :class:`~google.cloud.bigquery.table.TableReference`
+                     :class:`~google.cloud.bigquery.Table`
+                     :class:`~google.cloud.bigquery.TableReference`
         :param table: the destination table for the row data, or a reference
                       to it.
 
@@ -1110,7 +1114,7 @@ class Client(ClientWithProject):
             SQL query to be executed. Defaults to the standard SQL dialect.
             Use the ``job_config`` parameter to change dialects.
 
-        :type job_config: :class:`google.cloud.bigquery.job.QueryJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.QueryJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
         :type job_id: str
@@ -1152,14 +1156,15 @@ class Client(ClientWithProject):
            local copy of the schema is up-to-date, call ``client.get_table``.
 
         :type table: One of:
-                     :class:`~google.cloud.bigquery.table.Table`
-                     :class:`~google.cloud.bigquery.table.TableReference`
+                     :class:`~google.cloud.bigquery.Table`
+                     :class:`~google.cloud.bigquery.TableReference`
         :param table: the table to list, or a reference to it.
 
-        :type selected_fields: list of :class:`SchemaField`
+        :type selected_fields:
+            list of :class:`~google.cloud.bigquery.SchemaField`
         :param selected_fields:
             The fields to return. Required if ``table`` is a
-            :class:`~google.cloud.bigquery.table.TableReference`.
+            :class:`~google.cloud.bigquery.TableReference`.
 
         :type max_results: int
         :param max_results: maximum number of rows to return.
@@ -1221,8 +1226,8 @@ class Client(ClientWithProject):
         """List the partitions in a table.
 
         :type table: One of:
-                     :class:`~google.cloud.bigquery.table.Table`
-                     :class:`~google.cloud.bigquery.table.TableReference`
+                     :class:`~google.cloud.bigquery.Table`
+                     :class:`~google.cloud.bigquery.TableReference`
         :param table: the table to list, or a reference to it.
 
         :type retry: :class:`google.api_core.retry.Retry`
@@ -1297,7 +1302,7 @@ def _item_to_table(iterator, resource):
     :type resource: dict
     :param resource: An item to be converted to a table.
 
-    :rtype: :class:`~google.cloud.bigquery.table.Table`
+    :rtype: :class:`~google.cloud.bigquery.Table`
     :returns: The next table in the page.
     """
     return Table.from_api_repr(resource)

--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -146,7 +146,7 @@ class DatasetReference(object):
         :type table_id: str
         :param table_id: the ID of the table.
 
-        :rtype: :class:`google.cloud.bigquery.table.TableReference`
+        :rtype: :class:`google.cloud.bigquery.TableReference`
         :returns: a TableReference for a table in this dataset.
         """
         return TableReference(self, table_id)
@@ -169,7 +169,7 @@ class DatasetReference(object):
         Used to compute this instance's hashcode and evaluate equality.
 
         Returns:
-            tuple: The contents of this :class:`DatasetReference`.
+            tuple: The contents of this :class:`.DatasetReference`.
         """
         return (
             self._project,
@@ -197,7 +197,7 @@ class Dataset(object):
     See
     https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets
 
-    :type dataset_ref: :class:`~google.cloud.bigquery.dataset.DatasetReference`
+    :type dataset_ref: :class:`~google.cloud.bigquery.DatasetReference`
     :param dataset_ref: a pointer to a dataset
     """
 
@@ -238,7 +238,7 @@ class Dataset(object):
     def access_entries(self, value):
         """Update dataset's access entries
 
-        :type value: list of :class:`AccessEntry`
+        :type value: list of :class:`~google.cloud.bigquery.AccessEntry`
         :param value: roles granted to entities for this dataset
 
         :raises: TypeError if 'value' is not a sequence, or ValueError if
@@ -429,7 +429,7 @@ class Dataset(object):
         :type resource: dict
         :param resource: dataset resource representation returned from the API
 
-        :rtype: :class:`google.cloud.bigquery.dataset.Dataset`
+        :rtype: :class:`~google.cloud.bigquery.Dataset`
         :returns: Dataset parsed from ``resource``.
         """
         dsr = resource.get('datasetReference')
@@ -451,7 +451,7 @@ class Dataset(object):
         :type access: list of mappings
         :param access: each mapping represents a single access entry.
 
-        :rtype: list of :class:`AccessEntry`
+        :rtype: list of :class:`~google.cloud.bigquery.AccessEntry`
         :returns: a list of parsed entries.
         :raises: :class:`ValueError` if a entry in ``access`` has more keys
                  than ``role`` and one additional key.
@@ -530,7 +530,7 @@ class Dataset(object):
         :type table_id: str
         :param table_id: the ID of the table.
 
-        :rtype: :class:`google.cloud.bigquery.table.TableReference`
+        :rtype: :class:`~google.cloud.bigquery.TableReference`
         :returns: a TableReference for a table in this dataset.
         """
         return TableReference(self, table_id)

--- a/bigquery/google/cloud/bigquery/dbapi/__init__.py
+++ b/bigquery/google/cloud/bigquery/dbapi/__init__.py
@@ -19,11 +19,6 @@ for Google BigQuery.
 
 .. _Python Database API Specification v2.0 (DB-API):
    https://www.python.org/dev/peps/pep-0249/
-
-.. warning::
-   The ``dbapi`` module is **alpha**. The implementation is not complete. It
-   might be changed in backward-incompatible ways and is not subject to any SLA
-   or deprecation policy.
 """
 
 from google.cloud.bigquery.dbapi.connection import connect

--- a/bigquery/google/cloud/bigquery/external_config.py
+++ b/bigquery/google/cloud/bigquery/external_config.py
@@ -105,7 +105,7 @@ class BigtableColumn(object):
         :param resource:
             A column in the same representation as is returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.external_config.BigtableColumn`
+        :rtype: :class:`~google.cloud.bigquery.BigtableColumn`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -177,7 +177,7 @@ class BigtableColumnFamily(object):
             from the API.
 
         :rtype:
-            :class:`google.cloud.bigquery.external_config.BigtableColumnFamily`
+            :class:`~google.cloud.bigquery.BigtableColumnFamily`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -239,7 +239,7 @@ class BigtableOptions(object):
             A BigtableOptions in the same representation as is returned
             from the API.
 
-        :rtype: :class:`google.cloud.bigquery.external_config.BigtableOptions`
+        :rtype: :class:`~google.cloud.bigquery.BigtableOptions`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -321,7 +321,7 @@ class CSVOptions(object):
             A CSVOptions in the same representation as is
             returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.external_config.CSVOptions`
+        :rtype: :class:`~google.cloud.bigquery.CSVOptions`
         :returns: Configuration parsed from ``resource``.
         """
         slr = resource.get('skipLeadingRows')
@@ -369,7 +369,7 @@ class GoogleSheetsOptions(object):
             returned from the API.
 
         :rtype:
-            :class:`google.cloud.bigquery.external_config.GoogleSheetsOptions`
+            :class:`~google.cloud.bigquery.GoogleSheetsOptions`
         :returns: Configuration parsed from ``resource``.
         """
         slr = resource.get('skipLeadingRows')
@@ -476,7 +476,7 @@ class ExternalConfig(object):
             An extract job configuration in the same representation as is
             returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.external_config.CSVOptions`
+        :rtype: :class:`~google.cloud.bigquery.CSVOptions`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls(resource['sourceFormat'])

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -153,7 +153,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
     :type job_id: str
     :param job_id: the job's ID in the project associated with the client.
 
-    :type client: :class:`google.cloud.bigquery.client.Client`
+    :type client: :class:`google.cloud.bigquery.Client`
     :param client: A client which holds credentials and project configuration.
     """
     def __init__(self, job_id, client):
@@ -176,12 +176,12 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
     def _require_client(self, client):
         """Check client or verify over-ride.
 
-        :type client: :class:`~google.cloud.bigquery.client.Client` or
+        :type client: :class:`~google.cloud.bigquery.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
 
-        :rtype: :class:`google.cloud.bigquery.client.Client`
+        :rtype: :class:`google.cloud.bigquery.Client`
         :returns: The client passed in or the currently bound client.
         """
         if client is None:
@@ -374,7 +374,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert
 
-        :type client: :class:`~google.cloud.bigquery.client.Client` or
+        :type client: :class:`~google.cloud.bigquery.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
@@ -403,7 +403,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/get
 
-        :type client: :class:`~google.cloud.bigquery.client.Client` or
+        :type client: :class:`~google.cloud.bigquery.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
@@ -431,7 +431,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/get
 
-        :type client: :class:`~google.cloud.bigquery.client.Client` or
+        :type client: :class:`~google.cloud.bigquery.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
@@ -450,7 +450,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/cancel
 
-        :type client: :class:`~google.cloud.bigquery.client.Client` or
+        :type client: :class:`~google.cloud.bigquery.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
@@ -663,7 +663,7 @@ class LoadJobConfig(object):
             An extract job configuration in the same representation as is
             returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.job.ExtractJobConfig`
+        :rtype: :class:`google.cloud.bigquery.ExtractJobConfig`
         :returns: Configuration parsed from ``resource``.
         """
         schema = resource.pop('schema', {'fields': ()})
@@ -688,10 +688,10 @@ class LoadJob(_AsyncJob):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.sourceUris
         for supported URI formats. Pass None for jobs that load from a file.
 
-    :type destination: :class:`google.cloud.bigquery.table.TableReference`
+    :type destination: :class:`google.cloud.bigquery.TableReference`
     :param destination: reference to table into which data is to be loaded.
 
-    :type client: :class:`google.cloud.bigquery.client.Client`
+    :type client: :class:`google.cloud.bigquery.Client`
     :param client: A client which holds credentials and project configuration
                    for the dataset (which requires a project).
     """
@@ -712,98 +712,98 @@ class LoadJob(_AsyncJob):
     @property
     def allow_jagged_rows(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.allow_jagged_rows`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.allow_jagged_rows`.
         """
         return self._configuration.allow_jagged_rows
 
     @property
     def allow_quoted_newlines(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.allow_quoted_newlines`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.allow_quoted_newlines`.
         """
         return self._configuration.allow_quoted_newlines
 
     @property
     def autodetect(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.autodetect`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.autodetect`.
         """
         return self._configuration.autodetect
 
     @property
     def create_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.create_disposition`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.create_disposition`.
         """
         return self._configuration.create_disposition
 
     @property
     def encoding(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.encoding`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.encoding`.
         """
         return self._configuration.encoding
 
     @property
     def field_delimiter(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.field_delimiter`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.field_delimiter`.
         """
         return self._configuration.field_delimiter
 
     @property
     def ignore_unknown_values(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.ignore_unknown_values`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.ignore_unknown_values`.
         """
         return self._configuration.ignore_unknown_values
 
     @property
     def max_bad_records(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.max_bad_records`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.max_bad_records`.
         """
         return self._configuration.max_bad_records
 
     @property
     def null_marker(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.null_marker`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.null_marker`.
         """
         return self._configuration.null_marker
 
     @property
     def quote_character(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.quote_character`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.quote_character`.
         """
         return self._configuration.quote_character
 
     @property
     def skip_leading_rows(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.skip_leading_rows`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.skip_leading_rows`.
         """
         return self._configuration.skip_leading_rows
 
     @property
     def source_format(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.source_format`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.source_format`.
         """
         return self._configuration.source_format
 
     @property
     def write_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.write_disposition`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.write_disposition`.
         """
         return self._configuration.write_disposition
 
     @property
     def schema(self):
         """See
-        :class:`~google.cloud.bigquery.job.LoadJobConfig.schema`.
+        :class:`~google.cloud.bigquery.LoadJobConfig.schema`.
         """
         return self._configuration.schema
 
@@ -884,11 +884,11 @@ class LoadJob(_AsyncJob):
         :type resource: dict
         :param resource: dataset job representation returned from the API
 
-        :type client: :class:`google.cloud.bigquery.client.Client`
+        :type client: :class:`google.cloud.bigquery.Client`
         :param client: Client which holds credentials and project
                        configuration for the dataset.
 
-        :rtype: :class:`google.cloud.bigquery.job.LoadJob`
+        :rtype: :class:`google.cloud.bigquery.LoadJob`
         :returns: Job parsed from ``resource``.
         """
         job_id, config_resource = cls._get_resource_config(resource)
@@ -943,7 +943,7 @@ class CopyJobConfig(object):
             An extract job configuration in the same representation as is
             returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.job.ExtractJobConfig`
+        :rtype: :class:`google.cloud.bigquery.ExtractJobConfig`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -957,17 +957,17 @@ class CopyJob(_AsyncJob):
     :type job_id: str
     :param job_id: the job's ID, within the project belonging to ``client``.
 
-    :type sources: list of :class:`google.cloud.bigquery.table.TableReference`
+    :type sources: list of :class:`google.cloud.bigquery.TableReference`
     :param sources: Table into which data is to be loaded.
 
-    :type destination: :class:`google.cloud.bigquery.table.TableReference`
+    :type destination: :class:`google.cloud.bigquery.TableReference`
     :param destination: Table into which data is to be loaded.
 
-    :type client: :class:`google.cloud.bigquery.client.Client`
+    :type client: :class:`google.cloud.bigquery.Client`
     :param client: A client which holds credentials and project configuration
                    for the dataset (which requires a project).
 
-    :type job_config: :class:`~google.cloud.bigquery.job.CopyJobConfig`
+    :type job_config: :class:`~google.cloud.bigquery.CopyJobConfig`
     :param job_config:
         (Optional) Extra configuration options for the copy job.
     """
@@ -986,14 +986,14 @@ class CopyJob(_AsyncJob):
     @property
     def create_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.job.CopyJobConfig.create_disposition`.
+        :class:`~google.cloud.bigquery.CopyJobConfig.create_disposition`.
         """
         return self._configuration.create_disposition
 
     @property
     def write_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.job.CopyJobConfig.write_disposition`.
+        :class:`~google.cloud.bigquery.CopyJobConfig.write_disposition`.
         """
         return self._configuration.write_disposition
 
@@ -1040,11 +1040,11 @@ class CopyJob(_AsyncJob):
         :type resource: dict
         :param resource: dataset job representation returned from the API
 
-        :type client: :class:`google.cloud.bigquery.client.Client`
+        :type client: :class:`google.cloud.bigquery.Client`
         :param client: Client which holds credentials and project
                        configuration for the dataset.
 
-        :rtype: :class:`google.cloud.bigquery.job.CopyJob`
+        :rtype: :class:`google.cloud.bigquery.CopyJob`
         :returns: Job parsed from ``resource``.
         """
         job_id, config_resource = cls._get_resource_config(resource)
@@ -1118,7 +1118,7 @@ class ExtractJobConfig(object):
             An extract job configuration in the same representation as is
             returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.job.ExtractJobConfig`
+        :rtype: :class:`google.cloud.bigquery.ExtractJobConfig`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -1132,7 +1132,7 @@ class ExtractJob(_AsyncJob):
     :type job_id: str
     :param job_id: the job's ID
 
-    :type source: :class:`google.cloud.bigquery.table.TableReference`
+    :type source: :class:`google.cloud.bigquery.TableReference`
     :param source: Table into which data is to be loaded.
 
     :type destination_uris: list of string
@@ -1140,11 +1140,11 @@ class ExtractJob(_AsyncJob):
         URIs describing where the extracted data will be written in Cloud
         Storage, using the format ``gs://<bucket_name>/<object_name_or_glob>``.
 
-    :type client: :class:`google.cloud.bigquery.client.Client`
+    :type client: :class:`google.cloud.bigquery.Client`
     :param client:
         A client which holds credentials and project configuration.
 
-    :type job_config: :class:`~google.cloud.bigquery.job.ExtractJobConfig`
+    :type job_config: :class:`~google.cloud.bigquery.ExtractJobConfig`
     :param job_config:
         (Optional) Extra configuration options for the extract job.
     """
@@ -1164,28 +1164,28 @@ class ExtractJob(_AsyncJob):
     @property
     def compression(self):
         """See
-        :class:`~google.cloud.bigquery.job.ExtractJobConfig.compression`.
+        :class:`~google.cloud.bigquery.ExtractJobConfig.compression`.
         """
         return self._configuration.compression
 
     @property
     def destination_format(self):
         """See
-        :class:`~google.cloud.bigquery.job.ExtractJobConfig.destination_format`.
+        :class:`~google.cloud.bigquery.ExtractJobConfig.destination_format`.
         """
         return self._configuration.destination_format
 
     @property
     def field_delimiter(self):
         """See
-        :class:`~google.cloud.bigquery.job.ExtractJobConfig.field_delimiter`.
+        :class:`~google.cloud.bigquery.ExtractJobConfig.field_delimiter`.
         """
         return self._configuration.field_delimiter
 
     @property
     def print_header(self):
         """See
-        :class:`~google.cloud.bigquery.job.ExtractJobConfig.print_header`.
+        :class:`~google.cloud.bigquery.ExtractJobConfig.print_header`.
         """
         return self._configuration.print_header
 
@@ -1246,11 +1246,11 @@ class ExtractJob(_AsyncJob):
         :type resource: dict
         :param resource: dataset job representation returned from the API
 
-        :type client: :class:`google.cloud.bigquery.client.Client`
+        :type client: :class:`google.cloud.bigquery.Client`
         :param client: Client which holds credentials and project
                        configuration for the dataset.
 
-        :rtype: :class:`google.cloud.bigquery.job.ExtractJob`
+        :rtype: :class:`google.cloud.bigquery.ExtractJob`
         :returns: Job parsed from ``resource``.
         """
         job_id, config_resource = cls._get_resource_config(resource)
@@ -1351,7 +1351,7 @@ class QueryJobConfig(object):
             An extract job configuration in the same representation as is
             returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.job.ExtractJobConfig`
+        :rtype: :class:`google.cloud.bigquery.ExtractJobConfig`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -1421,9 +1421,9 @@ class QueryJobConfig(object):
         'query_parameters', _QUERY_PARAMETERS_KEY, _AbstractQueryParameter)
     """
     A list of
-    :class:`google.cloud.bigquery.query.ArrayQueryParameter`,
-    :class:`google.cloud.bigquery.query.ScalarQueryParameter`, or
-    :class:`google.cloud.bigquery.query.StructQueryParameter`
+    :class:`google.cloud.bigquery.ArrayQueryParameter`,
+    :class:`google.cloud.bigquery.ScalarQueryParameter`, or
+    :class:`google.cloud.bigquery.StructQueryParameter`
     (empty by default)
 
     See:
@@ -1433,7 +1433,7 @@ class QueryJobConfig(object):
     udf_resources = _ListApiResourceProperty(
         'udf_resources', _UDF_RESOURCES_KEY, UDFResource)
     """
-    A list of :class:`google.cloud.bigquery.query.UDFResource` (empty
+    A list of :class:`google.cloud.bigquery.UDFResource` (empty
     by default)
 
     See:
@@ -1462,7 +1462,7 @@ class QueryJobConfig(object):
         'table_definitions', 'tableDefinitions', dict)
     """
     Definitions for external tables. A dictionary from table names (strings)
-    to :class:`google.cloud.bigquery.external_config.ExternalConfig`.
+    to :class:`google.cloud.bigquery.ExternalConfig`.
 
     See
     https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.tableDefinitions
@@ -1495,11 +1495,11 @@ class QueryJob(_AsyncJob):
     :type query: str
     :param query: SQL query string
 
-    :type client: :class:`google.cloud.bigquery.client.Client`
+    :type client: :class:`google.cloud.bigquery.Client`
     :param client: A client which holds credentials and project configuration
                    for the dataset (which requires a project).
 
-    :type job_config: :class:`~google.cloud.bigquery.job.QueryJobConfig`
+    :type job_config: :class:`~google.cloud.bigquery.QueryJobConfig`
     :param job_config:
         (Optional) Extra configuration options for the query job.
     """
@@ -1522,105 +1522,105 @@ class QueryJob(_AsyncJob):
     @property
     def allow_large_results(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.allow_large_results`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.allow_large_results`.
         """
         return self._configuration.allow_large_results
 
     @property
     def create_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.create_disposition`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.create_disposition`.
         """
         return self._configuration.create_disposition
 
     @property
     def default_dataset(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.default_dataset`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.default_dataset`.
         """
         return self._configuration.default_dataset
 
     @property
     def destination(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.destination`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.destination`.
         """
         return self._configuration.destination
 
     @property
     def dry_run(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.dry_run`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.dry_run`.
         """
         return self._configuration.dry_run
 
     @property
     def flatten_results(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.flatten_results`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.flatten_results`.
         """
         return self._configuration.flatten_results
 
     @property
     def priority(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.priority`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.priority`.
         """
         return self._configuration.priority
 
     @property
     def query_parameters(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.query_parameters`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.query_parameters`.
         """
         return self._configuration.query_parameters
 
     @property
     def udf_resources(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.udf_resources`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.udf_resources`.
         """
         return self._configuration.udf_resources
 
     @property
     def use_legacy_sql(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.use_legacy_sql`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.use_legacy_sql`.
         """
         return self._configuration.use_legacy_sql
 
     @property
     def use_query_cache(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.use_query_cache`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.use_query_cache`.
         """
         return self._configuration.use_query_cache
 
     @property
     def write_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.write_disposition`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.write_disposition`.
         """
         return self._configuration.write_disposition
 
     @property
     def maximum_billing_tier(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.maximum_billing_tier`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.maximum_billing_tier`.
         """
         return self._configuration.maximum_billing_tier
 
     @property
     def maximum_bytes_billed(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.maximum_bytes_billed`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.maximum_bytes_billed`.
         """
         return self._configuration.maximum_bytes_billed
 
     @property
     def table_definitions(self):
         """See
-        :class:`~google.cloud.bigquery.job.QueryJobConfig.table_definitions`.
+        :class:`~google.cloud.bigquery.QueryJobConfig.table_definitions`.
         """
         return self._configuration.table_definitions
 
@@ -1681,11 +1681,11 @@ class QueryJob(_AsyncJob):
         :type resource: dict
         :param resource: dataset job representation returned from the API
 
-        :type client: :class:`google.cloud.bigquery.client.Client`
+        :type client: :class:`google.cloud.bigquery.Client`
         :param client: Client which holds credentials and project
                        configuration for the dataset.
 
-        :rtype: :class:`google.cloud.bigquery.job.RunAsyncQueryJob`
+        :rtype: :class:`google.cloud.bigquery.RunAsyncQueryJob`
         :returns: Job parsed from ``resource``.
         """
         job_id, config = cls._get_resource_config(resource)
@@ -1833,9 +1833,9 @@ class QueryJob(_AsyncJob):
 
         :rtype:
             list of
-            :class:`~google.cloud.bigquery.query.ArrayQueryParameter`,
-            :class:`~google.cloud.bigquery.query.ScalarQueryParameter`, or
-            :class:`~google.cloud.bigquery.query.StructQueryParameter`
+            :class:`~google.cloud.bigquery.ArrayQueryParameter`,
+            :class:`~google.cloud.bigquery.ScalarQueryParameter`, or
+            :class:`~google.cloud.bigquery.StructQueryParameter`
         :returns: undeclared parameters, or an empty list if the query has
                   not yet completed.
         """
@@ -1862,7 +1862,7 @@ class QueryJob(_AsyncJob):
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`~google.cloud.bigquery.query.QueryResults`
+        :rtype: :class:`~google.cloud.bigquery.QueryResults`
         :returns: results instance
         """
         if not self._query_results:

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -60,7 +60,7 @@ class _AbstractQueryParameter(object):
         :type resource: dict
         :param resource: JSON mapping of parameter
 
-        :rtype: :class:`ScalarQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.ScalarQueryParameter`
         """
         raise NotImplementedError
 
@@ -105,7 +105,7 @@ class ScalarQueryParameter(_AbstractQueryParameter):
                      :class:`datetime.date`.
         :param value: the scalar parameter value.
 
-        :rtype: :class:`ScalarQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.ScalarQueryParameter`
         :returns: instance without name
         """
         return cls(None, type_, value)
@@ -117,7 +117,7 @@ class ScalarQueryParameter(_AbstractQueryParameter):
         :type resource: dict
         :param resource: JSON mapping of parameter
 
-        :rtype: :class:`ScalarQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.ScalarQueryParameter`
         :returns: instance
         """
         name = resource.get('name')
@@ -154,7 +154,8 @@ class ScalarQueryParameter(_AbstractQueryParameter):
         Used to compute this instance's hashcode and evaluate equality.
 
         Returns:
-            tuple: The contents of this :class:`ScalarQueryParameter`.
+            tuple: The contents of this
+                   :class:`~google.cloud.bigquery.ScalarQueryParameter`.
         """
         return (
             self.name,
@@ -206,7 +207,7 @@ class ArrayQueryParameter(_AbstractQueryParameter):
         :type values: list of appropriate scalar type
         :param values: the parameter array values.
 
-        :rtype: :class:`ArrayQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.ArrayQueryParameter`
         :returns: instance without name
         """
         return cls(None, array_type, values)
@@ -249,7 +250,7 @@ class ArrayQueryParameter(_AbstractQueryParameter):
         :type resource: dict
         :param resource: JSON mapping of parameter
 
-        :rtype: :class:`ArrayQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.ArrayQueryParameter`
         :returns: instance
         """
         array_type = resource['parameterType']['arrayType']['type']
@@ -293,7 +294,8 @@ class ArrayQueryParameter(_AbstractQueryParameter):
         Used to compute this instance's hashcode and evaluate equality.
 
         Returns:
-            tuple: The contents of this :class:`ArrayQueryParameter`.
+            tuple: The contents of this
+                   :class:`~google.cloud.bigquery.ArrayQueryParameter`.
         """
         return (
             self.name,
@@ -320,7 +322,10 @@ class StructQueryParameter(_AbstractQueryParameter):
     :param name: Parameter name, used via ``@foo`` syntax.  If None, the
                  parameter can only be addressed via position (``?``).
 
-    :type sub_params: tuple of :class:`ScalarQueryParameter`
+    :type sub_params:
+        tuple of :class:`~google.cloud.bigquery.ScalarQueryParameter`,
+        :class:`~google.cloud.bigquery.ArrayQueryParameter`, or
+        :class:`~google.cloud.bigquery.StructQueryParameter`
     :param sub_params: the sub-parameters for the struct
     """
     def __init__(self, name, *sub_params):
@@ -342,10 +347,13 @@ class StructQueryParameter(_AbstractQueryParameter):
     def positional(cls, *sub_params):
         """Factory for positional parameters.
 
-        :type sub_params: tuple of :class:`ScalarQueryParameter`
+        :type sub_params:
+            tuple of :class:`~google.cloud.bigquery.ScalarQueryParameter`,
+            :class:`~google.cloud.bigquery.ArrayQueryParameter`, or
+            :class:`~google.cloud.bigquery.StructQueryParameter`
         :param sub_params: the sub-parameters for the struct
 
-        :rtype: :class:`StructQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.StructQueryParameter`
         :returns: instance without name
         """
         return cls(None, *sub_params)
@@ -357,7 +365,7 @@ class StructQueryParameter(_AbstractQueryParameter):
         :type resource: dict
         :param resource: JSON mapping of parameter
 
-        :rtype: :class:`StructQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.StructQueryParameter`
         :returns: instance
         """
         name = resource.get('name')
@@ -431,7 +439,8 @@ class StructQueryParameter(_AbstractQueryParameter):
         Used to compute this instance's hashcode and evaluate equality.
 
         Returns:
-            tuple: The contents of this :class:`ArrayQueryParameter`.
+            tuple: The contents of this
+                   :class:`~google.cloud.biquery.ArrayQueryParameter`.
         """
         return (
             self.name,

--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -32,7 +32,7 @@ class SchemaField(object):
     :type description: str
     :param description: optional description for the field.
 
-    :type fields: tuple of :class:`SchemaField`
+    :type fields: tuple of :class:`~google.cloud.bigquery.SchemaField`
     :param fields: subfields (requires ``field_type`` of 'RECORD').
     """
     def __init__(self, name, field_type, mode='NULLABLE',

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -39,7 +39,7 @@ class TableReference(object):
     See
     https://cloud.google.com/bigquery/docs/reference/rest/v2/tables
 
-    :type dataset_ref: :class:`google.cloud.bigquery.dataset.DatasetReference`
+    :type dataset_ref: :class:`google.cloud.bigquery.DatasetReference`
     :param dataset_ref: a pointer to the dataset
 
     :type table_id: str
@@ -95,7 +95,7 @@ class TableReference(object):
         :type resource: dict
         :param resource: table reference representation returned from the API
 
-        :rtype: :class:`google.cloud.bigquery.table.TableReference`
+        :rtype: :class:`google.cloud.bigquery.TableReference`
         :returns: Table reference parsed from ``resource``.
         """
         from google.cloud.bigquery.dataset import DatasetReference
@@ -152,10 +152,10 @@ class Table(object):
     See
     https://cloud.google.com/bigquery/docs/reference/rest/v2/tables
 
-    :type table_ref: :class:`google.cloud.bigquery.table.TableReference`
+    :type table_ref: :class:`google.cloud.bigquery.TableReference`
     :param table_ref: a pointer to a table
 
-    :type schema: list of :class:`SchemaField`
+    :type schema: list of :class:`~google.cloud.bigquery.SchemaField`
     :param schema: The table's schema
     """
 
@@ -217,7 +217,7 @@ class Table(object):
     def schema(self):
         """Table's schema.
 
-        :rtype: list of :class:`SchemaField`
+        :rtype: list of :class:`~google.cloud.bigquery.SchemaField`
         :returns: fields describing the schema
         """
         return list(self._schema)
@@ -226,7 +226,7 @@ class Table(object):
     def schema(self, value):
         """Update table's schema
 
-        :type value: list of :class:`SchemaField`
+        :type value: list of :class:`~google.cloud.bigquery.SchemaField`
         :param value: fields describing the schema
 
         :raises: TypeError if 'value' is not a sequence, or ValueError if
@@ -386,7 +386,7 @@ class Table(object):
         """Update the experation time in ms for a partition
 
         :type value: int
-        :param value: partition experiation time in ms
+        :param value: partition experiation time in milliseconds
         """
         if not isinstance(value, (int, type(None))):
             raise ValueError(
@@ -571,7 +571,7 @@ class Table(object):
     def streaming_buffer(self):
         """Information about a table's streaming buffer.
 
-        :rtype: :class:`StreamingBuffer`
+        :rtype: :class:`~google.cloud.bigquery.StreamingBuffer`
         :returns: Streaming buffer information, returned from get_table.
         """
         sb = self._properties.get('streamingBuffer')
@@ -584,7 +584,7 @@ class Table(object):
 
         If not set, None is returned.
 
-        :rtype: :class:`ExternalConfig`, or ``NoneType``
+        :rtype: :class:`~google.cloud.bigquery.ExternalConfig`, or ``NoneType``
         :returns: The external configuration, or None (the default).
         """
         return self._external_config
@@ -593,7 +593,8 @@ class Table(object):
     def external_data_configuration(self, value):
         """Sets the configuration for an external data source.
 
-        :type value: :class:`ExternalConfig`, or ``NoneType``
+        :type value:
+            :class:`~google.cloud.bigquery.ExternalConfig`, or ``NoneType``
         :param value: The ExternalConfig, or None to unset.
         """
         if not (value is None or isinstance(value, ExternalConfig)):
@@ -607,10 +608,10 @@ class Table(object):
         :type resource: dict
         :param resource: table resource representation returned from the API
 
-        :type dataset: :class:`google.cloud.bigquery.dataset.Dataset`
+        :type dataset: :class:`google.cloud.bigquery.Dataset`
         :param dataset: The dataset containing the table.
 
-        :rtype: :class:`google.cloud.bigquery.table.Table`
+        :rtype: :class:`google.cloud.bigquery.Table`
         :returns: Table parsed from ``resource``.
         """
         from google.cloud.bigquery import dataset
@@ -719,7 +720,7 @@ def _row_from_mapping(mapping, schema):
            required fields in the schema.  Keys which do not correspond
            to a field in the schema are ignored.
 
-    :type schema: list of :class:`SchemaField`
+    :type schema: list of :class:`~google.cloud.bigquery.SchemaField`
     :param schema: The schema of the table destination for the rows
 
     :rtype: tuple

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -113,7 +113,7 @@ class Table(object):
         .. warning::
 
            At most one of ``filter_`` and ``append`` can be used in a
-           :class:`Row`.
+           :class:`.Row`.
 
         :type row_key: bytes
         :param row_key: The key for the row being created.

--- a/docs/bigquery/client.rst
+++ b/docs/bigquery/client.rst
@@ -1,6 +1,0 @@
-Client
-======
-
-.. automodule:: google.cloud.bigquery.client
-  :members:
-  :show-inheritance:

--- a/docs/bigquery/dataset.rst
+++ b/docs/bigquery/dataset.rst
@@ -1,6 +1,0 @@
-Datasets
-~~~~~~~~
-
-.. automodule:: google.cloud.bigquery.dataset
-  :members:
-  :show-inheritance:

--- a/docs/bigquery/dbapi.rst
+++ b/docs/bigquery/dbapi.rst
@@ -1,0 +1,6 @@
+DB-API Reference
+~~~~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.bigquery.dbapi
+  :members:
+  :show-inheritance:

--- a/docs/bigquery/job.rst
+++ b/docs/bigquery/job.rst
@@ -1,7 +1,0 @@
-Jobs
-~~~~
-
-.. automodule:: google.cloud.bigquery.job
-  :members:
-  :inherited-members:
-  :show-inheritance:

--- a/docs/bigquery/query.rst
+++ b/docs/bigquery/query.rst
@@ -1,6 +1,0 @@
-Query
-~~~~~
-
-.. automodule:: google.cloud.bigquery.query
-  :members:
-  :show-inheritance:

--- a/docs/bigquery/reference.rst
+++ b/docs/bigquery/reference.rst
@@ -1,0 +1,6 @@
+API Reference
+~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.bigquery
+  :members:
+  :show-inheritance:

--- a/docs/bigquery/schema.rst
+++ b/docs/bigquery/schema.rst
@@ -1,6 +1,0 @@
-Schemas
-~~~~~~~
-
-.. automodule:: google.cloud.bigquery.schema
-  :members:
-  :show-inheritance:

--- a/docs/bigquery/table.rst
+++ b/docs/bigquery/table.rst
@@ -1,6 +1,0 @@
-Tables
-~~~~~~
-
-.. automodule:: google.cloud.bigquery.table
-  :members:
-  :show-inheritance:

--- a/docs/bigquery/usage.rst
+++ b/docs/bigquery/usage.rst
@@ -5,12 +5,8 @@ BigQuery
   :maxdepth: 2
   :hidden:
 
-  client
-  dataset
-  job
-  query
-  schema
-  table
+  reference
+  dbapi
 
 Authentication / Configuration
 ------------------------------

--- a/docs/bigquery/usage.rst
+++ b/docs/bigquery/usage.rst
@@ -207,7 +207,7 @@ Queries
 -------
 
 Querying data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. literalinclude:: snippets.py
    :start-after: [START client_query]
@@ -220,7 +220,7 @@ Querying data
 
 
 Run a query using a named query parameter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 See BigQuery documentation for more information on
 `parameterized queries <https://cloud.google.com/bigquery/docs/parameterized-queries>`_.


### PR DESCRIPTION
All the public classes we expect developers to use are included in the
`google.cloud.bigquery` module, and it is this module that we use in
code samples.

Also, I found one error in the Bigtable docs where `Row` was not being
used as a local reference and conflicted with the BigQuery Row.