### PR TITLE
BigQuery: populate exceptions for query_rows with context about the job.

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -509,16 +509,18 @@ class _AsyncJob(google.api.core.future.polling.PollingFuture):
     def result(self, timeout=None):
         """Start the job and wait for it to complete and get the result.
 
-        :type timeout: int
-        :param timeout: How long to wait for job to complete before raising
-            a :class:`TimeoutError`.
+        :type timeout: float
+        :param timeout:
+            How long (in seconds) to wait for job to complete before raising
+            a :class:`concurrent.futures.TimeoutError`.
 
         :rtype: _AsyncJob
         :returns: This instance.
 
-        :raises: :class:`~google.cloud.exceptions.GoogleCloudError` if the job
-            failed or  :class:`TimeoutError` if the job did not complete in the
-            given timeout.
+        :raises:
+            :class:`~google.cloud.exceptions.GoogleCloudError` if the job
+            failed or :class:`concurrent.futures.TimeoutError` if the job did
+            not complete in the given timeout.
         """
         if self.state is None:
             self.begin()
@@ -1913,8 +1915,8 @@ class QueryJob(_AsyncJob):
 
         :type timeout: float
         :param timeout:
-            How long to wait for job to complete before raising a
-            :class:`TimeoutError`.
+            How long (in seconds) to wait for job to complete before raising
+            a :class:`concurrent.futures.TimeoutError`.
 
         :type retry: :class:`google.api.core.retry.Retry`
         :param retry: (Optional) How to retry the call that retrieves rows.
@@ -1927,9 +1929,10 @@ class QueryJob(_AsyncJob):
             from the total number of rows in the current page:
             ``iterator.page.num_items``).
 
-        :raises: :class:`~google.cloud.exceptions.GoogleCloudError` if the job
-            failed or  :class:`TimeoutError` if the job did not complete in the
-            given timeout.
+        :raises:
+            :class:`~google.cloud.exceptions.GoogleCloudError` if the job
+            failed or :class:`concurrent.futures.TimeoutError` if the job did
+            not complete in the given timeout.
         """
         super(QueryJob, self).result(timeout=timeout)
         # Return an iterator instead of returning the job.

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import concurrent.futures
 import copy
 import email
 import io
@@ -1212,6 +1213,63 @@ class TestClient(unittest.TestCase):
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
         self.assertEqual(req['path'], '/projects/PROJECT/jobs/query_job')
+        self.assertEqual(req['query_params'], {'projection': 'full'})
+
+    def test_cancel_job_miss_w_explict_project(self):
+        from google.cloud.exceptions import NotFound
+
+        OTHER_PROJECT = 'OTHER_PROJECT'
+        JOB_ID = 'NONESUCH'
+        creds = _make_credentials()
+        client = self._make_one(self.PROJECT, creds)
+        conn = client._connection = _Connection()
+
+        with self.assertRaises(NotFound):
+            client.cancel_job(JOB_ID, project=OTHER_PROJECT)
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(
+            req['path'], '/projects/OTHER_PROJECT/jobs/NONESUCH/cancel')
+        self.assertEqual(req['query_params'], {'projection': 'full'})
+
+    def test_cancel_job_hit(self):
+        from google.cloud.bigquery.job import QueryJob
+
+        JOB_ID = 'query_job'
+        QUERY = 'SELECT * from test_dataset:test_table'
+        QUERY_JOB_RESOURCE = {
+            'id': '{}:{}'.format(self.PROJECT, JOB_ID),
+            'jobReference': {
+                'projectId': self.PROJECT,
+                'jobId': 'query_job',
+            },
+            'state': 'RUNNING',
+            'configuration': {
+                'query': {
+                    'query': QUERY,
+                }
+            },
+        }
+        RESOURCE = {
+            'job': QUERY_JOB_RESOURCE,
+        }
+        creds = _make_credentials()
+        client = self._make_one(self.PROJECT, creds)
+        conn = client._connection = _Connection(RESOURCE)
+
+        job = client.cancel_job(JOB_ID)
+
+        self.assertIsInstance(job, QueryJob)
+        self.assertEqual(job.job_id, JOB_ID)
+        self.assertEqual(job.query, QUERY)
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(
+            req['path'], '/projects/PROJECT/jobs/query_job/cancel')
         self.assertEqual(req['query_params'], {'projection': 'full'})
 
     def test_list_jobs_defaults(self):
@@ -2582,6 +2640,71 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['data']['jobReference']['jobId'], JOB)
         self.assertEqual(configuration['query']['useLegacySql'], True)
         self.assertEqual(configuration['dryRun'], True)
+
+    def test_query_rows_w_timeout_error(self):
+        JOB = 'job-id'
+        QUERY = 'SELECT COUNT(*) FROM persons'
+        RESOURCE = {
+            'jobReference': {
+                'projectId': self.PROJECT,
+                'jobId': JOB,
+            },
+            'configuration': {
+                'query': {
+                    'query': QUERY,
+                },
+            },
+            'status': {
+                'state': 'RUNNING',
+            },
+        }
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(
+            project=self.PROJECT, credentials=creds, _http=http)
+        client._connection = _Connection(RESOURCE)
+
+        with mock.patch(
+                'google.cloud.bigquery.job.QueryJob.result') as mock_result:
+            mock_result.side_effect = concurrent.futures.TimeoutError(
+                'time is up')
+
+            with self.assertRaises(concurrent.futures.TimeoutError) as context:
+                client.query_rows(
+                    QUERY,
+                    job_id_prefix='test_query_rows_w_timeout_',
+                    timeout=1)
+
+        exc = context.exception
+
+        self.assertEqual(exc.project, self.PROJECT)
+        self.assertIn('test_query_rows_w_timeout_', exc.job_id)
+        self.assertIn(exc.project, exc.full_job_id)
+        self.assertIn(exc.job_id, exc.full_job_id)
+
+    def test_query_rows_w_api_error(self):
+        from google.cloud.exceptions import NotFound
+
+        QUERY = 'SELECT COUNT(*) FROM persons'
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(
+            project=self.PROJECT, credentials=creds, _http=http)
+        client._connection = _Connection()
+
+        # Expect a 404 error since we didn't supply a job resource.
+        with self.assertRaises(NotFound) as context:
+            client.query_rows(
+                QUERY,
+                job_id_prefix='test_query_rows_w_timeout_',
+                timeout=1)
+
+        exc = context.exception
+
+        self.assertEqual(exc.project, self.PROJECT)
+        self.assertIn('test_query_rows_w_timeout_', exc.job_id)
+        self.assertIn(exc.project, exc.full_job_id)
+        self.assertIn(exc.job_id, exc.full_job_id)
 
     def test_list_rows(self):
         import datetime


### PR DESCRIPTION
This enables one to catch errors and get the job to wait for it or
cancel it.

Since a full job resource is not required to cancel the job, only the
ID, I also provide a Client.cancel_job method.