### PR TITLE
Updating some storage mocks after `google-resumable-media==0.3.1` release.

### DIFF
--- a/storage/setup.py
+++ b/storage/setup.py
@@ -53,7 +53,7 @@ SETUP_BASE = {
 REQUIREMENTS = [
     'google-cloud-core >= 0.27.0, < 0.28dev',
     'google-auth >= 1.0.0',
-    'google-resumable-media >= 0.3.0',
+    'google-resumable-media >= 0.3.1',
     'requests >= 2.18.0',
 ]
 

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -441,7 +441,9 @@ class Test_Blob(unittest.TestCase):
         response.status_code = status_code
         response.headers.update(headers)
         if stream:
-            response.raw = io.BytesIO(content)
+            raw = io.BytesIO(content)
+            raw.headers = headers
+            response.raw = raw
             response._content = False
         else:
             response.raw = None
@@ -677,15 +679,18 @@ class Test_Blob(unittest.TestCase):
         empty_hash = base64.b64encode(
             hashlib.md5(b'').digest()).decode(u'utf-8')
         headers = {'x-goog-hash': 'md5=' + empty_hash}
+        mock_raw = mock.Mock(headers=headers, spec=['headers'])
         response = mock.MagicMock(
             headers=headers,
             status_code=http_client.OK,
+            raw=mock_raw,
             spec=[
                 '__enter__',
                 '__exit__',
                 'headers',
                 'iter_content',
                 'status_code',
+                'raw',
             ],
         )
         # i.e. context manager returns ``self``.


### PR DESCRIPTION
Fixes #4243.

Also increasing the lower-bound on `google-resumable-media` to `0.3.1`.