### PR TITLE
BigQuery: cancel query on exception in query_rows.

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 
 import collections
+import concurrent.futures
 import functools
 import os
 import uuid
@@ -28,6 +29,8 @@ from google.resumable_media.requests import MultipartUpload
 from google.resumable_media.requests import ResumableUpload
 
 from google.api_core import page_iterator
+from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import NotFound
 
 from google.cloud import exceptions
 from google.cloud.client import ClientWithProject
@@ -506,7 +509,7 @@ class Client(ClientWithProject):
                 :class:`google.cloud.bigquery.LoadJob`,
                 :class:`google.cloud.bigquery.CopyJob`,
                 :class:`google.cloud.bigquery.ExtractJob`,
-                :class:`google.cloud.bigquery.QueryJob`
+                or :class:`google.cloud.bigquery.QueryJob`
         :returns: the job instance, constructed via the resource
         """
         config = resource['configuration']
@@ -540,7 +543,7 @@ class Client(ClientWithProject):
                 :class:`google.cloud.bigquery.LoadJob`,
                 :class:`google.cloud.bigquery.CopyJob`,
                 :class:`google.cloud.bigquery.ExtractJob`,
-                :class:`google.cloud.bigquery.QueryJob`
+                or :class:`google.cloud.bigquery.QueryJob`
         :returns:
             Concrete job instance, based on the resource returned by the API.
         """
@@ -555,6 +558,42 @@ class Client(ClientWithProject):
             retry, method='GET', path=path, query_params=extra_params)
 
         return self.job_from_resource(resource)
+
+    def cancel_job(self, job_id, project=None, retry=DEFAULT_RETRY):
+        """Attempt to cancel a job from a job ID.
+
+        See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/cancel
+
+        :type job_id: str
+        :param job_id: Name of the job.
+
+        :type project: str
+        :param project:
+            project ID owning the job (defaults to the client's project)
+
+        :type retry: :class:`google.api.core.retry.Retry`
+        :param retry: (Optional) How to retry the RPC.
+
+        :rtype: One of:
+                :class:`google.cloud.bigquery.job.LoadJob`,
+                :class:`google.cloud.bigquery.job.CopyJob`,
+                :class:`google.cloud.bigquery.job.ExtractJob`,
+                or :class:`google.cloud.bigquery.job.QueryJob`
+        :returns:
+            Concrete job instance, based on the resource returned by the API.
+        """
+        extra_params = {'projection': 'full'}
+
+        if project is None:
+            project = self.project
+
+        path = '/projects/{}/jobs/{}/cancel'.format(project, job_id)
+
+        resource = self._call_api(
+            retry, method='POST', path=path, query_params=extra_params)
+
+        return self.job_from_resource(resource['job'])
 
     def list_jobs(self, max_results=None, page_token=None, all_users=None,
                   state_filter=None, retry=DEFAULT_RETRY):
@@ -1101,8 +1140,9 @@ class Client(ClientWithProject):
 
         return errors
 
-    def query_rows(self, query, job_config=None, job_id=None, timeout=None,
-                   retry=DEFAULT_RETRY):
+    def query_rows(
+            self, query, job_config=None, job_id=None, job_id_prefix=None,
+            timeout=None, retry=DEFAULT_RETRY):
         """Start a query job and wait for the results.
 
         See
@@ -1119,10 +1159,15 @@ class Client(ClientWithProject):
         :type job_id: str
         :param job_id: (Optional) ID to use for the query job.
 
+        :type job_id_prefix: str or ``NoneType``
+        :param job_id_prefix: (Optional) the user-provided prefix for a
+                              randomly generated job ID. This parameter will be
+                              ignored if a ``job_id`` is also given.
+
         :type timeout: float
         :param timeout:
             (Optional) How long (in seconds) to wait for job to complete
-            before raising a :class:`TimeoutError`.
+            before raising a :class:`concurrent.futures.TimeoutError`.
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
         :returns:
@@ -1132,13 +1177,29 @@ class Client(ClientWithProject):
             from the total number of rows in the current page:
             ``iterator.page.num_items``).
 
-        :raises: :class:`~google.cloud.exceptions.GoogleCloudError` if the job
-            failed or  :class:`TimeoutError` if the job did not complete in the
-            given timeout.
+        :raises:
+            :class:`~google.api.core.exceptions.GoogleAPICallError` if the
+            job failed or :class:`concurrent.futures.TimeoutError` if the job
+            did not complete in the given timeout.
+
+            When an exception happens, the query job will be cancelled on a
+            best-effort basis.
         """
-        job = self.query(
-            query, job_config=job_config, job_id=job_id, retry=retry)
-        return job.result(timeout=timeout)
+        job_id = _make_job_id(job_id, job_id_prefix)
+
+        try:
+            job = self.query(
+                query, job_config=job_config, job_id=job_id, retry=retry)
+            rows_iterator = job.result(timeout=timeout)
+        except (GoogleAPICallError, concurrent.futures.TimeoutError):
+            try:
+                self.cancel_job(job_id)
+            except NotFound:
+                # It's OK if couldn't cancel because job never got created.
+                pass
+            raise
+
+        return rows_iterator
 
     def list_rows(self, table, selected_fields=None, max_results=None,
                   page_token=None, start_index=None, retry=DEFAULT_RETRY):

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -572,7 +572,7 @@ class Client(ClientWithProject):
         :param project:
             project ID owning the job (defaults to the client's project)
 
-        :type retry: :class:`google.api.core.retry.Retry`
+        :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
         :rtype: One of:
@@ -1178,7 +1178,7 @@ class Client(ClientWithProject):
             ``iterator.page.num_items``).
 
         :raises:
-            :class:`~google.api.core.exceptions.GoogleAPICallError` if the
+            :class:`~google.api_core.exceptions.GoogleAPICallError` if the
             job failed or :class:`concurrent.futures.TimeoutError` if the job
             did not complete in the given timeout.
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -509,16 +509,18 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
     def result(self, timeout=None):
         """Start the job and wait for it to complete and get the result.
 
-        :type timeout: int
-        :param timeout: How long to wait for job to complete before raising
-            a :class:`TimeoutError`.
+        :type timeout: float
+        :param timeout:
+            How long (in seconds) to wait for job to complete before raising
+            a :class:`concurrent.futures.TimeoutError`.
 
         :rtype: _AsyncJob
         :returns: This instance.
 
-        :raises: :class:`~google.cloud.exceptions.GoogleCloudError` if the job
-            failed or  :class:`TimeoutError` if the job did not complete in the
-            given timeout.
+        :raises:
+            :class:`~google.cloud.exceptions.GoogleCloudError` if the job
+            failed or :class:`concurrent.futures.TimeoutError` if the job did
+            not complete in the given timeout.
         """
         if self.state is None:
             self._begin()
@@ -1913,8 +1915,8 @@ class QueryJob(_AsyncJob):
 
         :type timeout: float
         :param timeout:
-            How long to wait for job to complete before raising a
-            :class:`TimeoutError`.
+            How long (in seconds) to wait for job to complete before raising
+            a :class:`concurrent.futures.TimeoutError`.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the call that retrieves rows.
@@ -1927,9 +1929,10 @@ class QueryJob(_AsyncJob):
             from the total number of rows in the current page:
             ``iterator.page.num_items``).
 
-        :raises: :class:`~google.cloud.exceptions.GoogleCloudError` if the job
-            failed or  :class:`TimeoutError` if the job did not complete in the
-            given timeout.
+        :raises:
+            :class:`~google.cloud.exceptions.GoogleCloudError` if the job
+            failed or :class:`concurrent.futures.TimeoutError` if the job did
+            not complete in the given timeout.
         """
         super(QueryJob, self).result(timeout=timeout)
         # Return an iterator instead of returning the job.

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -25,7 +25,6 @@ import uuid
 
 import six
 
-from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.exceptions import PreconditionFailed
 from google.cloud import bigquery
 from google.cloud.bigquery.dataset import Dataset, DatasetReference
@@ -822,7 +821,7 @@ class TestBigQuery(unittest.TestCase):
             Config.CLIENT.query_rows('invalid syntax;')
 
     def test_query_rows_w_timeout(self):
-        with self.assertRaises(concurrent.futures.TimeoutError) as context:
+        with self.assertRaises(concurrent.futures.TimeoutError):
             Config.CLIENT.query_rows(
                 'SELECT * FROM `bigquery-public-data.github_repos.commits`;',
                 job_id_prefix='test_query_rows_w_timeout_',

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -2670,7 +2670,7 @@ class TestClient(unittest.TestCase):
             mock_result.side_effect = concurrent.futures.TimeoutError(
                 'time is up')
 
-            with self.assertRaises(concurrent.futures.TimeoutError) as context:
+            with self.assertRaises(concurrent.futures.TimeoutError):
                 client.query_rows(
                     QUERY,
                     job_id_prefix='test_query_rows_w_timeout_',
@@ -2679,7 +2679,6 @@ class TestClient(unittest.TestCase):
         # Should attempt to create and cancel the job.
         self.assertEqual(len(conn._requested), 2)
         req = conn._requested[0]
-        configuration = req['data']['configuration']
         self.assertEqual(req['method'], 'POST')
         self.assertEqual(req['path'], '/projects/PROJECT/jobs')
         cancelreq = conn._requested[1]
@@ -2709,7 +2708,6 @@ class TestClient(unittest.TestCase):
         # Should attempt to create and cancel the job.
         self.assertEqual(len(conn._requested), 2)
         req = conn._requested[0]
-        configuration = req['data']['configuration']
         self.assertEqual(req['method'], 'POST')
         self.assertEqual(req['path'], '/projects/PROJECT/jobs')
         cancelreq = conn._requested[1]

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import concurrent.futures
 import copy
 import email
 import io
@@ -1212,6 +1213,63 @@ class TestClient(unittest.TestCase):
         req = conn._requested[0]
         self.assertEqual(req['method'], 'GET')
         self.assertEqual(req['path'], '/projects/PROJECT/jobs/query_job')
+        self.assertEqual(req['query_params'], {'projection': 'full'})
+
+    def test_cancel_job_miss_w_explict_project(self):
+        from google.cloud.exceptions import NotFound
+
+        OTHER_PROJECT = 'OTHER_PROJECT'
+        JOB_ID = 'NONESUCH'
+        creds = _make_credentials()
+        client = self._make_one(self.PROJECT, creds)
+        conn = client._connection = _Connection()
+
+        with self.assertRaises(NotFound):
+            client.cancel_job(JOB_ID, project=OTHER_PROJECT)
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(
+            req['path'], '/projects/OTHER_PROJECT/jobs/NONESUCH/cancel')
+        self.assertEqual(req['query_params'], {'projection': 'full'})
+
+    def test_cancel_job_hit(self):
+        from google.cloud.bigquery.job import QueryJob
+
+        JOB_ID = 'query_job'
+        QUERY = 'SELECT * from test_dataset:test_table'
+        QUERY_JOB_RESOURCE = {
+            'id': '{}:{}'.format(self.PROJECT, JOB_ID),
+            'jobReference': {
+                'projectId': self.PROJECT,
+                'jobId': 'query_job',
+            },
+            'state': 'RUNNING',
+            'configuration': {
+                'query': {
+                    'query': QUERY,
+                }
+            },
+        }
+        RESOURCE = {
+            'job': QUERY_JOB_RESOURCE,
+        }
+        creds = _make_credentials()
+        client = self._make_one(self.PROJECT, creds)
+        conn = client._connection = _Connection(RESOURCE)
+
+        job = client.cancel_job(JOB_ID)
+
+        self.assertIsInstance(job, QueryJob)
+        self.assertEqual(job.job_id, JOB_ID)
+        self.assertEqual(job.query, QUERY)
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(
+            req['path'], '/projects/PROJECT/jobs/query_job/cancel')
         self.assertEqual(req['query_params'], {'projection': 'full'})
 
     def test_list_jobs_defaults(self):
@@ -2583,6 +2641,84 @@ class TestClient(unittest.TestCase):
         self.assertEqual(configuration['query']['useLegacySql'], True)
         self.assertEqual(configuration['dryRun'], True)
 
+    def test_query_rows_w_timeout_error(self):
+        JOB = 'job-id'
+        QUERY = 'SELECT COUNT(*) FROM persons'
+        RESOURCE = {
+            'jobReference': {
+                'projectId': self.PROJECT,
+                'jobId': JOB,
+            },
+            'configuration': {
+                'query': {
+                    'query': QUERY,
+                },
+            },
+            'status': {
+                'state': 'RUNNING',
+            },
+        }
+        CANCEL_RESOURCE = {'job': RESOURCE}
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(
+            project=self.PROJECT, credentials=creds, _http=http)
+        conn = client._connection = _Connection(RESOURCE, CANCEL_RESOURCE)
+
+        with mock.patch(
+                'google.cloud.bigquery.job.QueryJob.result') as mock_result:
+            mock_result.side_effect = concurrent.futures.TimeoutError(
+                'time is up')
+
+            with self.assertRaises(concurrent.futures.TimeoutError) as context:
+                client.query_rows(
+                    QUERY,
+                    job_id_prefix='test_query_rows_w_timeout_',
+                    timeout=1)
+
+        # Should attempt to create and cancel the job.
+        self.assertEqual(len(conn._requested), 2)
+        req = conn._requested[0]
+        configuration = req['data']['configuration']
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/projects/PROJECT/jobs')
+        cancelreq = conn._requested[1]
+        self.assertEqual(cancelreq['method'], 'POST')
+        self.assertIn(
+            '/projects/PROJECT/jobs/test_query_rows_w_timeout_',
+            cancelreq['path'])
+        self.assertIn('/cancel', cancelreq['path'])
+
+    def test_query_rows_w_api_error(self):
+        from google.api_core.exceptions import NotFound
+
+        QUERY = 'SELECT COUNT(*) FROM persons'
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(
+            project=self.PROJECT, credentials=creds, _http=http)
+        conn = client._connection = _Connection()
+
+        # Expect a 404 error since we didn't supply a job resource.
+        with self.assertRaises(NotFound):
+            client.query_rows(
+                QUERY,
+                job_id_prefix='test_query_rows_w_error_',
+                timeout=1)
+
+        # Should attempt to create and cancel the job.
+        self.assertEqual(len(conn._requested), 2)
+        req = conn._requested[0]
+        configuration = req['data']['configuration']
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/projects/PROJECT/jobs')
+        cancelreq = conn._requested[1]
+        self.assertEqual(cancelreq['method'], 'POST')
+        self.assertIn(
+            '/projects/PROJECT/jobs/test_query_rows_w_error_',
+            cancelreq['path'])
+        self.assertIn('/cancel', cancelreq['path'])
+
     def test_list_rows(self):
         import datetime
         from google.cloud._helpers import UTC
@@ -3224,7 +3360,7 @@ class _Connection(object):
         self._requested = []
 
     def api_request(self, **kw):
-        from google.cloud.exceptions import NotFound
+        from google.api_core.exceptions import NotFound
         self._requested.append(kw)
 
         if len(self._responses) == 0:


### PR DESCRIPTION
This covers the primary reason one would want the job ID from an
exception in query rows: to cancel the job.

Replaces https://github.com/GoogleCloudPlatform/google-cloud-python/pull/4240.