### PR TITLE
Bigtable ReadRows doesn't handle empty string column qualifier

### DIFF
--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -283,10 +283,14 @@ class PartialRowsData(object):
                 row = self._row = PartialRowData(chunk.row_key)
 
             if cell is None:
+                qualifier = None
+                if chunk.HasField('qualifier'):
+                    qualifier = chunk.qualifier.value
+
                 cell = self._cell = PartialCellData(
                     chunk.row_key,
                     chunk.family_name.value,
-                    chunk.qualifier.value,
+                    qualifier,
                     chunk.timestamp_micros,
                     chunk.labels,
                     chunk.value)

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -114,7 +114,7 @@ class PartialRowData(object):
     """Representation of partial row in a Google Cloud Bigtable Table.
 
     These are expected to be updated directly from a
-   :class:`._generated.bigtable_service_messages_pb2.ReadRowsResponse`
+    :class:`._generated.bigtable_service_messages_pb2.ReadRowsResponse`
 
     :type row_key: bytes
     :param row_key: The key for the row holding the (partial) data.

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -421,7 +421,8 @@ class PartialRowsData(object):
                 cell.row_key = previous.row_key
             if not cell.family_name:
                 cell.family_name = previous.family_name
-            if cell.qualifier is None: # Note: qualifier can be empty string
+            # NOTE: ``cell.qualifier`` **can** be empty string.
+            if cell.qualifier is None:
                 cell.qualifier = previous.qualifier
 
     def _save_current_row(self):

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -114,7 +114,7 @@ class PartialRowData(object):
     """Representation of partial row in a Google Cloud Bigtable Table.
 
     These are expected to be updated directly from a
-    :class:`._generated.bigtable_service_messages_pb2.ReadRowsResponse`
+   :class:`._generated.bigtable_service_messages_pb2.ReadRowsResponse`
 
     :type row_key: bytes
     :param row_key: The key for the row holding the (partial) data.
@@ -421,7 +421,7 @@ class PartialRowsData(object):
                 cell.row_key = previous.row_key
             if not cell.family_name:
                 cell.family_name = previous.family_name
-            if not cell.qualifier:
+            if cell.qualifier is None: # Note: qualifier can be empty string
                 cell.qualifier = previous.qualifier
 
     def _save_current_row(self):

--- a/bigtable/tests/unit/read-rows-acceptance-test.json
+++ b/bigtable/tests/unit/read-rows-acceptance-test.json
@@ -1173,6 +1173,33 @@
           "error": false
         }
       ]
+    },
+    {
+      "name": "empty second qualifier",
+      "chunks": [
+        "row_key: \"RK\"\nfamily_name: \u003c\n  value: \"A\"\n\u003e\nqualifier: \u003c\n  value: \"C\"\n\u003e\ntimestamp_micros: 99\nvalue: \"value-VAL_1\"\ncommit_row: false\n",
+	"qualifier: \u003c\n  value: \"C\"\n\u003e\ntimestamp_micros: 98\nvalue: \"value-VAL_2\"\ncommit_row: true\n"
+      ],
+      "results": [
+        {
+          "rk": "RK",
+          "fm": "A",
+          "qual": "C",
+          "ts": 99,
+          "value": "value-VAL_1",
+          "label": "",
+          "error": false
+        },
+        {
+          "rk": "RK",
+          "fm": "A",
+          "qual": "",
+          "ts": 98,
+          "value": "value-VAL_2",
+          "label": "",
+          "error": false
+        }
+      ]
     }
   ]
 }

--- a/bigtable/tests/unit/read-rows-acceptance-test.json
+++ b/bigtable/tests/unit/read-rows-acceptance-test.json
@@ -1178,7 +1178,7 @@
       "name": "empty second qualifier",
       "chunks": [
         "row_key: \"RK\"\nfamily_name: \u003c\n  value: \"A\"\n\u003e\nqualifier: \u003c\n  value: \"C\"\n\u003e\ntimestamp_micros: 99\nvalue: \"value-VAL_1\"\ncommit_row: false\n",
-	"qualifier: \u003c\n  value: \"C\"\n\u003e\ntimestamp_micros: 98\nvalue: \"value-VAL_2\"\ncommit_row: true\n"
+        "qualifier: \u003c\n  value: \"\"\n\u003e\ntimestamp_micros: 98\nvalue: \"value-VAL_2\"\ncommit_row: true\n"
       ],
       "results": [
         {

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -334,7 +334,7 @@ class TestPartialRowsData(unittest.TestCase):
         prd._copy_from_previous(cell)
         self.assertEqual(cell.row_key, '')
         self.assertEqual(cell.family_name, u'')
-        self.assertEqual(cell.qualifier, None)
+        self.assertIsNone(cell.qualifier)
         self.assertEqual(cell.timestamp_micros, 0)
         self.assertEqual(cell.labels, [])
 
@@ -530,7 +530,6 @@ class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
     def _match_results(self, testcase_name, expected_result=_marker):
         chunks, results = self._load_json_test(testcase_name)
         response = _ReadRowsResponseV2(chunks)
-
         iterator = _MockCancellableIterator(response)
         prd = self._make_one(iterator)
         prd.consume_next()

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -334,7 +334,7 @@ class TestPartialRowsData(unittest.TestCase):
         prd._copy_from_previous(cell)
         self.assertEqual(cell.row_key, '')
         self.assertEqual(cell.family_name, u'')
-        self.assertEqual(cell.qualifier, b'')
+        self.assertEqual(cell.qualifier, None)
         self.assertEqual(cell.timestamp_micros, 0)
         self.assertEqual(cell.labels, [])
 
@@ -530,6 +530,7 @@ class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
     def _match_results(self, testcase_name, expected_result=_marker):
         chunks, results = self._load_json_test(testcase_name)
         response = _ReadRowsResponseV2(chunks)
+
         iterator = _MockCancellableIterator(response)
         prd = self._make_one(iterator)
         prd.consume_next()
@@ -635,6 +636,8 @@ class TestPartialRowsData_JSON_acceptance_tests(unittest.TestCase):
     def test_empty_cell_chunk(self):
         self._match_results('empty cell chunk')
 
+    def test_empty_second_qualifier(self):
+        self._match_results('empty second qualifier')
 
 def _flatten_cells(prd):
     # Match results format from JSON testcases.
@@ -678,7 +681,7 @@ class _PartialCellData(object):
 
     row_key = ''
     family_name = u''
-    qualifier = b''
+    qualifier = None
     timestamp_micros = 0
 
     def __init__(self, **kw):


### PR DESCRIPTION
This problem was reported by a customer. As background, the empty string is a valid column qualifier. A missing qualifier, as opposed to the empty string, means the previously seen qualifier should be applied instead.

I added a new test case that has a cell with a column qualifier of empty string arriving after a cell with a non-empty qualifier. The code fails to distinguish between a missing qualifier and an empty qualifier and overwrites the empty string with the first qualifier.

With no code changes the new test case fails. I attempted to fix the bug in `row_data.py` but this causes other failures. I was hoping someone could pick this up and investigate. 

