### PR TITLE
BigQuery: use full sub-module aliases in docstrings.

### DIFF
--- a/bigquery/google/cloud/bigquery/__init__.py
+++ b/bigquery/google/cloud/bigquery/__init__.py
@@ -16,6 +16,11 @@
 
 The main concepts with this API are:
 
+- :class:`~google.cloud.bigquery.client.Client` manages connections to the
+  BigQuery API. Use the client methods to run jobs (such as a
+  :class:`~google.cloud.bigquery.job.QueryJob` via
+  :meth:`~google.cloud.bigquery.client.Client.query`) and manage resources.
+
 - :class:`~google.cloud.bigquery.dataset.Dataset` represents a
   collection of tables.
 

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -184,7 +184,7 @@ class Client(ClientWithProject):
         :param retry: (Optional) How to retry the RPC.
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
-        :returns: Iterator of :class:`~google.cloud.bigquery.Dataset`.
+        :returns: Iterator of :class:`~google.cloud.bigquery.dataset.Dataset`.
                   accessible to the current client.
         """
         extra_params = {}
@@ -215,7 +215,7 @@ class Client(ClientWithProject):
         :param project: (Optional) project ID for the dataset (defaults to
                         the project of the client).
 
-        :rtype: :class:`google.cloud.bigquery.DatasetReference`
+        :rtype: :class:`google.cloud.bigquery.dataset.DatasetReference`
         :returns: a new ``DatasetReference`` instance
         """
         if project is None:
@@ -229,12 +229,12 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert
 
-        :type dataset: :class:`~google.cloud.bigquery.Dataset`
+        :type dataset: :class:`~google.cloud.bigquery.dataset.Dataset`
         :param dataset: A ``Dataset`` populated with the desired initial state.
                         If project is missing, it defaults to the project of
                         the client.
 
-        :rtype: ":class:`~google.cloud.bigquery.Dataset`"
+        :rtype: ":class:`~google.cloud.bigquery.dataset.Dataset`"
         :returns: a new ``Dataset`` returned from the service.
         """
         path = '/projects/%s/datasets' % (dataset.project,)
@@ -248,10 +248,10 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert
 
-        :type table: :class:`~google.cloud.bigquery.Table`
+        :type table: :class:`~google.cloud.bigquery.table.Table`
         :param table: A ``Table`` populated with the desired initial state.
 
-        :rtype: ":class:`~google.cloud.bigquery.Table`"
+        :rtype: ":class:`~google.cloud.bigquery.table.Table`"
         :returns: a new ``Table`` returned from the service.
         """
         path = '/projects/%s/datasets/%s/tables' % (
@@ -274,13 +274,13 @@ class Client(ClientWithProject):
         """Fetch the dataset referenced by ``dataset_ref``
 
         :type dataset_ref:
-            :class:`google.cloud.bigquery.DatasetReference`
+            :class:`google.cloud.bigquery.dataset.DatasetReference`
         :param dataset_ref: the dataset to use.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.Dataset`
+        :rtype: :class:`google.cloud.bigquery.dataset.Dataset`
         :returns: a ``Dataset`` instance
         """
         api_response = self._call_api(retry,
@@ -292,13 +292,13 @@ class Client(ClientWithProject):
         """Fetch the table referenced by ``table_ref``
 
         :type table_ref:
-            :class:`google.cloud.bigquery.TableReference`
+            :class:`google.cloud.bigquery.table.TableReference`
         :param table_ref: the table to use.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.Table`
+        :rtype: :class:`google.cloud.bigquery.table.Table`
         :returns: a ``Table`` instance
         """
         api_response = self._call_api(retry, method='GET', path=table_ref.path)
@@ -318,7 +318,7 @@ class Client(ClientWithProject):
         will only be saved if no modifications to the dataset occurred
         since the read.
 
-        :type dataset: :class:`google.cloud.bigquery.Dataset`
+        :type dataset: :class:`google.cloud.bigquery.dataset.Dataset`
         :param dataset: the dataset to update.
 
         :type fields: sequence of string
@@ -328,7 +328,7 @@ class Client(ClientWithProject):
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.Dataset`
+        :rtype: :class:`google.cloud.bigquery.dataset.Dataset`
         :returns: the modified ``Dataset`` instance
         """
         path = '/projects/%s/datasets/%s' % (dataset.project,
@@ -361,13 +361,13 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/update
 
         :type table:
-            :class:`google.cloud.bigquery.Table`
+            :class:`google.cloud.bigquery.table.Table`
         :param table_ref: the table to update.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.Table`
+        :rtype: :class:`google.cloud.bigquery.table.Table`
         :returns: a ``Table`` instance
         """
         partial = table._build_resource(properties)
@@ -388,8 +388,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list
 
         :type dataset: One of:
-                       :class:`~google.cloud.bigquery.Dataset`
-                       :class:`~google.cloud.bigquery.DatasetReference`
+                       :class:`~google.cloud.bigquery.dataset.Dataset`
+                       :class:`~google.cloud.bigquery.dataset.DatasetReference`
         :param dataset: the dataset whose tables to list, or a reference to it.
 
         :type max_results: int
@@ -405,7 +405,7 @@ class Client(ClientWithProject):
         :param retry: (Optional) How to retry the RPC.
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
-        :returns: Iterator of :class:`~google.cloud.bigquery.Table`
+        :returns: Iterator of :class:`~google.cloud.bigquery.table.Table`
                   contained within the current dataset.
         """
         if not isinstance(dataset, (Dataset, DatasetReference)):
@@ -429,8 +429,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/delete
 
         :type dataset: One of:
-                       :class:`~google.cloud.bigquery.Dataset`
-                       :class:`~google.cloud.bigquery.DatasetReference`
+                       :class:`~google.cloud.bigquery.dataset.Dataset`
+                       :class:`~google.cloud.bigquery.dataset.DatasetReference`
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
@@ -448,8 +448,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/delete
 
         :type table: One of:
-                     :class:`~google.cloud.bigquery.Table`
-                     :class:`~google.cloud.bigquery.TableReference`
+                     :class:`~google.cloud.bigquery.table.Table`
+                     :class:`~google.cloud.bigquery.table.TableReference`
         :param table: the table to delete, or a reference to it.
 
         :type retry: :class:`google.api_core.retry.Retry`
@@ -478,7 +478,7 @@ class Client(ClientWithProject):
             (Optional) number of milliseconds the the API call should wait for
             the query to complete before the request times out.
 
-        :rtype: :class:`google.cloud.bigquery.QueryResults`
+        :rtype: :class:`google.cloud.bigquery.query.QueryResults`
         :returns: a new ``QueryResults`` instance
         """
 
@@ -506,10 +506,10 @@ class Client(ClientWithProject):
         :param resource: one job resource from API response
 
         :rtype: One of:
-                :class:`google.cloud.bigquery.LoadJob`,
-                :class:`google.cloud.bigquery.CopyJob`,
-                :class:`google.cloud.bigquery.ExtractJob`,
-                or :class:`google.cloud.bigquery.QueryJob`
+                :class:`google.cloud.bigquery.job.LoadJob`,
+                :class:`google.cloud.bigquery.job.CopyJob`,
+                :class:`google.cloud.bigquery.job.ExtractJob`,
+                or :class:`google.cloud.bigquery.job.QueryJob`
         :returns: the job instance, constructed via the resource
         """
         config = resource['configuration']
@@ -540,10 +540,10 @@ class Client(ClientWithProject):
         :param retry: (Optional) How to retry the RPC.
 
         :rtype: One of:
-                :class:`google.cloud.bigquery.LoadJob`,
-                :class:`google.cloud.bigquery.CopyJob`,
-                :class:`google.cloud.bigquery.ExtractJob`,
-                or :class:`google.cloud.bigquery.QueryJob`
+                :class:`google.cloud.bigquery.job.LoadJob`,
+                :class:`google.cloud.bigquery.job.CopyJob`,
+                :class:`google.cloud.bigquery.job.ExtractJob`,
+                or :class:`google.cloud.bigquery.job.QueryJob`
         :returns:
             Concrete job instance, based on the resource returned by the API.
         """
@@ -673,14 +673,14 @@ class Client(ClientWithProject):
                               randomly generated job ID. This parameter will be
                               ignored if a ``job_id`` is also given.
 
-        :type job_config: :class:`google.cloud.bigquery.LoadJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.job.LoadJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.LoadJob`
-        :returns: a new ``LoadJob`` instance
+        :rtype: :class:`google.cloud.bigquery.job.LoadJob`
+        :returns: a new :class:`~google.cloud.bigquery.job.LoadJob` instance
         """
         job_id = _make_job_id(job_id, job_id_prefix)
         if isinstance(source_uris, six.string_types):
@@ -725,10 +725,10 @@ class Client(ClientWithProject):
                               randomly generated job ID. This parameter will be
                               ignored if a ``job_id`` is also given.
 
-        :type job_config: :class:`google.cloud.bigquery.LoadJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.job.LoadJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
-        :rtype: :class:`~google.cloud.bigquery.LoadJob`
+        :rtype: :class:`~google.cloud.bigquery.job.LoadJob`
 
         :returns: the job instance used to load the data (e.g., for
                   querying status).
@@ -868,9 +868,9 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy
 
         :type sources: One of:
-                       :class:`~google.cloud.bigquery.TableReference`
+                       :class:`~google.cloud.bigquery.table.TableReference`
                        sequence of
-                       :class:`~google.cloud.bigquery.TableReference`
+                       :class:`~google.cloud.bigquery.table.TableReference`
         :param sources: Table or tables to be copied.
 
 
@@ -885,14 +885,14 @@ class Client(ClientWithProject):
                               randomly generated job ID. This parameter will be
                               ignored if a ``job_id`` is also given.
 
-        :type job_config: :class:`google.cloud.bigquery.CopyJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.job.CopyJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.CopyJob`
-        :returns: a new ``CopyJob`` instance
+        :rtype: :class:`google.cloud.bigquery.job.copyjob`
+        :returns: a new :class:`google.cloud.bigquery.job.copyjob` instance
         """
         job_id = _make_job_id(job_id, job_id_prefix)
 
@@ -911,7 +911,7 @@ class Client(ClientWithProject):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.extract
 
-        :type source: :class:`google.cloud.bigquery.TableReference`
+        :type source: :class:`google.cloud.bigquery.table.TableReference`
         :param source: table to be extracted.
 
         :type destination_uris: One of:
@@ -932,14 +932,14 @@ class Client(ClientWithProject):
                               randomly generated job ID. This parameter will be
                               ignored if a ``job_id`` is also given.
 
-        :type job_config: :class:`google.cloud.bigquery.ExtractJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.job.ExtractJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.ExtractJob`
-        :returns: a new ``ExtractJob`` instance
+        :rtype: :class:`google.cloud.bigquery.job.ExtractJob`
+        :returns: a new :class:`google.cloud.bigquery.job.ExtractJob` instance
         """
         job_id = _make_job_id(job_id, job_id_prefix)
 
@@ -964,7 +964,7 @@ class Client(ClientWithProject):
             SQL query to be executed. Defaults to the standard SQL dialect.
             Use the ``job_config`` parameter to change dialects.
 
-        :type job_config: :class:`google.cloud.bigquery.QueryJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.job.QueryJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
         :type job_id: str
@@ -978,8 +978,8 @@ class Client(ClientWithProject):
         :type retry: :class:`google.api_core.retry.Retry`
         :param retry: (Optional) How to retry the RPC.
 
-        :rtype: :class:`google.cloud.bigquery.QueryJob`
-        :returns: a new ``QueryJob`` instance
+        :rtype: :class:`google.cloud.bigquery.job.QueryJob`
+        :returns: a new :class:`google.cloud.bigquery.job.QueryJob` instance
         """
         job_id = _make_job_id(job_id, job_id_prefix)
         job = QueryJob(job_id, query, client=self, job_config=job_config)
@@ -993,8 +993,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
 
         :type table: One of:
-                     :class:`~google.cloud.bigquery.Table`
-                     :class:`~google.cloud.bigquery.TableReference`
+                     :class:`~google.cloud.bigquery.table.Table`
+                     :class:`~google.cloud.bigquery.table.TableReference`
         :param table: the destination table for the row data, or a reference
                       to it.
 
@@ -1009,14 +1009,15 @@ class Client(ClientWithProject):
                      not correspond to a field in the schema are ignored.
 
         :type selected_fields:
-            list of :class:`~google.cloud.bigquery.SchemaField`
+            list of :class:`~google.cloud.bigquery.schema.SchemaField`
         :param selected_fields:
             The fields to return. Required if ``table`` is a
-            :class:`~google.cloud.bigquery.TableReference`.
+            :class:`~google.cloud.bigquery.table.TableReference`.
 
         :type kwargs: dict
-        :param kwargs: Keyword arguments to
-                       `~google.cloud.bigquery.Client.create_rows_json`
+        :param kwargs:
+            Keyword arguments to
+            :meth:`~google.cloud.bigquery.client.Client.create_rows_json`
 
         :rtype: list of mappings
         :returns: One mapping per row with insert errors:  the "index" key
@@ -1062,8 +1063,8 @@ class Client(ClientWithProject):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
 
         :type table: One of:
-                     :class:`~google.cloud.bigquery.Table`
-                     :class:`~google.cloud.bigquery.TableReference`
+                     :class:`~google.cloud.bigquery.table.Table`
+                     :class:`~google.cloud.bigquery.table.TableReference`
         :param table: the destination table for the row data, or a reference
                       to it.
 
@@ -1153,7 +1154,7 @@ class Client(ClientWithProject):
             SQL query to be executed. Defaults to the standard SQL dialect.
             Use the ``job_config`` parameter to change dialects.
 
-        :type job_config: :class:`google.cloud.bigquery.QueryJobConfig`
+        :type job_config: :class:`google.cloud.bigquery.job.QueryJobConfig`
         :param job_config: (Optional) Extra configuration options for the job.
 
         :type job_id: str
@@ -1216,15 +1217,15 @@ class Client(ClientWithProject):
            local copy of the schema is up-to-date, call ``client.get_table``.
 
         :type table: One of:
-                     :class:`~google.cloud.bigquery.Table`
-                     :class:`~google.cloud.bigquery.TableReference`
+                     :class:`~google.cloud.bigquery.table.Table`
+                     :class:`~google.cloud.bigquery.table.TableReference`
         :param table: the table to list, or a reference to it.
 
         :type selected_fields:
-            list of :class:`~google.cloud.bigquery.SchemaField`
+            list of :class:`~google.cloud.bigquery.schema.SchemaField`
         :param selected_fields:
             The fields to return. Required if ``table`` is a
-            :class:`~google.cloud.bigquery.TableReference`.
+            :class:`~google.cloud.bigquery.table.TableReference`.
 
         :type max_results: int
         :param max_results: maximum number of rows to return.
@@ -1286,8 +1287,8 @@ class Client(ClientWithProject):
         """List the partitions in a table.
 
         :type table: One of:
-                     :class:`~google.cloud.bigquery.Table`
-                     :class:`~google.cloud.bigquery.TableReference`
+                     :class:`~google.cloud.bigquery.table.Table`
+                     :class:`~google.cloud.bigquery.table.TableReference`
         :param table: the table to list, or a reference to it.
 
         :type retry: :class:`google.api_core.retry.Retry`
@@ -1362,7 +1363,7 @@ def _item_to_table(iterator, resource):
     :type resource: dict
     :param resource: An item to be converted to a table.
 
-    :rtype: :class:`~google.cloud.bigquery.Table`
+    :rtype: :class:`~google.cloud.bigquery.table.Table`
     :returns: The next table in the page.
     """
     return Table.from_api_repr(resource)

--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -146,7 +146,7 @@ class DatasetReference(object):
         :type table_id: str
         :param table_id: the ID of the table.
 
-        :rtype: :class:`google.cloud.bigquery.TableReference`
+        :rtype: :class:`google.cloud.bigquery.table.TableReference`
         :returns: a TableReference for a table in this dataset.
         """
         return TableReference(self, table_id)
@@ -197,7 +197,7 @@ class Dataset(object):
     See
     https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets
 
-    :type dataset_ref: :class:`~google.cloud.bigquery.DatasetReference`
+    :type dataset_ref: :class:`~google.cloud.bigquery.dataset.DatasetReference`
     :param dataset_ref: a pointer to a dataset
     """
 
@@ -238,7 +238,8 @@ class Dataset(object):
     def access_entries(self, value):
         """Update dataset's access entries
 
-        :type value: list of :class:`~google.cloud.bigquery.AccessEntry`
+        :type value:
+            list of :class:`~google.cloud.bigquery.dataset.AccessEntry`
         :param value: roles granted to entities for this dataset
 
         :raises: TypeError if 'value' is not a sequence, or ValueError if
@@ -401,8 +402,9 @@ class Dataset(object):
         """Labels for the dataset.
 
         This method always returns a dict. To change a dataset's labels,
-        modify the dict, then call ``Client.update_dataset``. To delete a
-        label, set its value to ``None`` before updating.
+        modify the dict, then call
+        :meth:`google.cloud.bigquery.client.Client.update_dataset`. To delete
+        a label, set its value to ``None`` before updating.
 
         :rtype: dict, {str -> str}
         :returns: A dict of the the dataset's labels.
@@ -429,7 +431,7 @@ class Dataset(object):
         :type resource: dict
         :param resource: dataset resource representation returned from the API
 
-        :rtype: :class:`~google.cloud.bigquery.Dataset`
+        :rtype: :class:`~google.cloud.bigquery.dataset.Dataset`
         :returns: Dataset parsed from ``resource``.
         """
         dsr = resource.get('datasetReference')
@@ -451,7 +453,7 @@ class Dataset(object):
         :type access: list of mappings
         :param access: each mapping represents a single access entry.
 
-        :rtype: list of :class:`~google.cloud.bigquery.AccessEntry`
+        :rtype: list of :class:`~google.cloud.bigquery.dataset.AccessEntry`
         :returns: a list of parsed entries.
         :raises: :class:`ValueError` if a entry in ``access`` has more keys
                  than ``role`` and one additional key.
@@ -530,7 +532,7 @@ class Dataset(object):
         :type table_id: str
         :param table_id: the ID of the table.
 
-        :rtype: :class:`~google.cloud.bigquery.TableReference`
+        :rtype: :class:`~google.cloud.bigquery.table.TableReference`
         :returns: a TableReference for a table in this dataset.
         """
         return TableReference(self, table_id)

--- a/bigquery/google/cloud/bigquery/external_config.py
+++ b/bigquery/google/cloud/bigquery/external_config.py
@@ -177,7 +177,7 @@ class BigtableColumnFamily(object):
             from the API.
 
         :rtype:
-            :class:`~google.cloud.bigquery.BigtableColumnFamily`
+            :class:`~google.cloud.bigquery.external_config.BigtableColumnFamily`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -239,7 +239,8 @@ class BigtableOptions(object):
             A BigtableOptions in the same representation as is returned
             from the API.
 
-        :rtype: :class:`~google.cloud.bigquery.BigtableOptions`
+        :rtype:
+            :class:`~google.cloud.bigquery.external_config.BigtableOptions`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -321,7 +322,7 @@ class CSVOptions(object):
             A CSVOptions in the same representation as is
             returned from the API.
 
-        :rtype: :class:`~google.cloud.bigquery.CSVOptions`
+        :rtype: :class:`~google.cloud.bigquery.external_config.CSVOptions`
         :returns: Configuration parsed from ``resource``.
         """
         slr = resource.get('skipLeadingRows')
@@ -369,7 +370,7 @@ class GoogleSheetsOptions(object):
             returned from the API.
 
         :rtype:
-            :class:`~google.cloud.bigquery.GoogleSheetsOptions`
+            :class:`~google.cloud.bigquery.external_config.GoogleSheetsOptions`
         :returns: Configuration parsed from ``resource``.
         """
         slr = resource.get('skipLeadingRows')
@@ -476,7 +477,7 @@ class ExternalConfig(object):
             An extract job configuration in the same representation as is
             returned from the API.
 
-        :rtype: :class:`~google.cloud.bigquery.CSVOptions`
+        :rtype: :class:`~google.cloud.bigquery.external_config.CSVOptions`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls(resource['sourceFormat'])

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -153,7 +153,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
     :type job_id: str
     :param job_id: the job's ID in the project associated with the client.
 
-    :type client: :class:`google.cloud.bigquery.Client`
+    :type client: :class:`google.cloud.bigquery.client.Client`
     :param client: A client which holds credentials and project configuration.
     """
     def __init__(self, job_id, client):
@@ -176,12 +176,12 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
     def _require_client(self, client):
         """Check client or verify over-ride.
 
-        :type client: :class:`~google.cloud.bigquery.Client` or
+        :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
 
-        :rtype: :class:`google.cloud.bigquery.Client`
+        :rtype: :class:`google.cloud.bigquery.client.Client`
         :returns: The client passed in or the currently bound client.
         """
         if client is None:
@@ -374,7 +374,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert
 
-        :type client: :class:`~google.cloud.bigquery.Client` or
+        :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
@@ -403,7 +403,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/get
 
-        :type client: :class:`~google.cloud.bigquery.Client` or
+        :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
@@ -431,7 +431,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/get
 
-        :type client: :class:`~google.cloud.bigquery.Client` or
+        :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
@@ -450,7 +450,7 @@ class _AsyncJob(google.api_core.future.polling.PollingFuture):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/cancel
 
-        :type client: :class:`~google.cloud.bigquery.Client` or
+        :type client: :class:`~google.cloud.bigquery.client.Client` or
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current dataset.
@@ -665,7 +665,7 @@ class LoadJobConfig(object):
             An extract job configuration in the same representation as is
             returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.ExtractJobConfig`
+        :rtype: :class:`google.cloud.bigquery.job.LoadJobConfig`
         :returns: Configuration parsed from ``resource``.
         """
         schema = resource.pop('schema', {'fields': ()})
@@ -693,7 +693,7 @@ class LoadJob(_AsyncJob):
     :type destination: :class:`google.cloud.bigquery.TableReference`
     :param destination: reference to table into which data is to be loaded.
 
-    :type client: :class:`google.cloud.bigquery.Client`
+    :type client: :class:`google.cloud.bigquery.client.Client`
     :param client: A client which holds credentials and project configuration
                    for the dataset (which requires a project).
     """
@@ -714,98 +714,98 @@ class LoadJob(_AsyncJob):
     @property
     def allow_jagged_rows(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.allow_jagged_rows`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.allow_jagged_rows`.
         """
         return self._configuration.allow_jagged_rows
 
     @property
     def allow_quoted_newlines(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.allow_quoted_newlines`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.allow_quoted_newlines`.
         """
         return self._configuration.allow_quoted_newlines
 
     @property
     def autodetect(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.autodetect`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.autodetect`.
         """
         return self._configuration.autodetect
 
     @property
     def create_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.create_disposition`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.create_disposition`.
         """
         return self._configuration.create_disposition
 
     @property
     def encoding(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.encoding`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.encoding`.
         """
         return self._configuration.encoding
 
     @property
     def field_delimiter(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.field_delimiter`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.field_delimiter`.
         """
         return self._configuration.field_delimiter
 
     @property
     def ignore_unknown_values(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.ignore_unknown_values`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.ignore_unknown_values`.
         """
         return self._configuration.ignore_unknown_values
 
     @property
     def max_bad_records(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.max_bad_records`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.max_bad_records`.
         """
         return self._configuration.max_bad_records
 
     @property
     def null_marker(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.null_marker`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.null_marker`.
         """
         return self._configuration.null_marker
 
     @property
     def quote_character(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.quote_character`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.quote_character`.
         """
         return self._configuration.quote_character
 
     @property
     def skip_leading_rows(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.skip_leading_rows`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.skip_leading_rows`.
         """
         return self._configuration.skip_leading_rows
 
     @property
     def source_format(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.source_format`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.source_format`.
         """
         return self._configuration.source_format
 
     @property
     def write_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.write_disposition`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.write_disposition`.
         """
         return self._configuration.write_disposition
 
     @property
     def schema(self):
         """See
-        :class:`~google.cloud.bigquery.LoadJobConfig.schema`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.schema`.
         """
         return self._configuration.schema
 
@@ -886,11 +886,11 @@ class LoadJob(_AsyncJob):
         :type resource: dict
         :param resource: dataset job representation returned from the API
 
-        :type client: :class:`google.cloud.bigquery.Client`
+        :type client: :class:`google.cloud.bigquery.client.Client`
         :param client: Client which holds credentials and project
                        configuration for the dataset.
 
-        :rtype: :class:`google.cloud.bigquery.LoadJob`
+        :rtype: :class:`google.cloud.bigquery.job.LoadJob`
         :returns: Job parsed from ``resource``.
         """
         job_id, config_resource = cls._get_resource_config(resource)
@@ -945,7 +945,7 @@ class CopyJobConfig(object):
             An extract job configuration in the same representation as is
             returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.ExtractJobConfig`
+        :rtype: :class:`google.cloud.bigquery.job.CopyJobConfig`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -965,11 +965,11 @@ class CopyJob(_AsyncJob):
     :type destination: :class:`google.cloud.bigquery.TableReference`
     :param destination: Table into which data is to be loaded.
 
-    :type client: :class:`google.cloud.bigquery.Client`
+    :type client: :class:`google.cloud.bigquery.client.Client`
     :param client: A client which holds credentials and project configuration
                    for the dataset (which requires a project).
 
-    :type job_config: :class:`~google.cloud.bigquery.CopyJobConfig`
+    :type job_config: :class:`~google.cloud.bigquery.job.CopyJobConfig`
     :param job_config:
         (Optional) Extra configuration options for the copy job.
     """
@@ -988,14 +988,14 @@ class CopyJob(_AsyncJob):
     @property
     def create_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.CopyJobConfig.create_disposition`.
+        :attr:`google.cloud.bigquery.job.CopyJobConfig.create_disposition`.
         """
         return self._configuration.create_disposition
 
     @property
     def write_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.CopyJobConfig.write_disposition`.
+        :attr:`google.cloud.bigquery.job.CopyJobConfig.write_disposition`.
         """
         return self._configuration.write_disposition
 
@@ -1042,11 +1042,11 @@ class CopyJob(_AsyncJob):
         :type resource: dict
         :param resource: dataset job representation returned from the API
 
-        :type client: :class:`google.cloud.bigquery.Client`
+        :type client: :class:`google.cloud.bigquery.client.Client`
         :param client: Client which holds credentials and project
                        configuration for the dataset.
 
-        :rtype: :class:`google.cloud.bigquery.CopyJob`
+        :rtype: :class:`google.cloud.bigquery.job.CopyJob`
         :returns: Job parsed from ``resource``.
         """
         job_id, config_resource = cls._get_resource_config(resource)
@@ -1120,7 +1120,7 @@ class ExtractJobConfig(object):
             An extract job configuration in the same representation as is
             returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.ExtractJobConfig`
+        :rtype: :class:`google.cloud.bigquery.job.ExtractJobConfig`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -1142,11 +1142,11 @@ class ExtractJob(_AsyncJob):
         URIs describing where the extracted data will be written in Cloud
         Storage, using the format ``gs://<bucket_name>/<object_name_or_glob>``.
 
-    :type client: :class:`google.cloud.bigquery.Client`
+    :type client: :class:`google.cloud.bigquery.client.Client`
     :param client:
         A client which holds credentials and project configuration.
 
-    :type job_config: :class:`~google.cloud.bigquery.ExtractJobConfig`
+    :type job_config: :class:`~google.cloud.bigquery.job.ExtractJobConfig`
     :param job_config:
         (Optional) Extra configuration options for the extract job.
     """
@@ -1166,28 +1166,28 @@ class ExtractJob(_AsyncJob):
     @property
     def compression(self):
         """See
-        :class:`~google.cloud.bigquery.ExtractJobConfig.compression`.
+        :attr:`google.cloud.bigquery.job.ExtractJobConfig.compression`.
         """
         return self._configuration.compression
 
     @property
     def destination_format(self):
         """See
-        :class:`~google.cloud.bigquery.ExtractJobConfig.destination_format`.
+        :attr:`google.cloud.bigquery.job.ExtractJobConfig.destination_format`.
         """
         return self._configuration.destination_format
 
     @property
     def field_delimiter(self):
         """See
-        :class:`~google.cloud.bigquery.ExtractJobConfig.field_delimiter`.
+        :attr:`google.cloud.bigquery.job.ExtractJobConfig.field_delimiter`.
         """
         return self._configuration.field_delimiter
 
     @property
     def print_header(self):
         """See
-        :class:`~google.cloud.bigquery.ExtractJobConfig.print_header`.
+        :attr:`google.cloud.bigquery.job.ExtractJobConfig.print_header`.
         """
         return self._configuration.print_header
 
@@ -1248,11 +1248,11 @@ class ExtractJob(_AsyncJob):
         :type resource: dict
         :param resource: dataset job representation returned from the API
 
-        :type client: :class:`google.cloud.bigquery.Client`
+        :type client: :class:`google.cloud.bigquery.client.Client`
         :param client: Client which holds credentials and project
                        configuration for the dataset.
 
-        :rtype: :class:`google.cloud.bigquery.ExtractJob`
+        :rtype: :class:`google.cloud.bigquery.job.ExtractJob`
         :returns: Job parsed from ``resource``.
         """
         job_id, config_resource = cls._get_resource_config(resource)
@@ -1353,7 +1353,7 @@ class QueryJobConfig(object):
             An extract job configuration in the same representation as is
             returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.ExtractJobConfig`
+        :rtype: :class:`google.cloud.bigquery.job.QueryJobConfig`
         :returns: Configuration parsed from ``resource``.
         """
         config = cls()
@@ -1369,7 +1369,9 @@ class QueryJobConfig(object):
 
     allow_large_results = _TypedApiResourceProperty(
         'allow_large_results', 'allowLargeResults', bool)
-    """See
+    """bool: Allow large query results tables (legacy SQL, only)
+
+    See
     https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.allowLargeResults
     """
 
@@ -1387,12 +1389,18 @@ class QueryJobConfig(object):
 
     destination = _TypedApiResourceProperty(
         'destination', 'destinationTable', TableReference)
-    """See
+    """
+    google.cloud.bigquery.table.TableReference: table where results are written
+
+    See
     https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationTable
     """
 
     dry_run = _TypedApiResourceProperty('dry_run', 'dryRun', bool)
-    """See
+    """
+    bool: ``True`` if this query should be a dry run to estimate costs.
+
+    See
     https://g.co/cloud/bigquery/docs/reference/v2/jobs#configuration.dryRun
     """
 
@@ -1497,11 +1505,11 @@ class QueryJob(_AsyncJob):
     :type query: str
     :param query: SQL query string
 
-    :type client: :class:`google.cloud.bigquery.Client`
+    :type client: :class:`google.cloud.bigquery.client.Client`
     :param client: A client which holds credentials and project configuration
                    for the dataset (which requires a project).
 
-    :type job_config: :class:`~google.cloud.bigquery.QueryJobConfig`
+    :type job_config: :class:`~google.cloud.bigquery.job.QueryJobConfig`
     :param job_config:
         (Optional) Extra configuration options for the query job.
     """
@@ -1524,105 +1532,105 @@ class QueryJob(_AsyncJob):
     @property
     def allow_large_results(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.allow_large_results`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.allow_large_results`.
         """
         return self._configuration.allow_large_results
 
     @property
     def create_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.create_disposition`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.create_disposition`.
         """
         return self._configuration.create_disposition
 
     @property
     def default_dataset(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.default_dataset`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.default_dataset`.
         """
         return self._configuration.default_dataset
 
     @property
     def destination(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.destination`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.destination`.
         """
         return self._configuration.destination
 
     @property
     def dry_run(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.dry_run`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.dry_run`.
         """
         return self._configuration.dry_run
 
     @property
     def flatten_results(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.flatten_results`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.flatten_results`.
         """
         return self._configuration.flatten_results
 
     @property
     def priority(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.priority`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.priority`.
         """
         return self._configuration.priority
 
     @property
     def query_parameters(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.query_parameters`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.query_parameters`.
         """
         return self._configuration.query_parameters
 
     @property
     def udf_resources(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.udf_resources`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.udf_resources`.
         """
         return self._configuration.udf_resources
 
     @property
     def use_legacy_sql(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.use_legacy_sql`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.use_legacy_sql`.
         """
         return self._configuration.use_legacy_sql
 
     @property
     def use_query_cache(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.use_query_cache`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.use_query_cache`.
         """
         return self._configuration.use_query_cache
 
     @property
     def write_disposition(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.write_disposition`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.write_disposition`.
         """
         return self._configuration.write_disposition
 
     @property
     def maximum_billing_tier(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.maximum_billing_tier`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.maximum_billing_tier`.
         """
         return self._configuration.maximum_billing_tier
 
     @property
     def maximum_bytes_billed(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.maximum_bytes_billed`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.maximum_bytes_billed`.
         """
         return self._configuration.maximum_bytes_billed
 
     @property
     def table_definitions(self):
         """See
-        :class:`~google.cloud.bigquery.QueryJobConfig.table_definitions`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.table_definitions`.
         """
         return self._configuration.table_definitions
 
@@ -1683,11 +1691,11 @@ class QueryJob(_AsyncJob):
         :type resource: dict
         :param resource: dataset job representation returned from the API
 
-        :type client: :class:`google.cloud.bigquery.Client`
+        :type client: :class:`google.cloud.bigquery.client.Client`
         :param client: Client which holds credentials and project
                        configuration for the dataset.
 
-        :rtype: :class:`google.cloud.bigquery.RunAsyncQueryJob`
+        :rtype: :class:`google.cloud.bigquery.job.QueryJob`
         :returns: Job parsed from ``resource``.
         """
         job_id, config = cls._get_resource_config(resource)

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -60,7 +60,7 @@ class _AbstractQueryParameter(object):
         :type resource: dict
         :param resource: JSON mapping of parameter
 
-        :rtype: :class:`~google.cloud.bigquery.ScalarQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.query.ScalarQueryParameter`
         """
         raise NotImplementedError
 
@@ -105,7 +105,7 @@ class ScalarQueryParameter(_AbstractQueryParameter):
                      :class:`datetime.date`.
         :param value: the scalar parameter value.
 
-        :rtype: :class:`~google.cloud.bigquery.ScalarQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.query.ScalarQueryParameter`
         :returns: instance without name
         """
         return cls(None, type_, value)
@@ -117,7 +117,7 @@ class ScalarQueryParameter(_AbstractQueryParameter):
         :type resource: dict
         :param resource: JSON mapping of parameter
 
-        :rtype: :class:`~google.cloud.bigquery.ScalarQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.query.ScalarQueryParameter`
         :returns: instance
         """
         name = resource.get('name')
@@ -155,7 +155,7 @@ class ScalarQueryParameter(_AbstractQueryParameter):
 
         Returns:
             tuple: The contents of this
-                   :class:`~google.cloud.bigquery.ScalarQueryParameter`.
+                   :class:`~google.cloud.bigquery.query.ScalarQueryParameter`.
         """
         return (
             self.name,
@@ -207,7 +207,7 @@ class ArrayQueryParameter(_AbstractQueryParameter):
         :type values: list of appropriate scalar type
         :param values: the parameter array values.
 
-        :rtype: :class:`~google.cloud.bigquery.ArrayQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.query.ArrayQueryParameter`
         :returns: instance without name
         """
         return cls(None, array_type, values)
@@ -250,7 +250,7 @@ class ArrayQueryParameter(_AbstractQueryParameter):
         :type resource: dict
         :param resource: JSON mapping of parameter
 
-        :rtype: :class:`~google.cloud.bigquery.ArrayQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.query.ArrayQueryParameter`
         :returns: instance
         """
         array_type = resource['parameterType']['arrayType']['type']
@@ -295,7 +295,7 @@ class ArrayQueryParameter(_AbstractQueryParameter):
 
         Returns:
             tuple: The contents of this
-                   :class:`~google.cloud.bigquery.ArrayQueryParameter`.
+                   :class:`~google.cloud.bigquery.query.ArrayQueryParameter`.
         """
         return (
             self.name,
@@ -323,9 +323,9 @@ class StructQueryParameter(_AbstractQueryParameter):
                  parameter can only be addressed via position (``?``).
 
     :type sub_params:
-        tuple of :class:`~google.cloud.bigquery.ScalarQueryParameter`,
-        :class:`~google.cloud.bigquery.ArrayQueryParameter`, or
-        :class:`~google.cloud.bigquery.StructQueryParameter`
+        tuple of :class:`~google.cloud.bigquery.query.ScalarQueryParameter`,
+        :class:`~google.cloud.bigquery.query.ArrayQueryParameter`, or
+        :class:`~google.cloud.bigquery.query.StructQueryParameter`
     :param sub_params: the sub-parameters for the struct
     """
     def __init__(self, name, *sub_params):
@@ -348,12 +348,13 @@ class StructQueryParameter(_AbstractQueryParameter):
         """Factory for positional parameters.
 
         :type sub_params:
-            tuple of :class:`~google.cloud.bigquery.ScalarQueryParameter`,
-            :class:`~google.cloud.bigquery.ArrayQueryParameter`, or
-            :class:`~google.cloud.bigquery.StructQueryParameter`
+            tuple of
+            :class:`~google.cloud.bigquery.query.ScalarQueryParameter`,
+            :class:`~google.cloud.bigquery.query.ArrayQueryParameter`, or
+            :class:`~google.cloud.bigquery.query.StructQueryParameter`
         :param sub_params: the sub-parameters for the struct
 
-        :rtype: :class:`~google.cloud.bigquery.StructQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.query.StructQueryParameter`
         :returns: instance without name
         """
         return cls(None, *sub_params)
@@ -365,7 +366,7 @@ class StructQueryParameter(_AbstractQueryParameter):
         :type resource: dict
         :param resource: JSON mapping of parameter
 
-        :rtype: :class:`~google.cloud.bigquery.StructQueryParameter`
+        :rtype: :class:`~google.cloud.bigquery.query.StructQueryParameter`
         :returns: instance
         """
         name = resource.get('name')

--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -32,7 +32,7 @@ class SchemaField(object):
     :type description: str
     :param description: optional description for the field.
 
-    :type fields: tuple of :class:`~google.cloud.bigquery.SchemaField`
+    :type fields: tuple of :class:`~google.cloud.bigquery.schema.SchemaField`
     :param fields: subfields (requires ``field_type`` of 'RECORD').
     """
     def __init__(self, name, field_type, mode='NULLABLE',
@@ -53,7 +53,8 @@ class SchemaField(object):
                 :meth:`to_api_repr`.
 
         Returns:
-            SchemaField: The ``SchemaField`` object.
+            google.cloud.biquery.schema.SchemaField:
+                The ``SchemaField`` object.
         """
         return cls(
             field_type=api_repr['type'].upper(),
@@ -131,7 +132,8 @@ class SchemaField(object):
         Used to compute this instance's hashcode and evaluate equality.
 
         Returns:
-            tuple: The contents of this :class:`SchemaField`.
+            tuple: The contents of this
+                   :class:`~google.cloud.bigquery.schema.SchemaField`.
         """
         return (
             self._name,
@@ -162,7 +164,9 @@ def _parse_schema_resource(info):
     :type info: mapping
     :param info: should contain a "fields" key to be parsed
 
-    :rtype: list of :class:`SchemaField`, or ``NoneType``
+    :rtype:
+        list of :class:`google.cloud.bigquery.schema.SchemaField`, or
+        ``NoneType``
     :returns: a list of parsed fields, or ``None`` if no "fields" key is
                 present in ``info``.
     """
@@ -184,7 +188,8 @@ def _parse_schema_resource(info):
 def _build_schema_resource(fields):
     """Generate a resource fragment for a schema.
 
-    :type fields: sequence of :class:`SchemaField`
+    :type fields:
+        sequence of :class:`~google.cloud.bigquery.schema.SchemaField`
     :param fields: schema to be dumped
 
     :rtype: mapping

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -95,7 +95,7 @@ class TableReference(object):
         :type resource: dict
         :param resource: table reference representation returned from the API
 
-        :rtype: :class:`google.cloud.bigquery.TableReference`
+        :rtype: :class:`google.cloud.bigquery.table.TableReference`
         :returns: Table reference parsed from ``resource``.
         """
         from google.cloud.bigquery.dataset import DatasetReference
@@ -152,10 +152,10 @@ class Table(object):
     See
     https://cloud.google.com/bigquery/docs/reference/rest/v2/tables
 
-    :type table_ref: :class:`google.cloud.bigquery.TableReference`
+    :type table_ref: :class:`google.cloud.bigquery.table.TableReference`
     :param table_ref: a pointer to a table
 
-    :type schema: list of :class:`~google.cloud.bigquery.SchemaField`
+    :type schema: list of :class:`~google.cloud.bigquery.schema.SchemaField`
     :param schema: The table's schema
     """
 
@@ -217,7 +217,7 @@ class Table(object):
     def schema(self):
         """Table's schema.
 
-        :rtype: list of :class:`~google.cloud.bigquery.SchemaField`
+        :rtype: list of :class:`~google.cloud.bigquery.schema.SchemaField`
         :returns: fields describing the schema
         """
         return list(self._schema)
@@ -226,7 +226,7 @@ class Table(object):
     def schema(self, value):
         """Update table's schema
 
-        :type value: list of :class:`~google.cloud.bigquery.SchemaField`
+        :type value: list of :class:`~google.cloud.bigquery.schema.SchemaField`
         :param value: fields describing the schema
 
         :raises: TypeError if 'value' is not a sequence, or ValueError if
@@ -611,7 +611,7 @@ class Table(object):
         :type dataset: :class:`google.cloud.bigquery.Dataset`
         :param dataset: The dataset containing the table.
 
-        :rtype: :class:`google.cloud.bigquery.Table`
+        :rtype: :class:`google.cloud.bigquery.table.Table`
         :returns: Table parsed from ``resource``.
         """
         from google.cloud.bigquery import dataset
@@ -720,7 +720,7 @@ def _row_from_mapping(mapping, schema):
            required fields in the schema.  Keys which do not correspond
            to a field in the schema are ignored.
 
-    :type schema: list of :class:`~google.cloud.bigquery.SchemaField`
+    :type schema: list of :class:`~google.cloud.bigquery.schema.SchemaField`
     :param schema: The schema of the table destination for the rows
 
     :rtype: tuple

--- a/docs/bigquery/reference.rst
+++ b/docs/bigquery/reference.rst
@@ -2,5 +2,28 @@ API Reference
 ~~~~~~~~~~~~~
 
 .. automodule:: google.cloud.bigquery
+  :no-members:
+
+.. automodule:: google.cloud.bigquery.client
+  :members:
+  :show-inheritance:
+
+.. automodule:: google.cloud.bigquery.job
+  :members:
+  :show-inheritance:
+
+.. automodule:: google.cloud.bigquery.dataset
+  :members:
+  :show-inheritance:
+
+.. automodule:: google.cloud.bigquery.table
+  :members:
+  :show-inheritance:
+
+.. automodule:: google.cloud.bigquery.schema
+  :members:
+  :show-inheritance:
+
+.. automodule:: google.cloud.bigquery.external_config
   :members:
   :show-inheritance:


### PR DESCRIPTION
Basically a revert of https://github.com/GoogleCloudPlatform/google-cloud-python/pull/4236.

The reason is that I did not see references to any of the properties on QueryJobConfig such as https://github.com/GoogleCloudPlatform/google-cloud-python/blob/09cf23a0f83baaaea95cd98c260ab7c2f8e4f699/bigquery/google/cloud/bigquery/job.py#L1386 in the docs I built with `nox -s docs`. I tried a few thing to get them to render, but with no success.

Per http://www.sphinx-doc.org/en/stable/ext/autodoc.html

> Note that attributes from imported modules will not be documented, because attribute documentation is discovered by parsing the source file of the current module.

So, we can't use imported modules from the `google.cloud.bigquery` package and also show the attribute docs. This change allows Sphinx to find the source files for documenting
properties/attributes.
