### PR TITLE
Retry for 'mutate_rows' that return retryable errors.

### DIFF
--- a/api_core/google/api_core/retry.py
+++ b/api_core/google/api_core/retry.py
@@ -56,6 +56,7 @@ a ``retry`` parameter that allows you to configure the behavior:
 
 from __future__ import unicode_literals
 
+import collections
 import datetime
 import functools
 import logging
@@ -199,6 +200,34 @@ def retry_target(target, predicate, sleep_generator, deadline, on_error=None):
         time.sleep(sleep)
 
     raise ValueError('Sleep generator stopped yielding sleep values.')
+
+
+class RetryOptions(
+        collections.namedtuple(
+            'RetryOptions',
+            ['initial',
+             'maximum',
+             'multiplier',
+             'deadline'])):
+    # pylint: disable=too-few-public-methods
+
+    def __new__(cls,
+                initial=_DEFAULT_INITIAL_DELAY,
+                maximum=_DEFAULT_MAXIMUM_DELAY,
+                multiplier=_DEFAULT_DELAY_MULTIPLIER,
+                deadline=_DEFAULT_DEADLINE):
+        assert isinstance(initial, float), 'should be a float'
+        assert isinstance(maximum, float), 'should be a float'
+        assert isinstance(multiplier, float), 'should be a float'
+        assert isinstance(deadline, float), 'should be a float'
+        assert initial <= maximum and initial <= deadline
+
+        return super(cls, RetryOptions).__new__(
+                cls,
+                initial,
+                maximum,
+                multiplier,
+                deadline)
 
 
 @six.python_2_unicode_compatible

--- a/api_core/google/api_core/retry.py
+++ b/api_core/google/api_core/retry.py
@@ -56,7 +56,6 @@ a ``retry`` parameter that allows you to configure the behavior:
 
 from __future__ import unicode_literals
 
-import collections
 import datetime
 import functools
 import logging
@@ -200,34 +199,6 @@ def retry_target(target, predicate, sleep_generator, deadline, on_error=None):
         time.sleep(sleep)
 
     raise ValueError('Sleep generator stopped yielding sleep values.')
-
-
-class RetryOptions(
-        collections.namedtuple(
-            'RetryOptions',
-            ['initial',
-             'maximum',
-             'multiplier',
-             'deadline'])):
-    # pylint: disable=too-few-public-methods
-
-    def __new__(cls,
-                initial=_DEFAULT_INITIAL_DELAY,
-                maximum=_DEFAULT_MAXIMUM_DELAY,
-                multiplier=_DEFAULT_DELAY_MULTIPLIER,
-                deadline=_DEFAULT_DEADLINE):
-        assert isinstance(initial, float), 'should be a float'
-        assert isinstance(maximum, float), 'should be a float'
-        assert isinstance(multiplier, float), 'should be a float'
-        assert isinstance(deadline, float), 'should be a float'
-        assert initial <= maximum and initial <= deadline
-
-        return super(cls, RetryOptions).__new__(
-                cls,
-                initial,
-                maximum,
-                multiplier,
-                deadline)
 
 
 @six.python_2_unicode_compatible

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -450,15 +450,19 @@ class _RetryableMutateRowsWorker(object):
         responses = self.client._data_stub.MutateRows(
             mutate_rows_request)
 
+        num_responses = 0
         num_retryable_responses = 0
         for response in responses:
             for entry in response.entries:
+                num_responses += 1
                 index = index_into_all_rows[entry.index]
                 self.responses_statuses[index] = entry.status
                 if self._is_retryable(entry.status):
                     num_retryable_responses += 1
                 if entry.status.code == 0:
                     self.rows[index].clear()
+
+        assert len(retryable_rows) == num_responses
 
         if num_retryable_responses:
             raise from_grpc_status(StatusCode.UNAVAILABLE,

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -39,7 +39,7 @@ from grpc import StatusCode
 # https://cloud.google.com/bigtable/docs/reference/data/rpc/google.bigtable.v2#google.bigtable.v2.MutateRowRequest
 _MAX_BULK_MUTATIONS = 100000
 
-_MILLIS_PER_SECOND = 1000
+_MILLIS_PER_SECOND = 1000.0
 
 
 class TableMismatchError(ValueError):

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -17,13 +17,13 @@
 
 import six
 
-from google.api.core.exceptions import RetryError
-from google.api.core.exceptions import Aborted
-from google.api.core.exceptions import DeadlineExceeded
-from google.api.core.exceptions import ServiceUnavailable
-from google.api.core.exceptions import from_grpc_status
-from google.api.core.retry import Retry
-from google.api.core.retry import if_exception_type
+from google.api_core.exceptions import RetryError
+from google.api_core.exceptions import Aborted
+from google.api_core.exceptions import DeadlineExceeded
+from google.api_core.exceptions import ServiceUnavailable
+from google.api_core.exceptions import from_grpc_status
+from google.api_core.retry import Retry
+from google.api_core.retry import if_exception_type
 from google.cloud._helpers import _to_bytes
 from google.cloud.bigtable._generated import (
     bigtable_pb2 as data_messages_v2_pb2)
@@ -326,7 +326,7 @@ class Table(object):
         :type rows: list
         :param rows: List or other iterable of :class:`.DirectRow` instances.
 
-        :type retry: :class:`~google.api.core.retry.Retry`
+        :type retry: :class:`~google.api_core.retry.Retry`
         :param retry: (Optional) Retry delay and deadline arguments. Can be
                       specified using ``DEFAULT_RETRY.with_delay`` and/or
                       ``DEFAULT_RETRY.with_deadline``.
@@ -430,7 +430,7 @@ class _RetryableMutateRowsWorker(object):
 
         :rtype: list
         :return: ``responses_statuses`` (`google.rpc.status_pb2.Status`)
-        :raises: :exc:`~google.api.core.exceptions.ServiceUnavailable` if any
+        :raises: :exc:`~google.api_core.exceptions.ServiceUnavailable` if any
                  row returned a transient error. An artificial exception
                  to work with ``DEFAULT_RETRY``.
         """

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -378,9 +378,9 @@ class Table(object):
 class _MutateRowsRetryableError(Exception):
     """A retryable error in Mutate Rows response."""
 
-    def __init__(self, retryable_responses):
+    def __init__(self, retryable_responses=None):
         super(_MutateRowsRetryableError, self).__init__()
-        self.retryable_responses = retryable_responses
+        self.retryable_responses = retryable_responses or []
 
 
 class _RetryableMutateRowsWorker(object):

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -409,7 +409,7 @@ class _RetryableMutateRowsWorker(object):
             if self._is_retryable(status):
                 return i
             i += 1
-        return i
+        return -1
 
     def _do_mutate_retryable_rows(self):
         retryable_rows = []

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -623,23 +623,6 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         response = [Status(code=code) for code in codes]
         return response
 
-    def test_next_retryable_row_index_empty_rows(self):
-        worker = self._make_worker(mock.MagicMock(), mock.MagicMock(), [])
-        worker.responses_statuses = self._make_responses_statuses([])
-        self.assertEqual(worker._next_retryable_row_index(0), -1)
-        self.assertEqual(worker._next_retryable_row_index(1), -1)
-
-    def test_next_retryable_row_index(self):
-        worker = self._make_worker(mock.MagicMock(), mock.MagicMock(), [])
-        worker.responses_statuses = self._make_responses_statuses(
-                [4, 10, 14, 0, 4, 1])
-        self.assertEqual(worker._next_retryable_row_index(0), 0)
-        self.assertEqual(worker._next_retryable_row_index(1), 1)
-        self.assertEqual(worker._next_retryable_row_index(2), 2)
-        self.assertEqual(worker._next_retryable_row_index(3), 4)
-        self.assertEqual(worker._next_retryable_row_index(4), 4)
-        self.assertEqual(worker._next_retryable_row_index(5), -1)
-
     def test_callable_empty_rows(self):
         client = _Client()
         instance = _Instance(self.INSTANCE_NAME, client=client)
@@ -736,7 +719,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
                     status=Status(code=4),
                 ),
                 MutateRowsResponse.Entry(
-                    index=1,
+                    index=2,
                     status=Status(code=1),
                 ),
             ],
@@ -793,7 +776,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
                     status=Status(code=1),
                 ),
                 MutateRowsResponse.Entry(
-                    index=0,
+                    index=1,
                     status=Status(code=0),
                 ),
             ],

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -591,7 +591,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(len(statuses), 0)
 
     def test_callable_retry(self):
-        from google.api.core.retry import Retry
+        from google.api_core.retry import Retry
         from google.cloud.bigtable._generated.bigtable_pb2 import (
             MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
@@ -662,7 +662,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_callable_retry_timeout(self):
-        from google.api.core.retry import Retry
+        from google.api_core.retry import Retry
         from google.cloud.bigtable._generated.bigtable_pb2 import (
             MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
@@ -675,7 +675,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         #   - Initial attempt will mutate all 2 rows.
         # Expectation:
         #   - Both rows always return retryable errors.
-        #   - google.api.core.Retry should keep retrying.
+        #   - google.api_core.Retry should keep retrying.
         #   - Check MutateRows is called multiple times.
         #   - By the time deadline is reached, statuses should be
         #       [retryable, retryable]
@@ -776,7 +776,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_do_mutate_retryable_rows_retry(self):
-        from google.api.core.exceptions import ServiceUnavailable
+        from google.api_core.exceptions import ServiceUnavailable
         from google.cloud.bigtable._generated.bigtable_pb2 import (
             MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
@@ -836,7 +836,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_do_mutate_retryable_rows_second_retry(self):
-        from google.api.core.exceptions import ServiceUnavailable
+        from google.api_core.exceptions import ServiceUnavailable
         from google.cloud.bigtable._generated.bigtable_pb2 import (
             MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -478,7 +478,7 @@ class TestTable(unittest.TestCase):
 
         response = [Status(code=0), Status(code=1)]
 
-        mock_worker = mock.Mock(side_effect=[_MutateRowsRetryableError([]), response])
+        mock_worker = mock.Mock(side_effect=[_MutateRowsRetryableError, response])
         with mock.patch(
                 'google.cloud.bigtable.table._RetryableMutateRowsWorker',
                 new=mock.MagicMock(return_value=mock_worker)):
@@ -498,7 +498,7 @@ class TestTable(unittest.TestCase):
         response = [Status(code=0), Status(code=4)]
 
         mock_worker = mock.Mock(
-                side_effect=[_MutateRowsRetryableError([]), _MutateRowsRetryableError([])],
+                side_effect=[_MutateRowsRetryableError, _MutateRowsRetryableError],
                 responses_statuses=response)
         # total_timeout_millis = 5 * 60 * 1000
         mock_time = mock.Mock(side_effect=[0, 2000, 5 * 60 * 1000])


### PR DESCRIPTION
Trying a new PR in place of (https://github.com/GoogleCloudPlatform/google-cloud-python/pull/4116). 

Reason: A mistake was made in `git rebase` commits that are already pushed to remote, where a `git merge` should have been done. 