### PR TITLE
Honor max_messages always.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/publisher/batch/base.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/batch/base.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 
 import abc
-import enum
 
 import six
 

--- a/pubsub/google/cloud/pubsub_v1/publisher/batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/batch/thread.py
@@ -63,6 +63,7 @@ class Batch(base.Batch):
 
         # These objects are all communicated between threads; ensure that
         # any writes to them are atomic.
+        # import pdb ; pdb.set_trace()
         self._futures = []
         self._messages = []
         self._size = 0
@@ -237,6 +238,8 @@ class Batch(base.Batch):
 
         # Store the actual message in the batch's message queue.
         self._messages.append(message)
+        if len(self._messages) >= self.settings.max_messages:
+            self.commit()
 
         # Return a Future. That future needs to be aware of the status
         # of this batch.

--- a/pubsub/google/cloud/pubsub_v1/publisher/batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/batch/thread.py
@@ -63,7 +63,6 @@ class Batch(base.Batch):
 
         # These objects are all communicated between threads; ensure that
         # any writes to them are atomic.
-        # import pdb ; pdb.set_trace()
         self._futures = []
         self._messages = []
         self._size = 0


### PR DESCRIPTION
Fixes a bug where `max_messages` is not honored when autocommit is on.