### PR TITLE
Add futures for subscriptions.

### DIFF
--- a/docs/pubsub/index.rst
+++ b/docs/pubsub/index.rst
@@ -100,7 +100,14 @@ use of a callback.
     >>> def callback(message):
     ...     print(message.data)
     ...     message.ack()
-    >>> subscription.open(callback)
+    >>> future = subscription.open(callback)
+
+You can use the future to block the main thread, and raise any exceptions
+that originate asychronously.
+
+.. code-block:: python
+
+    >>> future.result()
 
 To learn more, consult the :doc:`subscriber documentation <subscriber/index>`.
 

--- a/docs/pubsub/subscriber/index.rst
+++ b/docs/pubsub/subscriber/index.rst
@@ -91,7 +91,30 @@ Here is an example:
         message.ack()
 
     # Open the subscription, passing the callback.
-    subscription.open(callback)
+    future = subscription.open(callback)
+
+The :meth:`~.pubsub_v1.subscriber.policy.thread.Policy.open` method returns
+a :class:`~.pubsub_v1.subscriber.futures.Future`, which is both the interface
+to wait on messages (e.g. block the primary thread) and to address exceptions.
+
+To block the thread you are in while messages are coming in the stream,
+use the :meth:`~.pubsub_v1.subscriber.futures.Future.result` method:
+
+.. code-block:: python
+
+    future.result()
+
+You can also use this for error handling; any exceptions that crop up on a
+thread will be set on the future.
+
+.. code-block:: python
+
+    try:
+        future.result()
+    except Exception as ex:
+        subscription.close()
+        raise
+
 
 Explaining Ack
 --------------

--- a/pubsub/google/cloud/pubsub_v1/exceptions.py
+++ b/pubsub/google/cloud/pubsub_v1/exceptions.py
@@ -14,15 +14,9 @@
 
 from __future__ import absolute_import
 
-from google.api_core.exceptions import GoogleAPICallError
-from google.cloud.pubsub_v1.exceptions import TimeoutError
-
-
-class PublishError(GoogleAPICallError):
-    pass
+from concurrent.futures import TimeoutError
 
 
 __all__ = (
-    'PublishError',
     'TimeoutError',
 )

--- a/pubsub/google/cloud/pubsub_v1/futures.py
+++ b/pubsub/google/cloud/pubsub_v1/futures.py
@@ -1,0 +1,176 @@
+# Copyright 2017, Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import threading
+
+import google.api_core.future
+from google.cloud.pubsub_v1.publisher import exceptions
+
+
+class Future(google.api_core.future.Future):
+    """Encapsulation of the asynchronous execution of an action.
+
+    This object is returned from asychronous Pub/Sub calls, and is the
+    interface to determine the status of those calls.
+
+    This object should not be created directly, but is returned by other
+    methods in this library.
+    """
+    _SENTINEL = object()
+
+    def __init__(self):
+        self._result = self._SENTINEL
+        self._exception = self._SENTINEL
+        self._callbacks = []
+        self._completed = threading.Event()
+
+    def cancel(self):
+        """Actions in Pub/Sub generally may not be canceled.
+
+        This method always returns False.
+        """
+        return False
+
+    def cancelled(self):
+        """Actions in Pub/Sub generally may not be canceled.
+
+        This method always returns False.
+        """
+        return False
+
+    def running(self):
+        """Actions in Pub/Sub generally may not be canceled.
+
+        Returns:
+            bool: ``True`` if this method has not yet completed, or
+                ``False`` if it has completed.
+        """
+        if self.done():
+            return False
+        return True
+
+    def done(self):
+        """Return True if the publish has completed, False otherwise.
+
+        This still returns True in failure cases; checking :meth:`result` or
+        :meth:`exception` is the canonical way to assess success or failure.
+        """
+        return (self._exception is not self._SENTINEL or
+                self._result is not self._SENTINEL)
+
+    def result(self, timeout=None):
+        """Return the message ID, or raise an exception.
+
+        This blocks until the message has successfully been published, and
+        returns the message ID.
+
+        Args:
+            timeout (Union[int, float]): The number of seconds before this call
+                times out and raises TimeoutError.
+
+        Returns:
+            str: The message ID.
+
+        Raises:
+            ~.pubsub_v1.TimeoutError: If the request times out.
+            Exception: For undefined exceptions in the underlying
+                call execution.
+        """
+        # Attempt to get the exception if there is one.
+        # If there is not one, then we know everything worked, and we can
+        # return an appropriate value.
+        err = self.exception(timeout=timeout)
+        if err is None:
+            return self._result
+        raise err
+
+    def exception(self, timeout=None, _wait=1):
+        """Return the exception raised by the call, if any.
+
+        This blocks until the message has successfully been published, and
+        returns the exception. If the call succeeded, return None.
+
+        Args:
+            timeout (Union[int, float]): The number of seconds before this call
+                times out and raises TimeoutError.
+
+        Raises:
+            TimeoutError: If the request times out.
+
+        Returns:
+            Exception: The exception raised by the call, if any.
+        """
+        # Wait until the future is done.
+        if not self._completed.wait(timeout=timeout):
+            raise exceptions.TimeoutError('Timed out waiting for result.')
+
+        # If the batch completed successfully, this should return None.
+        if self._result is not self._SENTINEL:
+            return None
+
+        # Okay, this batch had an error; this should return it.
+        return self._exception
+
+    def add_done_callback(self, fn):
+        """Attach the provided callable to the future.
+
+        The provided function is called, with this future as its only argument,
+        when the future finishes running.
+        """
+        if self.done():
+            fn(self)
+        self._callbacks.append(fn)
+
+    def set_result(self, result):
+        """Set the result of the future to the provided result.
+
+        Args:
+            result (str): The message ID.
+        """
+        # Sanity check: A future can only complete once.
+        if self.done():
+            raise RuntimeError('set_result can only be called once.')
+
+        # Set the result and trigger the future.
+        self._result = result
+        self._trigger()
+
+    def set_exception(self, exception):
+        """Set the result of the future to the given exception.
+
+        Args:
+            exception (:exc:`Exception`): The exception raised.
+        """
+        # Sanity check: A future can only complete once.
+        if self.done():
+            raise RuntimeError('set_exception can only be called once.')
+
+        # Set the exception and trigger the future.
+        self._exception = exception
+        self._trigger()
+
+    def _trigger(self):
+        """Trigger all callbacks registered to this Future.
+
+        This method is called internally by the batch once the batch
+        completes.
+
+        Args:
+            message_id (str): The message ID, as a string.
+        """
+        self._completed.set()
+        for callback in self._callbacks:
+            callback(self)

--- a/pubsub/google/cloud/pubsub_v1/futures.py
+++ b/pubsub/google/cloud/pubsub_v1/futures.py
@@ -63,7 +63,7 @@ class Future(google.api_core.future.Future):
         return True
 
     def done(self):
-        """Return True if the publish has completed, False otherwise.
+        """Return True the future is done, False otherwise.
 
         This still returns True in failure cases; checking :meth:`result` or
         :meth:`exception` is the canonical way to assess success or failure.
@@ -131,14 +131,14 @@ class Future(google.api_core.future.Future):
         when the future finishes running.
         """
         if self.done():
-            fn(self)
+            return fn(self)
         self._callbacks.append(fn)
 
     def set_result(self, result):
         """Set the result of the future to the provided result.
 
         Args:
-            result (str): The message ID.
+            result (Any): The result
         """
         # Sanity check: A future can only complete once.
         if self.done():

--- a/pubsub/google/cloud/pubsub_v1/futures.py
+++ b/pubsub/google/cloud/pubsub_v1/futures.py
@@ -97,7 +97,7 @@ class Future(google.api_core.future.Future):
             return self._result
         raise err
 
-    def exception(self, timeout=None, _wait=1):
+    def exception(self, timeout=None):
         """Return the exception raised by the call, if any.
 
         This blocks until the message has successfully been published, and

--- a/pubsub/google/cloud/pubsub_v1/publisher/batch/base.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/batch/base.py
@@ -128,7 +128,7 @@ class Batch(object):
             message (~.pubsub_v1.types.PubsubMessage): The Pub/Sub message.
 
         Returns:
-            ~.pubsub_v1.publisher.batch.mp.Future: An object conforming to the
+            ~google.api_core.future.Future: An object conforming to the
                 :class:`concurrent.futures.Future` interface.
         """
         raise NotImplementedError

--- a/pubsub/google/cloud/pubsub_v1/publisher/batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/batch/thread.py
@@ -63,6 +63,7 @@ class Batch(base.Batch):
 
         # These objects are all communicated between threads; ensure that
         # any writes to them are atomic.
+        # import pdb ; pdb.set_trace()
         self._futures = []
         self._messages = []
         self._size = 0

--- a/pubsub/google/cloud/pubsub_v1/publisher/batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/batch/thread.py
@@ -63,7 +63,6 @@ class Batch(base.Batch):
 
         # These objects are all communicated between threads; ensure that
         # any writes to them are atomic.
-        # import pdb ; pdb.set_trace()
         self._futures = []
         self._messages = []
         self._size = 0

--- a/pubsub/google/cloud/pubsub_v1/publisher/batch/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/batch/thread.py
@@ -224,7 +224,7 @@ class Batch(base.Batch):
             message (~.pubsub_v1.types.PubsubMessage): The Pub/Sub message.
 
         Returns:
-            ~.pubsub_v1.publisher.futures.Future: An object conforming to
+            ~google.api_core.future.Future: An object conforming to
                 the :class:`concurrent.futures.Future` interface.
         """
         # Coerce the type, just in case.

--- a/pubsub/google/cloud/pubsub_v1/publisher/futures.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/futures.py
@@ -14,156 +14,27 @@
 
 from __future__ import absolute_import
 
-import threading
-
-import google.api_core.future
-from google.cloud.pubsub_v1.publisher import exceptions
+from google.cloud.pubsub_v1 import futures
 
 
-class Future(google.api_core.future.Future):
+class Future(futures.Future):
     """Encapsulation of the asynchronous execution of an action.
 
-    This object is returned from asychronous Pub/Sub calls, and is the
-    interface to determine the status of those calls.
+    This object is returned from asychronous Pub/Sub publishing calls, and is
+    the interface to determine the status of those calls.
 
     This object should not be created directly, but is returned by other
     methods in this library.
     """
-    def __init__(self):
-        self._callbacks = []
-        self._result = None
-        self._exception = None
-        self._completed = threading.Event()
+    # The publishing-side subclass does not need any special behavior
+    # at this time.
+    #
+    # However, there is still a subclass so that if someone attempts
+    # isinstance checks against a publisher-returned or subscriber-returned
+    # future, trying either one against the other returns False.
+    pass
 
-    def cancel(self):
-        """Publishes in Pub/Sub currently may not be canceled.
 
-        This method always returns False.
-        """
-        return False
-
-    def cancelled(self):
-        """Publishes in Pub/Sub currently may not be canceled.
-
-        This method always returns False.
-        """
-        return False
-
-    def running(self):
-        """Publishes in Pub/Sub currently may not be canceled.
-
-        This method always returns True.
-        """
-        return True
-
-    def done(self):
-        """Return True if the publish has completed, False otherwise.
-
-        This still returns True in failure cases; checking :meth:`result` or
-        :meth:`exception` is the canonical way to assess success or failure.
-        """
-        return self._exception is not None or self._result is not None
-
-    def result(self, timeout=None):
-        """Return the message ID, or raise an exception.
-
-        This blocks until the message has successfully been published, and
-        returns the message ID.
-
-        Args:
-            timeout (Union[int, float]): The number of seconds before this call
-                times out and raises TimeoutError.
-
-        Returns:
-            str: The message ID.
-
-        Raises:
-            ~.pubsub_v1.TimeoutError: If the request times out.
-            Exception: For undefined exceptions in the underlying
-                call execution.
-        """
-        # Attempt to get the exception if there is one.
-        # If there is not one, then we know everything worked, and we can
-        # return an appropriate value.
-        err = self.exception(timeout=timeout)
-        if err is None:
-            return self._result
-        raise err
-
-    def exception(self, timeout=None, _wait=1):
-        """Return the exception raised by the call, if any.
-
-        This blocks until the message has successfully been published, and
-        returns the exception. If the call succeeded, return None.
-
-        Args:
-            timeout (Union[int, float]): The number of seconds before this call
-                times out and raises TimeoutError.
-
-        Raises:
-            TimeoutError: If the request times out.
-
-        Returns:
-            Exception: The exception raised by the call, if any.
-        """
-        # Wait until the future is done.
-        if not self._completed.wait(timeout=timeout):
-            raise exceptions.TimeoutError('Timed out waiting for result.')
-
-        # If the batch completed successfully, this should return None.
-        if self._result is not None:
-            return None
-
-        # Okay, this batch had an error; this should return it.
-        return self._exception
-
-    def add_done_callback(self, fn):
-        """Attach the provided callable to the future.
-
-        The provided function is called, with this future as its only argument,
-        when the future finishes running.
-        """
-        if self.done():
-            fn(self)
-        self._callbacks.append(fn)
-
-    def set_result(self, result):
-        """Set the result of the future to the provided result.
-
-        Args:
-            result (str): The message ID.
-        """
-        # Sanity check: A future can only complete once.
-        if self._result is not None or self._exception is not None:
-            raise RuntimeError('set_result can only be called once.')
-
-        # Set the result and trigger the future.
-        self._result = result
-        self._trigger()
-
-    def set_exception(self, exception):
-        """Set the result of the future to the given exception.
-
-        Args:
-            exception (:exc:`Exception`): The exception raised.
-        """
-        # Sanity check: A future can only complete once.
-        if self._result is not None or self._exception is not None:
-            raise RuntimeError('set_exception can only be called once.')
-
-        # Set the exception and trigger the future.
-        self._exception = exception
-        self._trigger()
-
-    def _trigger(self):
-        """Trigger all callbacks registered to this Future.
-
-        This method is called internally by the batch once the batch
-        completes.
-
-        Args:
-            message_id (str): The message ID, as a string.
-        """
-        self._completed.set()
-        for callback in self._callbacks:
-            callback(self)
+__all__ = (
+    'Future',
+)

--- a/pubsub/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/futures.py
@@ -1,0 +1,192 @@
+# Copyright 2017, Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import threading
+
+import google.api_core.future
+from google.cloud.pubsub_v1.publisher import exceptions
+
+
+class Future(google.api_core.future.Future):
+    """Encapsulation of the asynchronous execution of an action.
+
+    This object is returned from opening a Pub/Sub subscription, and is the
+    interface to block on the subscription or query its status.
+
+    This object should not be created directly, but is returned by other
+    methods in this library.
+
+    Args:
+        policy (~.pubsub_v1.subscriber.policy.base.BasePolicy): The policy
+            that creates this Future.
+    """
+    _SENTINEL = object()
+
+    def __init__(self, policy):
+        self._policy = policy
+        self._result = self._SENTINEL
+        self._exception = self._SENTINEL
+        self._callbacks = []
+        self._completed = threading.Event()
+
+    def cancel(self):
+        """Subscriptions in Pub/Sub currently may not be canceled.
+
+        Use the :meth:`~.pubsub_v1.subscriber.policy.base.BasePolicy.close`
+        method to close a subscription.
+
+        This method always returns False.
+        """
+        return False
+
+    def cancelled(self):
+        """Subscriptions in Pub/Sub currently may not be canceled.
+
+        This method always returns False.
+        """
+        return False
+
+    def running(self):
+        """Return whether this subscription is opened with this Future.
+
+        .. note::
+
+            A ``False`` value here does not necessarily mean that the
+            subscription is closed; it merely means that _this_ future is
+            not the future applicable to it.
+
+            Since futures have a single result (or exception) and there is
+            not a concept of resetting them, a closing re-opening of a
+            subscription will therefore return a new future.
+
+        Returns:
+            bool: ``True`` if this subscription is opened with this future,
+                ``False`` otherwise.
+        """
+        return self._policy.future is self
+
+    def done(self):
+        """Return True if the publish has completed, False otherwise.
+
+        This still returns True in failure cases; checking :meth:`result` or
+        :meth:`exception` is the canonical way to assess success or failure.
+        """
+        return (self._exception is not self._SENTINEL or
+                self._result is not self._SENTINEL)
+
+    def result(self, timeout=None):
+        """Return the message ID, or raise an exception.
+
+        This blocks until the message has successfully been published, and
+        returns the message ID.
+
+        Args:
+            timeout (Union[int, float]): The number of seconds before this call
+                times out and raises TimeoutError.
+
+        Returns:
+            str: The message ID.
+
+        Raises:
+            ~.pubsub_v1.TimeoutError: If the request times out.
+            Exception: For undefined exceptions in the underlying
+                call execution.
+        """
+        # Attempt to get the exception if there is one.
+        # If there is not one, then we know everything worked, and we can
+        # return an appropriate value.
+        err = self.exception(timeout=timeout)
+        if err is self._SENTINEL:
+            return self._result
+        raise err
+
+    def exception(self, timeout=None, _wait=1):
+        """Return the exception raised by the call, if any.
+
+        This blocks until the message has successfully been published, and
+        returns the exception. If the call succeeded, return None.
+
+        Args:
+            timeout (Union[int, float]): The number of seconds before this call
+                times out and raises TimeoutError.
+
+        Raises:
+            TimeoutError: If the request times out.
+
+        Returns:
+            Exception: The exception raised by the call, if any.
+        """
+        # Wait until the future is done.
+        if not self._completed.wait(timeout=timeout):
+            raise exceptions.TimeoutError('Timed out waiting for result.')
+
+        # If the batch completed successfully, this should return None.
+        if self._result is not self._SENTINEL:
+            return None
+
+        # Okay, this batch had an error; this should return it.
+        return self._exception
+
+    def add_done_callback(self, fn):
+        """Attach the provided callable to the future.
+
+        The provided function is called, with this future as its only argument,
+        when the future finishes running.
+        """
+        if self.done():
+            fn(self)
+        self._callbacks.append(fn)
+
+    def set_result(self, result):
+        """Set the result of the future to the provided result.
+
+        Args:
+            result (str): The message ID.
+        """
+        # Sanity check: A future can only complete once.
+        if self.done():
+            raise RuntimeError('set_result can only be called once.')
+
+        # Set the result and trigger the future.
+        self._result = result
+        self._trigger()
+
+    def set_exception(self, exception):
+        """Set the result of the future to the given exception.
+
+        Args:
+            exception (:exc:`Exception`): The exception raised.
+        """
+        # Sanity check: A future can only complete once.
+        if self.done():
+            raise RuntimeError('set_exception can only be called once.')
+
+        # Set the exception and trigger the future.
+        self._exception = exception
+        self._trigger()
+
+    def _trigger(self):
+        """Trigger all callbacks registered to this Future.
+
+        This method is called internally by the batch once the batch
+        completes.
+
+        Args:
+            message_id (str): The message ID, as a string.
+        """
+        self._completed.set()
+        for callback in self._callbacks:
+            callback(self)

--- a/pubsub/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/futures.py
@@ -14,13 +14,10 @@
 
 from __future__ import absolute_import
 
-import threading
-
-import google.api_core.future
-from google.cloud.pubsub_v1.publisher import exceptions
+from google.cloud.pubsub_v1 import futures
 
 
-class Future(google.api_core.future.Future):
+class Future(futures.Future):
     """Encapsulation of the asynchronous execution of an action.
 
     This object is returned from opening a Pub/Sub subscription, and is the
@@ -33,31 +30,9 @@ class Future(google.api_core.future.Future):
         policy (~.pubsub_v1.subscriber.policy.base.BasePolicy): The policy
             that creates this Future.
     """
-    _SENTINEL = object()
-
     def __init__(self, policy):
         self._policy = policy
-        self._result = self._SENTINEL
-        self._exception = self._SENTINEL
-        self._callbacks = []
-        self._completed = threading.Event()
-
-    def cancel(self):
-        """Subscriptions in Pub/Sub currently may not be canceled.
-
-        Use the :meth:`~.pubsub_v1.subscriber.policy.base.BasePolicy.close`
-        method to close a subscription.
-
-        This method always returns False.
-        """
-        return False
-
-    def cancelled(self):
-        """Subscriptions in Pub/Sub currently may not be canceled.
-
-        This method always returns False.
-        """
-        return False
+        super(Future, self).__init__()
 
     def running(self):
         """Return whether this subscription is opened with this Future.
@@ -77,116 +52,3 @@ class Future(google.api_core.future.Future):
                 ``False`` otherwise.
         """
         return self._policy.future is self
-
-    def done(self):
-        """Return True if the publish has completed, False otherwise.
-
-        This still returns True in failure cases; checking :meth:`result` or
-        :meth:`exception` is the canonical way to assess success or failure.
-        """
-        return (self._exception is not self._SENTINEL or
-                self._result is not self._SENTINEL)
-
-    def result(self, timeout=None):
-        """Return the message ID, or raise an exception.
-
-        This blocks until the message has successfully been published, and
-        returns the message ID.
-
-        Args:
-            timeout (Union[int, float]): The number of seconds before this call
-                times out and raises TimeoutError.
-
-        Returns:
-            str: The message ID.
-
-        Raises:
-            ~.pubsub_v1.TimeoutError: If the request times out.
-            Exception: For undefined exceptions in the underlying
-                call execution.
-        """
-        # Attempt to get the exception if there is one.
-        # If there is not one, then we know everything worked, and we can
-        # return an appropriate value.
-        err = self.exception(timeout=timeout)
-        if err is self._SENTINEL:
-            return self._result
-        raise err
-
-    def exception(self, timeout=None, _wait=1):
-        """Return the exception raised by the call, if any.
-
-        This blocks until the message has successfully been published, and
-        returns the exception. If the call succeeded, return None.
-
-        Args:
-            timeout (Union[int, float]): The number of seconds before this call
-                times out and raises TimeoutError.
-
-        Raises:
-            TimeoutError: If the request times out.
-
-        Returns:
-            Exception: The exception raised by the call, if any.
-        """
-        # Wait until the future is done.
-        if not self._completed.wait(timeout=timeout):
-            raise exceptions.TimeoutError('Timed out waiting for result.')
-
-        # If the batch completed successfully, this should return None.
-        if self._result is not self._SENTINEL:
-            return None
-
-        # Okay, this batch had an error; this should return it.
-        return self._exception
-
-    def add_done_callback(self, fn):
-        """Attach the provided callable to the future.
-
-        The provided function is called, with this future as its only argument,
-        when the future finishes running.
-        """
-        if self.done():
-            fn(self)
-        self._callbacks.append(fn)
-
-    def set_result(self, result):
-        """Set the result of the future to the provided result.
-
-        Args:
-            result (str): The message ID.
-        """
-        # Sanity check: A future can only complete once.
-        if self.done():
-            raise RuntimeError('set_result can only be called once.')
-
-        # Set the result and trigger the future.
-        self._result = result
-        self._trigger()
-
-    def set_exception(self, exception):
-        """Set the result of the future to the given exception.
-
-        Args:
-            exception (:exc:`Exception`): The exception raised.
-        """
-        # Sanity check: A future can only complete once.
-        if self.done():
-            raise RuntimeError('set_exception can only be called once.')
-
-        # Set the exception and trigger the future.
-        self._exception = exception
-        self._trigger()
-
-    def _trigger(self):
-        """Trigger all callbacks registered to this Future.
-
-        This method is called internally by the batch once the batch
-        completes.
-
-        Args:
-            message_id (str): The message ID, as a string.
-        """
-        self._completed.set()
-        for callback in self._callbacks:
-            callback(self)

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
@@ -401,7 +401,7 @@ class BasePolicy(object):
                 Pub/Sub Message.
 
         Returns:
-            ~.pubsub_v1.subscriber.future.Future: A future that provides
+            ~google.api_core.future.Future: A future that provides
                 an interface to block on the subscription if desired, and
                 handle errors.
         """

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
@@ -69,6 +69,7 @@ class BasePolicy(object):
         self._consumer = _consumer.Consumer(self)
         self._ack_deadline = 10
         self._last_histogram_size = 0
+        self._future = None
         self.flow_control = flow_control
         self.histogram = _histogram.Histogram(data=histogram_data)
 
@@ -96,6 +97,16 @@ class BasePolicy(object):
         if len(self.histogram) > target:
             self._ack_deadline = self.histogram.percentile(percent=99)
         return self._ack_deadline
+
+    @property
+    def future(self):
+        """Return the Future in use, if any.
+
+        Returns:
+            ~.pubsub_v1.subscriber.future.Future: A Future conforming to the
+                ``~concurrent.futures.Future`` interface.
+        """
+        return self._future
 
     @property
     def managed_ack_ids(self):
@@ -388,5 +399,10 @@ class BasePolicy(object):
         Args:
             callback (Callable[Message]): A callable that receives a
                 Pub/Sub Message.
+
+        Returns:
+            ~.pubsub_v1.subscriber.future.Future: A future that provides
+                an interface to block on the subscription if desired, and
+                handle errors.
         """
         raise NotImplementedError

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -112,7 +112,7 @@ class Policy(base.BasePolicy):
             callback (Callable): The callback function.
 
         Returns:
-            ~.pubsub_v1.subscriber.future.Future: A future that provides
+            ~google.api_core.future.Future: A future that provides
                 an interface to block on the subscription if desired, and
                 handle errors.
         """

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -23,6 +23,7 @@ import grpc
 
 from google.cloud.pubsub_v1 import types
 from google.cloud.pubsub_v1.subscriber import _helper_threads
+from google.cloud.pubsub_v1.subscriber.futures import Future
 from google.cloud.pubsub_v1.subscriber.policy import base
 from google.cloud.pubsub_v1.subscriber.message import Message
 
@@ -63,6 +64,9 @@ class Policy(base.BasePolicy):
         # Default the callback to a no-op; it is provided by `.open`.
         self._callback = lambda message: None
 
+        # Default the future to None; it is provided by `.open`.
+        self._future = None
+
         # Create a queue for keeping track of shared state.
         if queue is None:
             queue = Queue()
@@ -87,9 +91,15 @@ class Policy(base.BasePolicy):
 
     def close(self):
         """Close the existing connection."""
-        # Close the main subscription connection.
+        # Stop consuming messages.
         self._consumer.helper_threads.stop('callback requests worker')
         self._consumer.stop_consuming()
+
+        # The subscription is closing cleanly; resolve the future if it is not
+        # resolved already.
+        if self._future and not self._future.done():
+            self._future.set_result(None)
+        self._future = None
 
     def open(self, callback):
         """Open a streaming pull connection and begin receiving messages.
@@ -100,7 +110,17 @@ class Policy(base.BasePolicy):
 
         Args:
             callback (Callable): The callback function.
+
+        Returns:
+            ~.pubsub_v1.subscriber.future.Future: A future that provides
+                an interface to block on the subscription if desired, and
+                handle errors.
         """
+        # Create the Future that this method will return.
+        # This future is the main thread's interface to handle exceptions,
+        # block on the subscription, etc.
+        self._future = Future(policy=self)
+
         # Start the thread to pass the requests.
         logger.debug('Starting callback requests worker.')
         self._callback = callback
@@ -120,6 +140,9 @@ class Policy(base.BasePolicy):
         self._leaser.daemon = True
         self._leaser.start()
 
+        # Return the future.
+        return self._future
+
     def on_callback_request(self, callback_request):
         """Map the callback request to the appropriate GRPC request."""
         action, kwargs = callback_request[0], callback_request[1]
@@ -136,8 +159,8 @@ class Policy(base.BasePolicy):
         if getattr(exception, 'code', lambda: None)() == deadline_exceeded:
             return
 
-        # Raise any other exception.
-        raise exception
+        # Set any other exception on the future.
+        self._future.set_exception(exception)
 
     def on_response(self, response):
         """Process all received Pub/Sub messages.

--- a/pubsub/tests/unit/pubsub_v1/publisher/test_futures.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/test_futures.py
@@ -29,7 +29,10 @@ def test_cancelled():
 
 
 def test_running():
-    assert Future().running() is True
+    future = Future()
+    assert future.running() is True
+    future.set_result('foobar')
+    assert future.running() is False
 
 
 def test_done():

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_futures_subscriber.py
@@ -1,0 +1,44 @@
+# Copyright 2017, Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import mock
+
+from google.auth import credentials
+from google.cloud.pubsub_v1 import subscriber
+from google.cloud.pubsub_v1.subscriber import futures
+from google.cloud.pubsub_v1.subscriber.policy import thread
+
+
+def create_policy(**kwargs):
+    creds = mock.Mock(spec=credentials.Credentials)
+    client = subscriber.Client(credentials=creds)
+    return thread.Policy(client, 'sub_name_c', **kwargs)
+
+
+def create_future(policy=None):
+    if policy is None:
+        policy = create_policy()
+    future = futures.Future(policy=policy)
+    policy._future = future
+    return future
+
+
+def test_running():
+    policy = create_policy()
+    future = create_future(policy=policy)
+    assert future.running() is True
+    policy._future = None
+    assert future.running() is False


### PR DESCRIPTION
This causes the `.open` method on subscriptions to return a future, which can be used to block the main thread or trap exceptions.

Fixes #3888.
Fixes #4019.

@jonparrott A couple items we should nail down and possibly tweak before merging this:

  * The current interface has a three-object pass to start consuming messages: instantiate a client, instantiate a subscription, then call `.open` on the subscription, which now returns a future. However, we currently have some shortcut logic that lets you pass a `callback` on step 2. You still get the subscription back, but `.open` is called implicitly; there's no good place for me to return the future in that case.
      * This is kind of a big deal; this future is basically _the_ way to both block and handle errata.
      * On the other hand, maybe this is fine; `.future` is a public property.
          * At the very minimum, I should update all documentation to show the full baton pass and highlight the future and what it is for.
  * There is not really any good way to stop consuming automatically. I can not do it in `on_exception` because that runs in one of the threads that the `helper_threads.stop_all()` method is trying to burn down, so it raises `RuntimeError`.
      * I could have an `.add_done_callback` call in `Future.__init__` that adds a callback that does the right thing, but this feels like an interface violation to me.
      * Maybe this is fine too; we (a) leave it up to users to decide how to handle errors, albeit (b) also fix bugs like #4234 so they are far less common.

Holding off on updating tests and docs until we make a decision.