### PR TITLE
Explicitly marking `google-cloud-core` and `google-api-core` as "dev".

### DIFF
--- a/api_core/setup.py
+++ b/api_core/setup.py
@@ -65,7 +65,7 @@ EXTRAS_REQUIREMENTS = {
 
 setup(
     name='google-api-core',
-    version='0.1.1',
+    version='0.1.2.dev1',
     description='Core Google API Client Library',
     long_description=README,
     namespace_packages=['google'],

--- a/core/setup.py
+++ b/core/setup.py
@@ -60,7 +60,7 @@ EXTRAS_REQUIREMENTS = {
 
 setup(
     name='google-cloud-core',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='API Client library for Google Cloud: Core Helpers',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
This is to make it clear the code is between releases. Towards #4208.

See: https://snarky.ca/how-i-manage-package-version-numbers/