### PR TITLE
Explicitly marking `google-cloud-bigquery` as "dev".

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -60,7 +60,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-bigquery',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='Python Client for Google BigQuery',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
This is to make it clear the code is between releases. Towards #4208.

See: https://snarky.ca/how-i-manage-package-version-numbers/

/cc @tswast 