### PR TITLE
BigQuery: moves Row class out of helpers and updates docstrings

### DIFF
--- a/bigquery/google/cloud/bigquery/__init__.py
+++ b/bigquery/google/cloud/bigquery/__init__.py
@@ -51,6 +51,7 @@ from google.cloud.bigquery.query import UDFResource
 from google.cloud.bigquery.schema import SchemaField
 from google.cloud.bigquery.table import Table
 from google.cloud.bigquery.table import TableReference
+from google.cloud.bigquery.table import Row
 from google.cloud.bigquery.external_config import ExternalConfig
 from google.cloud.bigquery.external_config import BigtableOptions
 from google.cloud.bigquery.external_config import BigtableColumnFamily
@@ -74,6 +75,7 @@ __all__ = [
     # Tables
     'Table',
     'TableReference',
+    'Row',
     'CopyJob',
     'CopyJobConfig',
     'ExtractJob',

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -209,7 +209,6 @@ def _row_tuple_from_json(row, schema):
 
 def _rows_from_json(values, schema):
     """Convert JSON row data to rows with appropriate types."""
-    # TODO(alixh) remove circular import
     from google.cloud.bigquery import Row
 
     field_to_index = _field_to_index_mapping(schema)
@@ -447,7 +446,6 @@ def _item_to_row(iterator, resource):
     :rtype: :class:`~google.cloud.bigquery.table.Row`
     :returns: The next row in the page.
     """
-    # TODO(alixh) remove circular import
     from google.cloud.bigquery import Row
 
     return Row(_row_tuple_from_json(resource, iterator.schema),

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -443,7 +443,7 @@ def _item_to_row(iterator, resource):
     :type resource: dict
     :param resource: An item to be converted to a row.
 
-    :rtype: :class:`~google.cloud.bigquery.Row`
+    :rtype: :class:`~google.cloud.bigquery.table.Row`
     :returns: The next row in the page.
     """
     from google.cloud.bigquery import Row

--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -209,6 +209,7 @@ def _row_tuple_from_json(row, schema):
 
 def _rows_from_json(values, schema):
     """Convert JSON row data to rows with appropriate types."""
+    # TODO(alixh) remove circular import
     from google.cloud.bigquery import Row
 
     field_to_index = _field_to_index_mapping(schema)
@@ -446,6 +447,7 @@ def _item_to_row(iterator, resource):
     :rtype: :class:`~google.cloud.bigquery.table.Row`
     :returns: The next row in the page.
     """
+    # TODO(alixh) remove circular import
     from google.cloud.bigquery import Row
 
     return Row(_row_tuple_from_json(resource, iterator.schema),

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1172,11 +1172,11 @@ class Client(ClientWithProject):
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
         :returns:
-            Iterator of row data :class:`~google.cloud.bigquery.Row`s. During
-            each page, the iterator will have the ``total_rows`` attribute set,
-            which counts the total number of rows **in the result set** (this
-            is distinct from the total number of rows in the current page:
-            ``iterator.page.num_items``).
+            Iterator of row data :class:`~google.cloud.bigquery.table.Row`-s.
+            During each page, the iterator will have the ``total_rows``
+            attribute set, which counts the total number of rows **in the
+            result set** (this is distinct from the total number of rows in
+            the current page: ``iterator.page.num_items``).
 
         :raises:
             :class:`~google.api_core.exceptions.GoogleAPICallError` if the
@@ -1242,11 +1242,12 @@ class Client(ClientWithProject):
         :param retry: (Optional) How to retry the RPC.
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
-        :returns: Iterator of row data :class:`~google.cloud.bigquery.Row`s.
-                  During each page, the iterator will have the ``total_rows``
-                  attribute set, which counts the total number of rows **in
-                  the table** (this is distinct from the total number of rows
-                  in the current page: ``iterator.page.num_items``).
+        :returns: Iterator of row data
+                  :class:`~google.cloud.bigquery.table.Row`-s. During each
+                  page, the iterator will have the ``total_rows`` attribute
+                  set, which counts the total number of rows **in the table**
+                  (this is distinct from the total number of rows in the
+                  current page: ``iterator.page.num_items``).
 
         """
         if selected_fields is not None:

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1172,10 +1172,10 @@ class Client(ClientWithProject):
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
         :returns:
-            Iterator of row data :class:`tuple`s. During each page, the
-            iterator will have the ``total_rows`` attribute set, which counts
-            the total number of rows **in the result set** (this is distinct
-            from the total number of rows in the current page:
+            Iterator of row data :class:`~google.cloud.bigquery.Row`s. During
+            each page, the iterator will have the ``total_rows`` attribute set,
+            which counts the total number of rows **in the result set** (this
+            is distinct from the total number of rows in the current page:
             ``iterator.page.num_items``).
 
         :raises:
@@ -1242,11 +1242,11 @@ class Client(ClientWithProject):
         :param retry: (Optional) How to retry the RPC.
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
-        :returns: Iterator of row data :class:`tuple`s. During each page, the
-                  iterator will have the ``total_rows`` attribute set,
-                  which counts the total number of rows **in the table**
-                  (this is distinct from the total number of rows in the
-                  current page: ``iterator.page.num_items``).
+        :returns: Iterator of row data :class:`~google.cloud.bigquery.Row`s.
+                  During each page, the iterator will have the ``total_rows``
+                  attribute set, which counts the total number of rows **in
+                  the table** (this is distinct from the total number of rows
+                  in the current page: ``iterator.page.num_items``).
 
         """
         if selected_fields is not None:

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1931,10 +1931,10 @@ class QueryJob(_AsyncJob):
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
         :returns:
-            Iterator of row data :class:`tuple`s. During each page, the
-            iterator will have the ``total_rows`` attribute set, which counts
-            the total number of rows **in the result set** (this is distinct
-            from the total number of rows in the current page:
+            Iterator of row data :class:`~google.cloud.bigquery.Row`s. During
+            each page, the iterator will have the ``total_rows`` attribute set,
+            which counts the total number of rows **in the result set** (this
+            is distinct from the total number of rows in the current page:
             ``iterator.page.num_items``).
 
         :raises:

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -690,7 +690,7 @@ class LoadJob(_AsyncJob):
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.sourceUris
         for supported URI formats. Pass None for jobs that load from a file.
 
-    :type destination: :class:`google.cloud.bigquery.TableReference`
+    :type destination: :class:`google.cloud.bigquery.table.TableReference`
     :param destination: reference to table into which data is to be loaded.
 
     :type client: :class:`google.cloud.bigquery.client.Client`
@@ -959,10 +959,10 @@ class CopyJob(_AsyncJob):
     :type job_id: str
     :param job_id: the job's ID, within the project belonging to ``client``.
 
-    :type sources: list of :class:`google.cloud.bigquery.TableReference`
+    :type sources: list of :class:`google.cloud.bigquery.table.TableReference`
     :param sources: Table into which data is to be loaded.
 
-    :type destination: :class:`google.cloud.bigquery.TableReference`
+    :type destination: :class:`google.cloud.bigquery.table.TableReference`
     :param destination: Table into which data is to be loaded.
 
     :type client: :class:`google.cloud.bigquery.client.Client`
@@ -1134,7 +1134,7 @@ class ExtractJob(_AsyncJob):
     :type job_id: str
     :param job_id: the job's ID
 
-    :type source: :class:`google.cloud.bigquery.TableReference`
+    :type source: :class:`google.cloud.bigquery.table.TableReference`
     :param source: Table into which data is to be loaded.
 
     :type destination_uris: list of string
@@ -1931,11 +1931,11 @@ class QueryJob(_AsyncJob):
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
         :returns:
-            Iterator of row data :class:`~google.cloud.bigquery.Row`s. During
-            each page, the iterator will have the ``total_rows`` attribute set,
-            which counts the total number of rows **in the result set** (this
-            is distinct from the total number of rows in the current page:
-            ``iterator.page.num_items``).
+            Iterator of row data :class:`~google.cloud.bigquery.table.Row`-s.
+            During each page, the iterator will have the ``total_rows``
+            attribute set, which counts the total number of rows **in the
+            result set** (this is distinct from the total number of rows in
+            the current page: ``iterator.page.num_items``).
 
         :raises:
             :class:`~google.cloud.exceptions.GoogleCloudError` if the job

--- a/bigquery/google/cloud/bigquery/query.py
+++ b/bigquery/google/cloud/bigquery/query.py
@@ -597,7 +597,7 @@ class QueryResults(object):
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#rows
 
-        :rtype: list of :class:`~google.cloud.bigquery.Row`
+        :rtype: list of :class:`~google.cloud.bigquery.table.Row`
         :returns: fields describing the schema (None until set by the server).
         """
         return _rows_from_json(self._properties.get('rows', ()), self.schema)

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -40,7 +40,7 @@ class TableReference(object):
     See
     https://cloud.google.com/bigquery/docs/reference/rest/v2/tables
 
-    :type dataset_ref: :class:`google.cloud.bigquery.DatasetReference`
+    :type dataset_ref: :class:`google.cloud.bigquery.dataset.DatasetReference`
     :param dataset_ref: a pointer to the dataset
 
     :type table_id: str
@@ -609,7 +609,7 @@ class Table(object):
         :type resource: dict
         :param resource: table resource representation returned from the API
 
-        :type dataset: :class:`google.cloud.bigquery.Dataset`
+        :type dataset: :class:`google.cloud.bigquery.dataset.Dataset`
         :param dataset: The dataset containing the table.
 
         :rtype: :class:`google.cloud.bigquery.table.Table`

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -786,20 +786,20 @@ class Row(object):
         return self._xxx_values
 
     def __getattr__(self, name):
-        i = self._xxx_field_to_index.get(name)
-        if i is None:
-            raise AttributeError('no row field "%s"' % name)
-        return self._xxx_values[i]
+        value = self._xxx_field_to_index.get(name)
+        if value is None:
+            raise AttributeError('no row field {!r}'.format(name))
+        return self._xxx_values[value]
 
     def __len__(self):
         return len(self._xxx_values)
 
     def __getitem__(self, key):
         if isinstance(key, six.string_types):
-            i = self._xxx_field_to_index.get(key)
-            if i is None:
-                raise KeyError('no row field "%s"' % key)
-            key = i
+            value = self._xxx_field_to_index.get(key)
+            if value is None:
+                raise KeyError('no row field {!r}'.format(key))
+            key = value
         return self._xxx_values[key]
 
     def __eq__(self, other):
@@ -816,5 +816,5 @@ class Row(object):
         # sort field dict by value, for determinism
         items = sorted(self._xxx_field_to_index.items(),
                        key=operator.itemgetter(1))
-        f2i = '{' + ', '.join('%r: %d' % i for i in items) + '}'
+        f2i = '{' + ', '.join('%r: %d' % item for item in items) + '}'
         return 'Row({}, {})'.format(self._xxx_values, f2i)

--- a/bigquery/tests/unit/test__helpers.py
+++ b/bigquery/tests/unit/test__helpers.py
@@ -466,25 +466,6 @@ class Test_row_tuple_from_json(unittest.TestCase):
                 {u'first': [5, 6], u'second': 7},
             ],))
 
-    def test_row(self):
-        from google.cloud.bigquery._helpers import Row
-
-        VALUES = (1, 2, 3)
-        r = Row(VALUES, {'a': 0, 'b': 1, 'c': 2})
-        self.assertEqual(r.a, 1)
-        self.assertEqual(r[1], 2)
-        self.assertEqual(r['c'], 3)
-        self.assertEqual(len(r), 3)
-        self.assertEqual(r.values(), VALUES)
-        self.assertEqual(repr(r),
-                         "Row((1, 2, 3), {'a': 0, 'b': 1, 'c': 2})")
-        self.assertFalse(r != r)
-        self.assertFalse(r == 3)
-        with self.assertRaises(AttributeError):
-            r.z
-        with self.assertRaises(KeyError):
-            r['z']
-
 
 class Test_rows_from_json(unittest.TestCase):
 
@@ -494,7 +475,7 @@ class Test_rows_from_json(unittest.TestCase):
         return _rows_from_json(rows, schema)
 
     def test_w_record_subfield(self):
-        from google.cloud.bigquery._helpers import Row
+        from google.cloud.bigquery.table import Row
 
         full_name = _Field('REQUIRED', 'full_name', 'STRING')
         area_code = _Field('REQUIRED', 'area_code', 'STRING')
@@ -541,7 +522,7 @@ class Test_rows_from_json(unittest.TestCase):
         self.assertEqual(coerced, expected)
 
     def test_w_int64_float64_bool(self):
-        from google.cloud.bigquery._helpers import Row
+        from google.cloud.bigquery.table import Row
 
         # "Standard" SQL dialect uses 'INT64', 'FLOAT64', 'BOOL'.
         candidate = _Field('REQUIRED', 'candidate', 'STRING')

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -2182,8 +2182,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['data'], SENT)
 
     def test_create_rows_w_list_of_Rows(self):
-        from google.cloud.bigquery._helpers import Row
-        from google.cloud.bigquery.table import Table, SchemaField
+        from google.cloud.bigquery.table import Table, SchemaField, Row
 
         PATH = 'projects/%s/datasets/%s/tables/%s/insertAll' % (
             self.PROJECT, self.DS_ID, self.TABLE_ID)
@@ -2465,7 +2464,7 @@ class TestClient(unittest.TestCase):
 
     def test_query_rows_defaults(self):
         from google.api_core.page_iterator import HTTPIterator
-        from google.cloud.bigquery._helpers import Row
+        from google.cloud.bigquery.table import Row
 
         JOB = 'job-id'
         QUERY = 'SELECT COUNT(*) FROM persons'
@@ -2720,8 +2719,7 @@ class TestClient(unittest.TestCase):
     def test_list_rows(self):
         import datetime
         from google.cloud._helpers import UTC
-        from google.cloud.bigquery.table import Table, SchemaField
-        from google.cloud.bigquery._helpers import Row
+        from google.cloud.bigquery.table import Table, SchemaField, Row
 
         PATH = 'projects/%s/datasets/%s/tables/%s/data' % (
             self.PROJECT, self.DS_ID, self.TABLE_ID)

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -2182,7 +2182,9 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['data'], SENT)
 
     def test_create_rows_w_list_of_Rows(self):
-        from google.cloud.bigquery.table import Table, SchemaField, Row
+        from google.cloud.bigquery.table import Table
+        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.table import Row
 
         PATH = 'projects/%s/datasets/%s/tables/%s/insertAll' % (
             self.PROJECT, self.DS_ID, self.TABLE_ID)
@@ -2719,7 +2721,9 @@ class TestClient(unittest.TestCase):
     def test_list_rows(self):
         import datetime
         from google.cloud._helpers import UTC
-        from google.cloud.bigquery.table import Table, SchemaField, Row
+        from google.cloud.bigquery.table import Table
+        from google.cloud.bigquery.table import SchemaField
+        from google.cloud.bigquery.table import Row
 
         PATH = 'projects/%s/datasets/%s/tables/%s/data' % (
             self.PROJECT, self.DS_ID, self.TABLE_ID)

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -751,3 +751,25 @@ class Test_row_from_mapping(unittest.TestCase, _SchemaBase):
         self.assertEqual(
             self._call_fut(MAPPING, table.schema),
             ('Phred Phlyntstone', 32, ['red', 'green'], None))
+
+
+class TestRow(unittest.TestCase):
+
+    def test_row(self):
+        from google.cloud.bigquery.table import Row
+
+        VALUES = (1, 2, 3)
+        r = Row(VALUES, {'a': 0, 'b': 1, 'c': 2})
+        self.assertEqual(r.a, 1)
+        self.assertEqual(r[1], 2)
+        self.assertEqual(r['c'], 3)
+        self.assertEqual(len(r), 3)
+        self.assertEqual(r.values(), VALUES)
+        self.assertEqual(repr(r),
+                         "Row((1, 2, 3), {'a': 0, 'b': 1, 'c': 2})")
+        self.assertFalse(r != r)
+        self.assertFalse(r == 3)
+        with self.assertRaises(AttributeError):
+            r.z
+        with self.assertRaises(KeyError):
+            r['z']

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -759,17 +759,17 @@ class TestRow(unittest.TestCase):
         from google.cloud.bigquery.table import Row
 
         VALUES = (1, 2, 3)
-        r = Row(VALUES, {'a': 0, 'b': 1, 'c': 2})
-        self.assertEqual(r.a, 1)
-        self.assertEqual(r[1], 2)
-        self.assertEqual(r['c'], 3)
-        self.assertEqual(len(r), 3)
-        self.assertEqual(r.values(), VALUES)
-        self.assertEqual(repr(r),
+        row = Row(VALUES, {'a': 0, 'b': 1, 'c': 2})
+        self.assertEqual(row.a, 1)
+        self.assertEqual(row[1], 2)
+        self.assertEqual(row['c'], 3)
+        self.assertEqual(len(row), 3)
+        self.assertEqual(row.values(), VALUES)
+        self.assertEqual(repr(row),
                          "Row((1, 2, 3), {'a': 0, 'b': 1, 'c': 2})")
-        self.assertFalse(r != r)
-        self.assertFalse(r == 3)
+        self.assertFalse(row != row)
+        self.assertFalse(row == 3)
         with self.assertRaises(AttributeError):
-            r.z
+            row.z
         with self.assertRaises(KeyError):
-            r['z']
+            row['z']

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -113,7 +113,7 @@ class Table(object):
         .. warning::
 
            At most one of ``filter_`` and ``append`` can be used in a
-           :class:`.Row`.
+           :class:`~google.cloud.bigtable.row.Row`.
 
         :type row_key: bytes
         :param row_key: The key for the row being created.
@@ -126,7 +126,7 @@ class Table(object):
         :param append: (Optional) Flag to determine if the row should be used
                        for append mutations.
 
-        :rtype: :class:`.Row`
+        :rtype: :class:`~google.cloud.bigtable.row.Row`
         :returns: A row owned by this table.
         :raises: :class:`ValueError <exceptions.ValueError>` if both
                  ``filter_`` and ``append`` are used.
@@ -469,8 +469,9 @@ def _check_row_table_name(table_name, row):
     :type table_name: str
     :param table_name: The name of the table.
 
-    :type row: :class:`.Row`
-    :param row: An instance of :class:`.Row` subclasses.
+    :type row: :class:`~google.cloud.bigtable.row.Row`
+    :param row: An instance of :class:`~google.cloud.bigtable.row.Row`
+                subclasses.
 
     :raises: :exc:`~.table.TableMismatchError` if the row does not belong to
              the table.
@@ -484,8 +485,9 @@ def _check_row_table_name(table_name, row):
 def _check_row_type(row):
     """Checks that a row is an instance of :class:`.DirectRow`.
 
-    :type row: :class:`.Row`
-    :param row: An instance of :class:`.Row` subclasses.
+    :type row: :class:`~google.cloud.bigtable.row.Row`
+    :param row: An instance of :class:`~google.cloud.bigtable.row.Row`
+                subclasses.
 
     :raises: :class:`TypeError <exceptions.TypeError>` if the row is not an
              instance of DirectRow.


### PR DESCRIPTION
- Imports `Row` in `__init__.py`
- Moves `Row` from `_helpers.py` to `table.py` because it is a public class
- Updates incorrect docstrings for functions returning an `Iterator` of `Row` objects