### PR TITLE
Marking all remaining versions as "dev".

### DIFF
--- a/bigtable/setup.py
+++ b/bigtable/setup.py
@@ -58,7 +58,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-bigtable',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='Python Client for Google Cloud Bigtable',
     long_description=README,
     namespace_packages=[

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-datastore',
-    version='1.4.0',
+    version='1.4.1.dev1',
     description='Python Client for Google Cloud Datastore',
     long_description=README,
     namespace_packages=[

--- a/dns/setup.py
+++ b/dns/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-dns',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='Python Client for Google Cloud DNS',
     long_description=README,
     namespace_packages=[

--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-error-reporting',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='Python Client for Stackdriver Error Reporting',
     long_description=README,
     namespace_packages=[

--- a/firestore/setup.py
+++ b/firestore/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
 
 setuptools.setup(
     name='google-cloud-firestore',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='Python Client for Google Cloud Firestore',
     long_description=README,
     namespace_packages=[

--- a/language/setup.py
+++ b/language/setup.py
@@ -61,7 +61,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name='google-cloud-language',
-    version='0.30.0',
+    version='0.30.1.dev1',
     description='Python Client for Google Cloud Natural Language',
     long_description=README,
     namespace_packages=[

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -58,7 +58,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-logging',
-    version='1.4.0',
+    version='1.4.1.dev1',
     description='Python Client for Stackdriver Logging',
     long_description=README,
     namespace_packages=[

--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-monitoring',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='Python Client for Stackdriver Monitoring',
     long_description=README,
     namespace_packages=[

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -60,7 +60,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-pubsub',
-    version='0.29.0',
+    version='0.29.1.dev1',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[

--- a/resource_manager/setup.py
+++ b/resource_manager/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-resource-manager',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='Python Client for Google Cloud Resource Manager',
     long_description=README,
     namespace_packages=[

--- a/runtimeconfig/setup.py
+++ b/runtimeconfig/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-runtimeconfig',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='Python Client for Google Cloud RuntimeConfig',
     long_description=README,
     namespace_packages=[

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='API Client library for Google Cloud',
     long_description=README,
     install_requires=REQUIREMENTS,

--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -61,7 +61,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-spanner',
-    version='0.29.0',
+    version='0.29.1.dev1',
     description='Python Client for Cloud Spanner',
     long_description=README,
     namespace_packages=[

--- a/speech/setup.py
+++ b/speech/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-speech',
-    version='0.30.0',
+    version='0.30.1.dev1',
     description='Python Client for Google Cloud Speech',
     long_description=README,
     namespace_packages=[

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -60,7 +60,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-storage',
-    version='1.6.0',
+    version='1.6.1.dev1',
     description='Python Client for Google Cloud Storage',
     long_description=README,
     namespace_packages=[

--- a/trace/setup.py
+++ b/trace/setup.py
@@ -15,7 +15,7 @@ install_requires = [
 
 setup(
     name='google-cloud-trace',
-    version='0.16.0',
+    version='0.16.1.dev1',
     author='Google Inc',
     author_email='googleapis-packages@google.com',
     classifiers=[

--- a/translate/setup.py
+++ b/translate/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-translate',
-    version='1.3.0',
+    version='1.3.1.dev1',
     description='Python Client for Google Cloud Translation API',
     long_description=README,
     namespace_packages=[

--- a/videointelligence/setup.py
+++ b/videointelligence/setup.py
@@ -29,7 +29,7 @@ setup(
     author='Google Cloud Platform',
     author_email='googleapis-publisher@google.com',
     name='google-cloud-videointelligence',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='Python Client for Google Cloud Video Intelligence',
     long_description=readme,
     namespace_packages=[

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -37,7 +37,7 @@ setup(
     author='Google Cloud Platform',
     author_email='googleapis-publisher@google.com',
     name='google-cloud-vision',
-    version='0.28.0',
+    version='0.28.1.dev1',
     description='Python Client for Google Cloud Vision',
     long_description=readme,
     namespace_packages=[


### PR DESCRIPTION
This is to make it clear the code is between releases. Any code that relies on a **new** feature (e.g. of `google-api-core`) will then be able to **explicitly** make this clear by using the lower bound of the `devN` version.

Fixes #4208.

See: https://snarky.ca/how-i-manage-package-version-numbers/