### PR TITLE
Fixing "Fore" -> "For" typo in README docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/bigquery/README.rst
+++ b/bigquery/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-bigquery
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/bigtable/README.rst
+++ b/bigtable/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-bigtable
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/core/README.rst
+++ b/core/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-core
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/datastore/README.rst
+++ b/datastore/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-datastore
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/dns/README.rst
+++ b/dns/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-dns
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,9 @@ The ``google-cloud`` library is ``pip`` install-able:
 
     $ pip install google-cloud
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/error_reporting/README.rst
+++ b/error_reporting/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-error-reporting
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/firestore/README.rst
+++ b/firestore/README.rst
@@ -16,7 +16,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-firestore
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/logging/README.rst
+++ b/logging/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-logging
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/monitoring/README.rst
+++ b/monitoring/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-monitoring
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/pubsub/README.rst
+++ b/pubsub/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-pubsub
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/resource_manager/README.rst
+++ b/resource_manager/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-resource-manager
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/runtimeconfig/README.rst
+++ b/runtimeconfig/README.rst
@@ -22,7 +22,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-runtimeconfig
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/spanner/README.rst
+++ b/spanner/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-spanner
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/speech/README.rst
+++ b/speech/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-speech
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/storage/README.rst
+++ b/storage/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-storage
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/trace/README.rst
+++ b/trace/README.rst
@@ -59,7 +59,9 @@ Windows
     <your-env>\Scripts\activate
     <your-env>\Scripts\pip.exe install gapic-google-cloud-trace-v1
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` and ``virtualenv`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/translate/README.rst
+++ b/translate/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-translate
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/videointelligence/README.rst
+++ b/videointelligence/README.rst
@@ -14,7 +14,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-videointelligence
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 

--- a/vision/README.rst
+++ b/vision/README.rst
@@ -18,7 +18,9 @@ Quick Start
 
     $ pip install --upgrade google-cloud-vision
 
-Fore more information on setting up your Python development environment, such as installing ``pip`` on your system, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+For more information on setting up your Python development environment,
+such as installing ``pip`` and ``virtualenv`` on your system, please refer
+to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 
 .. _Python Development Environment Setup Guide: https://cloud.google.com/python/setup
 


### PR DESCRIPTION
Also obeying an 80-column limit for the content and adding a missing "``virtualenv``" in the phrase "``pip`` and ``virtualenv``" in some of the docs.