### PR TITLE
Version bump for language / metapackage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [1]: https://pypi.org/project/google-cloud/#history
 
+## 0.29.0
+
+Feature / bugfix release for the following package:
+
+- [`google-cloud-language==0.31.0`](https://pypi.org/project/google-cloud-language/0.31.0/)
+
 ## 0.28.0
 
 Packages newly added to the `google-cloud` umbrella package:

--- a/language/CHANGELOG.md
+++ b/language/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 [1]: https://pypi.org/project/google-cloud-language/#history
 
+## 0.31.0
+
+### Release Candidate
+
+  * This update is considered a final "release candidate", and
+    the `google-cloud-language` package is preparing for a GA release
+    in the near future.
+
+### :warning: Breaking Changes!
+
+  * Some rarely-used arguments to the `LanguageServiceClient` constructor
+    have been removed (in favor of a subclass or a custom gRPC channel).
+    It is unlikely that you used these, but if you did, then this update
+    will represent a breaking change.
+      * The removed arguments are: `client_config`, `lib_name`, `lib_version`
+        `metrics_headers`, `ssl_credentials`, and `scopes`.
+
+### Features
+
+  * Added the `classify_text` method on the primary (`v1`) endpoint. (#4283)
+
 ## 0.30.0
 
 ### Documentation

--- a/language/setup.py
+++ b/language/setup.py
@@ -60,7 +60,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name='google-cloud-language',
-    version='0.30.1.dev1',
+    version='0.31.0',
     description='Python Client for Google Cloud Natural Language',
     long_description=README,
     namespace_packages=[

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ REQUIREMENTS = [
     'google-cloud-dns >= 0.28.0, < 0.29dev',
     'google-cloud-error-reporting >= 0.28.0, < 0.29dev',
     'google-cloud-firestore >= 0.28.0, < 0.29dev',
-    'google-cloud-language >= 0.30.0, < 0.31dev',
+    'google-cloud-language >= 0.31.0, < 0.32dev',
     'google-cloud-logging >= 1.4.0, < 1.5dev',
     'google-cloud-monitoring >= 0.28.0, < 0.29dev',
     'google-cloud-pubsub >= 0.29.0, < 0.30dev',
@@ -74,7 +74,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud',
-    version='0.28.1.dev1',
+    version='0.29.0',
     description='API Client library for Google Cloud',
     long_description=README,
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
# google-cloud-language v0.31.0

[![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style&#x3D;flat)](https://cloud.google.com/terms/launch-stages)

## Release Candidate

  * This update is considered a final "release candidate", and the `google-cloud-language` package is preparing for a GA release in the near future.

## :warning: Breaking Changes!

  * Some rarely-used arguments to the `LanguageServiceClient` constructor have been removed (in favor of a subclass or a custom gRPC channel). It is unlikely that you used these, but if you did, then this update will represent a breaking change.
      * The removed arguments are: `client_config`, `lib_name`, `lib_version`, `metrics_headers`, `ssl_credentials`, and `scopes`.

## Features

  * Added the `classify_text` method on the primary (`v1`) endpoint. (#4283)