### PR TITLE
Post-release cleanup for language and `google-cloud`.

### DIFF
--- a/docs/language/releases.rst
+++ b/docs/language/releases.rst
@@ -18,6 +18,7 @@
 * ``0.28.0`` (`PyPI <https://pypi.org/project/google-cloud-language/0.28.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/language-0.28.0>`__)
 * ``0.29.0`` (`PyPI <https://pypi.org/project/google-cloud-language/0.29.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/language-0.29.0>`__)
 * ``0.30.0`` (`PyPI <https://pypi.org/project/google-cloud-language/0.30.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/language-0.30.0>`__)
+* ``0.31.0`` (`PyPI <https://pypi.org/project/google-cloud-language/0.31.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/language-0.31.0>`__)
 
 ******************************************
 ``google-cloud-natural-language`` Releases

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -48,3 +48,4 @@ The ``google-cloud`` package (formerly ``gcloud``) contains
 * ``0.26.1`` (`PyPI <https://pypi.org/project/google-cloud/0.26.1/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/0.26.1>`__)
 * ``0.27.0`` (`PyPI <https://pypi.org/project/google-cloud/0.27.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/0.27.0>`__)
 * ``0.28.0`` (`PyPI <https://pypi.org/project/google-cloud/0.28.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/0.28.0>`__)
+* ``0.29.0`` (`PyPI <https://pypi.org/project/google-cloud/0.29.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/0.29.0>`__)

--- a/language/setup.py
+++ b/language/setup.py
@@ -60,7 +60,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name='google-cloud-language',
-    version='0.31.0',
+    version='0.31.1.dev1',
     description='Python Client for Google Cloud Natural Language',
     long_description=README,
     namespace_packages=[

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud',
-    version='0.29.0',
+    version='0.29.1.dev1',
     description='API Client library for Google Cloud',
     long_description=README,
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
In particular:

- Marking the package versions as "dev"
- Updating the `releases.rst` for the packages

(Again, this showcases a "need" for the `releases.rst` files to be checked in some automated way.)