### PR TITLE
api_core: Add routing header

### DIFF
--- a/api_core/google/api_core/gapic_v1/routing_header.py
+++ b/api_core/google/api_core/gapic_v1/routing_header.py
@@ -16,9 +16,11 @@
 
 METADATA_KEY = 'x-goog-header-params'
 
+
 def to_routing_header(params):
     """Returns the routing header string that the params form"""
     return "&".join(["{}={}".format(*pair) for pair in params])
+
 
 def to_grpc_metadata(params):
     """Returns the gRPC metadata that the routing header params form"""

--- a/api_core/google/api_core/gapic_v1/routing_header.py
+++ b/api_core/google/api_core/gapic_v1/routing_header.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from google.api_core.gapic_v1 import config
-from google.api_core.gapic_v1 import method
-from google.api_core.gapic_v1 import routing_header
+"""Helpers for handling routing header params."""
 
-__all__ = [
-    'config',
-    'method',
-    'routing_header',
-]
+METADATA_KEY = 'x-goog-header-params'
+
+def to_routing_header(params):
+    """Returns the routing header string that the params form"""
+    return "&".join(["{}={}".format(*pair) for pair in params])
+
+def to_grpc_metadata(params):
+    """Returns the gRPC metadata that the routing header params form"""
+    return (METADATA_KEY, to_routing_header(params))

--- a/api_core/google/api_core/gapic_v1/routing_header.py
+++ b/api_core/google/api_core/gapic_v1/routing_header.py
@@ -14,14 +14,30 @@
 
 """Helpers for handling routing header params."""
 
-METADATA_KEY = 'x-goog-header-params'
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    def urlencode(params):
+        return '&'.join(['{}={}'.format(*pair) for pair in params])
+
+ROUTING_METADATA_KEY = 'x-goog-header-params'
+
+
+def _to_url_string(x):
+    if not isinstance(x, bool):
+        return str(x)
+    elif x:
+        return '1'
+    else:
+        return '0'
 
 
 def to_routing_header(params):
     """Returns the routing header string that the params form"""
-    return "&".join(["{}={}".format(*pair) for pair in params])
+    return urlencode([(k, _to_url_string(v)) for k, v in params])
 
 
 def to_grpc_metadata(params):
     """Returns the gRPC metadata that the routing header params form"""
-    return (METADATA_KEY, to_routing_header(params))
+    return (ROUTING_METADATA_KEY, to_routing_header(params))

--- a/api_core/google/api_core/gapic_v1/routing_header.py
+++ b/api_core/google/api_core/gapic_v1/routing_header.py
@@ -15,27 +15,14 @@
 """Helpers for handling routing header params."""
 
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    def urlencode(params):
-        return '&'.join(['{}={}'.format(*pair) for pair in params])
+from six.moves.urllib.parse import urlencode
 
 ROUTING_METADATA_KEY = 'x-goog-header-params'
 
 
-def _to_url_string(x):
-    if not isinstance(x, bool):
-        return str(x)
-    elif x:
-        return '1'
-    else:
-        return '0'
-
-
 def to_routing_header(params):
     """Returns the routing header string that the params form"""
-    return urlencode([(k, _to_url_string(v)) for k, v in params])
+    return urlencode(params)
 
 
 def to_grpc_metadata(params):

--- a/api_core/google/api_core/gapic_v1/routing_header.py
+++ b/api_core/google/api_core/gapic_v1/routing_header.py
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Helpers for handling routing header params."""
+"""Helpers for constructing routing headers.
 
+These headers are used by Google infrastructure to determine how to route
+requests, especially for services that are regional.
+
+Generally, these headers are specified as gRPC metadata.
+"""
 
 from six.moves.urllib.parse import urlencode
 
@@ -21,10 +26,28 @@ ROUTING_METADATA_KEY = 'x-goog-header-params'
 
 
 def to_routing_header(params):
-    """Returns the routing header string that the params form"""
+    """Returns a routing header string for the given request parameters.
+
+    Args:
+        params (Mapping[str, Any]): A dictionary containing the request
+            parameters used for routing.
+
+    Returns:
+        str: The routing header string.
+    """
     return urlencode(params)
 
 
 def to_grpc_metadata(params):
-    """Returns the gRPC metadata that the routing header params form"""
+    """Returns the gRPC metadata containing the routing headers for the given
+    request parameters.
+
+    Args:
+        params (Mapping[str, Any]): A dictionary containing the request
+            parameters used for routing.
+
+    Returns:
+        Tuple(str, str): The gRPC metadata containing the routing header key
+            and value.
+    """
     return (ROUTING_METADATA_KEY, to_routing_header(params))

--- a/api_core/tests/unit/gapic/test_routing_header.py
+++ b/api_core/tests/unit/gapic/test_routing_header.py
@@ -17,13 +17,13 @@ from google.api_core.gapic_v1 import routing_header
 
 
 def test_to_routing_header():
-    params = [('name', 'meep'), ('book.read', True)]
+    params = [('name', 'meep'), ('book.read', '1')]
     value = routing_header.to_routing_header(params)
     assert value == "name=meep&book.read=1"
 
 
 def test_to_grpc_metadata():
-    params = [('name', 'meep'), ('book.read', True)]
+    params = [('name', 'meep'), ('book.read', '1')]
     metadata = routing_header.to_grpc_metadata(params)
     assert metadata == (
         routing_header.ROUTING_METADATA_KEY, "name=meep&book.read=1")

--- a/api_core/tests/unit/gapic/test_routing_header.py
+++ b/api_core/tests/unit/gapic/test_routing_header.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from google.api_core.gapic_v1 import config
-from google.api_core.gapic_v1 import method
+
 from google.api_core.gapic_v1 import routing_header
 
-__all__ = [
-    'config',
-    'method',
-    'routing_header',
-]
+def test_to_routing_header():
+    params = [('name', 'meep'), ('book.read', True)]
+    value = routing_header.to_routing_header(params)
+    assert value == "name=meep&book.read=True"
+
+def test_to_grpc_metadata():
+    params = [('name', 'meep'), ('book.read', True)]
+    metadata = routing_header.to_grpc_metadata(params)
+    assert metadata == (routing_header.METADATA_KEY, "name=meep&book.read=True")

--- a/api_core/tests/unit/gapic/test_routing_header.py
+++ b/api_core/tests/unit/gapic/test_routing_header.py
@@ -15,12 +15,15 @@
 
 from google.api_core.gapic_v1 import routing_header
 
+
 def test_to_routing_header():
     params = [('name', 'meep'), ('book.read', True)]
     value = routing_header.to_routing_header(params)
     assert value == "name=meep&book.read=True"
 
+
 def test_to_grpc_metadata():
     params = [('name', 'meep'), ('book.read', True)]
     metadata = routing_header.to_grpc_metadata(params)
-    assert metadata == (routing_header.METADATA_KEY, "name=meep&book.read=True")
+    assert metadata == (
+        routing_header.METADATA_KEY, "name=meep&book.read=True")

--- a/api_core/tests/unit/gapic/test_routing_header.py
+++ b/api_core/tests/unit/gapic/test_routing_header.py
@@ -19,11 +19,11 @@ from google.api_core.gapic_v1 import routing_header
 def test_to_routing_header():
     params = [('name', 'meep'), ('book.read', True)]
     value = routing_header.to_routing_header(params)
-    assert value == "name=meep&book.read=True"
+    assert value == "name=meep&book.read=1"
 
 
 def test_to_grpc_metadata():
     params = [('name', 'meep'), ('book.read', True)]
     metadata = routing_header.to_grpc_metadata(params)
     assert metadata == (
-        routing_header.METADATA_KEY, "name=meep&book.read=True")
+        routing_header.ROUTING_METADATA_KEY, "name=meep&book.read=1")


### PR DESCRIPTION
Example:
```python
routing_header = google.api_core.gapic_v1.routing_header(
            [('name', name), ('book.read', book.read)])
self._create_book(request, retry=retry, timeout=timeout, metadata=[routing_header])
```