### PR TITLE
Handle retry=None for mutate_rows, and some refactoring in test

### DIFF
--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -486,7 +486,7 @@ class _RetryableMutateRowsWorker(object):
 
         if len(retryable_rows) != num_responses:
             raise RuntimeError(
-                'Unexpected the number of responses', num_responses,
+                'Unexpected number of responses', num_responses,
                 'Expected', len(retryable_rows))
 
         if num_retryable_responses:

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -611,10 +611,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
 
     def test_callable_no_retry_strategy(self):
         from google.api_core.retry import Retry
-        from google.cloud.bigtable._generated.bigtable_pb2 import (
-            MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
-        from google.rpc.status_pb2 import Status
 
         # Setup:
         #   - Mutate 3 rows.
@@ -657,11 +654,8 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
 
     def test_callable_retry(self):
         from google.api_core.retry import Retry
-        from google.cloud.bigtable._generated.bigtable_pb2 import (
-            MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
         from google.cloud.bigtable.table import DEFAULT_RETRY
-        from google.rpc.status_pb2 import Status
 
         # Setup:
         #   - Mutate 3 rows.
@@ -710,11 +704,8 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
 
     def test_callable_retry_timeout(self):
         from google.api_core.retry import Retry
-        from google.cloud.bigtable._generated.bigtable_pb2 import (
-            MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
         from google.cloud.bigtable.table import DEFAULT_RETRY
-        from google.rpc.status_pb2 import Status
 
         # Setup:
         #   - Mutate 2 rows.
@@ -764,10 +755,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(len(statuses), 0)
 
     def test_do_mutate_retryable_rows(self):
-        from google.cloud.bigtable._generated.bigtable_pb2 import (
-            MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
-        from google.rpc.status_pb2 import Status
         from tests.unit._testing import _FakeStub
 
         # Setup:
@@ -801,11 +789,8 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_do_mutate_retryable_rows_retry(self):
-        from google.cloud.bigtable._generated.bigtable_pb2 import (
-            MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
         from google.cloud.bigtable.table import _BigtableRetryableError
-        from google.rpc.status_pb2 import Status
         from tests.unit._testing import _FakeStub
 
         # Setup:
@@ -849,11 +834,8 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_do_mutate_retryable_rows_second_retry(self):
-        from google.cloud.bigtable._generated.bigtable_pb2 import (
-            MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
         from google.cloud.bigtable.table import _BigtableRetryableError
-        from google.rpc.status_pb2 import Status
         from tests.unit._testing import _FakeStub
 
         # Setup:
@@ -909,10 +891,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_do_mutate_retryable_rows_second_try(self):
-        from google.cloud.bigtable._generated.bigtable_pb2 import (
-            MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
-        from google.rpc.status_pb2 import Status
         from tests.unit._testing import _FakeStub
 
         # Setup:
@@ -962,10 +941,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_do_mutate_retryable_rows_second_try_no_retryable(self):
-        from google.cloud.bigtable._generated.bigtable_pb2 import (
-            MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
-        from google.rpc.status_pb2 import Status
         from tests.unit._testing import _FakeStub
 
         # Setup:
@@ -998,10 +974,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_do_mutate_retryable_rows_mismatch_num_responses(self):
-        from google.cloud.bigtable._generated.bigtable_pb2 import (
-            MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
-        from google.rpc.status_pb2 import Status
         from tests.unit._testing import _FakeStub
 
         client = _Client()

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -834,10 +834,10 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_do_mutate_retryable_rows_retry(self):
-        from google.api_core.exceptions import ServiceUnavailable
         from google.cloud.bigtable._generated.bigtable_pb2 import (
             MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
+        from google.cloud.bigtable.table import _BigtableRetryableError
         from google.rpc.status_pb2 import Status
         from tests.unit._testing import _FakeStub
 
@@ -884,7 +884,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         worker = self._make_worker(table._instance._client,
                 table.name, [row_1, row_2, row_3])
 
-        with self.assertRaises(ServiceUnavailable):
+        with self.assertRaises(_BigtableRetryableError):
             worker._do_mutate_retryable_rows()
 
         statuses = worker.responses_statuses
@@ -894,10 +894,10 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_do_mutate_retryable_rows_second_retry(self):
-        from google.api_core.exceptions import ServiceUnavailable
         from google.cloud.bigtable._generated.bigtable_pb2 import (
             MutateRowsResponse)
         from google.cloud.bigtable.row import DirectRow
+        from google.cloud.bigtable.table import _BigtableRetryableError
         from google.rpc.status_pb2 import Status
         from tests.unit._testing import _FakeStub
 
@@ -949,7 +949,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         worker.responses_statuses = self._make_responses_statuses(
                 [0, 4, 1, 10])
 
-        with self.assertRaises(ServiceUnavailable):
+        with self.assertRaises(_BigtableRetryableError):
             worker._do_mutate_retryable_rows()
 
         statuses = worker.responses_statuses

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -580,6 +580,17 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         response = [Status(code=code) for code in codes]
         return response
 
+    def _make_responses(self, codes):
+        import six
+        from google.cloud.bigtable._generated.bigtable_pb2 import (
+            MutateRowsResponse)
+        from google.rpc.status_pb2 import Status
+
+        entries = [MutateRowsResponse.Entry(
+            index=i, status=Status(code=codes[i]))
+            for i in six.moves.xrange(len(codes))]
+        return MutateRowsResponse(entries=entries)
+
     def test_callable_empty_rows(self):
         client = _Client()
         instance = _Instance(self.INSTANCE_NAME, client=client)
@@ -618,22 +629,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         row_3 = DirectRow(row_key=b'row_key_3', table=table)
         row_3.set_cell('cf', b'col', b'value3')
 
-        response = MutateRowsResponse(
-            entries=[
-                MutateRowsResponse.Entry(
-                    index=0,
-                    status=Status(code=0),
-                ),
-                MutateRowsResponse.Entry(
-                    index=1,
-                    status=Status(code=4),
-                ),
-                MutateRowsResponse.Entry(
-                    index=2,
-                    status=Status(code=1),
-                ),
-            ],
-        )
+        response = self._make_responses([0, 4, 1])
 
         # Patch the stub used by the API method.
         client._data_stub = mock.MagicMock()
@@ -678,31 +674,8 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         row_3 = DirectRow(row_key=b'row_key_3', table=table)
         row_3.set_cell('cf', b'col', b'value3')
 
-        response_1 = MutateRowsResponse(
-            entries=[
-                MutateRowsResponse.Entry(
-                    index=0,
-                    status=Status(code=0),
-                ),
-                MutateRowsResponse.Entry(
-                    index=1,
-                    status=Status(code=4),
-                ),
-                MutateRowsResponse.Entry(
-                    index=2,
-                    status=Status(code=1),
-                ),
-            ],
-        )
-
-        response_2 = MutateRowsResponse(
-            entries=[
-                MutateRowsResponse.Entry(
-                    index=0,
-                    status=Status(code=0),
-                ),
-            ],
-        )
+        response_1 = self._make_responses([0, 4, 1])
+        response_2 = self._make_responses([0])
 
         # Patch the stub used by the API method.
         client._data_stub = mock.MagicMock()
@@ -747,18 +720,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         row_2 = DirectRow(row_key=b'row_key_2', table=table)
         row_2.set_cell('cf', b'col', b'value2')
 
-        response = MutateRowsResponse(
-            entries=[
-                MutateRowsResponse.Entry(
-                    index=0,
-                    status=Status(code=4),
-                ),
-                MutateRowsResponse.Entry(
-                    index=1,
-                    status=Status(code=4),
-                ),
-            ],
-        )
+        response = self._make_responses([4, 4])
 
         # Patch the stub used by the API method.
         client._data_stub = mock.MagicMock()
@@ -808,18 +770,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         row_2 = DirectRow(row_key=b'row_key_2', table=table)
         row_2.set_cell('cf', b'col', b'value2')
 
-        response = MutateRowsResponse(
-            entries=[
-                MutateRowsResponse.Entry(
-                    index=0,
-                    status=Status(code=0),
-                ),
-                MutateRowsResponse.Entry(
-                    index=1,
-                    status=Status(code=1),
-                ),
-            ],
-        )
+        response = self._make_responses([0, 1])
 
         # Patch the stub used by the API method.
         client._data_stub = _FakeStub([response])
@@ -861,22 +812,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         row_3 = DirectRow(row_key=b'row_key_3', table=table)
         row_3.set_cell('cf', b'col', b'value3')
 
-        response = MutateRowsResponse(
-            entries=[
-                MutateRowsResponse.Entry(
-                    index=0,
-                    status=Status(code=0),
-                ),
-                MutateRowsResponse.Entry(
-                    index=1,
-                    status=Status(code=4),
-                ),
-                MutateRowsResponse.Entry(
-                    index=2,
-                    status=Status(code=1),
-                ),
-            ],
-        )
+        response = self._make_responses([0, 4, 1])
 
         # Patch the stub used by the API method.
         client._data_stub = _FakeStub([response])
@@ -928,18 +864,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         row_4 = DirectRow(row_key=b'row_key_4', table=table)
         row_4.set_cell('cf', b'col', b'value4')
 
-        response = MutateRowsResponse(
-            entries=[
-                MutateRowsResponse.Entry(
-                    index=0,
-                    status=Status(code=0),
-                ),
-                MutateRowsResponse.Entry(
-                    index=1,
-                    status=Status(code=4),
-                ),
-            ],
-        )
+        response = self._make_responses([0, 4])
 
         # Patch the stub used by the API method.
         client._data_stub = _FakeStub([response])
@@ -988,18 +913,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         row_4 = DirectRow(row_key=b'row_key_4', table=table)
         row_4.set_cell('cf', b'col', b'value4')
 
-        response = MutateRowsResponse(
-            entries=[
-                MutateRowsResponse.Entry(
-                    index=0,
-                    status=Status(code=1),
-                ),
-                MutateRowsResponse.Entry(
-                    index=1,
-                    status=Status(code=0),
-                ),
-            ],
-        )
+        response = self._make_responses([1, 0])
 
         # Patch the stub used by the API method.
         client._data_stub = _FakeStub([response])
@@ -1068,14 +982,7 @@ class Test__RetryableMutateRowsWorker(unittest.TestCase):
         row_2 = DirectRow(row_key=b'row_key_2', table=table)
         row_2.set_cell('cf', b'col', b'value2')
 
-        response = MutateRowsResponse(
-            entries=[
-                MutateRowsResponse.Entry(
-                    index=0,
-                    status=Status(code=0),
-                ),
-            ],
-        )
+        response = self._make_responses([0])
 
         # Patch the stub used by the API method.
         client._data_stub = _FakeStub([response])

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -551,16 +551,18 @@ class TestTable(unittest.TestCase):
 
 
 class Test__RetryableMutateRowsWorker(unittest.TestCase):
+    from grpc import StatusCode
+
     PROJECT_ID = 'project-id'
     INSTANCE_ID = 'instance-id'
     INSTANCE_NAME = ('projects/' + PROJECT_ID + '/instances/' + INSTANCE_ID)
     TABLE_ID = 'table-id'
 
     # RPC Status Codes
-    SUCCESS = 0
-    RETRYABLE_1 = 4
-    RETRYABLE_2 = 10
-    NON_RETRYABLE = 1
+    SUCCESS = StatusCode.OK.value[0]
+    RETRYABLE_1 = StatusCode.DEADLINE_EXCEEDED.value[0]
+    RETRYABLE_2 = StatusCode.ABORTED.value[0]
+    NON_RETRYABLE = StatusCode.CANCELLED.value[0]
 
     @staticmethod
     def _get_target_class_for_worker():


### PR DESCRIPTION
/cc @dhermes 

As discussed in https://github.com/GoogleCloudPlatform/google-cloud-python/pull/4333, this change addresses the input retry=None for `mutate_rows`. @jonparrott I made an internal error `_BigtableRetryableError` and have it be used to trigger the retry instead of raising a fake `SerivceUnavailable`. Would like to get your opinion regarding this use.

Also factored out test response creation and replaced the magic numbers with constants for RPC Status Code. And removed the extra `the` from the error message.