### PR TITLE
Set next_page_token to none if there are no more result

### DIFF
--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -26,9 +26,10 @@ from google.cloud.datastore.key import Key
 
 
 _NOT_FINISHED = query_pb2.QueryResultBatch.NOT_FINISHED
+_NO_MORE_RESULTS = query_pb2.QueryResultBatch.NO_MORE_RESULTS
 
 _FINISHED = (
-    query_pb2.QueryResultBatch.NO_MORE_RESULTS,
+    _NO_MORE_RESULTS,
     query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_LIMIT,
     query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_CURSOR,
 )
@@ -470,7 +471,7 @@ class Iterator(page_iterator.Iterator):
         """
         self._skipped_results = response_pb.batch.skipped_results
 
-        if response_pb.batch.end_cursor == b'':  # Empty-value for bytes.
+        if response_pb.batch.more_results == _NO_MORE_RESULTS:
             self.next_page_token = None
         else:
             self.next_page_token = base64.urlsafe_b64encode(

--- a/datastore/tests/unit/test_query.py
+++ b/datastore/tests/unit/test_query.py
@@ -467,7 +467,7 @@ class TestIterator(unittest.TestCase):
         entity_pbs = [
             _make_entity('World', 1234, 'PROJECT'),
         ]
-        cursor_as_bytes = b''
+        cursor_as_bytes = b'\x9ai\xe7'
         skipped_results = 44
         more_results_enum = query_pb2.QueryResultBatch.NO_MORE_RESULTS
         response_pb = _make_query_response(


### PR DESCRIPTION
Depending on empty value of `response_pb.batch.end_cursor` is not reliable as the behaviour is not documented. It's better to check API response field `moreResults`, see
https://cloud.google.com/datastore/docs/reference/rpc/google.datastore.v1#google.datastore.v1.QueryResultBatch.

Closes #4347.
