### PR TITLE
Datastore: Add support for 'TransactionOptions'

### DIFF
--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -511,9 +511,13 @@ class Client(ClientWithProject):
         """Proxy to :class:`google.cloud.datastore.batch.Batch`."""
         return Batch(self)
 
-    def transaction(self):
-        """Proxy to :class:`google.cloud.datastore.transaction.Transaction`."""
-        return Transaction(self)
+    def transaction(self, **kwargs):
+        """Proxy to :class:`google.cloud.datastore.transaction.Transaction`.
+
+        :type kwargs: dict
+        :param kwargs: Keyword arguments to be passed in.
+        """
+        return Transaction(self, **kwargs)
 
     def query(self, **kwargs):
         """Proxy to :class:`google.cloud.datastore.query.Query`.

--- a/datastore/tests/system/test_system.py
+++ b/datastore/tests/system/test_system.py
@@ -22,6 +22,7 @@ import six
 from google.cloud._helpers import UTC
 from google.cloud import datastore
 from google.cloud.datastore.helpers import GeoPoint
+from google.cloud.datastore_v1 import types
 from google.cloud.environment_vars import GCD_DATASET
 from google.cloud.exceptions import Conflict
 

--- a/datastore/tests/unit/test_client.py
+++ b/datastore/tests/unit/test_client.py
@@ -934,6 +934,22 @@ class TestClient(unittest.TestCase):
             self.assertIs(xact, mock_klass.return_value)
             mock_klass.assert_called_once_with(client)
 
+    def test_read_only_transaction_defaults(self):
+        from google.cloud.datastore.transaction import Transaction
+        from google.cloud.datastore_v1.types import TransactionOptions
+        creds = _make_credentials()
+        client = self._make_one(credentials=creds)
+        xact = client.transaction(read_only=True)
+        self.assertEqual(xact._options,
+                         TransactionOptions(
+                             read_only=TransactionOptions.ReadOnly()
+                         )
+        )
+        self.assertFalse(xact._options.HasField("read_write"))
+        self.assertTrue(xact._options.HasField("read_only"))
+        self.assertEqual(xact._options.read_only,
+                         TransactionOptions.ReadOnly())
+
     def test_query_w_client(self):
         KIND = 'KIND'
 


### PR DESCRIPTION
Changes reflecting review and Luke's autogen (please see #4348 for issues regarding his autogen).  A manual fix has been included.

Closes #4335.  This includes reviews and changes from there.