### PR TITLE
Harden spanner system tests against stray databases

### DIFF
--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -274,12 +274,10 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
         # We want to make sure the operation completes.
         operation.result(30)  # raises on failure / timeout.
 
-        name_attr = operator.attrgetter('name')
-        expected = sorted([temp_db, self._db], key=name_attr)
-
-        databases = list(Config.INSTANCE.list_databases())
-        found = sorted(databases, key=name_attr)
-        self.assertEqual(found, expected)
+        database_ids = [
+            database.database_id
+            for database in Config.INSTANCE.list_databases()]
+        self.assertIn(temp_db_id, database_ids)
 
     def test_update_database_ddl(self):
         pool = BurstyPool()


### PR DESCRIPTION
Because of quota, we are sharing the instance we use to test CRUD of databases: we therefore cannot rely on having only the expected databases present, as other tests may be running simultaneously, or may have failed
in ways which left 'stray' databases in the instance.