### PR TITLE
Post #4350 cleanup: Missed a rename of a test helper due to concurrent merges

### DIFF
--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -2723,7 +2723,7 @@ class TestQueryJob(unittest.TestCase, _Base):
     def test_iter(self):
         import types
 
-        begun_resource = self._makeResource()
+        begun_resource = self._make_resource()
         query_resource = {
             'jobComplete': True,
             'jobReference': {


### PR DESCRIPTION
This happened because #4350 was sent before #4355 was merged.

/cc @alixhami This may have been avoidable (e.g. with a rebase) but since there were no changes needed in the review, it's likely that this was just unavoidable (except for superhumans).