### PR TITLE
BigQuery: add reference property to Table and Dataset

### DIFF
--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -280,6 +280,17 @@ class Dataset(object):
         return self._properties.get('id')
 
     @property
+    def reference(self):
+        """A :class:`~google.cloud.bigquery.dataset.DatasetReference` pointing to
+        this dataset.
+
+        Returns:
+            google.cloud.bigquery.dataset.DatasetReference:
+                A pointer to this dataset
+        """
+        return DatasetReference(self.project, self.dataset_id)
+
+    @property
     def etag(self):
         """ETag for the dataset resource.
 

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -34,6 +34,19 @@ _TABLE_HAS_NO_SCHEMA = "Table has no schema:  call 'client.get_table()'"
 _MARKER = object()
 
 
+def _reference_getter(table):
+    """A :class:`~google.cloud.bigquery.table.TableReference` pointing to
+    this table.
+
+    Returns:
+        google.cloud.bigquery.table.TableReference: pointer to this table
+    """
+    from google.cloud.bigquery import dataset
+
+    dataset_ref = dataset.DatasetReference(table.project, table.dataset_id)
+    return TableReference(dataset_ref, table.table_id)
+
+
 def _view_use_legacy_sql_getter(table):
     """Specifies whether to execute the view with Legacy or Standard SQL.
 
@@ -223,19 +236,7 @@ class Table(object):
         """
         return self._table_id
 
-    @property
-    def reference(self):
-        """A :class:`~google.cloud.bigquery.table.TableReference` pointing to
-        this table.
-
-        Returns:
-            google.cloud.bigquery.table.TableReference:
-                A pointer to this table
-        """
-        from google.cloud.bigquery import dataset
-
-        dataset_ref = dataset.DatasetReference(self.project, self.dataset_id)
-        return TableReference(dataset_ref, self.table_id)
+    reference = property(_reference_getter)
 
     @property
     def path(self):
@@ -778,18 +779,7 @@ class TableListItem(object):
         """
         return self._properties.get('tableReference', {}).get('tableId')
 
-    @property
-    def reference(self):
-        """A :class:`~google.cloud.bigquery.table.TableReference` pointing to
-        this table.
-
-        Returns:
-            google.cloud.bigquery.table.TableReference: pointer to this table
-        """
-        from google.cloud.bigquery import dataset
-
-        dataset_ref = dataset.DatasetReference(self.project, self.dataset_id)
-        return TableReference(dataset_ref, self.table_id)
+    reference = property(_reference_getter)
 
     @property
     def labels(self):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -224,6 +224,20 @@ class Table(object):
         return self._table_id
 
     @property
+    def reference(self):
+        """A :class:`~google.cloud.bigquery.table.TableReference` pointing to
+        this table.
+
+        Returns:
+            google.cloud.bigquery.table.TableReference:
+                A pointer to this table
+        """
+        from google.cloud.bigquery import dataset
+
+        dataset_ref = dataset.DatasetReference(self.project, self.dataset_id)
+        return TableReference(dataset_ref, self.table_id)
+
+    @property
     def path(self):
         """URL path for the table's APIs.
 

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -245,7 +245,10 @@ class TestDataset(unittest.TestCase):
 
     def _verify_readonly_resource_properties(self, dataset, resource):
 
+        self.assertEqual(dataset.project, self.PROJECT)
         self.assertEqual(dataset.dataset_id, self.DS_ID)
+        self.assertEqual(dataset.reference.project, self.PROJECT)
+        self.assertEqual(dataset.reference.dataset_id, self.DS_ID)
 
         if 'creationTime' in resource:
             self.assertEqual(dataset.created, self.WHEN)

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -293,6 +293,9 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertEqual(table.table_id, self.TABLE_NAME)
         self.assertEqual(table.project, self.PROJECT)
         self.assertEqual(table.dataset_id, self.DS_ID)
+        self.assertEqual(table.reference.table_id, self.TABLE_NAME)
+        self.assertEqual(table.reference.project, self.PROJECT)
+        self.assertEqual(table.reference.dataset_id, self.DS_ID)
         self.assertEqual(
             table.path,
             '/projects/%s/datasets/%s/tables/%s' % (


### PR DESCRIPTION
This makes it easier to call `get_table`, `get_dataset`, or other
functions that want just a reference, not a full resource.

Closes https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4327