### PR TITLE
BigQuery: Use TableListItem for table listing.

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -31,27 +31,28 @@ from google.resumable_media.requests import ResumableUpload
 from google.api_core import page_iterator
 from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.exceptions import NotFound
-
 from google.cloud import exceptions
 from google.cloud.client import ClientWithProject
+
+from google.cloud.bigquery._helpers import DEFAULT_RETRY
+from google.cloud.bigquery._helpers import _SCALAR_VALUE_TO_JSON_ROW
+from google.cloud.bigquery._helpers import _field_to_index_mapping
+from google.cloud.bigquery._helpers import _item_to_row
+from google.cloud.bigquery._helpers import _rows_page_start
+from google.cloud.bigquery._helpers import _snake_to_camel_case
 from google.cloud.bigquery._http import Connection
 from google.cloud.bigquery.dataset import Dataset
 from google.cloud.bigquery.dataset import DatasetReference
-from google.cloud.bigquery.table import Table, _TABLE_HAS_NO_SCHEMA
-from google.cloud.bigquery.table import TableListItem
-from google.cloud.bigquery.table import TableReference
-from google.cloud.bigquery.table import _row_from_mapping
 from google.cloud.bigquery.job import CopyJob
 from google.cloud.bigquery.job import ExtractJob
 from google.cloud.bigquery.job import LoadJob
 from google.cloud.bigquery.job import QueryJob, QueryJobConfig
 from google.cloud.bigquery.query import QueryResults
-from google.cloud.bigquery._helpers import _item_to_row
-from google.cloud.bigquery._helpers import _rows_page_start
-from google.cloud.bigquery._helpers import _field_to_index_mapping
-from google.cloud.bigquery._helpers import _SCALAR_VALUE_TO_JSON_ROW
-from google.cloud.bigquery._helpers import DEFAULT_RETRY
-from google.cloud.bigquery._helpers import _snake_to_camel_case
+from google.cloud.bigquery.table import Table
+from google.cloud.bigquery.table import TableListItem
+from google.cloud.bigquery.table import TableReference
+from google.cloud.bigquery.table import _TABLE_HAS_NO_SCHEMA
+from google.cloud.bigquery.table import _row_from_mapping
 
 
 _DEFAULT_CHUNKSIZE = 1048576  # 1024 * 1024 B = 1 MB

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -38,6 +38,7 @@ from google.cloud.bigquery._http import Connection
 from google.cloud.bigquery.dataset import Dataset
 from google.cloud.bigquery.dataset import DatasetReference
 from google.cloud.bigquery.table import Table, _TABLE_HAS_NO_SCHEMA
+from google.cloud.bigquery.table import TableListItem
 from google.cloud.bigquery.table import TableReference
 from google.cloud.bigquery.table import _row_from_mapping
 from google.cloud.bigquery.job import CopyJob
@@ -405,8 +406,9 @@ class Client(ClientWithProject):
         :param retry: (Optional) How to retry the RPC.
 
         :rtype: :class:`~google.api_core.page_iterator.Iterator`
-        :returns: Iterator of :class:`~google.cloud.bigquery.table.Table`
-                  contained within the current dataset.
+        :returns:
+            Iterator of :class:`~google.cloud.bigquery.table.TableListItem`
+            contained within the current dataset.
         """
         if not isinstance(dataset, (Dataset, DatasetReference)):
             raise TypeError('dataset must be a Dataset or a DatasetReference')
@@ -1367,7 +1369,7 @@ def _item_to_table(iterator, resource):
     :rtype: :class:`~google.cloud.bigquery.table.Table`
     :returns: The next table in the page.
     """
-    return Table.from_api_repr(resource)
+    return TableListItem(resource)
 
 
 def _make_job_id(job_id, prefix=None):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -713,6 +713,137 @@ class Table(object):
         return resource
 
 
+class TableListItem(object):
+    """Read-only table resource object with a subset of table properties.
+
+    See
+    https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list
+
+    Args:
+        resource (dict): A table resource object from a table list response.
+    """
+
+    def __init__(self, resource):
+        self._properties = resource
+
+    @property
+    def project(self):
+        """The project ID of the project this table belongs to.
+
+        Returns:
+            str: the project ID of the table.
+        """
+        return self._properties.get('tableReference', {}).get('projectId')
+
+    @property
+    def dataset_id(self):
+        """The dataset ID of the dataset this table belongs to.
+
+        Returns:
+            str: the dataset ID of the table.
+        """
+        return self._properties.get('tableReference', {}).get('datasetId')
+
+    @property
+    def table_id(self):
+        """The table ID.
+
+        Returns:
+            str: the table ID.
+        """
+        return self._properties.get('tableReference', {}).get('tableId')
+
+    @property
+    def reference(self):
+        """A :class:`~google.cloud.bigquery.table.TableReference` pointing to
+        this table.
+
+        Returns:
+            google.cloud.bigquery.table.TableReference: pointer to this table
+        """
+        from google.cloud.bigquery import dataset
+
+        dataset_ref = dataset.DatasetReference(self.project, self.dataset_id)
+        return TableReference(dataset_ref, self.table_id)
+
+    @property
+    def labels(self):
+        """Labels for the table.
+
+        This method always returns a dict. To change a table's labels,
+        modify the dict, then call ``Client.update_table``. To delete a
+        label, set its value to ``None`` before updating.
+
+        Returns:
+            Map[str, str]: A dictionary of the the table's labels
+        """
+        return self._properties.get('labels', {})
+
+    @property
+    def full_table_id(self):
+        """ID for the table, in the form ``project_id:dataset_id:table_id``.
+
+        Returns:
+            str: The fully-qualified ID of the table
+        """
+        return self._properties.get('id')
+
+    @property
+    def table_type(self):
+        """The type of the table.
+
+        Possible values are "TABLE", "VIEW", or "EXTERNAL".
+
+        Returns:
+            str: The kind of table
+        """
+        return self._properties.get('type')
+
+    @property
+    def partitioning_type(self):
+        """Time partitioning of the table.
+
+        Returns:
+            str:
+                Type of partitioning if the table is partitioned, None
+                otherwise.
+        """
+        return self._properties.get('timePartitioning', {}).get('type')
+
+    @property
+    def partition_expiration(self):
+        """Expiration time in ms for a partition
+
+        Returns:
+            int: The time in ms for partition expiration
+        """
+        return int(
+            self._properties.get('timePartitioning', {}).get('expirationMs'))
+
+    @property
+    def friendly_name(self):
+        """Title of the table.
+
+        Returns:
+            str: The name as set by the user, or None (the default)
+        """
+        return self._properties.get('friendlyName')
+
+    @property
+    def view_use_legacy_sql(self):
+        """Specifies whether to execute the view with Legacy or Standard SQL.
+
+        If this table is not a view, None is returned.
+
+        Returns:
+            bool: True if the view is using legacy SQL, or None if not a view
+        """
+        view = self._properties.get('view', {})
+        if self.table_type == 'VIEW':
+            # The server-side default for useLegacySql is True.
+            return view.get('useLegacySql', True)
+
+
 def _row_from_mapping(mapping, schema):
     """Convert a mapping to a row tuple using the schema.
 

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -717,13 +717,21 @@ class Table(object):
 
 
 class TableListItem(object):
-    """Read-only table resource object with a subset of table properties.
+    """A read-only table resource from a list operation.
 
-    See
-    https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list
+    For performance reasons, the BigQuery API only includes some of the table
+    properties when listing tables. Notably,
+    :attr:`google.cloud.bigquery.table.Table.schema` and
+    :attr:`google.cloud.bigquery.table.Table.num_rows` are missing.
+
+    For a full list of the properties that the BigQuery API returns, see the
+    `REST documentation for tables.list
+    <https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list>`.
+
 
     Args:
-        resource (dict): A table resource object from a table list response.
+        resource (dict):
+            A table-like resource object from a table list response.
     """
 
     def __init__(self, resource):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -726,7 +726,7 @@ class TableListItem(object):
 
     For a full list of the properties that the BigQuery API returns, see the
     `REST documentation for tables.list
-    <https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list>`.
+    <https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list>`_.
 
 
     Args:

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -721,8 +721,8 @@ class TableListItem(object):
 
     For performance reasons, the BigQuery API only includes some of the table
     properties when listing tables. Notably,
-    :attr:`google.cloud.bigquery.table.Table.schema` and
-    :attr:`google.cloud.bigquery.table.Table.num_rows` are missing.
+    :attr:`~google.cloud.bigquery.table.Table.schema` and
+    :attr:`~google.cloud.bigquery.table.Table.num_rows` are missing.
 
     For a full list of the properties that the BigQuery API returns, see the
     `REST documentation for tables.list

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -1002,7 +1002,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_dataset_tables_defaults(self):
-        from google.cloud.bigquery.table import Table
+        from google.cloud.bigquery.table import TableListItem
 
         TABLE_1 = 'table_one'
         TABLE_2 = 'table_two'
@@ -1039,7 +1039,7 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(len(tables), len(DATA['tables']))
         for found, expected in zip(tables, DATA['tables']):
-            self.assertIsInstance(found, Table)
+            self.assertIsInstance(found, TableListItem)
             self.assertEqual(found.full_table_id, expected['id'])
             self.assertEqual(found.table_type, expected['type'])
         self.assertEqual(token, TOKEN)
@@ -1050,7 +1050,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['path'], '/%s' % PATH)
 
     def test_list_dataset_tables_explicit(self):
-        from google.cloud.bigquery.table import Table
+        from google.cloud.bigquery.table import TableListItem
 
         TABLE_1 = 'table_one'
         TABLE_2 = 'table_two'
@@ -1087,7 +1087,7 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(len(tables), len(DATA['tables']))
         for found, expected in zip(tables, DATA['tables']):
-            self.assertIsInstance(found, Table)
+            self.assertIsInstance(found, TableListItem)
             self.assertEqual(found.full_table_id, expected['id'])
             self.assertEqual(found.table_type, expected['type'])
         self.assertIsNone(token)

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -817,9 +817,6 @@ class TestTableListItem(unittest.TestCase):
                 'tableId': table_id,
             },
             'type': 'VIEW',
-            'view': {
-                'useLegacySql': False,
-            },
         }
 
         table = self._make_one(resource)
@@ -833,7 +830,8 @@ class TestTableListItem(unittest.TestCase):
         self.assertEqual(table.reference.dataset_id, dataset_id)
         self.assertEqual(table.reference.table_id, table_id)
         self.assertEqual(table.table_type, 'VIEW')
-        self.assertFalse(table.view_use_legacy_sql)
+        # Server default for useLegacySql is True.
+        self.assertTrue(table.view_use_legacy_sql)
 
 
 class TestRow(unittest.TestCase):

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -753,6 +753,89 @@ class Test_row_from_mapping(unittest.TestCase, _SchemaBase):
             ('Phred Phlyntstone', 32, ['red', 'green'], None))
 
 
+class TestTableListItem(unittest.TestCase):
+
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.bigquery.table import TableListItem
+
+        return TableListItem
+
+    def _make_one(self, *args, **kw):
+        return self._get_target_class()(*args, **kw)
+
+    def test_ctor(self):
+        project = 'test-project'
+        dataset_id = 'test_dataset'
+        table_id = 'coffee_table'
+        resource = {
+            'kind': 'bigquery#table',
+            'id': '{}:{}:{}'.format(project, dataset_id, table_id),
+            'tableReference': {
+                'projectId': project,
+                'datasetId': dataset_id,
+                'tableId': table_id,
+            },
+            'friendlyName': 'Mahogany Coffee Table',
+            'type': 'TABLE',
+            'timePartitioning': {
+                'type': 'DAY',
+                'expirationMs': '10000',
+            },
+            'labels': {
+                'some-stuff': 'this-is-a-label',
+            },
+        }
+
+        table = self._make_one(resource)
+        self.assertEqual(table.project, project)
+        self.assertEqual(table.dataset_id, dataset_id)
+        self.assertEqual(table.table_id, table_id)
+        self.assertEqual(
+            table.full_table_id,
+            '{}:{}:{}'.format(project, dataset_id, table_id))
+        self.assertEqual(table.reference.project, project)
+        self.assertEqual(table.reference.dataset_id, dataset_id)
+        self.assertEqual(table.reference.table_id, table_id)
+        self.assertEqual(table.friendly_name, 'Mahogany Coffee Table')
+        self.assertEqual(table.table_type, 'TABLE')
+        self.assertEqual(table.partitioning_type, 'DAY')
+        self.assertEqual(table.partition_expiration, 10000)
+        self.assertEqual(table.labels['some-stuff'], 'this-is-a-label')
+        self.assertIsNone(table.view_use_legacy_sql)
+
+    def test_ctor_view(self):
+        project = 'test-project'
+        dataset_id = 'test_dataset'
+        table_id = 'just_looking'
+        resource = {
+            'kind': 'bigquery#table',
+            'id': '{}:{}:{}'.format(project, dataset_id, table_id),
+            'tableReference': {
+                'projectId': project,
+                'datasetId': dataset_id,
+                'tableId': table_id,
+            },
+            'type': 'VIEW',
+            'view': {
+                'useLegacySql': False,
+            },
+        }
+
+        table = self._make_one(resource)
+        self.assertEqual(table.project, project)
+        self.assertEqual(table.dataset_id, dataset_id)
+        self.assertEqual(table.table_id, table_id)
+        self.assertEqual(
+            table.full_table_id,
+            '{}:{}:{}'.format(project, dataset_id, table_id))
+        self.assertEqual(table.reference.project, project)
+        self.assertEqual(table.reference.dataset_id, dataset_id)
+        self.assertEqual(table.reference.table_id, table_id)
+        self.assertEqual(table.table_type, 'VIEW')
+        self.assertFalse(table.view_use_legacy_sql)
+
+
 class TestRow(unittest.TestCase):
 
     def test_row(self):


### PR DESCRIPTION
The table list response only includes a subset of all table properties.
This commit adds a new type to document explicitly which properties are
included, but also make it clear that this object should not be used in
place of a full Table object.

Towards #4373 (needs a similar change for dataset listing before closing that issue)