### PR TITLE
PubSub: Making `thread.Policy.on_exception` more robust.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
@@ -66,7 +66,7 @@ class BasePolicy(object):
     """
 
     _managed_ack_ids = None
-    _IDEMPOTENT_RETRIES = (
+    _RETRYABLE_STREAM_ERRORS = (
         exceptions.DeadlineExceeded,
         exceptions.ServiceUnavailable,
     )

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
@@ -21,6 +21,7 @@ import logging
 import random
 import time
 
+from google.api_core import exceptions
 import six
 
 from google.cloud.pubsub_v1 import types
@@ -65,6 +66,10 @@ class BasePolicy(object):
     """
 
     _managed_ack_ids = None
+    _IDEMPOTENT_RETRIES = (
+        exceptions.DeadlineExceeded,
+        exceptions.ServiceUnavailable,
+    )
 
     def __init__(self, client, subscription,
                  flow_control=types.FlowControl(), histogram_data=None):

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -155,7 +155,7 @@ class Policy(base.BasePolicy):
         """
         # If this is in the list of idempotent exceptions, then we want to
         # retry. That entails just returning None.
-        if isinstance(exception, self._IDEMPOTENT_RETRIES):
+        if isinstance(exception, self._RETRYABLE_STREAM_ERRORS):
             return
 
         # Set any other exception on the future.

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -21,7 +21,6 @@ import threading
 import grpc
 from six.moves import queue as queue_mod
 
-from google.api_core import exceptions
 from google.cloud.pubsub_v1 import types
 from google.cloud.pubsub_v1.subscriber import _helper_threads
 from google.cloud.pubsub_v1.subscriber.futures import Future
@@ -29,16 +28,12 @@ from google.cloud.pubsub_v1.subscriber.policy import base
 from google.cloud.pubsub_v1.subscriber.message import Message
 
 
-_LOGGER = logging.getLogger(__name__)
-_IDEMPOTENT_RETRY_CODES = (
-    grpc.StatusCode.DEADLINE_EXCEEDED,
-    grpc.StatusCode.UNAVAILABLE,
-)
+logger = logging.getLogger(__name__)
 
 
 def _callback_completed(future):
     """Simple callback that just logs a `Future`'s result."""
-    _LOGGER.debug('Result: %s', future.result())
+    logger.debug('Result: %s', future.result())
 
 
 class Policy(base.BasePolicy):
@@ -85,7 +80,7 @@ class Policy(base.BasePolicy):
         )
 
         # Also maintain a request queue and an executor.
-        _LOGGER.debug('Creating callback requests thread (not starting).')
+        logger.debug('Creating callback requests thread (not starting).')
         if executor is None:
             executor = futures.ThreadPoolExecutor(max_workers=10)
         self._executor = executor
@@ -127,7 +122,7 @@ class Policy(base.BasePolicy):
         self._future = Future(policy=self)
 
         # Start the thread to pass the requests.
-        _LOGGER.debug('Starting callback requests worker.')
+        logger.debug('Starting callback requests worker.')
         self._callback = callback
         self._consumer.helper_threads.start(
             'callback requests worker',
@@ -140,7 +135,7 @@ class Policy(base.BasePolicy):
 
         # Spawn a helper thread that maintains all of the leases for
         # this policy.
-        _LOGGER.debug('Spawning lease maintenance worker.')
+        logger.debug('Spawning lease maintenance worker.')
         self._leaser = threading.Thread(target=self.maintain_leases)
         self._leaser.daemon = True
         self._leaser.start()
@@ -158,16 +153,9 @@ class Policy(base.BasePolicy):
 
         This will cause the stream to exit loudly.
         """
-        if isinstance(exception, exceptions.GoogleAPICallError):
-            code = exception.grpc_status_code
-        else:
-            code = getattr(exception, 'code', None)
-            if callable(code):
-                code = code()
-
-        # If this is in the list of idempotent exceptions DEADLINE_EXCEEDED,
-        # then we want to retry. That entails just returning None.
-        if code in _IDEMPOTENT_RETRY_CODES:
+        # If this is in the list of idempotent exceptions, then we want to
+        # retry. That entails just returning None.
+        if isinstance(exception, self._IDEMPOTENT_RETRIES):
             return
 
         # Set any other exception on the future.
@@ -179,8 +167,8 @@ class Policy(base.BasePolicy):
         For each message, schedule a callback with the executor.
         """
         for msg in response.received_messages:
-            _LOGGER.debug('New message received from Pub/Sub: %r', msg)
-            _LOGGER.debug(self._callback)
+            logger.debug('New message received from Pub/Sub: %r', msg)
+            logger.debug(self._callback)
             message = Message(msg.message, msg.ack_id, self._request_queue)
             future = self._executor.submit(self._callback, message)
             future.add_done_callback(_callback_completed)

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_base.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_base.py
@@ -46,7 +46,7 @@ def test_idempotent_retry_codes():
         exceptions.exception_class_for_grpc_status(status_code)
         for status_code in status_codes
     )
-    assert base.BasePolicy._IDEMPOTENT_RETRIES == expected
+    assert base.BasePolicy._RETRYABLE_STREAM_ERRORS == expected
 
 
 def test_ack_deadline():

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
@@ -19,8 +19,6 @@ import threading
 
 from google.api_core import exceptions
 from google.auth import credentials
-import grpc
-import grpc._channel
 import mock
 import pytest
 from six.moves import queue
@@ -91,21 +89,15 @@ def test_on_callback_request():
 
 
 def test_on_exception_deadline_exceeded():
-    # Also traverses the raw gRPC exception path.
     policy = create_policy()
 
-    trailing = None
-    status_code = grpc.StatusCode.DEADLINE_EXCEEDED
     details = 'Bad thing happened. Time out, go sit in the corner.'
-    exc_state = grpc._channel._RPCState(
-        (), None, trailing, status_code, details)
-    exc = grpc._channel._Rendezvous(exc_state, None, None, None)
+    exc = exceptions.DeadlineExceeded(details)
 
     assert policy.on_exception(exc) is None
 
 
 def test_on_exception_unavailable():
-    # Also traverses the ``api_core`` exception path.
     policy = create_policy()
 
     details = 'UNAVAILABLE. Service taking nap.'

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
@@ -17,8 +17,10 @@ from __future__ import absolute_import
 from concurrent import futures
 import threading
 
+from google.api_core import exceptions
 from google.auth import credentials
 import grpc
+import grpc._channel
 import mock
 import pytest
 from six.moves import queue
@@ -89,9 +91,26 @@ def test_on_callback_request():
 
 
 def test_on_exception_deadline_exceeded():
+    # Also traverses the raw gRPC exception path.
     policy = create_policy()
-    exc = mock.Mock(spec=('code',))
-    exc.code.return_value = grpc.StatusCode.DEADLINE_EXCEEDED
+
+    trailing = None
+    status_code = grpc.StatusCode.DEADLINE_EXCEEDED
+    details = 'Bad thing happened. Time out, go sit in the corner.'
+    exc_state = grpc._channel._RPCState(
+        (), None, trailing, status_code, details)
+    exc = grpc._channel._Rendezvous(exc_state, None, None, None)
+
+    assert policy.on_exception(exc) is None
+
+
+def test_on_exception_unavailable():
+    # Also traverses the ``api_core`` exception path.
+    policy = create_policy()
+
+    details = 'UNAVAILABLE. Service taking nap.'
+    exc = exceptions.ServiceUnavailable(details)
+
     assert policy.on_exception(exc) is None
 
 


### PR DESCRIPTION
**NOTE**: I am **NOT** comfortable with this as a fix, it seems **WAAAAAY** too bolted on.

- ~~I'm surprised the retry strategy doesn't come into play here~~
- ~~There should a less hard-coded way to map to the idempotent retry codes~~
- ~~The method should have a straightforward way to determine the gRPC status code from the exception~~
- `RuntimeError: set_exception can only be called once` occurs if I don't filter out the `UNAVAILABLE` ([e.g.][1]). This seems like a bug in a different code path than is covered here.

----

- Adding special handling for API core exceptions
- Retrying on both types of idempotent error
- Also doing a "drive-by" hygiene fix changing a global from `logger` to `_LOGGER`

Towards #4234.

[1]: https://gist.github.com/dhermes/488bf528e10456d3e2266e163ae1a72d