### PR TITLE
PubSub: Don't throw exception to python interpreter.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
@@ -245,11 +245,8 @@ class Consumer(object):
             except KeyboardInterrupt:
                 self.stop_consuming()
             except Exception as exc:
-                try:
-                    self._policy.on_exception(exc)
-                except:
-                    self.active = False
-                    raise
+                self._policy.on_exception(exc)
+                self.stop_consuming()
 
     def start_consuming(self):
         """Start consuming the stream."""


### PR DESCRIPTION
Avoiding annoying traceback.