### PR TITLE
BigQuery: Rename `properties` arg to `fields` in `update_table`

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -20,7 +20,6 @@ import collections
 import functools
 import os
 import uuid
-import warnings
 
 import six
 
@@ -314,7 +313,7 @@ class Client(ClientWithProject):
         If ``dataset.etag`` is not ``None``, the update will only
         succeed if the dataset on the server has the same ETag. Thus
         reading a dataset with ``get_dataset``, changing its fields,
-        and then passing it ``update_dataset`` will ensure that the changes
+        and then passing it to ``update_dataset`` will ensure that the changes
         will only be saved if no modifications to the dataset occurred
         since the read.
 
@@ -363,7 +362,7 @@ class Client(ClientWithProject):
 
         If ``table.etag`` is not ``None``, the update will only succeed if
         the table on the server has the same ETag. Thus reading a table with
-        ``get_table``, changing its fields, and then passing it
+        ``get_table``, changing its fields, and then passing it to
         ``update_table`` will ensure that the changes will only be saved if
         no modifications to the table occurred since the read.
 
@@ -377,8 +376,7 @@ class Client(ClientWithProject):
 
         Returns:
             google.cloud.bigquery.table.Table:
-                The :class:``~google.cloud.bigquery.table.Table`` returned
-                from the API call to update the table.
+                The table resource returned from the API call.
         """
         partial = table._build_resource(fields)
         if table.etag is not None:

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -354,8 +354,7 @@ class Client(ClientWithProject):
             retry, method='PATCH', path=path, data=partial, headers=headers)
         return Dataset.from_api_repr(api_response)
 
-    def update_table(
-            self, table, fields=None, properties=None, retry=DEFAULT_RETRY):
+    def update_table(self, table, fields, retry=DEFAULT_RETRY):
         """Change some fields of a table.
 
         Use ``fields`` to specify which fields to update. At least one field
@@ -373,8 +372,6 @@ class Client(ClientWithProject):
             fields (Sequence[str]):
                 The fields of ``table`` to change, spelled as the Table
                 properties (e.g. "friendly_name").
-            properties (Sequence[str]):
-                Deprecated alias for ``fields`` argument.
             retry (google.api_core.retry.Retry):
                 (Optional) A description of how to retry the API call.
 
@@ -383,13 +380,6 @@ class Client(ClientWithProject):
                 The :class:``~google.cloud.bigquery.table.Table`` returned
                 from the API call to update the table.
         """
-        if properties is not None:
-            warnings.warn(
-                ('properties argument to update_table is deprecated. '
-                 'Use fields instead.'),
-                DeprecationWarning)
-            fields = properties
-
         partial = table._build_resource(fields)
         if table.etag is not None:
             headers = {'If-Match': table.etag}

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -778,53 +778,6 @@ class TestClient(unittest.TestCase):
         req = conn._requested[1]
         self.assertEqual(req['headers']['If-Match'], 'etag')
 
-    def test_update_table_w_deprecated_properties_arg(self):
-        from google.cloud.bigquery.table import Table
-
-        path = 'projects/%s/datasets/%s/tables/%s' % (
-            self.PROJECT, self.DS_ID, self.TABLE_ID)
-        description = 'description'
-        resource = {
-            'id': '%s:%s:%s' % (self.PROJECT, self.DS_ID, self.TABLE_ID),
-            'tableReference': {
-                'projectId': self.PROJECT,
-                'datasetId': self.DS_ID,
-                'tableId': self.TABLE_ID
-            },
-            'etag': 'etag',
-            'description': description,
-        }
-        creds = _make_credentials()
-        client = self._make_one(project=self.PROJECT, credentials=creds)
-        conn = client._connection = _Connection(resource, resource)
-        table = Table(self.TABLE_REF)
-        table.description = description
-
-        updated_table = client.update_table(
-            table, properties=['description'])
-
-        sent = {
-            'tableReference': {
-                'projectId': self.PROJECT,
-                'datasetId': self.DS_ID,
-                'tableId': self.TABLE_ID
-            },
-            'description': description,
-        }
-        self.assertEqual(len(conn._requested), 1)
-        req = conn._requested[0]
-        self.assertEqual(req['method'], 'PATCH')
-        self.assertEqual(req['data'], sent)
-        self.assertEqual(req['path'], '/' + path)
-        self.assertIsNone(req['headers'])
-        self.assertEqual(updated_table.description, table.description)
-
-        # ETag becomes If-Match header.
-        table._properties['etag'] = 'etag'
-        client.update_table(table, [])
-        req = conn._requested[1]
-        self.assertEqual(req['headers']['If-Match'], 'etag')
-
     def test_update_table_only_use_legacy_sql(self):
         from google.cloud.bigquery.table import Table
 

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -778,6 +778,53 @@ class TestClient(unittest.TestCase):
         req = conn._requested[1]
         self.assertEqual(req['headers']['If-Match'], 'etag')
 
+    def test_update_table_w_deprecated_properties_arg(self):
+        from google.cloud.bigquery.table import Table
+
+        path = 'projects/%s/datasets/%s/tables/%s' % (
+            self.PROJECT, self.DS_ID, self.TABLE_ID)
+        description = 'description'
+        resource = {
+            'id': '%s:%s:%s' % (self.PROJECT, self.DS_ID, self.TABLE_ID),
+            'tableReference': {
+                'projectId': self.PROJECT,
+                'datasetId': self.DS_ID,
+                'tableId': self.TABLE_ID
+            },
+            'etag': 'etag',
+            'description': description,
+        }
+        creds = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=creds)
+        conn = client._connection = _Connection(resource, resource)
+        table = Table(self.TABLE_REF)
+        table.description = description
+
+        updated_table = client.update_table(
+            table, properties=['description'])
+
+        sent = {
+            'tableReference': {
+                'projectId': self.PROJECT,
+                'datasetId': self.DS_ID,
+                'tableId': self.TABLE_ID
+            },
+            'description': description,
+        }
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'PATCH')
+        self.assertEqual(req['data'], sent)
+        self.assertEqual(req['path'], '/' + path)
+        self.assertIsNone(req['headers'])
+        self.assertEqual(updated_table.description, table.description)
+
+        # ETag becomes If-Match header.
+        table._properties['etag'] = 'etag'
+        client.update_table(table, [])
+        req = conn._requested[1]
+        self.assertEqual(req['headers']['If-Match'], 'etag')
+
     def test_update_table_only_use_legacy_sql(self):
         from google.cloud.bigquery.table import Table
 


### PR DESCRIPTION
This makes `update_table` consistent with `update_dataset`. Also,
documents the arguments to `update_table`.

Closes #4452.