### PR TITLE
Passing `posargs` to `nox -s unit` in Pub / Sub.

### DIFF
--- a/pubsub/nox.py
+++ b/pubsub/nox.py
@@ -47,7 +47,8 @@ def default(session):
         '--cov=google.cloud.pubsub',
         '--cov=google.cloud.pubsub_v1',
         '--cov-config=.coveragerc',
-        'tests/unit',
+        os.path.join('tests', 'unit'),
+        *session.posargs
     )
 
 

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
@@ -110,8 +110,8 @@ def test_on_exception_other():
     policy = create_policy()
     policy._future = Future(policy=policy)
     exc = TypeError('wahhhhhh')
+    assert policy.on_exception(exc) is None
     with pytest.raises(TypeError):
-        policy.on_exception(exc)
         policy.future.result()
 
 


### PR DESCRIPTION
Also modifying a unit test to call `policy.on_exception()` **outside** of an "assert raises".

I noticed these issues during review of #4380.