### PR TITLE
BigQuery docs: adds headers to API reference page

### DIFF
--- a/docs/bigquery/reference.rst
+++ b/docs/bigquery/reference.rst
@@ -4,25 +4,48 @@ API Reference
 .. automodule:: google.cloud.bigquery
   :no-members:
 
+Client
+======
+
 .. automodule:: google.cloud.bigquery.client
   :members:
   :show-inheritance:
+
+
+Job
+===
 
 .. automodule:: google.cloud.bigquery.job
   :members:
   :show-inheritance:
 
+
+Dataset
+=======
+
 .. automodule:: google.cloud.bigquery.dataset
   :members:
   :show-inheritance:
+
+
+Table
+=====
 
 .. automodule:: google.cloud.bigquery.table
   :members:
   :show-inheritance:
 
+
+Schema
+======
+
 .. automodule:: google.cloud.bigquery.schema
   :members:
   :show-inheritance:
+
+
+External Configuration
+======================
 
 .. automodule:: google.cloud.bigquery.external_config
   :members:


### PR DESCRIPTION
This PR adds headers to visually separate the sections in the API reference page of the BigQuery client library docs.