### PR TITLE
Pub/Sub logging hygiene.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
@@ -202,7 +202,7 @@ class Consumer(object):
         # First, yield the initial request. This occurs on every new
         # connection, fundamentally including a resumed connection.
         initial_request = self._policy.get_initial_request(ack_queue=True)
-        _LOGGER.debug('Sending initial request:\n%s', initial_request)
+        _LOGGER.debug('Sending initial request:\n%r', initial_request)
         yield initial_request
 
         # Now yield each of the items on the request queue, and block if there
@@ -213,7 +213,7 @@ class Consumer(object):
                 _LOGGER.debug('Request generator signaled to stop.')
                 break
 
-            _LOGGER.debug('Sending request:\n%s', request)
+            _LOGGER.debug('Sending request:\n%r', request)
             yield request
 
     def _blocking_consume(self):
@@ -231,7 +231,7 @@ class Consumer(object):
             response_generator = self._policy.call_rpc(request_generator)
             try:
                 for response in response_generator:
-                    _LOGGER.debug('Received response:\n%s', response)
+                    _LOGGER.debug('Received response:\n%r', response)
                     self._policy.on_response(response)
 
                 # If the loop above exits without an exception, then the

--- a/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
@@ -202,9 +202,7 @@ class Consumer(object):
         # First, yield the initial request. This occurs on every new
         # connection, fundamentally including a resumed connection.
         initial_request = self._policy.get_initial_request(ack_queue=True)
-        _LOGGER.debug('Sending initial request: {initial_request}'.format(
-            initial_request=initial_request,
-        ))
+        _LOGGER.debug('Sending initial request:\n%s', initial_request)
         yield initial_request
 
         # Now yield each of the items on the request queue, and block if there
@@ -215,7 +213,7 @@ class Consumer(object):
                 _LOGGER.debug('Request generator signaled to stop.')
                 break
 
-            _LOGGER.debug('Sending request: {}'.format(request))
+            _LOGGER.debug('Sending request:\n%s', request)
             yield request
 
     def _blocking_consume(self):
@@ -233,7 +231,7 @@ class Consumer(object):
             response_generator = self._policy.call_rpc(request_generator)
             try:
                 for response in response_generator:
-                    _LOGGER.debug('Received response: {0}'.format(response))
+                    _LOGGER.debug('Received response:\n%s', response)
                     self._policy.on_response(response)
 
                 # If the loop above exits without an exception, then the

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
@@ -307,7 +307,7 @@ class BasePolicy(object):
             in an appropriate form of subprocess.
         """
         while True:
-            # Sanity check: Should this infinitely loop quit?
+            # Sanity check: Should this infinite loop quit?
             if not self._consumer.active:
                 return
 


### PR DESCRIPTION
Uses newline character when logging protobufs that may end up having newlines in them. These are harder to grok in the log output since it "blends" the protobuf and the description. For example.

```
Received response: received_messages {
  ack_id: "Pn41MEV..."
  message {
    data: ...
```

vs.

```
Received response:
received_messages {
  ack_id: "Pn41MEV..."
  message {
    data: ...
```

Also

- replaced a `lambda` with a simple function
- added docstrings to two default callbacks used by the `policy.thread.Policy` implementation.
- updated grammatical error in a comment
- replaced a bare `if future` with `if future is not None`

----

Context: I have discovered each of these "issues" while dealing with #4463 and #4234.