### PR TITLE
PubSub: `Policy.on_exception` actually used to make consumer go inactive.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
@@ -244,10 +244,9 @@ class Consumer(object):
                 self.stop_consuming()
             except Exception as exc:
                 try:
-                    self._policy.on_exception(exc)
+                    self.active = self._policy.on_exception(exc)
                 except:
                     self.active = False
-                    raise
 
     def start_consuming(self):
         """Start consuming the stream."""

--- a/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
@@ -243,10 +243,7 @@ class Consumer(object):
             except KeyboardInterrupt:
                 self.stop_consuming()
             except Exception as exc:
-                try:
-                    self.active = self._policy.on_exception(exc)
-                except:
-                    self.active = False
+                self.active = self._policy.on_exception(exc)
 
     def start_consuming(self):
         """Start consuming the stream."""

--- a/pubsub/google/cloud/pubsub_v1/subscriber/futures.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/futures.py
@@ -39,16 +39,19 @@ class Future(futures.Future):
 
         .. note::
 
-            A ``False`` value here does not necessarily mean that the
+            A :data:`False` value here does not necessarily mean that the
             subscription is closed; it merely means that _this_ future is
             not the future applicable to it.
 
             Since futures have a single result (or exception) and there is
-            not a concept of resetting them, a closing re-opening of a
+            not a concept of resetting them, a closing / re-opening of a
             subscription will therefore return a new future.
 
         Returns:
-            bool: ``True`` if this subscription is opened with this future,
-                ``False`` otherwise.
+            bool: :data:`True` if this subscription is opened with this
+            future, :data:`False` otherwise.
         """
-        return self._policy.future is self
+        if self._policy.future is not self:
+            return False
+
+        return super(Future, self).running()

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
@@ -376,8 +376,11 @@ class BasePolicy(object):
         """Called when a gRPC exception occurs.
 
         If this method does nothing, then the stream is re-started. If this
-        raises an exception, it will stop the consumer thread.
-        This is executed on the response consumer helper thread.
+        raises an exception, it will stop the consumer thread. This is
+        executed on the response consumer helper thread.
+
+        Implementations should return :data:`True` if they want the consumer
+        thread to remain active, otherwise they should return :data:`False`.
 
         Args:
             exception (Exception): The exception raised by the RPC.

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -176,9 +176,9 @@ class Policy(base.BasePolicy):
         """Handle the exception.
 
         If the exception is one of the retryable exceptions, this will signal
-        to the consumer thread that is should remain active.
+        to the consumer thread that it should remain active.
 
-        This will cause the stream to exit.
+        This will cause the stream to exit when it returns :data:`False`.
 
         Returns:
             bool: Indicates if the caller should remain active or shut down.

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -173,17 +173,26 @@ class Policy(base.BasePolicy):
         getattr(self, action)(**kwargs)
 
     def on_exception(self, exception):
-        """Bubble the exception.
+        """Handle the exception.
 
-        This will cause the stream to exit loudly.
+        If the exception is one of the retryable exceptions, this will signal
+        to the consumer thread that is should remain active.
+
+        This will cause the stream to exit.
+
+        Returns:
+            bool: Indicates if the caller should remain active or shut down.
+            Will be :data:`True` if the ``exception`` is "acceptable", i.e.
+            in a list of retryable / idempotent exceptions.
         """
         # If this is in the list of idempotent exceptions, then we want to
         # retry. That entails just returning None.
         if isinstance(exception, self._RETRYABLE_STREAM_ERRORS):
-            return
+            return True
 
         # Set any other exception on the future.
         self._future.set_exception(exception)
+        return False
 
     def on_response(self, response):
         """Process all received Pub/Sub messages.

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
@@ -94,7 +94,7 @@ def test_on_exception_deadline_exceeded():
     details = 'Bad thing happened. Time out, go sit in the corner.'
     exc = exceptions.DeadlineExceeded(details)
 
-    assert policy.on_exception(exc) is None
+    assert policy.on_exception(exc) is True
 
 
 def test_on_exception_unavailable():
@@ -103,14 +103,14 @@ def test_on_exception_unavailable():
     details = 'UNAVAILABLE. Service taking nap.'
     exc = exceptions.ServiceUnavailable(details)
 
-    assert policy.on_exception(exc) is None
+    assert policy.on_exception(exc) is True
 
 
 def test_on_exception_other():
     policy = create_policy()
     policy._future = Future(policy=policy)
     exc = TypeError('wahhhhhh')
-    assert policy.on_exception(exc) is None
+    assert policy.on_exception(exc) is False
     with pytest.raises(TypeError):
         policy.future.result()
 


### PR DESCRIPTION
Towards #4463.