### PR TITLE
Renaming "Consumer helper" threads in Pub/Sub.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
@@ -254,7 +254,7 @@ class Consumer(object):
         self.active = True
         self._exiting.clear()
         self.helper_threads.start(
-            'consume bidirectional stream',
+            'ConsumeBidirectionalStream',
             self._request_queue,
             self._blocking_consume,
         )

--- a/pubsub/google/cloud/pubsub_v1/subscriber/_helper_threads.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_helper_threads.py
@@ -62,7 +62,7 @@ class HelperThreadRegistry(object):
         """
         # Create and start the helper thread.
         thread = threading.Thread(
-            name='Consumer helper: {}'.format(name),
+            name='Thread-ConsumerHelper-{}'.format(name),
             target=target,
             *args,
             **kwargs

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -149,7 +149,7 @@ class Policy(base.BasePolicy):
         _LOGGER.debug('Starting callback requests worker.')
         self._callback = callback
         self._consumer.helper_threads.start(
-            'callback requests worker',
+            'CallbackRequestsWorker',
             self._request_queue,
             self._callback_requests,
         )

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_consumer.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_consumer.py
@@ -109,7 +109,7 @@ def test_start_consuming():
         assert consumer._exiting.is_set() is False
         assert consumer.active is True
         start.assert_called_once_with(
-            'consume bidirectional stream',
+            'ConsumeBidirectionalStream',
             consumer._request_queue,
             consumer._blocking_consume,
         )


### PR DESCRIPTION
Now names will show up in logs as

```
Thread-ConsumerHelper-CallbackRequestsWorker
Thread-ConsumerHelper-ConsumeBidirectionalStream
```

instead of as

```
Consumer helper: callback requests worker
Consumer helper: consume bidirectional stream
```

This is a follow up to #4474.