### PR TITLE
Spanner: Make rows, consume_all and consume_next private

### DIFF
--- a/spanner/google/cloud/spanner_v1/streamed.py
+++ b/spanner/google/cloud/spanner_v1/streamed.py
@@ -39,22 +39,13 @@ class StreamedResultSet(object):
     """
     def __init__(self, response_iterator, source=None):
         self._response_iterator = response_iterator
-        self._processed_rows = []   # Fully-processed rows
+        self._rows = []             # Fully-processed rows
         self._counter = 0           # Counter for processed responses
         self._metadata = None       # Until set from first PRS
         self._stats = None          # Until set from last PRS
         self._current_row = []      # Accumulated values for incomplete row
         self._pending_chunk = None  # Incomplete value
         self._source = source       # Source snapshot
-
-    @property
-    def _rows(self):
-        """Fully-processed rows.
-
-        :rtype: list of row-data lists.
-        :returns: list of completed row data, from proceesd PRS responses.
-        """
-        return self._processed_rows
 
     @property
     def fields(self):
@@ -141,14 +132,6 @@ class StreamedResultSet(object):
             self._pending_chunk = values.pop()
 
         self._merge_values(values)
-
-    def _consume_all(self):
-        """Consume the streamed responses until there are no more."""
-        while True:
-            try:
-                self._consume_next()
-            except StopIteration:
-                break
 
     def __iter__(self):
         iter_rows, self._rows[:] = self._rows[:], ()

--- a/spanner/google/cloud/spanner_v1/streamed.py
+++ b/spanner/google/cloud/spanner_v1/streamed.py
@@ -39,7 +39,7 @@ class StreamedResultSet(object):
     """
     def __init__(self, response_iterator, source=None):
         self._response_iterator = response_iterator
-        self._rows = []             # Fully-processed rows
+        self._processed_rows = []             # Fully-processed rows
         self._counter = 0           # Counter for processed responses
         self._metadata = None       # Until set from first PRS
         self._stats = None          # Until set from last PRS
@@ -48,13 +48,13 @@ class StreamedResultSet(object):
         self._source = source       # Source snapshot
 
     @property
-    def rows(self):
+    def _rows(self):
         """Fully-processed rows.
 
         :rtype: list of row-data lists.
         :returns: list of completed row data, from proceesd PRS responses.
         """
-        return self._rows
+        return self._processed_rows
 
     @property
     def fields(self):
@@ -115,7 +115,7 @@ class StreamedResultSet(object):
                 self._rows.append(self._current_row)
                 self._current_row = []
 
-    def consume_next(self):
+    def _consume_next(self):
         """Consume the next partial result set from the stream.
 
         Parse the result set into new/existing rows in :attr:`_rows`
@@ -142,11 +142,11 @@ class StreamedResultSet(object):
 
         self._merge_values(values)
 
-    def consume_all(self):
+    def _consume_all(self):
         """Consume the streamed responses until there are no more."""
         while True:
             try:
-                self.consume_next()
+                self._consume_next()
             except StopIteration:
                 break
 
@@ -154,7 +154,7 @@ class StreamedResultSet(object):
         iter_rows, self._rows[:] = self._rows[:], ()
         while True:
             if not iter_rows:
-                self.consume_next()  # raises StopIteration
+                self._consume_next()  # raises StopIteration
                 iter_rows, self._rows[:] = self._rows[:], ()
             while iter_rows:
                 yield iter_rows.pop(0)

--- a/spanner/google/cloud/spanner_v1/streamed.py
+++ b/spanner/google/cloud/spanner_v1/streamed.py
@@ -39,7 +39,7 @@ class StreamedResultSet(object):
     """
     def __init__(self, response_iterator, source=None):
         self._response_iterator = response_iterator
-        self._processed_rows = []             # Fully-processed rows
+        self._processed_rows = []   # Fully-processed rows
         self._counter = 0           # Counter for processed responses
         self._metadata = None       # Until set from first PRS
         self._stats = None          # Until set from last PRS

--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -865,17 +865,11 @@ class TestSessionAPI(unittest.TestCase, _TestData):
 
         snapshot = session.snapshot(read_timestamp=committed)
         streamed = snapshot.read(self.TABLE, self.COLUMNS, self.ALL)
+        keyset = KeySet(all_=True)
+        rows = list(session.read(self.TABLE, self.COLUMNS, keyset))
+        items = [item for item in iter(streamed)]
 
-        retrieved = 0
-        while True:
-            try:
-                streamed._consume_next()
-            except StopIteration:
-                break
-            retrieved += len(streamed._rows)
-            streamed._rows[:] = ()
-
-        self.assertEqual(retrieved, ROW_COUNT)
+        self.assertEqual(items, rows)
         self.assertEqual(streamed._current_row, [])
         self.assertEqual(streamed._pending_chunk, None)
 
@@ -1187,17 +1181,11 @@ class TestSessionAPI(unittest.TestCase, _TestData):
 
         snapshot = session.snapshot(read_timestamp=committed)
         streamed = snapshot.execute_sql(self.SQL)
+        keyset = KeySet(all_=True)
+        rows = list(session.read(self.TABLE, self.COLUMNS, keyset))
+        items = [item for item in iter(streamed)]
 
-        retrieved = 0
-        while True:
-            try:
-                streamed._consume_next()
-            except StopIteration:
-                break
-            retrieved += len(streamed._rows)
-            streamed._rows[:] = ()
-
-        self.assertEqual(retrieved, ROW_COUNT)
+        self.assertEqual(items, rows)
         self.assertEqual(streamed._current_row, [])
         self.assertEqual(streamed._pending_chunk, None)
 

--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -859,20 +859,6 @@ class TestSessionAPI(unittest.TestCase, _TestData):
         after = list(exact.read(self.TABLE, self.COLUMNS, self.ALL))
         self._check_row_data(after, all_data_rows)
 
-    def test_read_w_manual_consume(self):
-        ROW_COUNT = 3000
-        session, committed = self._set_up_table(ROW_COUNT)
-
-        snapshot = session.snapshot(read_timestamp=committed)
-        streamed = snapshot.read(self.TABLE, self.COLUMNS, self.ALL)
-        keyset = KeySet(all_=True)
-        rows = list(session.read(self.TABLE, self.COLUMNS, keyset))
-        items = [item for item in iter(streamed)]
-
-        self.assertEqual(items, rows)
-        self.assertEqual(streamed._current_row, [])
-        self.assertEqual(streamed._pending_chunk, None)
-
     def test_read_w_index(self):
         ROW_COUNT = 2000
         # Indexed reads cannot return non-indexed columns

--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -869,11 +869,11 @@ class TestSessionAPI(unittest.TestCase, _TestData):
         retrieved = 0
         while True:
             try:
-                streamed.consume_next()
+                streamed._consume_next()
             except StopIteration:
                 break
-            retrieved += len(streamed.rows)
-            streamed.rows[:] = ()
+            retrieved += len(streamed._rows)
+            streamed._rows[:] = ()
 
         self.assertEqual(retrieved, ROW_COUNT)
         self.assertEqual(streamed._current_row, [])
@@ -1191,11 +1191,11 @@ class TestSessionAPI(unittest.TestCase, _TestData):
         retrieved = 0
         while True:
             try:
-                streamed.consume_next()
+                streamed._consume_next()
             except StopIteration:
                 break
-            retrieved += len(streamed.rows)
-            streamed.rows[:] = ()
+            retrieved += len(streamed._rows)
+            streamed._rows[:] = ()
 
         self.assertEqual(retrieved, ROW_COUNT)
         self.assertEqual(streamed._current_row, [])

--- a/spanner/tests/unit/test_snapshot.py
+++ b/spanner/tests/unit/test_snapshot.py
@@ -252,8 +252,6 @@ class Test_SnapshotBase(unittest.TestCase):
         else:
             self.assertIsNone(result_set._source)
 
-#        result_set._consume_all()
-
         self.assertEqual(list(result_set), VALUES)
         self.assertEqual(result_set.metadata, metadata_pb)
         self.assertEqual(result_set.stats, stats_pb)

--- a/spanner/tests/unit/test_snapshot.py
+++ b/spanner/tests/unit/test_snapshot.py
@@ -252,9 +252,9 @@ class Test_SnapshotBase(unittest.TestCase):
         else:
             self.assertIsNone(result_set._source)
 
-        result_set.consume_all()
+        result_set._consume_all()
 
-        self.assertEqual(list(result_set.rows), VALUES)
+        self.assertEqual(list(result_set._rows), VALUES)
         self.assertEqual(result_set.metadata, metadata_pb)
         self.assertEqual(result_set.stats, stats_pb)
 
@@ -392,9 +392,9 @@ class Test_SnapshotBase(unittest.TestCase):
         else:
             self.assertIsNone(result_set._source)
 
-        result_set.consume_all()
+        result_set._consume_all()
 
-        self.assertEqual(list(result_set.rows), VALUES)
+        self.assertEqual(list(result_set._rows), VALUES)
         self.assertEqual(result_set.metadata, metadata_pb)
         self.assertEqual(result_set.stats, stats_pb)
 

--- a/spanner/tests/unit/test_snapshot.py
+++ b/spanner/tests/unit/test_snapshot.py
@@ -252,9 +252,9 @@ class Test_SnapshotBase(unittest.TestCase):
         else:
             self.assertIsNone(result_set._source)
 
-        result_set._consume_all()
+#        result_set._consume_all()
 
-        self.assertEqual(list(result_set._rows), VALUES)
+        self.assertEqual(list(result_set), VALUES)
         self.assertEqual(result_set.metadata, metadata_pb)
         self.assertEqual(result_set.stats, stats_pb)
 
@@ -392,9 +392,7 @@ class Test_SnapshotBase(unittest.TestCase):
         else:
             self.assertIsNone(result_set._source)
 
-        result_set._consume_all()
-
-        self.assertEqual(list(result_set._rows), VALUES)
+        self.assertEqual(list(result_set), VALUES)
         self.assertEqual(result_set.metadata, metadata_pb)
         self.assertEqual(result_set.stats, stats_pb)
 

--- a/spanner/tests/unit/test_streamed.py
+++ b/spanner/tests/unit/test_streamed.py
@@ -33,7 +33,7 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         self.assertIs(streamed._response_iterator, iterator)
         self.assertIsNone(streamed._source)
-        self.assertEqual(streamed.rows, [])
+        self.assertEqual(streamed._rows, [])
         self.assertIsNone(streamed.metadata)
         self.assertIsNone(streamed.stats)
 
@@ -43,7 +43,7 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator, source=source)
         self.assertIs(streamed._response_iterator, iterator)
         self.assertIs(streamed._source, source)
-        self.assertEqual(streamed.rows, [])
+        self.assertEqual(streamed._rows, [])
         self.assertIsNone(streamed.metadata)
         self.assertIsNone(streamed.stats)
 
@@ -484,7 +484,7 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed._metadata = self._make_result_set_metadata(FIELDS)
         streamed._current_row = []
         streamed._merge_values([])
-        self.assertEqual(streamed.rows, [])
+        self.assertEqual(streamed._rows, [])
         self.assertEqual(streamed._current_row, [])
 
     def test_merge_values_empty_and_partial(self):
@@ -500,7 +500,7 @@ class TestStreamedResultSet(unittest.TestCase):
         VALUES = [self._make_value(bare) for bare in BARE]
         streamed._current_row = []
         streamed._merge_values(VALUES)
-        self.assertEqual(streamed.rows, [])
+        self.assertEqual(streamed._rows, [])
         self.assertEqual(streamed._current_row, BARE)
 
     def test_merge_values_empty_and_filled(self):
@@ -516,7 +516,7 @@ class TestStreamedResultSet(unittest.TestCase):
         VALUES = [self._make_value(bare) for bare in BARE]
         streamed._current_row = []
         streamed._merge_values(VALUES)
-        self.assertEqual(streamed.rows, [BARE])
+        self.assertEqual(streamed._rows, [BARE])
         self.assertEqual(streamed._current_row, [])
 
     def test_merge_values_empty_and_filled_plus(self):
@@ -536,7 +536,7 @@ class TestStreamedResultSet(unittest.TestCase):
         VALUES = [self._make_value(bare) for bare in BARE]
         streamed._current_row = []
         streamed._merge_values(VALUES)
-        self.assertEqual(streamed.rows, [BARE[0:3], BARE[3:6]])
+        self.assertEqual(streamed._rows, [BARE[0:3], BARE[3:6]])
         self.assertEqual(streamed._current_row, BARE[6:])
 
     def test_merge_values_partial_and_empty(self):
@@ -553,7 +553,7 @@ class TestStreamedResultSet(unittest.TestCase):
         ]
         streamed._current_row[:] = BEFORE
         streamed._merge_values([])
-        self.assertEqual(streamed.rows, [])
+        self.assertEqual(streamed._rows, [])
         self.assertEqual(streamed._current_row, BEFORE)
 
     def test_merge_values_partial_and_partial(self):
@@ -570,7 +570,7 @@ class TestStreamedResultSet(unittest.TestCase):
         MERGED = [42]
         TO_MERGE = [self._make_value(item) for item in MERGED]
         streamed._merge_values(TO_MERGE)
-        self.assertEqual(streamed.rows, [])
+        self.assertEqual(streamed._rows, [])
         self.assertEqual(streamed._current_row, BEFORE + MERGED)
 
     def test_merge_values_partial_and_filled(self):
@@ -589,7 +589,7 @@ class TestStreamedResultSet(unittest.TestCase):
         MERGED = [42, True]
         TO_MERGE = [self._make_value(item) for item in MERGED]
         streamed._merge_values(TO_MERGE)
-        self.assertEqual(streamed.rows, [BEFORE + MERGED])
+        self.assertEqual(streamed._rows, [BEFORE + MERGED])
         self.assertEqual(streamed._current_row, [])
 
     def test_merge_values_partial_and_filled_plus(self):
@@ -613,25 +613,25 @@ class TestStreamedResultSet(unittest.TestCase):
         TO_MERGE = [self._make_value(item) for item in MERGED]
         VALUES = BEFORE + MERGED
         streamed._merge_values(TO_MERGE)
-        self.assertEqual(streamed.rows, [VALUES[0:3], VALUES[3:6]])
+        self.assertEqual(streamed._rows, [VALUES[0:3], VALUES[3:6]])
         self.assertEqual(streamed._current_row, VALUES[6:])
 
     def test_one_or_none_no_value(self):
         streamed = self._make_one(_MockCancellableIterator())
-        with mock.patch.object(streamed, 'consume_next') as consume_next:
+        with mock.patch.object(streamed, '_consume_next') as consume_next:
             consume_next.side_effect = StopIteration
             self.assertIsNone(streamed.one_or_none())
 
     def test_one_or_none_single_value(self):
         streamed = self._make_one(_MockCancellableIterator())
-        streamed._rows = ['foo']
-        with mock.patch.object(streamed, 'consume_next') as consume_next:
+        streamed._processed_rows = ['foo']
+        with mock.patch.object(streamed, '_consume_next') as consume_next:
             consume_next.side_effect = StopIteration
             self.assertEqual(streamed.one_or_none(), 'foo')
 
     def test_one_or_none_multiple_values(self):
         streamed = self._make_one(_MockCancellableIterator())
-        streamed._rows = ['foo', 'bar']
+        streamed._processed_rows = ['foo', 'bar']
         with self.assertRaises(ValueError):
             streamed.one_or_none()
 
@@ -643,8 +643,8 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test_one_single_value(self):
         streamed = self._make_one(_MockCancellableIterator())
-        streamed._rows = ['foo']
-        with mock.patch.object(streamed, 'consume_next') as consume_next:
+        streamed._processed_rows = ['foo']
+        with mock.patch.object(streamed, '_consume_next') as consume_next:
             consume_next.side_effect = StopIteration
             self.assertEqual(streamed.one(), 'foo')
 
@@ -653,7 +653,7 @@ class TestStreamedResultSet(unittest.TestCase):
 
         iterator = _MockCancellableIterator(['foo'])
         streamed = self._make_one(iterator)
-        with mock.patch.object(streamed, 'consume_next') as consume_next:
+        with mock.patch.object(streamed, '_consume_next') as consume_next:
             consume_next.side_effect = StopIteration
             with self.assertRaises(exceptions.NotFound):
                 streamed.one()
@@ -662,7 +662,7 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
         with self.assertRaises(StopIteration):
-            streamed.consume_next()
+            streamed._consume_next()
 
     def test_consume_next_first_set_partial(self):
         TXN_ID = b'DEADBEEF'
@@ -679,8 +679,8 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator(result_set)
         source = mock.Mock(_transaction_id=None, spec=['_transaction_id'])
         streamed = self._make_one(iterator, source=source)
-        streamed.consume_next()
-        self.assertEqual(streamed.rows, [])
+        streamed._consume_next()
+        self.assertEqual(streamed._rows, [])
         self.assertEqual(streamed._current_row, BARE)
         self.assertEqual(streamed.metadata, metadata)
         self.assertEqual(source._transaction_id, TXN_ID)
@@ -700,8 +700,8 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator(result_set)
         source = mock.Mock(_transaction_id=TXN_ID, spec=['_transaction_id'])
         streamed = self._make_one(iterator, source=source)
-        streamed.consume_next()
-        self.assertEqual(streamed.rows, [])
+        streamed._consume_next()
+        self.assertEqual(streamed._rows, [])
         self.assertEqual(streamed._current_row, BARE)
         self.assertEqual(streamed.metadata, metadata)
         self.assertEqual(source._transaction_id, TXN_ID)
@@ -719,8 +719,8 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator(result_set)
         streamed = self._make_one(iterator)
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed.consume_next()
-        self.assertEqual(streamed.rows, [])
+        streamed._consume_next()
+        self.assertEqual(streamed._rows, [])
         self.assertEqual(streamed._current_row, [])
         self.assertEqual(streamed._pending_chunk, VALUES[0])
 
@@ -741,8 +741,8 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         streamed._metadata = self._make_result_set_metadata(FIELDS)
         streamed._pending_chunk = self._make_value(u'Phred ')
-        streamed.consume_next()
-        self.assertEqual(streamed.rows, [
+        streamed._consume_next()
+        self.assertEqual(streamed._rows, [
             [u'Phred Phlyntstone', BARE[1], BARE[2]],
             [BARE[3], BARE[4], BARE[5]],
         ])
@@ -767,15 +767,15 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator(result_set)
         streamed = self._make_one(iterator)
         streamed._metadata = metadata
-        streamed.consume_next()
-        self.assertEqual(streamed.rows, [BARE])
+        streamed._consume_next()
+        self.assertEqual(streamed._rows, [BARE])
         self.assertEqual(streamed._current_row, [])
         self.assertEqual(streamed._stats, stats)
 
     def test_consume_all_empty(self):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)
-        streamed.consume_all()
+        streamed._consume_all()
 
     def test_consume_all_one_result_set_partial(self):
         FIELDS = [
@@ -789,8 +789,8 @@ class TestStreamedResultSet(unittest.TestCase):
         result_set = self._make_partial_result_set(VALUES, metadata=metadata)
         iterator = _MockCancellableIterator(result_set)
         streamed = self._make_one(iterator)
-        streamed.consume_all()
-        self.assertEqual(streamed.rows, [])
+        streamed._consume_all()
+        self.assertEqual(streamed._rows, [])
         self.assertEqual(streamed._current_row, BARE)
         self.assertEqual(streamed.metadata, metadata)
 
@@ -812,8 +812,8 @@ class TestStreamedResultSet(unittest.TestCase):
         result_set2 = self._make_partial_result_set(VALUES[4:])
         iterator = _MockCancellableIterator(result_set1, result_set2)
         streamed = self._make_one(iterator)
-        streamed.consume_all()
-        self.assertEqual(streamed.rows, [
+        streamed._consume_all()
+        self.assertEqual(streamed._rows, [
             [BARE[0], BARE[1], BARE[2]],
             [BARE[3], BARE[4], BARE[5]],
             [BARE[6], BARE[7], BARE[8]],
@@ -841,7 +841,7 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         found = list(streamed)
         self.assertEqual(found, [])
-        self.assertEqual(streamed.rows, [])
+        self.assertEqual(streamed._rows, [])
         self.assertEqual(streamed._current_row, BARE)
         self.assertEqual(streamed.metadata, metadata)
 
@@ -869,7 +869,7 @@ class TestStreamedResultSet(unittest.TestCase):
             [BARE[3], BARE[4], BARE[5]],
             [BARE[6], BARE[7], BARE[8]],
         ])
-        self.assertEqual(streamed.rows, [])
+        self.assertEqual(streamed._rows, [])
         self.assertEqual(streamed._current_row, [])
         self.assertIsNone(streamed._pending_chunk)
 
@@ -895,14 +895,14 @@ class TestStreamedResultSet(unittest.TestCase):
         result_set2 = self._make_partial_result_set(VALUES[4:])
         iterator = _MockCancellableIterator(result_set1, result_set2)
         streamed = self._make_one(iterator)
-        streamed._rows[:] = ALREADY
+        streamed._processed_rows[:] = ALREADY
         found = list(streamed)
         self.assertEqual(found, ALREADY + [
             [BARE[0], BARE[1], BARE[2]],
             [BARE[3], BARE[4], BARE[5]],
             [BARE[6], BARE[7], BARE[8]],
         ])
-        self.assertEqual(streamed.rows, [])
+        self.assertEqual(streamed._processed_rows, [])
         self.assertEqual(streamed._current_row, [])
         self.assertIsNone(streamed._pending_chunk)
 
@@ -952,11 +952,11 @@ class TestStreamedResultSet_JSON_acceptance_tests(unittest.TestCase):
         partial_result_sets, expected = self._load_json_test(testcase_name)
         iterator = _MockCancellableIterator(*partial_result_sets)
         partial = self._make_one(iterator)
-        partial.consume_all()
+        partial._consume_all()
         if assert_equality is not None:
-            assert_equality(partial.rows, expected)
+            assert_equality(partial._rows, expected)
         else:
-            self.assertEqual(partial.rows, expected)
+            self.assertEqual(partial._rows, expected)
 
     def test_basic(self):
         self._match_results('Basic Test')


### PR DESCRIPTION
See #4414 and #4204