### PR TITLE
Various hygiene changes to Pub / Sub subscriber.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
@@ -123,7 +123,9 @@ from six.moves import queue
 
 from google.cloud.pubsub_v1.subscriber import _helper_threads
 
+
 _LOGGER = logging.getLogger(__name__)
+_BIDIRECTIONAL_CONSUMER_NAME = 'ConsumeBidirectionalStream'
 
 
 class Consumer(object):
@@ -250,7 +252,7 @@ class Consumer(object):
         self.active = True
         self._exiting.clear()
         self.helper_threads.start(
-            'ConsumeBidirectionalStream',
+            _BIDIRECTIONAL_CONSUMER_NAME,
             self._request_queue,
             self._blocking_consume,
         )

--- a/pubsub/google/cloud/pubsub_v1/subscriber/message.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/message.py
@@ -37,6 +37,7 @@ class Message(object):
         publish_time (datetime): The time that this message was originally
             published.
     """
+
     def __init__(self, message, ack_id, request_queue):
         """Construct the Message.
 
@@ -128,11 +129,16 @@ class Message(object):
             receive any given message more than once.
         """
         time_to_ack = math.ceil(time.time() - self._received_timestamp)
-        self._request_queue.put(('ack', {
-            'ack_id': self._ack_id,
-            'byte_size': self.size,
-            'time_to_ack': time_to_ack,
-        }))
+        self._request_queue.put(
+            (
+                'ack',
+                {
+                    'ack_id': self._ack_id,
+                    'byte_size': self.size,
+                    'time_to_ack': time_to_ack,
+                },
+            ),
+        )
 
     def drop(self):
         """Release the message from lease management.
@@ -147,10 +153,15 @@ class Message(object):
             both call this one. You probably do not want to call this method
             directly.
         """
-        self._request_queue.put(('drop', {
-            'ack_id': self._ack_id,
-            'byte_size': self.size,
-        }))
+        self._request_queue.put(
+            (
+                'drop',
+                {
+                    'ack_id': self._ack_id,
+                    'byte_size': self.size,
+                },
+            ),
+        )
 
     def lease(self):
         """Inform the policy to lease this message continually.
@@ -159,10 +170,15 @@ class Message(object):
             This method is called by the constructor, and you should never
             need to call it manually.
         """
-        self._request_queue.put(('lease', {
-            'ack_id': self._ack_id,
-            'byte_size': self.size,
-        }))
+        self._request_queue.put(
+            (
+                'lease',
+                {
+                    'ack_id': self._ack_id,
+                    'byte_size': self.size,
+                },
+            ),
+        )
 
     def modify_ack_deadline(self, seconds):
         """Set the deadline for acknowledgement to the given value.
@@ -182,17 +198,27 @@ class Message(object):
                 to. This should be between 0 and 600. Due to network latency,
                 values below 10 are advised against.
         """
-        self._request_queue.put(('modify_ack_deadline', {
-            'ack_id': self._ack_id,
-            'seconds': seconds,
-        }))
+        self._request_queue.put(
+            (
+                'modify_ack_deadline',
+                {
+                    'ack_id': self._ack_id,
+                    'seconds': seconds,
+                },
+            ),
+        )
 
     def nack(self):
         """Decline to acknowldge the given message.
 
         This will cause the message to be re-delivered to the subscription.
         """
-        self._request_queue.put(('nack', {
-            'ack_id': self._ack_id,
-            'byte_size': self.size,
-        }))
+        self._request_queue.put(
+            (
+                'nack',
+                {
+                    'ack_id': self._ack_id,
+                    'byte_size': self.size,
+                },
+            ),
+        )


### PR DESCRIPTION
- Using `%`-formatting in all `logging.log()` calls (e.g. `info()`). I am not opposed to using `.format()` but `logging` "prefers" `%`-formatting (and I wanted to be consistent because hobgoblins).
- Adding non-public globals for helper thread names, this was especially needed because I accidentally broke this in #4476 when I changed `callback requests worker` to `CallbackRequestsWorker` in one place, not two.
- Adding docstring to `QueueCallbackThread` that explains what it does (I'll refactor this class in a follow-up)
- Adding a logging statement when a `QueueCallbackThread` exits
- Changing indents / using much more vertical space in calls to `request_queue.put()` in `subscriber.message.Message`. (I came across these when trying to understand how `QueueCallbackThread` interacts with `Policy.on_callback_request`)
- Logging an exit statement when `maintain_leases` exits
- Changing `GPRC` to `gRPC` in a docstring
- Moving "Creating callback requests thread (not starting)." until right before the resource is created
- Changing "Spawning" to "Starting" in a log message to match others

----

**NOTE**: Many of these can be construed as "nit picks" but I wanted to get them out of my staged changed while working on #4463.