### PR TITLE
Adding `.dev1` suffix to recently released packages.

### DIFF
--- a/pubsub/CHANGELOG.md
+++ b/pubsub/CHANGELOG.md
@@ -23,14 +23,6 @@
   - Using a named logger in `publisher.batch.thread` (#4473)
   - Adding newlines before logging protobuf payloads (#4471)
 
-### Documentation
-
-- Fixing broken examples in quick start (#4398)
-
-### Dependencies
-
-- Dropping
-
 PyPI: https://pypi.org/project/google-cloud-pubsub/0.29.2/
 
 ## 0.29.1

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-pubsub',
-    version='0.29.2',
+    version='0.29.3.dev1',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud',
-    version='0.31.0',
+    version='0.31.1.dev1',
     description='API Client library for Google Cloud',
     long_description=README,
     install_requires=REQUIREMENTS,

--- a/videointelligence/setup.py
+++ b/videointelligence/setup.py
@@ -29,7 +29,7 @@ setup(
     author='Google Cloud Platform',
     author_email='googleapis-publisher@google.com',
     name='google-cloud-videointelligence',
-    version='1.0.0',
+    version='1.0.1.dev1',
     description='Python Client for Google Cloud Video Intelligence',
     long_description=readme,
     namespace_packages=[


### PR DESCRIPTION
Follow-up to today's releases.

Has #4500 as diffbase.

@lukesneeringer Do we have a tag for the "uber"-package / umbrella-package?