### PR TITLE
Make sure inactive request generator is stopped before spawning new one in Pub / Sub consumer.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
@@ -262,10 +262,12 @@ class Consumer(object):
                         'Request generator could not be closed but '
                         'request queue is not empty.')
                     return False
-                # If we **cannot** close the request generator,
-                # then there is no blocking get on the queue. Since
-                # we have locked ``.put()`` this means that the
-                # queue **was** and remains empty.
+                # At this point we know:
+                #   1. The queue is empty and we hold the ``put()`` lock
+                #   2. We **cannot** ``close()`` the request generator.
+                # This means that the request generator is blocking at
+                # ``get()`` from the queue and will continue to block since
+                # we have locked ``.put()``.
                 self._request_queue.put(_helper_threads.STOP)
                 # Wait for the request generator to ``.get()`` the ``STOP``.
                 _LOGGER.debug(

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -159,7 +159,7 @@ class Policy(base.BasePolicy):
         self._callback = callback
         self._consumer.helper_threads.start(
             _CALLBACK_WORKER_NAME,
-            self._request_queue,
+            self._request_queue.put,
             self._callback_requests,
         )
 

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_consumer.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_consumer.py
@@ -43,7 +43,7 @@ def test_send_request():
 
 def test_request_generator_thread():
     consumer = create_consumer()
-    generator = consumer._request_generator_thread()
+    generator = consumer._request_generator_thread(consumer._request_queue)
 
     # The first request that comes from the request generator thread
     # should always be the initial request.
@@ -142,6 +142,6 @@ def test_start_consuming():
         assert consumer.active is True
         start.assert_called_once_with(
             'ConsumeBidirectionalStream',
-            consumer._request_queue,
+            consumer.send_request,
             consumer._blocking_consume,
         )

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_consumer.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_consumer.py
@@ -79,15 +79,13 @@ def test_blocking_consume():
 
 class OnException(object):
 
-    def __init__(self, exiting_event, acceptable=None):
-        self.exiting_event = exiting_event
+    def __init__(self, acceptable=None):
         self.acceptable = acceptable
 
     def __call__(self, exception):
         if exception is self.acceptable:
             return True
         else:
-            self.exiting_event.set()
             return False
 
 
@@ -98,7 +96,7 @@ def test_blocking_consume_on_exception():
     policy.on_response.side_effect = exc
 
     consumer = _consumer.Consumer(policy=policy)
-    policy.on_exception.side_effect = OnException(consumer._exiting)
+    policy.on_exception.side_effect = OnException()
 
     # Establish that we get responses until we are sent the exiting event.
     consumer._blocking_consume()
@@ -120,8 +118,7 @@ def test_blocking_consume_two_exceptions():
     policy.on_response.side_effect = (exc1, exc2)
 
     consumer = _consumer.Consumer(policy=policy)
-    policy.on_exception.side_effect = OnException(
-        consumer._exiting, acceptable=exc1)
+    policy.on_exception.side_effect = OnException(acceptable=exc1)
 
     # Establish that we get responses until we are sent the exiting event.
     consumer._blocking_consume()

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_consumer.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_consumer.py
@@ -147,6 +147,7 @@ def test_start_consuming():
             consumer._blocking_consume,
         )
 
+
 def test_stop_request_generator_not_running():
     consumer = create_consumer()
     request_generator = mock.Mock(spec=('close',))

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_helper_threads.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_helper_threads.py
@@ -45,7 +45,7 @@ def test_stop_current_thread(_current_thread):
     name = 'here'
     registry._helper_threads[name] = _helper_threads._HelperThread(
         name=name,
-        queue=queue_,
+        queue_put=queue_.put,
         thread=_current_thread.return_value,
     )
     assert list(registry._helper_threads.keys()) == [name]
@@ -63,7 +63,7 @@ def test_stop_dead_thread():
     registry = _helper_threads.HelperThreadRegistry()
     registry._helper_threads['foo'] = _helper_threads._HelperThread(
         name='foo',
-        queue=None,
+        queue_put=None,
         thread=threading.Thread(target=lambda: None),
     )
     assert len(registry._helper_threads) == 1
@@ -79,9 +79,10 @@ def test_stop_alive_thread(join, is_alive, put):
 
     # Set up a registry with a helper thread in it.
     registry = _helper_threads.HelperThreadRegistry()
+    queue_ = queue.Queue()
     registry._helper_threads['foo'] = _helper_threads._HelperThread(
         name='foo',
-        queue=queue.Queue(),
+        queue_put=queue_.put,
         thread=threading.Thread(target=lambda: None),
     )
 
@@ -101,7 +102,7 @@ def test_stop_all():
     registry = _helper_threads.HelperThreadRegistry()
     registry._helper_threads['foo'] = _helper_threads._HelperThread(
         name='foo',
-        queue=None,
+        queue_put=None,
         thread=threading.Thread(target=lambda: None),
     )
     assert len(registry._helper_threads) == 1


### PR DESCRIPTION
~~This makes the `request_queue` used by `Consumer._request_generator_thread()` local to the caller. This way on recovery a new queue can be used for the new thread.~~