### PR TITLE
Bugfix: Using `max` where `min` was used by mistake to ensure a value is non-negative

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
@@ -212,7 +212,10 @@ class BasePolicy(object):
         if ack_id in self.managed_ack_ids:
             self.managed_ack_ids.remove(ack_id)
             self._bytes -= byte_size
-            self._bytes = min([self._bytes, 0])
+            if self._bytes < 0:
+                _LOGGER.debug(
+                    'Bytes was unexpectedly negative: %d', self._bytes)
+                self._bytes = 0
 
         # If we have been paused by flow control, check and see if we are
         # back within our limits.

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_base.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import time
 
 from google.api_core import exceptions
@@ -134,6 +135,18 @@ def test_drop():
     policy.drop('ack_id_string', 20)
     assert len(policy.managed_ack_ids) == 0
     assert policy._bytes == 0
+
+
+@mock.patch.object(base, '_LOGGER', spec=logging.Logger)
+def test_drop_unexpected_negative(_LOGGER):
+    policy = create_policy()
+    policy.managed_ack_ids.add('ack_id_string')
+    policy._bytes = 0
+    policy.drop('ack_id_string', 20)
+    assert len(policy.managed_ack_ids) == 0
+    assert policy._bytes == 0
+    _LOGGER.debug.assert_called_once_with(
+        'Bytes was unexpectedly negative: %d', -20)
 
 
 def test_drop_below_threshold():


### PR DESCRIPTION
The original intent was to keep `bytes` at or above `0` but `min([-n, 0]) == -n` and more importantly `min([n, 0]) = 0` so that `bytes` would be artificially dropped to `0` when `drop()` is called.

FWIW I was worried this was a data race issue, but I'm fairly certain it isn't. If in fact it turns out to be, we can add a no-op lock class on `base.BasePolicy`

```python
import contextlib

@contextlib.contextmanager
def _no_op_lock():
    """No-op context manager."""
    yield

class BasePolicy(object):
    _LOCK_TYPE = _no_op_lock
    def __init__(self, ...):
        ...
        self._bytes_lock = self._LOCK_TYPE()
```

and then define `_LOCK_TYPE = threading.Lock` on our concrete implementation and use `self._bytes_lock` whenever modifying `Policy().bytes`.

Fixes #4516.