### PR TITLE
Pinning `django` test dependency to < 2.0 in Python 2.7.

### DIFF
--- a/logging/nox.py
+++ b/logging/nox.py
@@ -23,6 +23,14 @@ LOCAL_DEPS = (
     os.path.join('..', 'api_core'),
     os.path.join('..', 'core'),
 )
+UNIT_TEST_DEPS = (
+    'mock',
+    'pytest',
+    'pytest-cov',
+    'flask',
+    'webapp2',
+    'webob',
+)
 
 
 @nox.session
@@ -35,9 +43,14 @@ def default(session):
     run the tests.
     """
     # Install all test dependencies, then install this package in-place.
-    session.install(
-        'mock', 'pytest', 'pytest-cov',
-        'flask', 'webapp2', 'webob', 'django', *LOCAL_DEPS)
+    deps = UNIT_TEST_DEPS
+    if session.interpreter == 'python2.7':
+        deps += ('django >= 1.11.0, < 2.0.0dev',)
+    else:
+        deps += ('django',)
+
+    deps += LOCAL_DEPS
+    session.install(*deps)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.


### PR DESCRIPTION
See:
https://www.djangoproject.com/weblog/2017/dec/02/django-20-released/

Python 2.7 support is explicitly removed.