### PR TITLE
Requiring latest release of concurrent futures backport.

### DIFF
--- a/api_core/setup.py
+++ b/api_core/setup.py
@@ -62,7 +62,7 @@ REQUIREMENTS = [
 ]
 
 EXTRAS_REQUIREMENTS = {
-    ':python_version<"3.2"': ['futures >= 3.0.0'],
+    ':python_version<"3.2"': ['futures >= 3.2.0'],
     'grpc': ['grpcio >= 1.7.0'],
 }
 

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -108,7 +108,7 @@ class Policy(base.BasePolicy):
         # Also maintain a request queue and an executor.
         if executor is None:
             executor_kwargs = {}
-            if sys.version_info >= (3, 6):
+            if sys.version_info[:2] == (2, 7) or sys.version_info >= (3, 6):
                 executor_kwargs['thread_name_prefix'] = (
                     'ThreadPoolExecutor-SubscriberPolicy')
             executor = futures.ThreadPoolExecutor(

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -51,7 +51,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-api-core[grpc] >= 0.1.1, < 0.2.0dev',
+    'google-api-core[grpc] >= 0.1.2.dev1, < 0.2.0dev',
     'google-auth >= 1.0.2, < 2.0dev',
     'grpc-google-iam-v1 >= 0.11.1, < 0.12dev',
     'psutil >= 5.2.2, < 6.0dev',


### PR DESCRIPTION
See: https://github.com/agronholm/pythonfutures/issues/63

----

ASIDE: For the first time, the `.dev1` versions come in handy to specify the actual ways a package depends on **in development** vs. published.