### PR TITLE
Removing "rename" from bigtable table.py comments

### DIFF
--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -78,7 +78,6 @@ class Table(object):
     We can use a :class:`Table` to:
 
     * :meth:`create` the table
-    * :meth:`rename` the table
     * :meth:`delete` the table
     * :meth:`list_column_families` in the table
 


### PR DESCRIPTION
Bigtable tables cannot be renamed.  I'm removing the comment that says that rename is allowed.