### PR TITLE
Dropping usage of `HelperThreadRegistry` in Pub / Sub policy.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_helper_threads.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_helper_threads.py
@@ -57,9 +57,6 @@ class HelperThreadRegistry(object):
     def __init__(self):
         self._helper_threads = {}
 
-    def __contains__(self, needle):
-        return needle in self._helper_threads
-
     def start(self, name, queue_put, target):
         """Create and start a helper thread.
 

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -151,7 +151,10 @@ class Policy(base.BasePolicy):
         # Stop consuming messages.
         self._request_queue.put(_helper_threads.STOP)
         self._dispatch_thread.join()  # Wait until stopped.
+        self._dispatch_thread = None
         self._consumer.stop_consuming()
+        self._leases_thread.join()
+        self._leases_thread = None
         self._executor.shutdown()
 
         # The subscription is closing cleanly; resolve the future if it is not

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_base.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_base.py
@@ -180,8 +180,10 @@ def test_load():
     assert policy._load == 0.2
 
     # Returning a number above 100% is fine.
-    policy.lease(ack_id='three', byte_size=1000)
-    assert policy._load == 1.16
+    with mock.patch.object(policy, 'close') as close:
+        policy.lease(ack_id='three', byte_size=1000)
+        assert policy._load == 1.16
+        close.assert_called_once_with()
 
 
 def test_modify_ack_deadline():

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
@@ -21,6 +21,7 @@ from google.api_core import exceptions
 from google.auth import credentials
 import mock
 import pytest
+import six
 from six.moves import queue
 
 from google.cloud.pubsub_v1 import subscriber
@@ -50,35 +51,54 @@ def test_init_with_executor():
 
 def test_close():
     policy = create_policy()
+    policy._dispatch_thread = mock.Mock(spec=('join',))
     consumer = policy._consumer
     with mock.patch.object(consumer, 'stop_consuming') as stop_consuming:
         policy.close()
         stop_consuming.assert_called_once_with()
-    assert 'callback request worker' not in policy._consumer.helper_threads
+
+    policy._dispatch_thread.join.assert_called_once_with()
 
 
 def test_close_with_future():
     policy = create_policy()
+    policy._dispatch_thread = mock.Mock(spec=('join',))
     policy._future = Future(policy=policy)
     consumer = policy._consumer
     with mock.patch.object(consumer, 'stop_consuming') as stop_consuming:
         future = policy.future
         policy.close()
         stop_consuming.assert_called_once_with()
+
+    policy._dispatch_thread.join.assert_called_once_with()
     assert policy.future != future
     assert future.result() is None
 
 
-@mock.patch.object(_helper_threads.HelperThreadRegistry, 'start')
-@mock.patch.object(threading.Thread, 'start')
-def test_open(thread_start, htr_start):
+def test_open():
     policy = create_policy()
-    with mock.patch.object(policy._consumer, 'start_consuming') as consuming:
+    consumer = policy._consumer
+    threads = (
+        mock.Mock(spec=('name', 'start')),
+        mock.Mock(spec=('name', 'start')),
+        mock.Mock(spec=('name', 'start')),
+    )
+    with mock.patch.object(threading, 'Thread', side_effect=threads):
         policy.open(mock.sentinel.CALLBACK)
-        assert policy._callback is mock.sentinel.CALLBACK
-        consuming.assert_called_once_with()
-        htr_start.assert_called()
-        thread_start.assert_called()
+
+    assert policy._callback is mock.sentinel.CALLBACK
+
+    assert policy._dispatch_thread is threads[0]
+    threads[0].start.assert_called_once_with()
+
+    threads_dict = consumer.helper_threads._helper_threads
+    assert len(threads_dict) == 1
+    helper_thread = next(six.itervalues(threads_dict))
+    assert helper_thread.thread is threads[1]
+    threads[1].start.assert_called_once_with()
+
+    assert policy._leases_thread is threads[2]
+    threads[2].start.assert_called_once_with()
 
 
 def test_dispatch_callback_valid_actions():

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
@@ -50,19 +50,30 @@ def test_init_with_executor():
 
 
 def test_close():
+    dispatch_thread = mock.Mock(spec=threading.Thread)
+    leases_thread = mock.Mock(spec=threading.Thread)
+
     policy = create_policy()
-    policy._dispatch_thread = mock.Mock(spec=('join',))
+    policy._dispatch_thread = dispatch_thread
+    policy._leases_thread = leases_thread
     consumer = policy._consumer
     with mock.patch.object(consumer, 'stop_consuming') as stop_consuming:
         policy.close()
         stop_consuming.assert_called_once_with()
 
-    policy._dispatch_thread.join.assert_called_once_with()
+    assert policy._dispatch_thread is None
+    dispatch_thread.join.assert_called_once_with()
+    assert policy._leases_thread is None
+    leases_thread.join.assert_called_once_with()
 
 
 def test_close_with_future():
+    dispatch_thread = mock.Mock(spec=threading.Thread)
+    leases_thread = mock.Mock(spec=threading.Thread)
+
     policy = create_policy()
-    policy._dispatch_thread = mock.Mock(spec=('join',))
+    policy._dispatch_thread = dispatch_thread
+    policy._leases_thread = leases_thread
     policy._future = Future(policy=policy)
     consumer = policy._consumer
     with mock.patch.object(consumer, 'stop_consuming') as stop_consuming:
@@ -70,7 +81,10 @@ def test_close_with_future():
         policy.close()
         stop_consuming.assert_called_once_with()
 
-    policy._dispatch_thread.join.assert_called_once_with()
+    assert policy._dispatch_thread is None
+    dispatch_thread.join.assert_called_once_with()
+    assert policy._leases_thread is None
+    leases_thread.join.assert_called_once_with()
     assert policy.future != future
     assert future.result() is None
 


### PR DESCRIPTION
~~Has #4535 as diffbase.~~

I'll follow this up with a PR that completely removes the `HelperThreadRegistry`.