### PR TITLE
Removing Pub / Sub HelperThreadRegistry.

### DIFF
--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_helper_threads.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_helper_threads.py
@@ -12,109 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import threading
-
 import mock
 from six.moves import queue
 
 from google.cloud.pubsub_v1.subscriber import _helper_threads
-
-
-def test_start():
-    registry = _helper_threads.HelperThreadRegistry()
-    queue_ = queue.Queue()
-    target = mock.Mock(spec=())
-    with mock.patch.object(threading.Thread, 'start', autospec=True) as start:
-        registry.start('foo', queue_, target)
-        assert start.called
-
-
-def test_stop_noop():
-    registry = _helper_threads.HelperThreadRegistry()
-    assert len(registry._helper_threads) == 0
-    registry.stop('foo')
-    assert len(registry._helper_threads) == 0
-
-
-@mock.patch.object(
-    _helper_threads, '_current_thread', return_value=mock.sentinel.thread)
-def test_stop_current_thread(_current_thread):
-    registry = _helper_threads.HelperThreadRegistry()
-    queue_ = mock.Mock(spec=('put',))
-
-    name = 'here'
-    registry._helper_threads[name] = _helper_threads._HelperThread(
-        name=name,
-        queue_put=queue_.put,
-        thread=_current_thread.return_value,
-    )
-    assert list(registry._helper_threads.keys()) == [name]
-    registry.stop(name)
-    # Make sure it hasn't been removed from the registry ...
-    assert list(registry._helper_threads.keys()) == [name]
-    # ... but it did receive the STOP signal.
-    queue_.put.assert_called_once_with(_helper_threads.STOP)
-
-    # Verify that our mock was only called once.
-    _current_thread.assert_called_once_with()
-
-
-def test_stop_dead_thread():
-    registry = _helper_threads.HelperThreadRegistry()
-    registry._helper_threads['foo'] = _helper_threads._HelperThread(
-        name='foo',
-        queue_put=None,
-        thread=threading.Thread(target=lambda: None),
-    )
-    assert len(registry._helper_threads) == 1
-    registry.stop('foo')
-    assert len(registry._helper_threads) == 0
-
-
-@mock.patch.object(queue.Queue, 'put')
-@mock.patch.object(threading.Thread, 'is_alive')
-@mock.patch.object(threading.Thread, 'join')
-def test_stop_alive_thread(join, is_alive, put):
-    is_alive.return_value = True
-
-    # Set up a registry with a helper thread in it.
-    registry = _helper_threads.HelperThreadRegistry()
-    queue_ = queue.Queue()
-    registry._helper_threads['foo'] = _helper_threads._HelperThread(
-        name='foo',
-        queue_put=queue_.put,
-        thread=threading.Thread(target=lambda: None),
-    )
-
-    # Assert that the helper thread is present, and removed correctly
-    # on stop.
-    assert len(registry._helper_threads) == 1
-    registry.stop('foo')
-    assert len(registry._helper_threads) == 0
-
-    # Assert that all of our mocks were called in the expected manner.
-    is_alive.assert_called_once_with()
-    join.assert_called_once_with()
-    put.assert_called_once_with(_helper_threads.STOP)
-
-
-def test_stop_all():
-    registry = _helper_threads.HelperThreadRegistry()
-    registry._helper_threads['foo'] = _helper_threads._HelperThread(
-        name='foo',
-        queue_put=None,
-        thread=threading.Thread(target=lambda: None),
-    )
-    assert len(registry._helper_threads) == 1
-    registry.stop_all()
-    assert len(registry._helper_threads) == 0
-
-
-def test_stop_all_noop():
-    registry = _helper_threads.HelperThreadRegistry()
-    assert len(registry._helper_threads) == 0
-    registry.stop_all()
-    assert len(registry._helper_threads) == 0
 
 
 def test_queue_callback_worker():

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
@@ -21,7 +21,6 @@ from google.api_core import exceptions
 from google.auth import credentials
 import mock
 import pytest
-import six
 from six.moves import queue
 
 from google.cloud.pubsub_v1 import subscriber
@@ -105,10 +104,7 @@ def test_open():
     assert policy._dispatch_thread is threads[0]
     threads[0].start.assert_called_once_with()
 
-    threads_dict = consumer.helper_threads._helper_threads
-    assert len(threads_dict) == 1
-    helper_thread = next(six.itervalues(threads_dict))
-    assert helper_thread.thread is threads[1]
+    assert consumer._consumer_thread is threads[1]
     threads[1].start.assert_called_once_with()
 
     assert policy._leases_thread is threads[2]


### PR DESCRIPTION
I'll likely put back in **some** of the features (especially the concept of the namedtuple that knows about the thread **AND** the queue / threading.Event).