### PR TITLE
Preparing release 0.17.0 of trace

### DIFF
--- a/docs/trace/releases.rst
+++ b/docs/trace/releases.rst
@@ -5,3 +5,4 @@
 * ``0.15.4`` (`PyPI <https://pypi.org/project/google-cloud-trace/0.15.4/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/trace-0.15.4>`__)
 * ``0.15.5`` (`PyPI <https://pypi.org/project/google-cloud-trace/0.15.5/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/trace-0.15.5>`__)
 * ``0.16.0`` (`PyPI <https://pypi.org/project/google-cloud-trace/0.16.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/trace-0.16.0>`__)
+* ``0.17.0`` (`PyPI <https://pypi.org/project/google-cloud-trace/0.17.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/trace-0.17.0>`__)

--- a/trace/CHANGELOG.md
+++ b/trace/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 [1]: https://pypi.org/project/google-cloud-trace/#history
 
+## 0.17.0
+
+### Notable Implementation Changes
+
+- Default to use Stackdriver Trace V2 API if calling `from google.cloud import trace`.
+  Using V1 API needs to be explicitly specified in the import.(#4437)
+
+PyPI: https://pypi.org/project/google-cloud-trace/0.17.0/
+
 ## 0.16.0
 
 ### Dependencies
@@ -12,13 +21,3 @@
   on `google-api-core` (#4221, #4280)
 
 PyPI: https://pypi.org/project/google-cloud-trace/0.16.0/
-
-## 0.17.0
-
-### Notable Implementation Changes
-
-- Default to use Stackdriver Trace V2 API if calling `from google.cloud import trace`.
-  Using V1 API needs to be explicitly specified in the import.(#4437)
-- Comparing `datetime.datetime`-s in trace unit tests. (#4323)
-
-PyPI: https://pypi.org/project/google-cloud-trace/0.17.0/

--- a/trace/CHANGELOG.md
+++ b/trace/CHANGELOG.md
@@ -12,3 +12,13 @@
   on `google-api-core` (#4221, #4280)
 
 PyPI: https://pypi.org/project/google-cloud-trace/0.16.0/
+
+## 0.17.0
+
+### Notable Implementation Changes
+
+- Default to use Stackdriver Trace V2 API if calling `from google.cloud import trace`.
+  Using V1 API needs to be explicitly specified in the import.(#4437)
+- Comparing `datetime.datetime`-s in trace unit tests. (#4323)
+
+PyPI: https://pypi.org/project/google-cloud-trace/0.17.0/

--- a/trace/setup.py
+++ b/trace/setup.py
@@ -15,7 +15,7 @@ install_requires = [
 
 setup(
     name='google-cloud-trace',
-    version='0.16.1.dev1',
+    version='0.17.0',
     author='Google Inc',
     author_email='googleapis-packages@google.com',
     classifiers=[


### PR DESCRIPTION
@dhermes I need to bump the version number from 0.16.0 to 0.17.0 to avoid breaking the OpenCensus package which is depending on `google-cloud-trace>=0.16.0, <0.17dev`. Could you do a release for the trace package? Thanks a lot!