### PR TITLE
Break Policy<->Consumer reference cycle.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_histogram.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_histogram.py
@@ -23,7 +23,7 @@ class Histogram(object):
 
     The default implementation uses the 99th percentile of previous ack
     times to implicitly lease messages; however, custom
-    :class:`~.pubsub_v1.subscriber.consumer.base.BaseConsumer` subclasses
+    :class:`~.pubsub_v1.subscriber._consumer.Consumer` subclasses
     are free to use a different formula.
 
     The precision of data stored is to the nearest integer. Additionally,

--- a/pubsub/google/cloud/pubsub_v1/subscriber/client.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/client.py
@@ -97,7 +97,7 @@ class Client(object):
         """Return a representation of an individual subscription.
 
         This method creates and returns a ``Consumer`` object (that is, a
-        :class:`~.pubsub_v1.subscriber.consumer.base.BaseConsumer`)
+        :class:`~.pubsub_v1.subscriber._consumer.Consumer`)
         subclass) bound to the topic. It does `not` create the subcription
         on the backend (or do any API call at all); it simply returns an
         object capable of doing these things.
@@ -122,7 +122,7 @@ class Client(object):
                 inundated with too many messages at once.
 
         Returns:
-            ~.pubsub_v1.subscriber.consumer.base.BaseConsumer: An instance
+            ~.pubsub_v1.subscriber._consumer.Consumer: An instance
                 of the defined ``consumer_class`` on the client.
 
         Raises:

--- a/pubsub/google/cloud/pubsub_v1/subscriber/message.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/message.py
@@ -26,7 +26,7 @@ class Message(object):
     them in callbacks on subscriptions; most users should never have a need
     to instantiate them by hand. (The exception to this is if you are
     implementing a custom subclass to
-    :class:`~.pubsub_v1.subscriber.consumer.BaseConsumer`.)
+    :class:`~.pubsub_v1.subscriber._consumer.Consumer`.)
 
     Attributes:
         message_id (str): The message ID. In general, you should not need
@@ -186,7 +186,7 @@ class Message(object):
         The default implementation handles this for you; you should not need
         to manually deal with setting ack deadlines. The exception case is
         if you are implementing your own custom subclass of
-        :class:`~.pubsub_v1.subcriber.consumer.BaseConsumer`.
+        :class:`~.pubsub_v1.subcriber._consumer.Consumer`.
 
         .. note::
             This is not an extension; it *sets* the deadline to the given

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
@@ -75,7 +75,7 @@ class BasePolicy(object):
                  flow_control=types.FlowControl(), histogram_data=None):
         self._client = client
         self._subscription = subscription
-        self._consumer = _consumer.Consumer(self)
+        self._consumer = _consumer.Consumer()
         self._ack_deadline = 10
         self._last_histogram_size = 0
         self._future = None

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -234,7 +234,7 @@ class Policy(base.BasePolicy):
         self._callback = callback
         self._start_dispatch()
         # Actually start consuming messages.
-        self._consumer.start_consuming()
+        self._consumer.start_consuming(self)
         self._start_lease_worker()
 
         # Return the future.


### PR DESCRIPTION
Make `Policy` the parent of `Consumer` and explicitly require passing a `policy` into `Consumer.start_consuming()` (and its helpers).