### PR TITLE
Adding pause/resume to Pub / Sub consumer.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/_consumer.py
@@ -444,8 +444,4 @@ def _pausable_iterator(iterator, can_continue):
     """
     while True:
         can_continue.wait()
-
-        try:
-            yield next(iterator)
-        except StopIteration:
-            break
+        yield next(iterator)

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/base.py
@@ -225,7 +225,7 @@ class BasePolicy(object):
         # before restarting.
         if self._paused and self._load < self.flow_control.resume_threshold:
             self._paused = False
-            self.open(self._callback)
+            self._consumer.resume()
 
     def get_initial_request(self, ack_queue=False):
         """Return the initial request.
@@ -291,7 +291,7 @@ class BasePolicy(object):
         # If we do, we need to stop the stream.
         if self._load >= 1.0:
             self._paused = True
-            self.close()
+            self._consumer.pause()
 
     def maintain_leases(self):
         """Maintain all of the leases being managed by the policy.


### PR DESCRIPTION
Using these (rather then open/close on the subscription Policy) when the flow control signals the message load is too great.