### PR TITLE
Post PR #4559: add back `.dev1` to version numbers.

### DIFF
--- a/api_core/CHANGELOG.md
+++ b/api_core/CHANGELOG.md
@@ -8,10 +8,21 @@
 
 - Upgrading `concurrent.futures` backport from `>= 3.0.0`
   to `>= 3.2.0` (#4521).
+- Moved `datetime`-related helpers from `google.cloud.core` to
+  `google.api_core.datetime_helpers` (#4399).
+- Added missing `client_info` to `gapic_v1/__init__.py`'s
+  `__all__` (#4567).
+- Added helpers for routing headers to `gapic_v1` (#4336).
+
+PyPI: https://pypi.org/project/google-api-core/0.1.2/
 
 ## 0.1.1
 
+### Dependencies
+
 - Upgrading `grpcio` dependency from `1.2.0, < 1.6dev` to `>= 1.7.0` (#4280)
+
+PyPI: https://pypi.org/project/google-api-core/0.1.1/
 
 ## 0.1.0
 
@@ -42,3 +53,5 @@ relevant changes from that package are included here.
 - Port gax proto helper methods (#4249)
 - Remove gapic_v1.method.wrap_with_paging (#4257)
 - Add final set of protobuf helpers to api_core (#4259)
+
+PyPI: https://pypi.org/project/google-api-core/0.1.0/

--- a/api_core/setup.py
+++ b/api_core/setup.py
@@ -68,7 +68,7 @@ EXTRAS_REQUIREMENTS = {
 
 setup(
     name='google-api-core',
-    version='0.1.2',
+    version='0.1.3.dev1',
     description='Core Google API Client Library',
     long_description=README,
     namespace_packages=['google'],

--- a/pubsub/CHANGELOG.md
+++ b/pubsub/CHANGELOG.md
@@ -49,7 +49,7 @@ PyPI: https://pypi.org/project/google-cloud-pubsub/0.29.4/
 - Upgrading `google-api-core` dependency to latest revision (`0.1.2`)
   since we rely on the latest version of the `concurrent.futures` backport
   to provide the `thread_name_prefix` argument for thread pool
-  executor (#4521, #XYZ).
+  executor (#4521, #4559).
 
 PyPI: https://pypi.org/project/google-cloud-pubsub/0.29.3/
 

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-pubsub',
-    version='0.29.4',
+    version='0.29.5.dev1',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
@jonparrott I would like to squeeze in a change to `api_core/CHANGELOG.md` to this PR as well with the updates based on the (currently not mentioned in notes) PRs #4339, #4336, #4367, #4399.