### PR TITLE
Revert "Do not use easily-misread glyphs in Firestore auto-IDs."

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/collection.py
+++ b/firestore/google/cloud/firestore_v1beta1/collection.py
@@ -24,7 +24,8 @@ from google.cloud.firestore_v1beta1 import query as query_mod
 from google.cloud.firestore_v1beta1.proto import document_pb2
 
 
-_AUTO_ID_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789'
+_AUTO_ID_CHARS = (
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789')
 
 
 class CollectionReference(object):
@@ -92,7 +93,7 @@ class CollectionReference(object):
         Args:
             document_id (Optional[str]): The document identifier
                 within the current collection. If not provided, will default
-                to a random 21 character string composed of digits,
+                to a random 20 character string composed of digits,
                 uppercase and lowercase and letters.
 
         Returns:
@@ -138,7 +139,7 @@ class CollectionReference(object):
             document_id (Optional[str]): The document identifier within the
                 current collection. If not provided, an ID will be
                 automatically assigned by the server (the assigned ID will be
-                a random 21 character string composed of digits,
+                a random 20 character string composed of digits,
                 uppercase and lowercase letters).
 
         Returns:
@@ -375,8 +376,8 @@ def _auto_id():
     """Generate a "random" automatically generated ID.
 
     Returns:
-        str: A 21 character string composed of digits, uppercase and
+        str: A 20 character string composed of digits, uppercase and
         lowercase and letters.
     """
     return ''.join(
-        random.choice(_AUTO_ID_CHARS) for _ in six.moves.xrange(21))
+        random.choice(_AUTO_ID_CHARS) for _ in six.moves.xrange(20))

--- a/firestore/tests/unit/test_collection.py
+++ b/firestore/tests/unit/test_collection.py
@@ -427,12 +427,12 @@ class Test__auto_id(unittest.TestCase):
     def test_it(self, mock_rand_choice):
         from google.cloud.firestore_v1beta1.collection import _AUTO_ID_CHARS
 
-        mock_result = '23456789abcdefghjkmnp'
+        mock_result = '0123456789abcdefghij'
         mock_rand_choice.side_effect = list(mock_result)
         result = self._call_fut()
         self.assertEqual(result, mock_result)
 
-        mock_calls = [mock.call(_AUTO_ID_CHARS)] * 21
+        mock_calls = [mock.call(_AUTO_ID_CHARS)] * 20
         self.assertEqual(mock_rand_choice.mock_calls, mock_calls)
 
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/google-cloud-python#4107