### PR TITLE
BigQuery: removes support for python 3.4

### DIFF
--- a/bigquery/CHANGELOG.md
+++ b/bigquery/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [1]: https://pypi.org/project/google-cloud-bigquery/#history
 
+## 0.x.y
+
+- Remove support for Python version 3.4. (#4597)
+
+
 ## 0.28.0
 
 **0.28.0 significantly changes the interface for this package.** For examples

--- a/bigquery/nox.py
+++ b/bigquery/nox.py
@@ -54,7 +54,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -42,7 +42,6 @@ SETUP_BASE = {
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Internet',

--- a/docs/bigquery/usage.rst
+++ b/docs/bigquery/usage.rst
@@ -9,6 +9,10 @@ BigQuery
   reference
   dbapi
 
+.. note::
+
+  Python version 3.4 is no longer supported.
+
 Authentication / Configuration
 ------------------------------
 


### PR DESCRIPTION
Addresses https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4587

I queried the [pypi dataset](https://bigquery.cloud.google.com/dataset/the-psf:pypi) to see which versions of Python have been used with google-cloud-bigquery for the last 6 months.

python version | % of downloads
--- | ---
2.7 | 91.3%
3.6 | 4.1%
3.5 | 2.8%
3.4 | 1.5%
null | 0.3%
other | 0.01%