### PR TITLE
Adding a `Consumer.active` property to Pub / Sub.

### DIFF
--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_consumer.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_consumer.py
@@ -75,8 +75,8 @@ def test_blocking_consume():
 @mock.patch.object(_consumer, '_LOGGER')
 def test_blocking_consume_when_exiting(_LOGGER):
     consumer = _consumer.Consumer()
-    assert consumer.stopped.is_set() is False
-    consumer.stopped.set()
+    assert consumer._stopped.is_set() is False
+    consumer._stopped.set()
 
     # Make sure method cleanly exits.
     assert consumer._blocking_consume(None) is None
@@ -207,7 +207,7 @@ def test_start_consuming():
     with mock.patch.object(threading, 'Thread', autospec=True) as Thread:
         consumer.start_consuming(policy)
 
-    assert consumer.stopped.is_set() is False
+    assert consumer._stopped.is_set() is False
     Thread.assert_called_once_with(
         name=_consumer._BIDIRECTIONAL_CONSUMER_NAME,
         target=consumer._blocking_consume,
@@ -218,14 +218,14 @@ def test_start_consuming():
 
 def test_stop_consuming():
     consumer = _consumer.Consumer()
-    assert consumer.stopped.is_set() is False
+    assert consumer._stopped.is_set() is False
     thread = mock.Mock(spec=threading.Thread)
     consumer._consumer_thread = thread
 
     assert consumer.stop_consuming() is None
 
     # Make sure state was updated.
-    assert consumer.stopped.is_set() is True
+    assert consumer._stopped.is_set() is True
     assert consumer._consumer_thread is None
     # Check mocks.
     thread.join.assert_called_once_with()

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_base.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_base.py
@@ -85,7 +85,7 @@ def test_subscription():
 
 def test_ack():
     policy = create_policy()
-    policy._consumer.stopped.clear()
+    policy._consumer._stopped.clear()
     with mock.patch.object(policy._consumer, 'send_request') as send_request:
         policy.ack('ack_id_string', 20)
         send_request.assert_called_once_with(types.StreamingPullRequest(
@@ -97,7 +97,7 @@ def test_ack():
 
 def test_ack_no_time():
     policy = create_policy()
-    policy._consumer.stopped.clear()
+    policy._consumer._stopped.clear()
     with mock.patch.object(policy._consumer, 'send_request') as send_request:
         policy.ack('ack_id_string')
         send_request.assert_called_once_with(types.StreamingPullRequest(
@@ -109,7 +109,7 @@ def test_ack_no_time():
 def test_ack_paused():
     policy = create_policy()
     consumer = policy._consumer
-    consumer.stopped.set()
+    consumer._stopped.set()
     assert consumer.paused is True
 
     policy.ack('ack_id_string')
@@ -203,20 +203,20 @@ def test_modify_ack_deadline():
 
 def test_maintain_leases_inactive_consumer():
     policy = create_policy()
-    policy._consumer.stopped.set()
+    policy._consumer._stopped.set()
     assert policy.maintain_leases() is None
 
 
 def test_maintain_leases_ack_ids():
     policy = create_policy()
-    policy._consumer.stopped.clear()
+    policy._consumer._stopped.clear()
     policy.lease('my ack id', 50)
 
     # Mock the sleep object.
     with mock.patch.object(time, 'sleep', autospec=True) as sleep:
         def trigger_inactive(seconds):
             assert 0 < seconds < 10
-            policy._consumer.stopped.set()
+            policy._consumer._stopped.set()
 
         sleep.side_effect = trigger_inactive
 
@@ -232,11 +232,11 @@ def test_maintain_leases_ack_ids():
 
 def test_maintain_leases_no_ack_ids():
     policy = create_policy()
-    policy._consumer.stopped.clear()
+    policy._consumer._stopped.clear()
     with mock.patch.object(time, 'sleep', autospec=True) as sleep:
         def trigger_inactive(seconds):
             assert 0 < seconds < 10
-            policy._consumer.stopped.set()
+            policy._consumer._stopped.set()
 
         sleep.side_effect = trigger_inactive
         policy.maintain_leases()


### PR DESCRIPTION
**NOTE**: Has #4603 as diffbase.

I think the function call overhead is worth the trade-off of a "clean" surface (i.e. we could swap out `Consumer` for a `multiprocessing` implementation if need be).