### PR TITLE
Making it impossible to call `Policy.open()` on an already opened policy.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -147,7 +147,22 @@ class Policy(base.BasePolicy):
             return executor
 
     def close(self):
-        """Close the existing connection."""
+        """Close the existing connection.
+
+        .. warning::
+
+            This method is not thread-safe. For example, if this method is
+            called while another thread is executing :meth:`open`, then the
+            policy could end up in an undefined state. The **same** policy
+            instance is not intended to be used by multiple workers (though
+            each policy instance **does** have a threadsafe private queue).
+
+        Raises:
+            ValueError: If the policy has not been opened yet.
+        """
+        if self._future is None:
+            raise ValueError('This policy has not been opened yet.')
+
         # Stop consuming messages.
         self._request_queue.put(_helper_threads.STOP)
         self._dispatch_thread.join()  # Wait until stopped.
@@ -159,7 +174,7 @@ class Policy(base.BasePolicy):
 
         # The subscription is closing cleanly; resolve the future if it is not
         # resolved already.
-        if self._future is not None and not self._future.done():
+        if not self._future.done():
             self._future.set_result(None)
         self._future = None
 
@@ -213,6 +228,14 @@ class Policy(base.BasePolicy):
     def open(self, callback):
         """Open a streaming pull connection and begin receiving messages.
 
+        .. warning::
+
+            This method is not thread-safe. For example, if this method is
+            called while another thread is executing :meth:`close`, then the
+            policy could end up in an undefined state. The **same** policy
+            instance is not intended to be used by multiple workers (though
+            each policy instance **does** have a threadsafe private queue).
+
         For each message received, the ``callback`` function is fired with
         a :class:`~.pubsub_v1.subscriber.message.Message` as its only
         argument.
@@ -224,7 +247,13 @@ class Policy(base.BasePolicy):
             ~google.api_core.future.Future: A future that provides
                 an interface to block on the subscription if desired, and
                 handle errors.
+
+        Raises:
+            ValueError: If the policy has already been opened.
         """
+        if self._future is not None:
+            raise ValueError('This policy has already been opened.')
+
         # Create the Future that this method will return.
         # This future is the main thread's interface to handle exceptions,
         # block on the subscription, etc.

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -157,6 +157,10 @@ class Policy(base.BasePolicy):
             instance is not intended to be used by multiple workers (though
             each policy instance **does** have a thread-safe private queue).
 
+        Returns:
+            ~google.api_core.future.Future: The future that **was** attached
+            to the subscription.
+
         Raises:
             ValueError: If the policy has not been opened yet.
         """
@@ -176,7 +180,9 @@ class Policy(base.BasePolicy):
         # resolved already.
         if not self._future.done():
             self._future.set_result(None)
+        future = self._future
         self._future = None
+        return future
 
     def _start_dispatch(self):
         """Start a thread to dispatch requests queued up by callbacks.
@@ -245,8 +251,8 @@ class Policy(base.BasePolicy):
 
         Returns:
             ~google.api_core.future.Future: A future that provides
-                an interface to block on the subscription if desired, and
-                handle errors.
+            an interface to block on the subscription if desired, and
+            handle errors.
 
         Raises:
             ValueError: If the policy has already been opened.

--- a/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/policy/thread.py
@@ -155,7 +155,7 @@ class Policy(base.BasePolicy):
             called while another thread is executing :meth:`open`, then the
             policy could end up in an undefined state. The **same** policy
             instance is not intended to be used by multiple workers (though
-            each policy instance **does** have a threadsafe private queue).
+            each policy instance **does** have a thread-safe private queue).
 
         Raises:
             ValueError: If the policy has not been opened yet.
@@ -234,7 +234,7 @@ class Policy(base.BasePolicy):
             called while another thread is executing :meth:`close`, then the
             policy could end up in an undefined state. The **same** policy
             instance is not intended to be used by multiple workers (though
-            each policy instance **does** have a threadsafe private queue).
+            each policy instance **does** have a thread-safe private queue).
 
         For each message received, the ``callback`` function is fired with
         a :class:`~.pubsub_v1.subscriber.message.Message` as its only

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_thread.py
@@ -61,13 +61,14 @@ def test_close():
 
     consumer = policy._consumer
     with mock.patch.object(consumer, 'stop_consuming') as stop_consuming:
-        policy.close()
+        closed_fut = policy.close()
         stop_consuming.assert_called_once_with()
 
     assert policy._dispatch_thread is None
     dispatch_thread.join.assert_called_once_with()
     assert policy._leases_thread is None
     leases_thread.join.assert_called_once_with()
+    assert closed_fut is future
     assert policy._future is None
     future.done.assert_called_once_with()
 
@@ -93,14 +94,15 @@ def test_close_with_unfinished_future():
     consumer = policy._consumer
     with mock.patch.object(consumer, 'stop_consuming') as stop_consuming:
         future = policy.future
-        policy.close()
+        closed_fut = policy.close()
         stop_consuming.assert_called_once_with()
 
     assert policy._dispatch_thread is None
     dispatch_thread.join.assert_called_once_with()
     assert policy._leases_thread is None
     leases_thread.join.assert_called_once_with()
-    assert policy.future != future
+    assert policy._future is None
+    assert closed_fut is future
     assert future.result() is None
 
 


### PR DESCRIPTION
Similar with `Policy.close()`.

Fixes #4488.