### PR TITLE
Creating `google-cloud-pubsub==0.30.0` release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 [1]: https://pypi.org/project/google-cloud/#history
 
+## 0.32.0
+
+Packages newly added to the `google-cloud` umbrella package:
+
+- [`google-cloud-bigquery-datatransfer==0.1.0`](https://pypi.org/project/google-cloud-bigquery-datatransfer/0.1.0/)
+- [`google-cloud-container==0.1.0`](https://pypi.org/project/google-cloud-container/0.1.0/)
+
+Feature / bugfix release for the following packages:
+
+- [`google-api-core==0.1.2`](https://pypi.org/project/google-api-core/0.1.2/)
+- [`google-cloud-bigtable==0.28.1`](https://pypi.org/project/google-cloud-bigtable/0.28.1/)
+- [`google-cloud-pubsub==0.30.0`](https://pypi.org/project/google-cloud-pubsub/0.30.0/)
+- [`google-cloud-trace==0.17.0`](https://pypi.org/project/google-cloud-trace/0.17.0/)
+- [`google-cloud-vision==0.29.0`](https://pypi.org/project/google-cloud-/0.29.0/)
+
 ## 0.31.0
 
 Feature / bugfix release for the following packages:

--- a/bigquery_datatransfer/setup.py
+++ b/bigquery_datatransfer/setup.py
@@ -35,7 +35,7 @@ with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
 
 setup(
     name='google-cloud-bigquery-datatransfer',
-    version='0.1.0',
+    version='0.1.1.dev1',
     author='Google LLC',
     author_email='googleapis-packages@google.com',
     classifiers=[

--- a/container/setup.py
+++ b/container/setup.py
@@ -35,7 +35,7 @@ with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
 
 setup(
     name='google-cloud-container',
-    version='0.1.0',
+    version='0.1.1.dev1',
     author='Google Inc',
     author_email='googleapis-packages@google.com',
     classifiers=[

--- a/docs/pubsub/releases.rst
+++ b/docs/pubsub/releases.rst
@@ -20,3 +20,4 @@
 * ``0.29.2`` (`PyPI <https://pypi.org/project/google-cloud-pubsub/0.29.2/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/pubsub-0.29.2>`__)
 * ``0.29.3`` (`PyPI <https://pypi.org/project/google-cloud-pubsub/0.29.3/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/pubsub-0.29.3>`__)
 * ``0.29.4`` (`PyPI <https://pypi.org/project/google-cloud-pubsub/0.29.4/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/pubsub-0.29.4>`__)
+* ``0.30.0`` (`PyPI <https://pypi.org/project/google-cloud-pubsub/0.30.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/pubsub-0.30.0>`__)

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -51,3 +51,4 @@ The ``google-cloud`` package (formerly ``gcloud``) contains
 * ``0.29.0`` (`PyPI <https://pypi.org/project/google-cloud/0.29.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/0.29.0>`__)
 * ``0.30.0`` (`PyPI <https://pypi.org/project/google-cloud/0.30.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/0.30.0>`__)
 * ``0.31.0`` (`PyPI <https://pypi.org/project/google-cloud/0.31.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/0.31.0>`__)
+* ``0.32.0`` (`PyPI <https://pypi.org/project/google-cloud/0.32.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/0.32.0>`__)

--- a/pubsub/CHANGELOG.md
+++ b/pubsub/CHANGELOG.md
@@ -26,6 +26,11 @@
   - Moving `will_accept()` check out of `PublisherClient.batch()`
     factory (#4613).
   - Checking `Batch.will_accept` in thread-safe way (#4616).
+- **Breaking API change**: As part of #4613, changing `PublisherClient.batch()`
+  to no longer accept a `message` (since the `will_accept` check needs to
+  happen in a more concurrency friendly way). In addition, changing the
+  `create` argument so that it means "create even if batch already exists"
+  rather than "create if missing".
 
 ### Documentation
 

--- a/pubsub/CHANGELOG.md
+++ b/pubsub/CHANGELOG.md
@@ -4,6 +4,36 @@
 
 [1]: https://pypi.org/project/google-cloud-pubsub/#history
 
+## 0.30.0
+
+### Notable Implementation Changes
+
+- Dropping redundant Pub / Sub `Policy._paused` data member (#4568).
+- Removing redundant "active" check in policy (#4603).
+- Adding a `Consumer.active` property (#4604).
+- Making it impossible to call `Policy.open()` on an already opened
+  policy (#4606).
+- **Bug fix** (#4575): Fix bug with async publish for batches. There
+  were two related bugs. The first: if a batch exceeds the `max_messages`
+  from the batch settings, then the `commit()` will fail. The second:
+  when a "monitor" worker that after `max_latency` seconds, a failure
+  can occur if a new message is added to the batch during the publish.
+  To fix, the following changes were implemented:
+  - Adding a "STARTING" status for `Batch.commit()` (#4614). This
+    fixes the issue when the batch exceeds `max_messages`.
+  - Adding extra check in `Batch.will_accept` for the number of
+    messages (#4612).
+  - Moving `will_accept()` check out of `PublisherClient.batch()`
+    factory (#4613).
+  - Checking `Batch.will_accept` in thread-safe way (#4616).
+
+### Documentation
+
+- Add more explicit documentation for Pub / Sub `Message.attributes` (#4601).
+- Make `Message.__repr__` a bit prettier / more useful (#4602).
+
+PyPI: https://pypi.org/project/google-cloud-pubsub/0.30.0/
+
 ## 0.29.4
 
 ### Notable Implementation Changes

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-pubsub',
-    version='0.29.5.dev1',
+    version='0.30.0',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,11 @@ SETUP_BASE = {
 }
 
 REQUIREMENTS = [
-    'google-api-core >= 0.1.1, < 0.2.0dev',
+    'google-api-core >= 0.1.2, < 0.2.0dev',
     'google-cloud-bigquery >= 0.28.0, < 0.29dev',
-    'google-cloud-bigtable >= 0.28.0, < 0.29dev',
+    'google-cloud-bigquery-datatransfer >= 0.1.0, < 0.2dev',
+    'google-cloud-bigtable >= 0.28.1, < 0.29dev',
+    'google-cloud-container >= 0.1.0, < 0.2dev',
     'google-cloud-core >= 0.28.0, < 0.29dev',
     'google-cloud-datastore >= 1.4.0, < 1.5dev',
     'google-cloud-dns >= 0.28.0, < 0.29dev',
@@ -60,21 +62,21 @@ REQUIREMENTS = [
     'google-cloud-language >= 1.0.0, < 1.1dev',
     'google-cloud-logging >= 1.4.0, < 1.5dev',
     'google-cloud-monitoring >= 0.28.0, < 0.29dev',
-    'google-cloud-pubsub >= 0.29.1, < 0.30dev',
+    'google-cloud-pubsub >= 0.30.0, < 0.31dev',
     'google-cloud-resource-manager >= 0.28.0, < 0.29dev',
     'google-cloud-runtimeconfig >= 0.28.0, < 0.29dev',
     'google-cloud-spanner >= 0.29.0, < 0.30dev',
     'google-cloud-speech >= 0.30.0, < 0.31dev',
     'google-cloud-storage >= 1.6.0, < 1.7dev',
-    'google-cloud-trace >= 0.16.0, < 0.17dev',
+    'google-cloud-trace >= 0.17.0, < 0.18dev',
     'google-cloud-translate >= 1.3.0, < 1.4dev',
     'google-cloud-videointelligence >= 1.0.0, < 1.1dev',
-    'google-cloud-vision >= 0.28.0, < 0.29dev',
+    'google-cloud-vision >= 0.29.0, < 0.30dev',
 ]
 
 setup(
     name='google-cloud',
-    version='0.31.1.dev1',
+    version='0.32.0',
     description='API Client library for Google Cloud',
     long_description=README,
     install_requires=REQUIREMENTS,

--- a/trace/setup.py
+++ b/trace/setup.py
@@ -1,3 +1,17 @@
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """A setup module for the GAPIC Stackdriver Trace API library.
 
 See:
@@ -15,7 +29,7 @@ install_requires = [
 
 setup(
     name='google-cloud-trace',
-    version='0.17.0',
+    version='0.17.1.dev1',
     author='Google Inc',
     author_email='googleapis-packages@google.com',
     classifiers=[


### PR DESCRIPTION
Also:

- Making a release of the umbrella package (since `google-cloud-pubsub` has transition from `0.29.x` to `0.30.x`)
- Updating version with `.dev1` suffix in `bigquery_datatransfer`, `container` and `trace` packages
- Adding `google-cloud-bigquery-datatransfer` and `google-cloud-container` to umbrella package

~~**NOTE**: This **must** wait on #4616.~~