### PR TITLE
Stop using a non-public `grpcio` API in Spanner tests.

### DIFF
--- a/spanner/tests/unit/test_session.py
+++ b/spanner/tests/unit/test_session.py
@@ -899,16 +899,17 @@ class _SpannerApi(_GAXBaseAPI):
     def _trailing_metadata(self):
         from google.protobuf.duration_pb2 import Duration
         from google.rpc.error_details_pb2 import RetryInfo
-        from grpc._common import to_cygrpc_metadata
 
         if self._commit_abort_retry_nanos is None:
-            return to_cygrpc_metadata(())
+            return []
+
         retry_info = RetryInfo(
             retry_delay=Duration(
                 seconds=self._commit_abort_retry_seconds,
                 nanos=self._commit_abort_retry_nanos))
-        return to_cygrpc_metadata([
-            ('google.rpc.retryinfo-bin', retry_info.SerializeToString())])
+        return [
+            ('google.rpc.retryinfo-bin', retry_info.SerializeToString()),
+        ]
 
     def commit(self, session, mutations,
                transaction_id='', single_use_transaction=None, options=None):


### PR DESCRIPTION
Fixes #4580.