### PR TITLE
Adding back `.dev1` suffixes after #4619.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Feature / bugfix release for the following packages:
 - [`google-cloud-bigtable==0.28.1`](https://pypi.org/project/google-cloud-bigtable/0.28.1/)
 - [`google-cloud-pubsub==0.30.0`](https://pypi.org/project/google-cloud-pubsub/0.30.0/)
 - [`google-cloud-trace==0.17.0`](https://pypi.org/project/google-cloud-trace/0.17.0/)
-- [`google-cloud-vision==0.29.0`](https://pypi.org/project/google-cloud-/0.29.0/)
+- [`google-cloud-vision==0.29.0`](https://pypi.org/project/google-cloud-vision/0.29.0/)
 
 ## 0.31.0
 

--- a/pubsub/CHANGELOG.md
+++ b/pubsub/CHANGELOG.md
@@ -16,9 +16,9 @@
 - **Bug fix** (#4575): Fix bug with async publish for batches. There
   were two related bugs. The first: if a batch exceeds the `max_messages`
   from the batch settings, then the `commit()` will fail. The second:
-  when a "monitor" worker that after `max_latency` seconds, a failure
-  can occur if a new message is added to the batch during the publish.
-  To fix, the following changes were implemented:
+  when a "monitor" worker calls `commit()` after `max_latency` seconds,
+  a failure can occur if a new message is added to the batch **during**
+  the commit. To fix, the following changes were implemented:
   - Adding a "STARTING" status for `Batch.commit()` (#4614). This
     fixes the issue when the batch exceeds `max_messages`.
   - Adding extra check in `Batch.will_accept` for the number of

--- a/pubsub/CHANGELOG.md
+++ b/pubsub/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Notable Implementation Changes
 
-- Dropping redundant Pub / Sub `Policy._paused` data member (#4568).
+- Dropping redundant `Policy._paused` data member (#4568).
 - Removing redundant "active" check in policy (#4603).
 - Adding a `Consumer.active` property (#4604).
 - Making it impossible to call `Policy.open()` on an already opened
@@ -34,7 +34,7 @@
 
 ### Documentation
 
-- Add more explicit documentation for Pub / Sub `Message.attributes` (#4601).
+- Add more explicit documentation for `Message.attributes` (#4601).
 - Make `Message.__repr__` a bit prettier / more useful (#4602).
 
 PyPI: https://pypi.org/project/google-cloud-pubsub/0.30.0/

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-pubsub',
-    version='0.30.0',
+    version='0.30.1.dev1',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud',
-    version='0.32.0',
+    version='0.32.1.dev1',
     description='API Client library for Google Cloud',
     long_description=README,
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
Also

- Removing "Pub / Sub" mention from the Pub / Sub changelog since it is redundant.
- Fixing a bad link (to vision package on PyPI) in the umbrella package changelog