### PR TITLE
Fix build issue with dataproc docs.

### DIFF
--- a/dataproc/google/cloud/dataproc_v1/gapic/cluster_controller_client.py
+++ b/dataproc/google/cloud/dataproc_v1/gapic/cluster_controller_client.py
@@ -276,6 +276,7 @@ class ClusterControllerClient(object):
                         }
                       }
                     }
+
                 Similarly, to change the number of preemptible workers in a cluster to 5,
                 the ``update_mask`` parameter would be
                 ``config.secondary_worker_config.num_instances``, and the ``PATCH`` request
@@ -290,30 +291,19 @@ class ClusterControllerClient(object):
                         }
                       }
                     }
-                <strong>Note:</strong> Currently, only the following fields can be updated:
 
-                 <table>
-                 <tbody>
-                 <tr>
-                 <td><strong>Mask</strong></td>
-                 <td><strong>Purpose</strong></td>
-                 </tr>
-                 <tr>
-                 <td><strong><em>labels</em></strong></td>
-                 <td>Update labels</td>
-                 </tr>
-                 <tr>
-                 <td><strong><em>config.worker_config.num_instances</em></strong></td>
-                 <td>Resize primary worker group</td>
-                 </tr>
-                 <tr>
-                 <td><strong><em>config.secondary_worker_config.num_instances</em></strong></td>
-                 <td>Resize secondary worker group</td>
-                 </tr>
-                 </tbody>
-                 </table>
-                If a dict is provided, it must be of the same form as the protobuf
-                message :class:`~google.cloud.dataproc_v1.types.FieldMask`
+                .. note::
+
+                    Currently, only the following fields can be updated:
+
+                    * ``labels``: Update labels
+                    * ``config.worker_config.num_instances``: Resize primary
+                      worker group
+                    * ``config.secondary_worker_config.num_instances``: Resize
+                      secondary worker group
+
+                    If a dict is provided, it must be of the same form as the protobuf
+                    message :class:`~google.cloud.dataproc_v1.types.FieldMask`
             retry (Optional[google.api_core.retry.Retry]):  A retry object used
                 to retry requests. If ``None`` is specified, requests will not
                 be retried.

--- a/dataproc/setup.py
+++ b/dataproc/setup.py
@@ -34,7 +34,7 @@ with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
 
 setup(
     name='google-cloud-dataproc',
-    version='0.1.0',
+    version='0.1.0.dev1',
     author='Google LLC',
     author_email='googleapis-packages@google.com',
     classifiers=[

--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -43,7 +43,7 @@ class Client(object):
     Args:
         batch_settings (~google.cloud.pubsub_v1.types.BatchSettings): The
             settings for batch publishing.
-        batch_class (Optional[type]): A class that describes how to handle
+        batch_class (Optional[Type]): A class that describes how to handle
             batches. You may subclass the
             :class:`.pubsub_v1.publisher.batch.base.BaseBatch` class in
             order to define your own batcher. This is primarily provided to


### PR DESCRIPTION
Also:

- Fix an ambiguous name (`type`) in Pub / Sub (was introduced
  because I merged with the docs build failing)
- Marking the `dataproc` version as `.dev1`