### PR TITLE
Use a UUID (rather than a sentinel object) for sentinel on Pub / Sub `Future`.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/futures.py
+++ b/pubsub/google/cloud/pubsub_v1/futures.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 import threading
+import uuid
 
 import google.api_core.future
 from google.cloud.pubsub_v1.publisher import exceptions
@@ -29,7 +30,11 @@ class Future(google.api_core.future.Future):
     This object should not be created directly, but is returned by other
     methods in this library.
     """
-    _SENTINEL = object()
+
+    # This could be a sentinel object or None, but the sentinel object's ID
+    # can change if the process is forked, and None has the possibility of
+    # actually being a result.
+    _SENTINEL = uuid.uuid4()
 
     def __init__(self):
         self._result = self._SENTINEL

--- a/pubsub/google/cloud/pubsub_v1/futures.py
+++ b/pubsub/google/cloud/pubsub_v1/futures.py
@@ -73,8 +73,8 @@ class Future(google.api_core.future.Future):
         This still returns True in failure cases; checking :meth:`result` or
         :meth:`exception` is the canonical way to assess success or failure.
         """
-        return (self._exception is not self._SENTINEL or
-                self._result is not self._SENTINEL)
+        return (self._exception != self._SENTINEL or
+                self._result != self._SENTINEL)
 
     def result(self, timeout=None):
         """Return the message ID, or raise an exception.
@@ -123,7 +123,7 @@ class Future(google.api_core.future.Future):
             raise exceptions.TimeoutError('Timed out waiting for result.')
 
         # If the batch completed successfully, this should return None.
-        if self._result is not self._SENTINEL:
+        if self._result != self._SENTINEL:
             return None
 
         # Okay, this batch had an error; this should return it.


### PR DESCRIPTION
Similar to [`STOP`][1]. ~~Though empirically I'm not seeing the object ID change across threads or across `multiprocessing` processes.~~

Since I wanted to be thorough, here is why we do this. An object ID won't change (on unix) when using "fork". Running

```python
# do_it.py
import multiprocessing
import sys


SENTINEL = object()


def f():
    process = multiprocessing.current_process()
    print('multiprocessing.current_process(): {}'.format(process))
    print('SENTINEL: {}'.format(SENTINEL))


def main():
    # >>> multiprocessing.get_all_start_methods()
    # ['fork', 'spawn', 'forkserver']
    multiprocessing.set_start_method(sys.argv[1])
    print(SENTINEL)

    proc1 = multiprocessing.Process(target=f)
    proc2 = multiprocessing.Process(target=f)

    proc1.start()
    proc2.start()

    proc1.join()
    proc2.join()


if __name__ == '__main__':
    main()
```

we see:

```
$ python do_it.py fork
<object object at 0x7ff33c64c180>
multiprocessing.current_process(): <Process(Process-1, started)>
SENTINEL: <object object at 0x7ff33c64c180>
multiprocessing.current_process(): <Process(Process-2, started)>
SENTINEL: <object object at 0x7ff33c64c180>
```

but it will change when using "spawn":

```
$ python do_it.py spawn
<object object at 0x7fe8d1a59180>
multiprocessing.current_process(): <Process(Process-2, started)>
SENTINEL: <object object at 0x7fc6bf36b1b0>
multiprocessing.current_process(): <Process(Process-1, started)>
SENTINEL: <object object at 0x7f3faf15f1b0>
```

and there are changes with "forkserver":

```
$ python do_it.py forkserver
<object object at 0x7f6ccda97180>
multiprocessing.current_process(): <Process(Process-1, started)>
SENTINEL: <object object at 0x7f74541111e0>
multiprocessing.current_process(): <Process(Process-2, started)>
SENTINEL: <object object at 0x7f74541111e0>
```

[1]: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/56864fc339f2688e094444951b909448838e56ec/pubsub/google/cloud/pubsub_v1/subscriber/_helper_threads.py#L27-L31