### PR TITLE
Adds optional location_prefix kwarg in to_legacy_urlsafe

### DIFF
--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -298,7 +298,7 @@ class Key(object):
 
         return key
 
-    def to_legacy_urlsafe(self):
+    def to_legacy_urlsafe(self, location_prefix=None):
         """Convert to a base64 encode urlsafe string for App Engine.
 
         This is intended to work with the "legacy" representation of a
@@ -310,13 +310,25 @@ class Key(object):
         .. note::
 
             The string returned by ``to_legacy_urlsafe`` is equivalent, but
-            not identical, to the string returned by ``ndb``.
+            not identical, to the string returned by ``ndb``. The location
+            prefix may need to be specified to obtain idendentical urlsafe
+            keys.
+
+        :type location_prefix: str
+        :param location_prefix: The location prefix of ones project. Often
+                                this value is 's~', but may be 'dev~', 'e~', or
+                                other location prefixes currently unknown.
 
         :rtype: bytes
         :returns: A bytestring containing the key encoded as URL-safe base64.
         """
+        if location_prefix:
+            project_id = location_prefix + self.project
+        else:
+            project_id = self.project
+
         reference = _app_engine_key_pb2.Reference(
-            app=self.project,
+            app=project_id,
             path=_to_legacy_path(self._path),  # Avoid the copy.
             name_space=self.namespace,
         )

--- a/datastore/google/cloud/datastore/key.py
+++ b/datastore/google/cloud/datastore/key.py
@@ -311,21 +311,22 @@ class Key(object):
 
             The string returned by ``to_legacy_urlsafe`` is equivalent, but
             not identical, to the string returned by ``ndb``. The location
-            prefix may need to be specified to obtain idendentical urlsafe
+            prefix may need to be specified to obtain identical urlsafe
             keys.
 
         :type location_prefix: str
-        :param location_prefix: The location prefix of ones project. Often
-                                this value is 's~', but may be 'dev~', 'e~', or
-                                other location prefixes currently unknown.
+        :param location_prefix: The location prefix of an App Engine project
+                                ID. Often this value is 's~', but may also be
+                                'e~', or other location prefixes currently
+                                unknown.
 
         :rtype: bytes
         :returns: A bytestring containing the key encoded as URL-safe base64.
         """
-        if location_prefix:
-            project_id = location_prefix + self.project
-        else:
+        if location_prefix is None:
             project_id = self.project
+        else:
+            project_id = location_prefix + self.project
 
         reference = _app_engine_key_pb2.Reference(
             app=project_id,

--- a/datastore/tests/unit/test_key.py
+++ b/datastore/tests/unit/test_key.py
@@ -34,12 +34,10 @@ class TestKey(unittest.TestCase):
     _URLSAFE_FLAT_PATH1 = ('Parent', 59, 'Child', 'Feather')
     _URLSAFE_EXAMPLE2 = b'agZzfmZpcmVyDwsSBEtpbmQiBVRoaW5nDA'
     _URLSAFE_APP2 = 's~fire'
-    _URLSAFE_APP3 = 'sample-app-no-location'
-    _URLSAFE_LOCATION_PREFIX = 's~'
-    _URLSAFE_EXAMPLE3 = (
-        b'ahhzfnNhbXBsZS1hcHAtbm8tbG9jYXRpb25yHgsSBlBhcmVudBg7DAsSBUNoaWxkIgdG'
-        b'ZWF0aGVyDKIBBXNwYWNl')
     _URLSAFE_FLAT_PATH2 = ('Kind', 'Thing')
+    _URLSAFE_EXAMPLE3 = b'ahhzfnNhbXBsZS1hcHAtbm8tbG9jYXRpb25yCgsSBFpvcnAYWAw'
+    _URLSAFE_APP3 = 'sample-app-no-location'
+    _URLSAFE_FLAT_PATH3 = ('Zorp', 88)
 
     @staticmethod
     def _get_target_class():
@@ -415,11 +413,9 @@ class TestKey(unittest.TestCase):
 
     def test_to_legacy_urlsafe_with_location_prefix(self):
         key = self._make_one(
-            *self._URLSAFE_FLAT_PATH1,
-            project=self._URLSAFE_APP3,
-            namespace=self._URLSAFE_NAMESPACE1)
-        # NOTE: ``key.project`` is somewhat "invalid" but that is OK.
-        urlsafe = key.to_legacy_urlsafe(self._URLSAFE_LOCATION_PREFIX)
+            *self._URLSAFE_FLAT_PATH3,
+            project=self._URLSAFE_APP3)
+        urlsafe = key.to_legacy_urlsafe(location_prefix='s~')
         self.assertEqual(urlsafe, self._URLSAFE_EXAMPLE3)
 
     def test_from_legacy_urlsafe(self):
@@ -443,6 +439,15 @@ class TestKey(unittest.TestCase):
         self.assertEqual('s~' + key.project, self._URLSAFE_APP2)
         self.assertIsNone(key.namespace)
         self.assertEqual(key.flat_path, self._URLSAFE_FLAT_PATH2)
+
+    def test_from_legacy_urlsafe_with_location_prefix(self):
+        klass = self._get_target_class()
+        # Make sure it will have base64 padding added.
+        key = klass.from_legacy_urlsafe(self._URLSAFE_EXAMPLE3)
+
+        self.assertEqual(key.project, self._URLSAFE_APP3)
+        self.assertIsNone(key.namespace)
+        self.assertEqual(key.flat_path, self._URLSAFE_FLAT_PATH3)
 
     def test_is_partial_no_name_or_id(self):
         key = self._make_one('KIND', project=self._DEFAULT_PROJECT)

--- a/datastore/tests/unit/test_key.py
+++ b/datastore/tests/unit/test_key.py
@@ -34,6 +34,11 @@ class TestKey(unittest.TestCase):
     _URLSAFE_FLAT_PATH1 = ('Parent', 59, 'Child', 'Feather')
     _URLSAFE_EXAMPLE2 = b'agZzfmZpcmVyDwsSBEtpbmQiBVRoaW5nDA'
     _URLSAFE_APP2 = 's~fire'
+    _URLSAFE_APP3 = 'sample-app-no-location'
+    _URLSAFE_LOCATION_PREFIX = 's~'
+    _URLSAFE_EXAMPLE3 = (
+        b'ahhzfnNhbXBsZS1hcHAtbm8tbG9jYXRpb25yHgsSBlBhcmVudBg7DAsSBUNoaWxkIgdG'
+        b'ZWF0aGVyDKIBBXNwYWNl')
     _URLSAFE_FLAT_PATH2 = ('Kind', 'Thing')
 
     @staticmethod
@@ -429,6 +434,15 @@ class TestKey(unittest.TestCase):
         self.assertEqual('s~' + key.project, self._URLSAFE_APP2)
         self.assertIsNone(key.namespace)
         self.assertEqual(key.flat_path, self._URLSAFE_FLAT_PATH2)
+
+    def test_from_legacy_urlsafe_with_location_prefix(self):
+        key = self._make_one(
+            *self._URLSAFE_FLAT_PATH1,
+            project=self._URLSAFE_APP3,
+            namespace=self._URLSAFE_NAMESPACE1)
+        # NOTE: ``key.project`` is somewhat "invalid" but that is OK.
+        urlsafe = key.to_legacy_urlsafe(self._URLSAFE_LOCATION_PREFIX)
+        self.assertEqual(urlsafe, self._URLSAFE_EXAMPLE3)
 
     def test_is_partial_no_name_or_id(self):
         key = self._make_one('KIND', project=self._DEFAULT_PROJECT)

--- a/datastore/tests/unit/test_key.py
+++ b/datastore/tests/unit/test_key.py
@@ -413,6 +413,15 @@ class TestKey(unittest.TestCase):
         # Make sure it started with base64 padding.
         self.assertNotEqual(len(self._URLSAFE_EXAMPLE2) % 4, 0)
 
+    def test_to_legacy_urlsafe_with_location_prefix(self):
+        key = self._make_one(
+            *self._URLSAFE_FLAT_PATH1,
+            project=self._URLSAFE_APP3,
+            namespace=self._URLSAFE_NAMESPACE1)
+        # NOTE: ``key.project`` is somewhat "invalid" but that is OK.
+        urlsafe = key.to_legacy_urlsafe(self._URLSAFE_LOCATION_PREFIX)
+        self.assertEqual(urlsafe, self._URLSAFE_EXAMPLE3)
+
     def test_from_legacy_urlsafe(self):
         klass = self._get_target_class()
         key = klass.from_legacy_urlsafe(self._URLSAFE_EXAMPLE1)
@@ -434,15 +443,6 @@ class TestKey(unittest.TestCase):
         self.assertEqual('s~' + key.project, self._URLSAFE_APP2)
         self.assertIsNone(key.namespace)
         self.assertEqual(key.flat_path, self._URLSAFE_FLAT_PATH2)
-
-    def test_from_legacy_urlsafe_with_location_prefix(self):
-        key = self._make_one(
-            *self._URLSAFE_FLAT_PATH1,
-            project=self._URLSAFE_APP3,
-            namespace=self._URLSAFE_NAMESPACE1)
-        # NOTE: ``key.project`` is somewhat "invalid" but that is OK.
-        urlsafe = key.to_legacy_urlsafe(self._URLSAFE_LOCATION_PREFIX)
-        self.assertEqual(urlsafe, self._URLSAFE_EXAMPLE3)
 
     def test_is_partial_no_name_or_id(self):
         key = self._make_one('KIND', project=self._DEFAULT_PROJECT)


### PR DESCRIPTION
Fixes #3597

I encountered an issue with respect to urlsafe keys in a system that is using _both_ `google-cloud-datastore` and `ndb` in different services.  I was receiving incompatible urlsafe keys when using the _output_ of `to_legacy_urlsafe` in things like `ndb.Key(urlsafe=<output_from_legacy_urlsafe>)` running under App Engine. I received the following error:

```
BadRequestError: app s~your-app-id cannot access app your-app-id's data
```

 I then tried the suggestion as per #3597 of adding the location prefix to the project under cloud-datastore like so:

`datastore.Client(project='s~your-app-id')`

Unfortunately, I was met with this error (where `your-app-id` is a real project, with active datastore db which I can access via the Google Cloud Console):

```
The project s~your-app-id does not exist or it does not contain an active Cloud Datastore database.
```

I was able to produce compatible urlsafe keys by specifying the location prefix _only_ when creating the urlsafe keys. This PR contains that small change. 