### PR TITLE
Replacing references to `stable/` docs with `latest/`.

### DIFF
--- a/bigquery_datatransfer/README.rst
+++ b/bigquery_datatransfer/README.rst
@@ -9,7 +9,7 @@ scheduled, managed basis.
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _BigQuery Data Transfer API: https://cloud.google.com/bigquerydatatransfer
-.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigquerydatatransfer-usage
+.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/bigquery_datatransfer/index.html
 .. _Product Documentation:  https://cloud.google.com/bigquerydatatransfer
 
 Quick Start
@@ -23,7 +23,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable the BigQuery Data Transfer API.:  https://cloud.google.com/bigquerydatatransfer
-.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/stable/google-cloud-auth
+.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/latest/core/auth.html
 
 Installation
 ~~~~~~~~~~~~

--- a/bigquery_datatransfer/docs/index.rst
+++ b/bigquery_datatransfer/docs/index.rst
@@ -9,7 +9,7 @@ scheduled, managed basis.
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _BigQuery Data Transfer API: https://cloud.google.com/bigquerydatatransfer
-.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/bigquerydatatransfer-usage
+.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/bigquery_datatransfer/index.html
 .. _Product Documentation:  https://cloud.google.com/bigquerydatatransfer
 
 Quick Start
@@ -23,7 +23,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable the BigQuery Data Transfer API.:  https://cloud.google.com/bigquerydatatransfer
-.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/stable/google-cloud-auth
+.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/latest/core/auth.html
 
 Installation
 ~~~~~~~~~~~~

--- a/container/README.rst
+++ b/container/README.rst
@@ -9,7 +9,7 @@ based applications, powered by the open source Kubernetes technology.
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Google Container Engine API: https://cloud.google.com/container
-.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/container-usage
+.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/container/index.html
 .. _Product Documentation:  https://cloud.google.com/container
 
 Quick Start
@@ -23,7 +23,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable the Google Container Engine API.:  https://cloud.google.com/container
-.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/stable/google-cloud-auth
+.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/latest/core/auth.html
 
 Installation
 ~~~~~~~~~~~~

--- a/container/docs/index.rst
+++ b/container/docs/index.rst
@@ -9,7 +9,7 @@ based applications, powered by the open source Kubernetes technology.
 
 .. _Beta: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Google Container Engine API: https://cloud.google.com/container
-.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/container-usage
+.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/container/index.html
 .. _Product Documentation:  https://cloud.google.com/container
 
 Quick Start
@@ -23,7 +23,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable the Google Container Engine API.:  https://cloud.google.com/container
-.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/stable/google-cloud-auth
+.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/latest/core/auth.html
 
 Installation
 ~~~~~~~~~~~~

--- a/dataproc/README.rst
+++ b/dataproc/README.rst
@@ -8,7 +8,7 @@ Python Client for Google Cloud Dataproc API (`Alpha`_)
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Google Cloud Dataproc API: https://cloud.google.com/dataproc
-.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/dataproc/usage.html
+.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/dataproc/usage.html
 .. _Product Documentation:  https://cloud.google.com/dataproc
 
 Quick Start
@@ -24,7 +24,7 @@ In order to use this library, you first need to go through the following steps:
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
 .. _Enable the Google Cloud Dataproc API.:  https://cloud.google.com/dataproc
-.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/stable/core/auth.html
+.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/latest/core/auth.html
 
 Installation
 ~~~~~~~~~~~~

--- a/dataproc/docs/index.rst
+++ b/dataproc/docs/index.rst
@@ -8,7 +8,7 @@ Python Client for Google Cloud Dataproc API (`Alpha`_)
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Google Cloud Dataproc API: https://cloud.google.com/dataproc
-.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/dataproc/usage.html
+.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/dataproc/usage.html
 .. _Product Documentation:  https://cloud.google.com/dataproc
 
 Quick Start
@@ -24,7 +24,7 @@ In order to use this library, you first need to go through the following steps:
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
 .. _Enable the Google Cloud Dataproc API.:  https://cloud.google.com/dataproc
-.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/stable/core/auth.html
+.. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/latest/core/auth.html
 
 Installation
 ~~~~~~~~~~~~

--- a/test_utils/scripts/update_docs.sh
+++ b/test_utils/scripts/update_docs.sh
@@ -64,20 +64,8 @@ CURRENT_VERSION=$(python ${DIR}/get_version.py)
 
 # Update gh-pages with the created docs.
 cd ${GH_PAGES_DIR}
-if [[ -n "${CIRCLE_TAG}" ]]; then
-    if [[ -d ${CURRENT_VERSION} ]]; then
-        echo "The directory ${CURRENT_VERSION} already exists."
-        exit 1
-    fi
-    git rm -fr stable/
-
-    # Put the new release in stable and with the actual version.
-    cp -R ../docs/_build/html/ stable/
-    cp -R ../docs/_build/html/ "${CURRENT_VERSION}/"
-else
-    git rm -fr latest/
-    cp -R ../docs/_build/html/ latest/
-fi
+git rm -fr latest/
+cp -R ../docs/_build/html/ latest/
 
 # Update the files push to gh-pages.
 git add .


### PR DESCRIPTION
Also fixing some bad links in the 3 newest packages.

(This is only for **our** docs, projects that don't secretly contain 15+ subprojects typically have useful `stable/` docs.)

Related to #4637.