### PR TITLE
Updated version number for 0.1.0 release

### DIFF
--- a/dataproc/docs/index.rst
+++ b/dataproc/docs/index.rst
@@ -106,5 +106,6 @@ Api Reference
 .. toctree::
     :maxdepth: 2
 
+    releases
     gapic/v1/api
     gapic/v1/types

--- a/dataproc/docs/releases.rst
+++ b/dataproc/docs/releases.rst
@@ -1,0 +1,5 @@
+###################################
+``google-cloud-dataproc`` Releases
+###################################
+
+* ``0.1.0`` (`PyPI <https://pypi.org/project/google-cloud-dataproc/0.1.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-dataproc/releases/tag/dataproc-0.1.0>`__)

--- a/dataproc/setup.py
+++ b/dataproc/setup.py
@@ -34,7 +34,7 @@ with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
 
 setup(
     name='google-cloud-dataproc',
-    version='0.1.0.dev1',
+    version='0.1.0',
     author='Google LLC',
     author_email='googleapis-packages@google.com',
     classifiers=[


### PR DESCRIPTION
This step was also straightforward. 

Maybe put a template in the doc for how to format the releases.rst if it can't be generated? I copied/modified from another api.