### PR TITLE
Requiring 'grpcio >= 1.8.2'.

### DIFF
--- a/api_core/setup.py
+++ b/api_core/setup.py
@@ -63,7 +63,7 @@ REQUIREMENTS = [
 
 EXTRAS_REQUIREMENTS = {
     ':python_version<"3.2"': ['futures >= 3.2.0'],
-    'grpc': ['grpcio >= 1.7.0'],
+    'grpc': ['grpcio >= 1.8.2'],
 }
 
 setup(

--- a/core/setup.py
+++ b/core/setup.py
@@ -55,7 +55,7 @@ REQUIREMENTS = [
 ]
 
 EXTRAS_REQUIREMENTS = {
-    'grpc': ['grpcio >= 1.7.0'],
+    'grpc': ['grpcio >= 1.8.2'],
 }
 
 setup(

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -52,6 +52,7 @@ SETUP_BASE = {
 
 REQUIREMENTS = [
     'google-api-core[grpc] >= 0.1.2, < 0.2.0dev',
+    'grpcio >= 1.8.2',
     'google-auth >= 1.0.2, < 2.0dev',
     'grpc-google-iam-v1 >= 0.11.1, < 0.12dev',
     'psutil >= 5.2.2, < 6.0dev',


### PR DESCRIPTION
This is due to a nasty spinlock [bug][1] that has been partially [fixed][2] in `1.8.2`.

[1]: https://github.com/grpc/grpc/issues/9688
[2]: https://github.com/grpc/grpc/pull/13665