### PR TITLE
Making `google-cloud-pubsub==0.30.1` release.

### DIFF
--- a/api_core/CHANGELOG.md
+++ b/api_core/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 [1]: https://pypi.org/project/google-api-core/#history
 
+## 0.1.3
+
+### Notable Implementation Changes
+
+- Apply scopes to explicitly provided credentials if needed (#4594).
+- Removing `google.api_core.gapic_v1.method.METRICS_METADATA_KEY`. It
+  can be accessed via
+  `google.api_core.gapic_v1.client_info.METRICS_METADATA_KEY` (#4588).
+
+### Dependencies
+
+- Upgrading to latest `grpcio==1.8.2` (#4642). For details, see
+  related gRPC [bug](https://github.com/grpc/grpc/issues/9688)
+  and [fix](https://github.com/grpc/grpc/pull/13665).
+
+PyPI: https://pypi.org/project/google-api-core/0.1.3/
+
 ## 0.1.2
 
 - Upgrading `concurrent.futures` backport from `>= 3.0.0`

--- a/api_core/setup.py
+++ b/api_core/setup.py
@@ -68,7 +68,7 @@ EXTRAS_REQUIREMENTS = {
 
 setup(
     name='google-api-core',
-    version='0.1.3.dev1',
+    version='0.1.3',
     description='Core Google API Client Library',
     long_description=README,
     namespace_packages=['google'],

--- a/docs/core/releases.rst
+++ b/docs/core/releases.rst
@@ -32,3 +32,4 @@ much of the functionality has been split out into a new package
 * ``0.1.0`` (`PyPI <https://pypi.org/project/google-api-core/0.1.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/api-core-0.1.0>`__)
 * ``0.1.1`` (`PyPI <https://pypi.org/project/google-api-core/0.1.1/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/api-core-0.1.1>`__)
 * ``0.1.2`` (`PyPI <https://pypi.org/project/google-api-core/0.1.2/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/api-core-0.1.2>`__)
+* ``0.1.3`` (`PyPI <https://pypi.org/project/google-api-core/0.1.3/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/api-core-0.1.3>`__)

--- a/docs/pubsub/releases.rst
+++ b/docs/pubsub/releases.rst
@@ -21,3 +21,4 @@
 * ``0.29.3`` (`PyPI <https://pypi.org/project/google-cloud-pubsub/0.29.3/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/pubsub-0.29.3>`__)
 * ``0.29.4`` (`PyPI <https://pypi.org/project/google-cloud-pubsub/0.29.4/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/pubsub-0.29.4>`__)
 * ``0.30.0`` (`PyPI <https://pypi.org/project/google-cloud-pubsub/0.30.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/pubsub-0.30.0>`__)
+* ``0.30.1`` (`PyPI <https://pypi.org/project/google-cloud-pubsub/0.30.1/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/pubsub-0.30.1>`__)

--- a/pubsub/CHANGELOG.md
+++ b/pubsub/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 [1]: https://pypi.org/project/google-cloud-pubsub/#history
 
+## 0.30.1
+
+### Notable Implementation Changes
+
+- Moving lock factory used in publisher client to the Batch
+  implementation (#4628).
+- Use a UUID (rather than a sentinel object) on `Future` (#4634).
+
+### Dependencies
+
+- Upgrading to latest `grpcio==1.8.2` (#4642). This fixes #4600. For
+  details, see related gRPC [bug](https://github.com/grpc/grpc/issues/9688)
+  and [fix](https://github.com/grpc/grpc/pull/13665).
+
+PyPI: https://pypi.org/project/google-cloud-pubsub/0.30.1/
+
 ## 0.30.0
 
 ### Notable Implementation Changes

--- a/pubsub/CHANGELOG.md
+++ b/pubsub/CHANGELOG.md
@@ -14,9 +14,10 @@
 
 ### Dependencies
 
-- Upgrading to latest `grpcio==1.8.2` (#4642). This fixes #4600. For
-  details, see related gRPC [bug](https://github.com/grpc/grpc/issues/9688)
-  and [fix](https://github.com/grpc/grpc/pull/13665).
+- Upgrading to `google-api-core==0.1.3` which depends on the latest
+  `grpcio==1.8.2` (#4642). This fixes #4600. For details, see related
+  gRPC [bug](https://github.com/grpc/grpc/issues/9688) and
+  [fix](https://github.com/grpc/grpc/pull/13665).
 
 PyPI: https://pypi.org/project/google-cloud-pubsub/0.30.1/
 

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -60,7 +60,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-pubsub',
-    version='0.30.1.dev1',
+    version='0.30.1',
     description='Python Client for Google Cloud Pub/Sub',
     long_description=README,
     namespace_packages=[

--- a/pubsub/setup.py
+++ b/pubsub/setup.py
@@ -51,8 +51,7 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-api-core[grpc] >= 0.1.2, < 0.2.0dev',
-    'grpcio >= 1.8.2',
+    'google-api-core[grpc] >= 0.1.3, < 0.2.0dev',
     'google-auth >= 1.0.2, < 2.0dev',
     'grpc-google-iam-v1 >= 0.11.1, < 0.12dev',
     'psutil >= 5.2.2, < 6.0dev',


### PR DESCRIPTION
Also making `google-api-core==0.1.3` release.

This settles my "should I or shouldn't I?" hesitation about explicitly depending on `grpcio` in `google-cloud-pubsub`.