### PR TITLE
BigQuery: Add Client.insert_rows, deprecate Client.create_rows

### DIFF
--- a/bigquery/CHANGELOG.md
+++ b/bigquery/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 -   Add `Client.insert_rows()` and `Client.insert_rows_json()`, deprecate
     `Client.create_rows()` and `Client.create_rows_json()`.
-    ([#????](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/????))
+    ([#4657](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/4657))
 -   Add `Client.list_tables`, deprecate `Client.list_dataset_tables`.
     ([#4653](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/4653))
 -   `Client.list_tables` returns an iterators of `TableListItem`. The API

--- a/bigquery/CHANGELOG.md
+++ b/bigquery/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-cloud-bigquery/#history
 
+## 0.29.0 (unreleased)
+
+## Interface changes / breaking changes
+
+-   Add `Client.insert_rows()` and `Client.insert_rows_json()`, deprecate
+    `Client.create_rows()` and `Client.create_rows_json()`.
+    ([#????](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/????))
+
 ## 0.28.0
 
 **0.28.0 significantly changes the interface for this package.** For examples

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -20,6 +20,7 @@ import collections
 import functools
 import os
 import uuid
+import warnings
 
 import six
 
@@ -996,8 +997,8 @@ class Client(ClientWithProject):
         job._begin(retry=retry)
         return job
 
-    def create_rows(self, table, rows, selected_fields=None, **kwargs):
-        """API call:  insert table data via a POST request
+    def insert_rows(self, table, rows, selected_fields=None, **kwargs):
+        """Insert rows into a table via the streaming API.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
@@ -1062,12 +1063,12 @@ class Client(ClientWithProject):
 
             json_rows.append(json_row)
 
-        return self.create_rows_json(table, json_rows, **kwargs)
+        return self.insert_rows_json(table, json_rows, **kwargs)
 
-    def create_rows_json(self, table, json_rows, row_ids=None,
+    def insert_rows_json(self, table, json_rows, row_ids=None,
                          skip_invalid_rows=None, ignore_unknown_values=None,
                          template_suffix=None, retry=DEFAULT_RETRY):
-        """API call:  insert table data via a POST request
+        """Insert rows into a table without applying local type conversions.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
@@ -1150,6 +1151,27 @@ class Client(ClientWithProject):
                            'errors': error['errors']})
 
         return errors
+
+    def create_rows(self, *args, **kwargs):
+        """DEPRECATED: Insert rows into a table via the streaming API.
+
+        Use :func:`~google.cloud.bigquery.client.Client.insert_rows` instead.
+        """
+        warnings.warn(
+            'create_rows is deprecated, use insert_rows instead.',
+            DeprecationWarning)
+        return self.insert_rows(*args, **kwargs)
+
+    def create_rows_json(self, *args, **kwargs):
+        """DEPRECATED: Insert rows into a table without type conversions.
+
+        Use :func:`~google.cloud.bigquery.client.Client.insert_rows_json`
+        instead.
+        """
+        warnings.warn(
+            'create_rows_json is deprecated, use insert_rows_json instead.',
+            DeprecationWarning)
+        return self.insert_rows_json(*args, **kwargs)
 
     def list_rows(self, table, selected_fields=None, max_results=None,
                   page_token=None, start_index=None, retry=DEFAULT_RETRY):

--- a/docs/bigquery/snippets.py
+++ b/docs/bigquery/snippets.py
@@ -419,7 +419,7 @@ def test_table_insert_rows(client, to_delete):
     """Insert / fetch table data."""
     dataset_id = 'table_insert_rows_dataset_{}'.format(_millis())
     table_id = 'table_insert_rows_table_{}'.format(_millis())
-    dataset = bigquery.Dataset(client.dataset(DATASET_ID))
+    dataset = bigquery.Dataset(client.dataset(dataset_id))
     dataset = client.create_dataset(dataset)
     to_delete.append(dataset)
 

--- a/docs/bigquery/snippets.py
+++ b/docs/bigquery/snippets.py
@@ -23,6 +23,7 @@ a ``to_delete`` list;  the function adds to the list any objects created which
 need to be deleted during teardown.
 """
 
+import json
 import time
 
 import pytest
@@ -64,9 +65,9 @@ def to_delete(client):
     doomed = []
     yield doomed
     for item in doomed:
-        if isinstance(item, bigquery.Dataset):
+        if isinstance(item, (bigquery.Dataset, bigquery.DatasetReference)):
             client.delete_dataset(item)
-        elif isinstance(item, bigquery.Table):
+        elif isinstance(item, (bigquery.Table, bigquery.TableReference)):
             client.delete_table(item)
         else:
             item.delete()
@@ -414,28 +415,28 @@ def test_update_table_multiple_properties(client, to_delete):
     # [END update_table_multiple_properties]
 
 
-def test_table_create_rows(client, to_delete):
+def test_table_insert_rows(client, to_delete):
     """Insert / fetch table data."""
-    DATASET_ID = 'table_create_rows_dataset_{}'.format(_millis())
-    TABLE_ID = 'table_create_rows_table_{}'.format(_millis())
+    dataset_id = 'table_insert_rows_dataset_{}'.format(_millis())
+    table_id = 'table_insert_rows_table_{}'.format(_millis())
     dataset = bigquery.Dataset(client.dataset(DATASET_ID))
     dataset = client.create_dataset(dataset)
     to_delete.append(dataset)
 
-    table = bigquery.Table(dataset.table(TABLE_ID), schema=SCHEMA)
+    table = bigquery.Table(dataset.table(table_id), schema=SCHEMA)
     table = client.create_table(table)
     to_delete.insert(0, table)
 
-    # [START table_create_rows]
-    ROWS_TO_INSERT = [
+    # [START table_insert_rows]
+    rows_to_insert = [
         (u'Phred Phlyntstone', 32),
         (u'Wylma Phlyntstone', 29),
     ]
 
-    errors = client.create_rows(table, ROWS_TO_INSERT)  # API request
+    errors = client.insert_rows(table, rows_to_insert)  # API request
 
     assert errors == []
-    # [END table_create_rows]
+    # [END table_insert_rows]
 
 
 def test_load_table_from_file(client, to_delete):
@@ -600,9 +601,20 @@ def test_extract_table(client, to_delete):
     to_delete.append(dataset)
 
     table_ref = dataset.table('person_ages')
-    table = client.create_table(bigquery.Table(table_ref, schema=SCHEMA))
-    to_delete.insert(0, table)
-    client.create_rows(table, ROWS)
+    to_insert = [
+        {'full_name': name, 'age': age}
+        for name, age in ROWS
+    ]
+    rows = [json.dumps(row) for row in to_insert]
+    body = six.StringIO('{}\n'.format('\n'.join(rows)))
+    job_config = bigquery.LoadJobConfig()
+    job_config.write_disposition = 'WRITE_TRUNCATE'
+    job_config.source_format = 'NEWLINE_DELIMITED_JSON'
+    job_config.schema = SCHEMA
+    to_delete.insert(0, table_ref)
+    # Load a table using a local JSON file from memory.
+    client.load_table_from_file(
+        body, table_ref, job_config=job_config).result()
 
     bucket_name = 'extract_person_ages_job_{}'.format(_millis())
     # [START extract_table]

--- a/docs/bigquery/usage.rst
+++ b/docs/bigquery/usage.rst
@@ -176,8 +176,8 @@ Utilize iterator properties returned with row data:
 Insert rows into a table's data:
 
 .. literalinclude:: snippets.py
-   :start-after: [START table_create_rows]
-   :end-before: [END table_create_rows]
+   :start-after: [START table_insert_rows]
+   :end-before: [END table_insert_rows]
 
 Upload table data from a file:
 


### PR DESCRIPTION
`insert_rows` aligns better with API request (Tabledata.insertAll). Feedback from BQ GA review.

Note that the [`create_rows()` sample in the Python migration guide](https://cloud.google.com/bigquery/docs/python-client-migration#streaming_data_into_a_table) already points to a commit hash, so this should be safe to merge whenever.