### PR TITLE
refactor retry logic on mutate row

### DIFF
--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -19,8 +19,6 @@ import struct
 
 import six
 
-from concurrent import futures
-
 from google.cloud._helpers import _datetime_from_microseconds
 from google.cloud._helpers import _microseconds_from_datetime
 from google.cloud._helpers import _to_bytes
@@ -437,13 +435,7 @@ class DirectRow(_SetDeleteRow):
         retry_ = retry.Retry(
             predicate=retry.if_exception_type(exceptions.GrpcRendezvous),
             deadline=30)
-
-        try:
-            retry_(retry_commit)()
-        except exceptions.RetryError:
-            raise futures.\
-                TimeoutError('Operation did not complete '
-                             'within the designated timeout.')
+        retry_(retry_commit)()
 
         self.clear()
 

--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -239,13 +239,6 @@ class _SetDeleteRow(Row):
             mutations_list.extend(to_append)
 
 
-def wrapped_partial(func, *args, **kwargs):
-    """Create partial wrapper for a function"""
-    partial_func = functools.partial(func, *args, **kwargs)
-    functools.update_wrapper(partial_func, func)
-    return partial_func
-
-
 def call_mutate_row(table, request_pb):
     """Call the MutateRow"""
     client = table._instance._client
@@ -429,9 +422,10 @@ class DirectRow(_SetDeleteRow):
             mutations=mutations_list,
         )
 
-        retry_commit = wrapped_partial(call_mutate_row,
-                                       self._table,
-                                       request_pb)
+        retry_commit = functools.partial(
+            call_mutate_row,
+            table=self._table,
+            request_pb=request_pb)
         retry_ = retry.Retry(
             predicate=retry.if_exception_type(exceptions.GrpcRendezvous),
             deadline=30)

--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -431,7 +431,9 @@ class DirectRow(_SetDeleteRow):
             mutations=mutations_list,
         )
 
-        retry_commit = wrapped_partial(call_mutate_row, self._table, request_pb)
+        retry_commit = wrapped_partial(call_mutate_row,
+                                       self._table,
+                                       request_pb)
         retry_ = retry.Retry(
             predicate=retry.if_exception_type(exceptions.GrpcRendezvous),
             deadline=30)

--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -17,8 +17,8 @@
 
 import struct
 
-import six
 import functools
+import six
 import grpc
 
 from google.cloud._helpers import _datetime_from_microseconds

--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -18,6 +18,7 @@
 import struct
 
 import six
+import functools
 
 from google.cloud._helpers import _datetime_from_microseconds
 from google.cloud._helpers import _microseconds_from_datetime
@@ -28,20 +29,12 @@ from google.cloud.bigtable._generated import (
     bigtable_pb2 as messages_v2_pb2)
 from google.api_core import retry
 from google.cloud import exceptions
-from functools import partial, update_wrapper
 
 
 _PACK_I64 = struct.Struct('>q').pack
 
 MAX_MUTATIONS = 100000
 """The maximum number of mutations that a row can accumulate."""
-
-
-def wrapped_partial(func, *args, **kwargs):
-    """Create partial wrapper for a function"""
-    partial_func = partial(func, *args, **kwargs)
-    update_wrapper(partial_func, func)
-    return partial_func
 
 
 class Row(object):
@@ -244,6 +237,13 @@ class _SetDeleteRow(Row):
             # We don't add the mutations until all columns have been
             # processed without error.
             mutations_list.extend(to_append)
+
+
+def wrapped_partial(func, *args, **kwargs):
+    """Create partial wrapper for a function"""
+    partial_func = functools.partial(func, *args, **kwargs)
+    functools.update_wrapper(partial_func, func)
+    return partial_func
 
 
 def call_mutate_row(table, request_pb):

--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -439,8 +439,9 @@ class DirectRow(_SetDeleteRow):
         try:
             retry_(retry_commit)()
         except exceptions.RetryError:
-            raise futures.TimeoutError('Operation did not complete '
-                                       'within the designated timeout.')
+            raise futures.\
+                TimeoutError('Operation did not complete '
+                             'within the designated timeout.')
 
         self.clear()
 

--- a/bigtable/tests/unit/test_row.py
+++ b/bigtable/tests/unit/test_row.py
@@ -367,14 +367,14 @@ class TestDirectRow(unittest.TestCase):
         )])
         self.assertEqual(row._pb_mutations, [])
 
-    def test_commit_retry_on_failure(self):
+    def test_retry_commit_exception(self):
         import threading
         import grpc
         import functools
         from grpc._channel import _Rendezvous
         from google.api_core import retry
-        from google.cloud.bigtable.row import _retry_commit_exception
         from google.api_core import exceptions
+        from google.cloud.bigtable.row import _retry_commit_exception
 
         klass = self._get_target_class()
 

--- a/bigtable/tests/unit/test_row.py
+++ b/bigtable/tests/unit/test_row.py
@@ -373,15 +373,15 @@ class TestDirectRow(unittest.TestCase):
 
         from google.cloud.bigtable.row import _retry_commit_exception
 
-        class MockRendevouz(grpc.RpcError, grpc.Call):
-            """Rendevouz exception"""
+        class ErrorUnavailable(grpc.RpcError, grpc.Call):
+            """ErrorUnavailable exception"""
 
         message = 'Endpoint read failed'
-        mock_rendevouz = mock.create_autospec(MockRendevouz, instance=True)
-        mock_rendevouz.code.return_value = grpc.StatusCode.UNAVAILABLE
-        mock_rendevouz.details.return_value = message
+        error = mock.create_autospec(ErrorUnavailable, instance=True)
+        error.code.return_value = grpc.StatusCode.UNAVAILABLE
+        error.details.return_value = message
 
-        result = _retry_commit_exception(mock_rendevouz)
+        result = _retry_commit_exception(error)
         self.assertEqual(result, True)
 
         result = _retry_commit_exception(ValueError)

--- a/bigtable/tests/unit/test_row.py
+++ b/bigtable/tests/unit/test_row.py
@@ -370,6 +370,7 @@ class TestDirectRow(unittest.TestCase):
     def test_commit_retry_on_failure(self):
         import threading
         import grpc
+        import functools
         from grpc._channel import _Rendezvous
         from google.api_core import retry
         from google.cloud.bigtable.row import _retry_commit_exception
@@ -400,7 +401,7 @@ class TestDirectRow(unittest.TestCase):
 
         row_key = b'row_key'
         table = object()
-        mock_row = MockRow(row_key, table)
+        mock_row = functools.partial(MockRow(row_key, table))
 
         # After retrying for 10 seconds, raise a RetryError exception
         retry_ = retry.Retry(

--- a/core/google/cloud/exceptions.py
+++ b/core/google/cloud/exceptions.py
@@ -55,6 +55,5 @@ MethodNotImplemented = exceptions.MethodNotImplemented
 BadGateway = exceptions.BadGateway
 ServiceUnavailable = exceptions.ServiceUnavailable
 GatewayTimeout = exceptions.GatewayTimeout
-RetryError = exceptions.RetryError
 from_http_status = exceptions.from_http_status
 from_http_response = exceptions.from_http_response

--- a/core/google/cloud/exceptions.py
+++ b/core/google/cloud/exceptions.py
@@ -55,5 +55,6 @@ MethodNotImplemented = exceptions.MethodNotImplemented
 BadGateway = exceptions.BadGateway
 ServiceUnavailable = exceptions.ServiceUnavailable
 GatewayTimeout = exceptions.GatewayTimeout
+RetryError = exceptions.RetryError
 from_http_status = exceptions.from_http_status
 from_http_response = exceptions.from_http_response


### PR DESCRIPTION
Added retry logic for commit on a DirectRow. The retry uses the retry.py module and performs retry when a Rendezvous exception is thrown due to a disconnect on the channel. The retry will call MutateRow on the original protobuf request with a timeout backoff algorithm provided in retry.py. This has been tested using an endurance test framework that runs for 23 hours and was receiving 8+ exceptions previously. Now all the retries are successful.