### PR TITLE
BigQueryDataTransfer: update 404 link for API documentation

### DIFF
--- a/bigquery_datatransfer/README.rst
+++ b/bigquery_datatransfer/README.rst
@@ -8,9 +8,9 @@ scheduled, managed basis.
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
-.. _BigQuery Data Transfer API: https://cloud.google.com/bigquerydatatransfer
+.. _BigQuery Data Transfer API: https://cloud.google.com/bigquery/docs/transfer-service-overview
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/bigquery_datatransfer/index.html
-.. _Product Documentation:  https://cloud.google.com/bigquerydatatransfer
+.. _Product Documentation:  https://cloud.google.com/bigquery/docs/transfer-service-overview
 
 Quick Start
 -----------
@@ -22,7 +22,7 @@ In order to use this library, you first need to go through the following steps:
 3. `Setup Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
-.. _Enable the BigQuery Data Transfer API.:  https://cloud.google.com/bigquerydatatransfer
+.. _Enable the BigQuery Data Transfer API.:  https://cloud.google.com/bigquery/docs/transfer-service-overview
 .. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/latest/core/auth.html
 
 Installation
@@ -96,5 +96,5 @@ Next Steps
 -  View this `repository’s main README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Data Transfer API Product documentation:  https://cloud.google.com/bigquerydatatransfer
+.. _BigQuery Data Transfer API Product documentation:  https://cloud.google.com/bigquery/docs/transfer-service-overview
 .. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst

--- a/bigquery_datatransfer/docs/index.rst
+++ b/bigquery_datatransfer/docs/index.rst
@@ -8,7 +8,7 @@ scheduled, managed basis.
 - `Product Documentation`_
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
-.. _BigQuery Data Transfer API: https://cloud.google.com/bigquerydatatransfer
+.. _BigQuery Data Transfer API: https://cloud.google.com/bigquery/docs/transfer-service-overview
 .. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/bigquery_datatransfer/index.html
 .. _Product Documentation:  https://cloud.google.com/bigquerydatatransfer
 
@@ -22,7 +22,7 @@ In order to use this library, you first need to go through the following steps:
 3. `Setup Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
-.. _Enable the BigQuery Data Transfer API.:  https://cloud.google.com/bigquerydatatransfer
+.. _Enable the BigQuery Data Transfer API.:  https://cloud.google.com/bigquery/docs/transfer-service-overview
 .. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/latest/core/auth.html
 
 Installation
@@ -96,7 +96,7 @@ Next Steps
 -  View this `repository’s main README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _BigQuery Data Transfer API Product documentation:  https://cloud.google.com/bigquerydatatransfer
+.. _BigQuery Data Transfer API Product documentation:  https://cloud.google.com/bigquery/docs/transfer-service-overview
 .. _repository’s main README: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 
 Api Reference


### PR DESCRIPTION
Closes #4668 