### PR TITLE
Prep bigquery-0.29.0 release.

### DIFF
--- a/bigquery/CHANGELOG.md
+++ b/bigquery/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 [1]: https://pypi.org/project/google-cloud-bigquery/#history
 
-## 0.29.0 (unreleased)
+## 0.29.0
 
-## Interface changes / additions
+### Interface changes / additions
 
 -   Add `to_dataframe()` method to row iterators. When Pandas is installed this
     method returns a `DataFrame` containing the query's or table's rows.
@@ -22,7 +22,7 @@
     ([#4393](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/4393),
     [#4413](https://github.com/GoogleCloudPlatform/google-cloud-python/pull/4413))
 
-## Interface changes / breaking changes
+### Interface changes / breaking changes
 
 -   Add `Client.insert_rows()` and `Client.insert_rows_json()`, deprecate
     `Client.create_rows()` and `Client.create_rows_json()`.

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -64,7 +64,7 @@ EXTRAS_REQUIREMENTS = {
 
 setup(
     name='google-cloud-bigquery',
-    version='0.28.1.dev1',
+    version='0.29.0',
     description='Python Client for Google BigQuery',
     long_description=README,
     namespace_packages=[

--- a/docs/bigquery/releases.rst
+++ b/docs/bigquery/releases.rst
@@ -12,3 +12,4 @@
 * ``0.26.0`` (`PyPI <https://pypi.org/project/google-cloud-bigquery/0.26.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/bigquery-0.26.0>`__)
 * ``0.27.0`` (`PyPI <https://pypi.org/project/google-cloud-bigquery/0.27.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/bigquery-0.27.0>`__)
 * ``0.28.0`` (`PyPI <https://pypi.org/project/google-cloud-bigquery/0.28.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/bigquery-0.28.0>`__)
+* ``0.29.0`` (`PyPI <https://pypi.org/project/google-cloud-bigquery/0.29.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/bigquery-0.29.0>`__)


### PR DESCRIPTION
Draft release notes:

## google-cloud-bigquery 0.29.0


### Breaking changes / deprecations

-  Remove `QueryJob.query_results()`. Use `QueryJob.result()` instead (#4652).
-  Remove `Client.query_rows()`. Use `Client.query()` instead (#4429).
-  Make `Client.list_tables` return an iterator of `TableListItem`, because the API only returns a subset of properties of a table when listing (#4427).
-  Make `Client.list_datasets` return an iterator of `DatasetListItem`, because the API only returns a subset of properties of a dataset when listing (#4439).
-  Add `Client.insert_rows()` and `Client.insert_rows_json()`, deprecate `Client.create_rows()` and `Client.create_rows_json()` (#4657).
-  Add `Client.list_tables`, deprecate `Client.list_dataset_tables` (#4653).

### Notable Implementation Changes

-  Add `to_dataframe()` method to row iterators. When Pandas is installed, it returns a `DataFrame` containing the query's or table's rows (#4354).
-  Iterate over a `QueryJob` to wait for and get the query results (#4350).
-  Add `Table.reference` and `Dataset.reference` properties to get the  `TableReference` or `DatasetReference` corresponding to that `Table` or   `Dataset`, respectively (#4405).
-   Add `Row.keys()`, `Row.items()`, and `Row.get()`, making `Row` act more like a built-in `dict` (#4393).
  