### PR TITLE
Mark bigquery as back under dev after 0.29.0 release.

### DIFF
--- a/bigquery/CHANGELOG.md
+++ b/bigquery/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [1]: https://pypi.org/project/google-cloud-bigquery/#history
 
+## 0.29.1 (unreleased)
+
+- TBD
+
 ## 0.29.0
 
 ### Interface changes / additions

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -64,7 +64,7 @@ EXTRAS_REQUIREMENTS = {
 
 setup(
     name='google-cloud-bigquery',
-    version='0.29.0',
+    version='0.29.1.dev1',
     description='Python Client for Google BigQuery',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
[ci skip]