### PR TITLE
Harden test for 'retrieve_metadata_server' against transparent DNS proxies

### DIFF
--- a/logging/tests/unit/test__helpers.py
+++ b/logging/tests/unit/test__helpers.py
@@ -110,7 +110,7 @@ class Test_retrieve_metadata_server(unittest.TestCase):
         metadata_key = 'test_url_cannot_connect'
         metadata_url = 'http://metadata.invalid/'
 
-        requests_get_mock = mock.Mock()
+        requests_get_mock = mock.Mock(spec=['__call__'])
         requests_get_mock.side_effect = requests.exceptions.RequestException
 
         requests_get_patch = mock.patch('requests.get', requests_get_mock)

--- a/logging/tests/unit/test__helpers.py
+++ b/logging/tests/unit/test__helpers.py
@@ -105,15 +105,23 @@ class Test_retrieve_metadata_server(unittest.TestCase):
         self.assertIsNone(metadata)
 
     def test_request_exception(self):
+        import requests
+
         metadata_key = 'test_url_cannot_connect'
         metadata_url = 'http://metadata.invalid/'
 
-        patch = mock.patch(
+        requests_get_mock = mock.Mock()
+        requests_get_mock.side_effect = requests.exceptions.RequestException
+
+        requests_get_patch = mock.patch('requests.get', requests_get_mock)
+
+        url_patch = mock.patch(
             'google.cloud.logging._helpers.METADATA_URL',
             new=metadata_url)
 
-        with patch:
-            metadata = self._call_fut(metadata_key)
+        with requests_get_patch:
+            with url_patch:
+                metadata = self._call_fut(metadata_key)
 
         self.assertIsNone(metadata)
 


### PR DESCRIPTION
Grrr.