### PR TITLE
Move 'unique_writer_identity' from LogSink ctor to 'create'

### DIFF
--- a/logging/google/cloud/logging/sink.py
+++ b/logging/google/cloud/logging/sink.py
@@ -38,19 +38,12 @@ class Sink(object):
     :type client: :class:`google.cloud.logging.client.Client`
     :param client: A client which holds credentials and project configuration
                    for the sink (which requires a project).
-
-    :type unique_writer_identity: bool
-    :param unique_writer_identity: (Optional) determines the kind of
-                                   IAM identity returned as
-                                   writer_identity in the new sink.
     """
-    def __init__(self, name, filter_=None, destination=None, client=None,
-                 unique_writer_identity=False):
+    def __init__(self, name, filter_=None, destination=None, client=None):
         self.name = name
         self.filter_ = filter_
         self.destination = destination
         self._client = client
-        self._unique_writer_identity = unique_writer_identity
         self._writer_identity = None
 
     @property
@@ -117,7 +110,7 @@ class Sink(object):
             client = self._client
         return client
 
-    def create(self, client=None):
+    def create(self, client=None, unique_writer_identity=False):
         """API call:  create the sink via a PUT request
 
         See
@@ -127,11 +120,16 @@ class Sink(object):
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current sink.
+
+        :type unique_writer_identity: bool
+        :param unique_writer_identity: (Optional) determines the kind of
+                                    IAM identity returned as
+                                    writer_identity in the new sink.
         """
         client = self._require_client(client)
         client.sinks_api.sink_create(
             self.project, self.name, self.filter_, self.destination,
-            unique_writer_identity=self._unique_writer_identity,
+            unique_writer_identity=unique_writer_identity,
         )
 
     def exists(self, client=None):

--- a/logging/tests/unit/test_sink.py
+++ b/logging/tests/unit/test_sink.py
@@ -122,7 +122,7 @@ class TestSink(unittest.TestCase):
                               client=client1)
         api = client2.sinks_api = _DummySinksAPI()
 
-        sink.create(client=client2)
+        sink.create(client=client2, unique_writer_identity=True)
 
         self.assertEqual(
             api._sink_create_called_with,
@@ -131,7 +131,7 @@ class TestSink(unittest.TestCase):
                 self.SINK_NAME,
                 self.FILTER,
                 self.DESTINATION_URI,
-                False,
+                True,
             ),
         )
 


### PR DESCRIPTION
Preps support for passing it to 'update' as well.

See:
https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4703#issuecomment-355622741