### PR TITLE
Support passing 'uniqueWriterIdentity' to 'Sink.update'.

### DIFF
--- a/logging/google/cloud/logging/_gax.py
+++ b/logging/google/cloud/logging/_gax.py
@@ -265,7 +265,8 @@ class _SinksAPI(object):
         #       so `MessageToDict`` can safely be used.
         return MessageToDict(sink_pb)
 
-    def sink_update(self, project, sink_name, filter_, destination):
+    def sink_update(self, project, sink_name, filter_, destination,
+                    unique_writer_identity=False):
         """API call:  update a sink resource.
 
         :type project: str
@@ -282,15 +283,24 @@ class _SinksAPI(object):
         :param destination: destination URI for the entries exported by
                             the sink.
 
+        :type unique_writer_identity: bool
+        :param unique_writer_identity: (Optional) determines the kind of
+                                       IAM identity returned as
+                                       writer_identity in the new sink.
+
         :rtype: dict
-        :returns: The sink object returned from the API (converted from a
+        :returns: The sink resource returned from the API (converted from a
                   protobuf to a dictionary).
         """
         options = None
         path = 'projects/%s/sinks/%s' % (project, sink_name)
         sink_pb = LogSink(name=path, filter=filter_, destination=destination)
         try:
-            sink_pb = self._gax_api.update_sink(path, sink_pb, options=options)
+            sink_pb = self._gax_api.update_sink(
+                path,
+                sink_pb,
+                unique_writer_identity=unique_writer_identity,
+                options=options)
         except GaxError as exc:
             if exc_to_code(exc.cause) == StatusCode.NOT_FOUND:
                 raise NotFound(path)

--- a/logging/google/cloud/logging/_http.py
+++ b/logging/google/cloud/logging/_http.py
@@ -290,7 +290,8 @@ class _SinksAPI(object):
         target = '/projects/%s/sinks/%s' % (project, sink_name)
         return self.api_request(method='GET', path=target)
 
-    def sink_update(self, project, sink_name, filter_, destination):
+    def sink_update(self, project, sink_name, filter_, destination,
+                    unique_writer_identity=False):
         """API call:  update a sink resource.
 
         See
@@ -310,6 +311,11 @@ class _SinksAPI(object):
         :param destination: destination URI for the entries exported by
                             the sink.
 
+        :type unique_writer_identity: bool
+        :param unique_writer_identity: (Optional) determines the kind of
+                                       IAM identity returned as
+                                       writer_identity in the new sink.
+
         :rtype: dict
         :returns: The returned (updated) resource.
         """
@@ -319,7 +325,9 @@ class _SinksAPI(object):
             'filter': filter_,
             'destination': destination,
         }
-        return self.api_request(method='PUT', path=target, data=data)
+        query_params = {'uniqueWriterIdentity': unique_writer_identity}
+        return self.api_request(
+            method='PUT', path=target, query_params=query_params, data=data)
 
     def sink_delete(self, project, sink_name):
         """API call:  delete a sink resource.

--- a/logging/google/cloud/logging/sink.py
+++ b/logging/google/cloud/logging/sink.py
@@ -175,7 +175,7 @@ class Sink(object):
         resource = client.sinks_api.sink_get(self.project, self.name)
         self._update_from_api_repr(resource)
 
-    def update(self, client=None):
+    def update(self, client=None, unique_writer_identity=False):
         """API call:  update sink configuration via a PUT request
 
         See
@@ -185,10 +185,18 @@ class Sink(object):
                       ``NoneType``
         :param client: the client to use.  If not passed, falls back to the
                        ``client`` stored on the current sink.
+
+        :type unique_writer_identity: bool
+        :param unique_writer_identity: (Optional) determines the kind of
+                                    IAM identity returned as
+                                    writer_identity in the new sink.
         """
         client = self._require_client(client)
-        client.sinks_api.sink_update(
-            self.project, self.name, self.filter_, self.destination)
+        resource = client.sinks_api.sink_update(
+            self.project, self.name, self.filter_, self.destination,
+            unique_writer_identity=unique_writer_identity,
+        )
+        self._update_from_api_repr(resource)
 
     def delete(self, client=None):
         """API call:  delete a sink via a DELETE request


### PR DESCRIPTION
~~Uses #4707 as a base.~~

Also, capture server-set read-only properties returned from `sinks.update`, such as `writerIdentity`.
  