### PR TITLE
Do not quote embedded slashes for public / signed URLs

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -244,7 +244,7 @@ class Blob(_PropertyMixin):
         return '{storage_base_url}/{bucket_name}/{quoted_name}'.format(
             storage_base_url=_API_ACCESS_ENDPOINT,
             bucket_name=self.bucket.name,
-            quoted_name=quote(self.name))
+            quoted_name=quote(self.name.encode('utf-8')))
 
     def generate_signed_url(self, expiration, method='GET',
                             content_type=None,

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -244,7 +244,7 @@ class Blob(_PropertyMixin):
         return '{storage_base_url}/{bucket_name}/{quoted_name}'.format(
             storage_base_url=_API_ACCESS_ENDPOINT,
             bucket_name=self.bucket.name,
-            quoted_name=_quote(self.name))
+            quoted_name=quote(self.name))
 
     def generate_signed_url(self, expiration, method='GET',
                             content_type=None,
@@ -315,7 +315,7 @@ class Blob(_PropertyMixin):
         """
         resource = '/{bucket_name}/{quoted_name}'.format(
             bucket_name=self.bucket.name,
-            quoted_name=_quote(self.name))
+            quoted_name=quote(self.name))
 
         if credentials is None:
             client = self._require_client(client)
@@ -1706,7 +1706,7 @@ def _quote(value):
     :returns: The encoded value (bytes in Python 2, unicode in Python 3).
     """
     value = _to_bytes(value, encoding='utf-8')
-    return quote(value)
+    return quote(value, safe='')
 
 
 def _maybe_rewind(stream, rewind=False):

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -1706,7 +1706,7 @@ def _quote(value):
     :returns: The encoded value (bytes in Python 2, unicode in Python 3).
     """
     value = _to_bytes(value, encoding='utf-8')
-    return quote(value, safe='')
+    return quote(value)
 
 
 def _maybe_rewind(stream, rewind=False):

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -137,7 +137,7 @@ class Test_Blob(unittest.TestCase):
         BLOB_NAME = 'parent/child'
         bucket = _Bucket()
         blob = self._make_one(BLOB_NAME, bucket=bucket)
-        self.assertEqual(blob.path, '/b/name/o/parent%2Fchild')
+        self.assertEqual(blob.path, '/b/name/o/parent/child')
 
     def test_path_with_non_ascii(self):
         blob_name = u'Caf\xe9'
@@ -172,7 +172,7 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertEqual(
             blob.public_url,
-            'https://storage.googleapis.com/name/parent%2Fchild')
+            'https://storage.googleapis.com/name/parent/child')
 
     def test_public_url_with_non_ascii(self):
         blob_name = u'winter \N{snowman}'
@@ -275,7 +275,7 @@ class Test_Blob(unittest.TestCase):
             'api_access_endpoint': 'https://storage.googleapis.com',
             'expiration': EXPIRATION,
             'method': 'GET',
-            'resource': '/name/parent%2Fchild',
+            'resource': '/name/parent/child',
             'content_type': None,
             'response_type': None,
             'response_disposition': None,

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -137,7 +137,7 @@ class Test_Blob(unittest.TestCase):
         BLOB_NAME = 'parent/child'
         bucket = _Bucket()
         blob = self._make_one(BLOB_NAME, bucket=bucket)
-        self.assertEqual(blob.path, '/b/name/o/parent/child')
+        self.assertEqual(blob.path, '/b/name/o/parent%2Fchild')
 
     def test_path_with_non_ascii(self):
         blob_name = u'Caf\xe9'


### PR DESCRIPTION
Closes #3809.

As noted on that issue, the `public_url` and `generate_signed_url` methods use the XML endpoints, which allow for / expect the slash not to be quoted.  All other methods use the JSON endpoints, which *require* quoting the embedded slashes.