### PR TITLE
Prep storage-1.7.0 release.

### DIFF
--- a/docs/storage/releases.rst
+++ b/docs/storage/releases.rst
@@ -17,6 +17,7 @@
 * ``1.4.0`` (`PyPI <https://pypi.org/project/google-cloud-storage/1.4.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/storage-1.4.0>`__)
 * ``1.5.0`` (`PyPI <https://pypi.org/project/google-cloud-storage/1.5.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/storage-1.5.0>`__)
 * ``1.6.0`` (`PyPI <https://pypi.org/project/google-cloud-storage/1.6.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/storage-1.6.0>`__)
+* ``1.7.0`` (`PyPI <https://pypi.org/project/google-cloud-storage/1.7.0/>`__, `Release Notes <https://github.com/GoogleCloudPlatform/google-cloud-python/releases/tag/storage-1.7.0>`__)
 
 ***********************************
 ``google-resumable-media`` Releases

--- a/storage/CHANGELOG.md
+++ b/storage/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 [1]: https://pypi.org/project/google-cloud-storage/#history
 
+## 1.7.0
+
+### Features
+
+- Enable anonymous access to blobs in public buckets (#4315)
+- Make project optional / overridable for storage client (#4381)
+- Relax regex used to test for valid project IDs (#4543)
+- Add support for `source_generation` parameter to `Bucket.copy_blob` (#4546)
+
 ## 1.6.0
 
 ### Documentation

--- a/storage/setup.py
+++ b/storage/setup.py
@@ -60,7 +60,7 @@ REQUIREMENTS = [
 
 setup(
     name='google-cloud-storage',
-    version='1.6.1.dev1',
+    version='1.7.0',
     description='Python Client for Google Cloud Storage',
     long_description=README,
     namespace_packages=[


### PR DESCRIPTION
Draft release notes:

## google-cloud-storage 1.7.0

### Notable Implementation Changes

- Enable anonymous access to blobs in public buckets (#4315).
- Make `project` optional / overridable for storage client (#4381).
- Relax regex used to test for valid project IDs (#4543).
- Add support for `source_generation` parameter to `Bucket.copy_blob` (#4546).
