### PR TITLE
Revert "Spanner: Make sure **exactly** one of `start_*`/`end_*` are p…

### DIFF
--- a/spanner/google/cloud/spanner_v1/keyset.py
+++ b/spanner/google/cloud/spanner_v1/keyset.py
@@ -24,40 +24,28 @@ from google.cloud.spanner_v1._helpers import _make_list_value_pbs
 class KeyRange(object):
     """Identify range of table rows via start / end points.
 
-    .. note::
+    :type start_open: list of scalars
+    :param start_open: keys identifying start of range (this key excluded)
 
-        Exactly one of ``start_open`` and ``start_closed`` must be
-        passed and exactly one of ``end_open`` and ``end_closed`` must be.
-        To "start at the beginning" (i.e. specify no start for the range)
-        pass ``start_closed=[]``. To "go to the end" (i.e. specify no end
-        for the range) pass ``end_closed=[]``.
+    :type start_closed: list of scalars
+    :param start_closed: keys identifying start of range (this key included)
 
-    Args:
-        start_open (List): Keys identifying start of range (this key
-            excluded).
-        start_closed (List): Keys identifying start of range (this key
-            included).
-        end_open (List): Keys identifying end of range (this key
-            excluded).
-        end_closed (List): Keys identifying end of range (this key
-            included).
+    :type end_open: list of scalars
+    :param end_open: keys identifying end of range (this key excluded)
 
-    Raises:
-        ValueError: If **neither** ``start_open`` or ``start_closed`` is
-            passed.
-        ValueError: If **both** ``start_open`` and ``start_closed`` are passed.
-        ValueError: If **neither** ``end_open`` or ``end_closed`` is passed.
-        ValueError: If **both** ``end_open`` and ``end_closed`` are passed.
+    :type end_closed: list of scalars
+    :param end_closed: keys identifying end of range (this key included)
     """
     def __init__(self, start_open=None, start_closed=None,
                  end_open=None, end_closed=None):
-        if ((start_open is None and start_closed is None)
-                or (start_open is not None and start_closed is not None)):
-            raise ValueError('Specify exactly one of start_closed or start_open')
+        if not any([start_open, start_closed, end_open, end_closed]):
+            raise ValueError("Must specify at least a start or end row.")
 
-        if ((end_open is None and end_closed is None)
-                or (end_open is not None and end_closed is not None)):
-            raise ValueError('Specify exactly one of end_closed or end_open')
+        if start_open and start_closed:
+            raise ValueError("Specify one of 'start_open' / 'start_closed'.")
+
+        if end_open and end_closed:
+            raise ValueError("Specify one of 'end_open' / 'end_closed'.")
 
         self.start_open = start_open
         self.start_closed = start_closed
@@ -72,16 +60,16 @@ class KeyRange(object):
         """
         kwargs = {}
 
-        if self.start_open is not None:
+        if self.start_open:
             kwargs['start_open'] = _make_list_value_pb(self.start_open)
 
-        if self.start_closed is not None:
+        if self.start_closed:
             kwargs['start_closed'] = _make_list_value_pb(self.start_closed)
 
-        if self.end_open is not None:
+        if self.end_open:
             kwargs['end_open'] = _make_list_value_pb(self.end_open)
 
-        if self.end_closed is not None:
+        if self.end_closed:
             kwargs['end_closed'] = _make_list_value_pb(self.end_closed)
 
         return KeyRangePB(**kwargs)

--- a/spanner/google/cloud/spanner_v1/keyset.py
+++ b/spanner/google/cloud/spanner_v1/keyset.py
@@ -60,16 +60,16 @@ class KeyRange(object):
         """
         kwargs = {}
 
-        if self.start_open:
+        if self.start_open is not None:
             kwargs['start_open'] = _make_list_value_pb(self.start_open)
 
-        if self.start_closed:
+        if self.start_closed is not None:
             kwargs['start_closed'] = _make_list_value_pb(self.start_closed)
 
-        if self.end_open:
+        if self.end_open is not None:
             kwargs['end_open'] = _make_list_value_pb(self.end_open)
 
-        if self.end_closed:
+        if self.end_closed is not None:
             kwargs['end_closed'] = _make_list_value_pb(self.end_closed)
 
         return KeyRangePB(**kwargs)

--- a/spanner/tests/unit/test_keyset.py
+++ b/spanner/tests/unit/test_keyset.py
@@ -30,47 +30,49 @@ class TestKeyRange(unittest.TestCase):
         with self.assertRaises(ValueError):
             self._make_one()
 
-    def test_ctor_start_open_and_start_closed(self):
+    def test_ctor_w_start_open_and_start_closed(self):
         KEY_1 = [u'key_1']
         KEY_2 = [u'key_2']
         with self.assertRaises(ValueError):
             self._make_one(start_open=KEY_1, start_closed=KEY_2)
 
-    def test_ctor_end_open_and_end_closed(self):
+    def test_ctor_w_end_open_and_end_closed(self):
         KEY_1 = [u'key_1']
         KEY_2 = [u'key_2']
         with self.assertRaises(ValueError):
             self._make_one(end_open=KEY_1, end_closed=KEY_2)
 
-    def test_ctor_conflicting_start(self):
+    def test_ctor_w_only_start_open(self):
         KEY_1 = [u'key_1']
-        with self.assertRaises(ValueError):
-            self._make_one(start_open=[], start_closed=[], end_closed=KEY_1)
+        krange = self._make_one(start_open=KEY_1)
+        self.assertEqual(krange.start_open, KEY_1)
+        self.assertEqual(krange.start_closed, None)
+        self.assertEqual(krange.end_open, None)
+        self.assertEqual(krange.end_closed, None)
 
-    def test_ctor_conflicting_end(self):
+    def test_ctor_w_only_start_closed(self):
         KEY_1 = [u'key_1']
-        with self.assertRaises(ValueError):
-            self._make_one(start_open=KEY_1, end_open=[], end_closed=[])
+        krange = self._make_one(start_closed=KEY_1)
+        self.assertEqual(krange.start_open, None)
+        self.assertEqual(krange.start_closed, KEY_1)
+        self.assertEqual(krange.end_open, None)
+        self.assertEqual(krange.end_closed, None)
 
-    def test_ctor_single_key_start_closed(self):
+    def test_ctor_w_only_end_open(self):
         KEY_1 = [u'key_1']
-        with self.assertRaises(ValueError):
-            self._make_one(start_closed=KEY_1)
+        krange = self._make_one(end_open=KEY_1)
+        self.assertEqual(krange.start_open, None)
+        self.assertEqual(krange.start_closed, None)
+        self.assertEqual(krange.end_open, KEY_1)
+        self.assertEqual(krange.end_closed, None)
 
-    def test_ctor_single_key_start_open(self):
+    def test_ctor_w_only_end_closed(self):
         KEY_1 = [u'key_1']
-        with self.assertRaises(ValueError):
-            self._make_one(start_open=KEY_1)
-
-    def test_ctor_single_key_end_closed(self):
-        KEY_1 = [u'key_1']
-        with self.assertRaises(ValueError):
-            self._make_one(end_closed=KEY_1)
-
-    def test_ctor_single_key_end_open(self):
-        KEY_1 = [u'key_1']
-        with self.assertRaises(ValueError):
-            self._make_one(end_open=KEY_1)
+        krange = self._make_one(end_closed=KEY_1)
+        self.assertEqual(krange.start_open, None)
+        self.assertEqual(krange.start_closed, None)
+        self.assertEqual(krange.end_open, None)
+        self.assertEqual(krange.end_closed, KEY_1)
 
     def test_ctor_w_start_open_and_end_closed(self):
         KEY_1 = [u'key_1']
@@ -91,58 +93,31 @@ class TestKeyRange(unittest.TestCase):
         self.assertEqual(krange.end_closed, None)
 
     def test_to_pb_w_start_closed_and_end_open(self):
-        from google.protobuf.struct_pb2 import ListValue
-        from google.protobuf.struct_pb2 import Value
         from google.cloud.spanner_v1.proto.keys_pb2 import KeyRange
 
-        key1 = u'key_1'
-        key2 = u'key_2'
-        key_range = self._make_one(start_closed=[key1], end_open=[key2])
-        key_range_pb = key_range.to_pb()
-        expected = KeyRange(
-            start_closed=ListValue(values=[
-                Value(string_value=key1)
-            ]),
-            end_open=ListValue(values=[
-                Value(string_value=key2)
-            ]),
-        )
-        self.assertEqual(key_range_pb, expected)
+        KEY_1 = [u'key_1']
+        KEY_2 = [u'key_2']
+        krange = self._make_one(start_closed=KEY_1, end_open=KEY_2)
+        krange_pb = krange.to_pb()
+        self.assertIsInstance(krange_pb, KeyRange)
+        self.assertEqual(len(krange_pb.start_closed), 1)
+        self.assertEqual(krange_pb.start_closed.values[0].string_value,
+                         KEY_1[0])
+        self.assertEqual(len(krange_pb.end_open), 1)
+        self.assertEqual(krange_pb.end_open.values[0].string_value, KEY_2[0])
 
     def test_to_pb_w_start_open_and_end_closed(self):
-        from google.protobuf.struct_pb2 import ListValue
-        from google.protobuf.struct_pb2 import Value
         from google.cloud.spanner_v1.proto.keys_pb2 import KeyRange
 
-        key1 = u'key_1'
-        key2 = u'key_2'
-        key_range = self._make_one(start_open=[key1], end_closed=[key2])
-        key_range_pb = key_range.to_pb()
-        expected = KeyRange(
-            start_open=ListValue(values=[
-                Value(string_value=key1)
-            ]),
-            end_closed=ListValue(values=[
-                Value(string_value=key2)
-            ]),
-        )
-        self.assertEqual(key_range_pb, expected)
-
-    def test_to_pb_w_empty_list(self):
-        from google.protobuf.struct_pb2 import ListValue
-        from google.protobuf.struct_pb2 import Value
-        from google.cloud.spanner_v1.proto.keys_pb2 import KeyRange
-
-        key = u'key'
-        key_range = self._make_one(start_closed=[], end_closed=[key])
-        key_range_pb = key_range.to_pb()
-        expected = KeyRange(
-            start_closed=ListValue(values=[]),
-            end_closed=ListValue(values=[
-                Value(string_value=key)
-            ]),
-        )
-        self.assertEqual(key_range_pb, expected)
+        KEY_1 = [u'key_1']
+        KEY_2 = [u'key_2']
+        krange = self._make_one(start_open=KEY_1, end_closed=KEY_2)
+        krange_pb = krange.to_pb()
+        self.assertIsInstance(krange_pb, KeyRange)
+        self.assertEqual(len(krange_pb.start_open), 1)
+        self.assertEqual(krange_pb.start_open.values[0].string_value, KEY_1[0])
+        self.assertEqual(len(krange_pb.end_closed), 1)
+        self.assertEqual(krange_pb.end_closed.values[0].string_value, KEY_2[0])
 
 
 class TestKeySet(unittest.TestCase):


### PR DESCRIPTION
…assed to KeyRange (#4618)"

This reverts commit 4d6cd26c32ede99afd36ec96558c54d6120791f4.

Towards #4694