### PR TITLE
Revert "Revert "api_core: Make PageIterator.item_to_value public. (#4702)""

### DIFF
--- a/api_core/google/api_core/page_iterator.py
+++ b/api_core/google/api_core/page_iterator.py
@@ -179,15 +179,6 @@ class Iterator(object):
         """int: The total number of results fetched so far."""
 
     @property
-    def _item_to_value(self):
-        """DEPRECATED: Backwards-compatible alias to ``item_to_value``."""
-        return self.item_to_value
-
-    @_item_to_value.setter
-    def _item_to_value(self, value):
-        self.item_to_value = value
-
-    @property
     def pages(self):
         """Iterator of pages in the response.
 

--- a/api_core/google/api_core/page_iterator.py
+++ b/api_core/google/api_core/page_iterator.py
@@ -158,12 +158,34 @@ class Iterator(object):
                  page_token=None, max_results=None):
         self._started = False
         self.client = client
-        self._item_to_value = item_to_value
+        """Optional[Any]: The client that created this iterator."""
+        self.item_to_value = item_to_value
+        """Callable[Iterator, Any]: Callable to convert an item from the type
+            in the raw API response into the native object. Will be called with
+            the iterator and a
+            single item.
+        """
         self.max_results = max_results
+        """int: The maximum number of results to fetch."""
+
         # The attributes below will change over the life of the iterator.
         self.page_number = 0
+        """int: The current page of results."""
         self.next_page_token = page_token
+        """str: The token for the next page of results. If this is set before
+            the iterator starts, it effectively offsets the iterator to a
+            specific starting point."""
         self.num_results = 0
+        """int: The total number of results fetched so far."""
+
+    @property
+    def _item_to_value(self):
+        """DEPRECATED: Backwards-compatible alias to ``item_to_value``."""
+        return self.item_to_value
+
+    @_item_to_value.setter
+    def _item_to_value(self, value):
+        self.item_to_value = value
 
     @property
     def pages(self):
@@ -335,7 +357,7 @@ class HTTPIterator(Iterator):
         if self._has_next_page():
             response = self._get_next_page_response()
             items = response.get(self._items_key, ())
-            page = Page(self, items, self._item_to_value)
+            page = Page(self, items, self.item_to_value)
             self._page_start(self, page, response)
             self.next_page_token = response.get(self._next_token)
             return page
@@ -428,7 +450,7 @@ class _GAXIterator(Iterator):
         """
         try:
             items = six.next(self._gax_page_iter)
-            page = Page(self, items, self._item_to_value)
+            page = Page(self, items, self.item_to_value)
             self.next_page_token = self._gax_page_iter.page_token or None
             return page
         except StopIteration:
@@ -500,7 +522,7 @@ class GRPCIterator(Iterator):
 
         self.next_page_token = getattr(response, self._response_token_field)
         items = getattr(response, self._items_field)
-        page = Page(self, items, self._item_to_value)
+        page = Page(self, items, self.item_to_value)
 
         return page
 

--- a/api_core/tests/unit/test_page_iterator.py
+++ b/api_core/tests/unit/test_page_iterator.py
@@ -95,12 +95,6 @@ class TestIterator(object):
         assert iterator.next_page_token == token
         assert iterator.num_results == 0
 
-    def test__item_to_value_alias(self):
-        iterator = PageIteratorImpl(None, None)
-        assert iterator._item_to_value is iterator.item_to_value
-        iterator._item_to_value = mock.sentinel.item_to_value
-        assert iterator._item_to_value is iterator.item_to_value
-
     def test_pages_property_starts(self):
         iterator = PageIteratorImpl(None, None)
 

--- a/api_core/tests/unit/test_page_iterator.py
+++ b/api_core/tests/unit/test_page_iterator.py
@@ -88,12 +88,18 @@ class TestIterator(object):
 
         assert not iterator._started
         assert iterator.client is client
-        assert iterator._item_to_value == item_to_value
+        assert iterator.item_to_value == item_to_value
         assert iterator.max_results == max_results
         # Changing attributes.
         assert iterator.page_number == 0
         assert iterator.next_page_token == token
         assert iterator.num_results == 0
+
+    def test__item_to_value_alias(self):
+        iterator = PageIteratorImpl(None, None)
+        assert iterator._item_to_value is iterator.item_to_value
+        iterator._item_to_value = mock.sentinel.item_to_value
+        assert iterator._item_to_value is iterator.item_to_value
 
     def test_pages_property_starts(self):
         iterator = PageIteratorImpl(None, None)
@@ -214,7 +220,7 @@ class TestHTTPIterator(object):
         assert not iterator._started
         assert iterator.client is client
         assert iterator.path == path
-        assert iterator._item_to_value is mock.sentinel.item_to_value
+        assert iterator.item_to_value is mock.sentinel.item_to_value
         assert iterator._items_key == 'items'
         assert iterator.max_results is None
         assert iterator.extra_params == {}
@@ -419,10 +425,10 @@ class TestGRPCIterator(object):
         assert not iterator._started
         assert iterator.client is client
         assert iterator.max_results is None
+        assert iterator.item_to_value is page_iterator._item_to_value_identity
         assert iterator._method == mock.sentinel.method
         assert iterator._request == mock.sentinel.request
         assert iterator._items_field == items_field
-        assert iterator._item_to_value is page_iterator._item_to_value_identity
         assert (iterator._request_token_field ==
                 page_iterator.GRPCIterator._DEFAULT_REQUEST_TOKEN_FIELD)
         assert (iterator._response_token_field ==
@@ -446,10 +452,10 @@ class TestGRPCIterator(object):
 
         assert iterator.client is client
         assert iterator.max_results == 42
+        assert iterator.item_to_value is mock.sentinel.item_to_value
         assert iterator._method == mock.sentinel.method
         assert iterator._request == mock.sentinel.request
         assert iterator._items_field == items_field
-        assert iterator._item_to_value is mock.sentinel.item_to_value
         assert iterator._request_token_field == request_field
         assert iterator._response_token_field == response_field
 
@@ -517,7 +523,7 @@ class TestGAXIterator(object):
 
         assert not iterator._started
         assert iterator.client is client
-        assert iterator._item_to_value is item_to_value
+        assert iterator.item_to_value is item_to_value
         assert iterator.max_results == max_results
         assert iterator._gax_page_iter is page_iter
         # Changing attributes.

--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -30,7 +30,7 @@ version = '0.30.0'
 release_status = 'Development Status :: 4 - Beta'
 dependencies = [
     'google-cloud-core<0.29dev,>=0.28.0',
-    'google-api-core<0.2.0dev,>=0.1.1',
+    'google-api-core<0.2.0dev,>=0.1.5.dev1',
     'google-resumable-media>=0.2.1',
 ]
 extras = {

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1027,7 +1027,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertFalse(iterator._started)
         self.assertIs(iterator.client, client)
         self.assertEqual(iterator.path, path)
-        self.assertIs(iterator._item_to_value, _item_to_row)
+        self.assertIs(iterator.item_to_value, _item_to_row)
         self.assertEqual(iterator._items_key, 'rows')
         self.assertIsNone(iterator.max_results)
         self.assertEqual(iterator.extra_params, {})

--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -515,7 +515,7 @@ class Iterator(page_iterator.Iterator):
             query=query_pb,
         )
         entity_pbs = self._process_query_results(response_pb)
-        return page_iterator.Page(self, entity_pbs, self._item_to_value)
+        return page_iterator.Page(self, entity_pbs, self.item_to_value)
 
 
 def _pb_from_query(query):

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -30,7 +30,7 @@ version = '1.5.0'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
     'google-cloud-core<0.29dev,>=0.28.0',
-    'google-api-core[grpc]<0.2.0dev,>=0.1.1',
+    'google-api-core[grpc]<0.2.0dev,>=0.1.5.dev1',
 ]
 extras = {
 }

--- a/datastore/tests/unit/test_query.py
+++ b/datastore/tests/unit/test_query.py
@@ -361,7 +361,6 @@ class TestIterator(unittest.TestCase):
 
         self.assertFalse(iterator._started)
         self.assertIs(iterator.client, client)
-        self.assertIsNotNone(iterator._item_to_value)
         self.assertIsNone(iterator.max_results)
         self.assertEqual(iterator.page_number, 0)
         self.assertIsNone(iterator.next_page_token,)
@@ -384,7 +383,6 @@ class TestIterator(unittest.TestCase):
 
         self.assertFalse(iterator._started)
         self.assertIs(iterator.client, client)
-        self.assertIsNotNone(iterator._item_to_value)
         self.assertEqual(iterator.max_results, limit)
         self.assertEqual(iterator.page_number, 0)
         self.assertEqual(iterator.next_page_token, start_cursor)

--- a/spanner/google/cloud/spanner_v1/client.py
+++ b/spanner/google/cloud/spanner_v1/client.py
@@ -205,7 +205,7 @@ class Client(ClientWithProject):
         page_iter = self.instance_admin_api.list_instance_configs(
             path, page_size=page_size, metadata=metadata)
         page_iter.next_page_token = page_token
-        page_iter._item_to_value = _item_to_instance_config
+        page_iter.item_to_value = _item_to_instance_config
         return page_iter
 
     def instance(self, instance_id,
@@ -265,7 +265,7 @@ class Client(ClientWithProject):
         path = 'projects/%s' % (self.project,)
         page_iter = self.instance_admin_api.list_instances(
             path, page_size=page_size, metadata=metadata)
-        page_iter._item_to_value = self._item_to_instance
+        page_iter.item_to_value = self._item_to_instance
         page_iter.next_page_token = page_token
         return page_iter
 

--- a/spanner/google/cloud/spanner_v1/instance.py
+++ b/spanner/google/cloud/spanner_v1/instance.py
@@ -349,7 +349,7 @@ class Instance(object):
         page_iter = self._client.database_admin_api.list_databases(
             self.name, page_size=page_size, metadata=metadata)
         page_iter.next_page_token = page_token
-        page_iter._item_to_value = self._item_to_database
+        page_iter.item_to_value = self._item_to_database
         return page_iter
 
     def _item_to_database(self, iterator, database_pb):

--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -30,7 +30,7 @@ version = '1.0.0'
 release_status = 'Development Status :: 4 - Beta'
 dependencies = [
     'google-cloud-core<0.29dev,>=0.28.0',
-    'google-api-core[grpc]<0.2.0dev,>=0.1.4',
+    'google-api-core[grpc]<0.2.0dev,>=0.1.5.dev1',
     'grpc-google-iam-v1<0.12dev,>=0.11.4',
 ]
 extras = {


### PR DESCRIPTION
Reverts GoogleCloudPlatform/google-cloud-python#4731

![inception-meme](https://user-images.githubusercontent.com/250995/34803241-0f21ce5e-f627-11e7-8569-445c6dbc9fe3.png)

Do not merge until api_core 0.2.0 is being prepped for release.

Context: 

> This is done to prevent a release-the-world scenario in order to release bigquery, spanner, and datastore. It will be re-reverted before the next minor release of api_core.