### PR TITLE
Adding a unit test with the empty list case in `KeyRange.to_pb()`.

### DIFF
--- a/spanner/tests/unit/test_keyset.py
+++ b/spanner/tests/unit/test_keyset.py
@@ -93,31 +93,58 @@ class TestKeyRange(unittest.TestCase):
         self.assertEqual(krange.end_closed, None)
 
     def test_to_pb_w_start_closed_and_end_open(self):
+        from google.protobuf.struct_pb2 import ListValue
+        from google.protobuf.struct_pb2 import Value
         from google.cloud.spanner_v1.proto.keys_pb2 import KeyRange
 
-        KEY_1 = [u'key_1']
-        KEY_2 = [u'key_2']
-        krange = self._make_one(start_closed=KEY_1, end_open=KEY_2)
-        krange_pb = krange.to_pb()
-        self.assertIsInstance(krange_pb, KeyRange)
-        self.assertEqual(len(krange_pb.start_closed), 1)
-        self.assertEqual(krange_pb.start_closed.values[0].string_value,
-                         KEY_1[0])
-        self.assertEqual(len(krange_pb.end_open), 1)
-        self.assertEqual(krange_pb.end_open.values[0].string_value, KEY_2[0])
+        key1 = u'key_1'
+        key2 = u'key_2'
+        key_range = self._make_one(start_closed=[key1], end_open=[key2])
+        key_range_pb = key_range.to_pb()
+        expected = KeyRange(
+            start_closed=ListValue(values=[
+                Value(string_value=key1)
+            ]),
+            end_open=ListValue(values=[
+                Value(string_value=key2)
+            ]),
+        )
+        self.assertEqual(key_range_pb, expected)
 
     def test_to_pb_w_start_open_and_end_closed(self):
+        from google.protobuf.struct_pb2 import ListValue
+        from google.protobuf.struct_pb2 import Value
         from google.cloud.spanner_v1.proto.keys_pb2 import KeyRange
 
-        KEY_1 = [u'key_1']
-        KEY_2 = [u'key_2']
-        krange = self._make_one(start_open=KEY_1, end_closed=KEY_2)
-        krange_pb = krange.to_pb()
-        self.assertIsInstance(krange_pb, KeyRange)
-        self.assertEqual(len(krange_pb.start_open), 1)
-        self.assertEqual(krange_pb.start_open.values[0].string_value, KEY_1[0])
-        self.assertEqual(len(krange_pb.end_closed), 1)
-        self.assertEqual(krange_pb.end_closed.values[0].string_value, KEY_2[0])
+        key1 = u'key_1'
+        key2 = u'key_2'
+        key_range = self._make_one(start_open=[key1], end_closed=[key2])
+        key_range_pb = key_range.to_pb()
+        expected = KeyRange(
+            start_open=ListValue(values=[
+                Value(string_value=key1)
+            ]),
+            end_closed=ListValue(values=[
+                Value(string_value=key2)
+            ]),
+        )
+        self.assertEqual(key_range_pb, expected)
+
+    def test_to_pb_w_empty_list(self):
+        from google.protobuf.struct_pb2 import ListValue
+        from google.protobuf.struct_pb2 import Value
+        from google.cloud.spanner_v1.proto.keys_pb2 import KeyRange
+
+        key = u'key'
+        key_range = self._make_one(start_closed=[], end_closed=[key])
+        key_range_pb = key_range.to_pb()
+        expected = KeyRange(
+            start_closed=ListValue(values=[]),
+            end_closed=ListValue(values=[
+                Value(string_value=key)
+            ]),
+        )
+        self.assertEqual(key_range_pb, expected)
 
 
 class TestKeySet(unittest.TestCase):


### PR DESCRIPTION
Also reworked the `to_pb()` tests to just create a protobuf and
just use one assertion.

--------------------------------------------------------------------------------------------------
This test got reverted and I think it should still be there.