### PR TITLE
BigTable: Cell.from_pb() performance improvement

### DIFF
--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -35,9 +35,9 @@ class Cell(object):
     :param labels: (Optional) List of strings. Labels applied to the cell.
     """
 
-    def __init__(self, value, timestamp, labels=()):
+    def __init__(self, value, timestamp_micros, labels=()):
         self.value = value
-        self.timestamp = timestamp
+        self.timestamp_micros = timestamp_micros
         self.labels = list(labels)
 
     @classmethod
@@ -50,17 +50,20 @@ class Cell(object):
         :rtype: :class:`Cell`
         :returns: The cell corresponding to the protobuf.
         """
-        timestamp = _datetime_from_microseconds(cell_pb.timestamp_micros)
         if cell_pb.labels:
-            return cls(cell_pb.value, timestamp, labels=cell_pb.labels)
+            return cls(cell_pb.value, cell_pb.timestamp_micros, labels=cell_pb.labels)
         else:
-            return cls(cell_pb.value, timestamp)
+            return cls(cell_pb.value, cell_pb.timestamp_micros)
+
+    @property
+    def timestamp(self):
+        return _datetime_from_microseconds(self.timestamp_micros)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return NotImplemented
         return (other.value == self.value and
-                other.timestamp == self.timestamp and
+                other.timestamp_micros == self.timestamp_micros and
                 other.labels == self.labels)
 
     def __ne__(self, other):

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -28,8 +28,8 @@ class Cell(object):
     :type value: bytes
     :param value: The value stored in the cell.
 
-    :type timestamp: :class:`datetime.datetime`
-    :param timestamp: The timestamp when the cell was stored.
+    :type timestamp_micros: int
+    :param timestamp_micros: The timestamp_micros when the cell was stored.
 
     :type labels: list
     :param labels: (Optional) List of strings. Labels applied to the cell.

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -51,7 +51,8 @@ class Cell(object):
         :returns: The cell corresponding to the protobuf.
         """
         if cell_pb.labels:
-            return cls(cell_pb.value, cell_pb.timestamp_micros, labels=cell_pb.labels)
+            return cls(cell_pb.value, cell_pb.timestamp_micros,
+                       labels=cell_pb.labels)
         else:
             return cls(cell_pb.value, cell_pb.timestamp_micros)
 

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -42,15 +42,16 @@ class TestCell(unittest.TestCase):
         if labels is None:
             cell_pb = data_v2_pb2.Cell(
                 value=value, timestamp_micros=timestamp_micros)
-            cell_expected = self._make_one(value, timestamp)
+            cell_expected = self._make_one(value, timestamp_micros)
         else:
             cell_pb = data_v2_pb2.Cell(
                 value=value, timestamp_micros=timestamp_micros, labels=labels)
-            cell_expected = self._make_one(value, timestamp, labels=labels)
+            cell_expected = self._make_one(value, timestamp_micros, labels=labels)
 
         klass = self._get_target_class()
         result = klass.from_pb(cell_pb)
         self.assertEqual(result, cell_expected)
+        self.assertEqual(result.timestamp, timestamp)
 
     def test_from_pb(self):
         self._from_pb_test_helper()

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -19,6 +19,7 @@ import mock
 
 
 class TestCell(unittest.TestCase):
+    timestamp_micros = 18738724000  # Make sure millis granularity
 
     @staticmethod
     def _get_target_class():
@@ -35,7 +36,7 @@ class TestCell(unittest.TestCase):
         from google.cloud.bigtable._generated import (
             data_pb2 as data_v2_pb2)
 
-        timestamp_micros = 18738724000  # Make sure millis granularity
+        timestamp_micros = TestCell.timestamp_micros
         timestamp = _EPOCH + datetime.timedelta(microseconds=timestamp_micros)
         value = b'value-bytes'
 
@@ -62,16 +63,13 @@ class TestCell(unittest.TestCase):
 
     def test_constructor(self):
         value = object()
-        timestamp = object()
-        cell = self._make_one(value, timestamp)
+        cell = self._make_one(value, TestCell.timestamp_micros)
         self.assertEqual(cell.value, value)
-        self.assertEqual(cell.timestamp, timestamp)
 
     def test___eq__(self):
         value = object()
-        timestamp = object()
-        cell1 = self._make_one(value, timestamp)
-        cell2 = self._make_one(value, timestamp)
+        cell1 = self._make_one(value, TestCell.timestamp_micros)
+        cell2 = self._make_one(value, TestCell.timestamp_micros)
         self.assertEqual(cell1, cell2)
 
     def test___eq__type_differ(self):
@@ -81,18 +79,16 @@ class TestCell(unittest.TestCase):
 
     def test___ne__same_value(self):
         value = object()
-        timestamp = object()
-        cell1 = self._make_one(value, timestamp)
-        cell2 = self._make_one(value, timestamp)
+        cell1 = self._make_one(value, TestCell.timestamp_micros)
+        cell2 = self._make_one(value, TestCell.timestamp_micros)
         comparison_val = (cell1 != cell2)
         self.assertFalse(comparison_val)
 
     def test___ne__(self):
         value1 = 'value1'
         value2 = 'value2'
-        timestamp = object()
-        cell1 = self._make_one(value1, timestamp)
-        cell2 = self._make_one(value2, timestamp)
+        cell1 = self._make_one(value1, TestCell.timestamp_micros)
+        cell2 = self._make_one(value2, TestCell.timestamp_micros)
         self.assertNotEqual(cell1, cell2)
 
 


### PR DESCRIPTION
Change to have Cell store the milliseconds from the Cell protobuf and to use a property annotation to get the timestamp as a datetime, when requested. This moves the performance penalty to only the code which needs to access this timestamp, which may actually be a small amount of code. There is better than a 5% performance improvement for reading rows with 10 cells.