### PR TITLE
Add handling of missing properties in SchemaField.from_api_repr()

### DIFF
--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -56,10 +56,13 @@ class SchemaField(object):
             google.cloud.biquery.schema.SchemaField:
                 The ``SchemaField`` object.
         """
+        # Handle optional properties with default values
+        mode = api_repr.get('mode', 'NULLABLE')
+        fields = api_repr.get('fields', ())
         return cls(
             field_type=api_repr['type'].upper(),
-            fields=[cls.from_api_repr(f) for f in api_repr.get('fields', ())],
-            mode=api_repr['mode'].upper(),
+            fields=[cls.from_api_repr(f) for f in fields],
+            mode=mode.upper(),
             name=api_repr['name'],
         )
 

--- a/bigquery/tests/unit/test_schema.py
+++ b/bigquery/tests/unit/test_schema.py
@@ -102,6 +102,16 @@ class TestSchemaField(unittest.TestCase):
         self.assertEqual(field.fields[0].field_type, 'INTEGER')
         self.assertEqual(field.fields[0].mode, 'NULLABLE')
 
+    def test_from_api_repr_defaults(self):
+        field = self._get_target_class().from_api_repr({
+            'name': 'foo',
+            'type': 'record',
+        })
+        self.assertEqual(field.name, 'foo')
+        self.assertEqual(field.field_type, 'RECORD')
+        self.assertEqual(field.mode, 'NULLABLE')
+        self.assertEqual(len(field.fields), 0)
+
     def test_name_property(self):
         name = 'lemon-ness'
         schema_field = self._make_one(name, 'INTEGER')


### PR DESCRIPTION
This should fix #4456 

I added safe attribute access to the optional properties `mode` and `fields` in the param dictionary, using the default parameteres from the constructor as fallback values.

I couldn't find the appropiate place to update the docs if it's necessary, so any pointer is greatly appreciated. :)

🐍 