### PR TITLE
Make row assertion in sample tests account for non-deterministic order

### DIFF
--- a/docs/bigquery/snippets.py
+++ b/docs/bigquery/snippets.py
@@ -485,15 +485,13 @@ Wylma Phlyntstone,29
     token = iterator.next_page_token
     # [END table_list_rows_iterator_properties]
 
-    expected_rows = [
-        bigquery.Row(('Wylma Phlyntstone', 29), {'full_name': 0, 'age': 1}),
-        bigquery.Row(('Phred Phlyntstone', 32), {'full_name': 0, 'age': 1}),
-    ]
     assert len(rows) == total == 2
     assert token is None
     # Order is not preserved, so compare individually
-    for row in expected_rows:
-        assert row in rows
+    row1 = bigquery.Row(('Wylma Phlyntstone', 29), {'full_name': 0, 'age': 1})
+    assert row1 in rows
+    row2 = bigquery.Row(('Phred Phlyntstone', 32), {'full_name': 0, 'age': 1})
+    assert row2 in rows
 
 
 def test_load_table_from_uri(client, to_delete):

--- a/docs/bigquery/snippets.py
+++ b/docs/bigquery/snippets.py
@@ -491,7 +491,9 @@ Wylma Phlyntstone,29
     ]
     assert len(rows) == total == 2
     assert token is None
-    assert rows == expected_rows
+    # Order is not preserved, so compare individually
+    for row in expected_rows:
+        assert row in rows
 
 
 def test_load_table_from_uri(client, to_delete):


### PR DESCRIPTION
This was causing some fun failures: https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/5213?utm_campaign=build-failed&utm_medium=email&utm_source=notification