### PR TITLE
Datastore: Allow empty lists in protobuf array value

### DIFF
--- a/datastore/google/cloud/datastore/helpers.py
+++ b/datastore/google/cloud/datastore/helpers.py
@@ -134,18 +134,16 @@ def entity_from_protobuf(pb):
         # Check if ``value_pb`` was excluded from index. Lists need to be
         # special-cased and we require all ``exclude_from_indexes`` values
         # in a list agree.
-        if is_list:
-            if len(value) > 0:
-                exclude_values = set(value_pb.exclude_from_indexes
-                                     for value_pb
-                                     in value_pb.array_value.values)
-                if len(exclude_values) != 1:
-                    raise ValueError('For an array_value, subvalues must '
-                                     'either all be indexed or all excluded '
-                                     'from indexes.')
+        if is_list and len(value) > 0:
+            exclude_values = set(value_pb.exclude_from_indexes
+                                 for value_pb in value_pb.array_value.values)
+            if len(exclude_values) != 1:
+                raise ValueError('For an array_value, subvalues must either '
+                                 'all be indexed or all excluded from '
+                                 'indexes.')
 
-                if exclude_values.pop():
-                    exclude_from_indexes.append(prop_name)
+            if exclude_values.pop():
+                exclude_from_indexes.append(prop_name)
         else:
             if value_pb.exclude_from_indexes:
                 exclude_from_indexes.append(prop_name)

--- a/datastore/google/cloud/datastore/helpers.py
+++ b/datastore/google/cloud/datastore/helpers.py
@@ -135,15 +135,17 @@ def entity_from_protobuf(pb):
         # special-cased and we require all ``exclude_from_indexes`` values
         # in a list agree.
         if is_list:
-            exclude_values = set(value_pb.exclude_from_indexes
-                                 for value_pb in value_pb.array_value.values)
-            if len(exclude_values) != 1:
-                raise ValueError('For an array_value, subvalues must either '
-                                 'all be indexed or all excluded from '
-                                 'indexes.')
+            if len(value) > 0:
+                exclude_values = set(value_pb.exclude_from_indexes
+                                     for value_pb
+                                     in value_pb.array_value.values)
+                if len(exclude_values) != 1:
+                    raise ValueError('For an array_value, subvalues must '
+                                     'either all be indexed or all excluded '
+                                     'from indexes.')
 
-            if exclude_values.pop():
-                exclude_from_indexes.append(prop_name)
+                if exclude_values.pop():
+                    exclude_from_indexes.append(prop_name)
         else:
             if value_pb.exclude_from_indexes:
                 exclude_from_indexes.append(prop_name)

--- a/datastore/tests/system/test_system.py
+++ b/datastore/tests/system/test_system.py
@@ -425,6 +425,21 @@ class TestDatastoreQuery(TestDatastore):
         self.assertEqual(entities[0]['name'], 'Catelyn')
         self.assertEqual(entities[1]['name'], 'Arya')
 
+    def test_empty_array_value(self):
+        from google.cloud import datastore
+        from google.cloud.datastore_v1.proto import datastore_pb2
+        from google.cloud.datastore_v1.proto import entity_pb2
+        client = self.CLIENT
+        key = client.key('Foo', 'Bar')
+        entity = datastore.Entity(key=key)
+        with client.batch() as batch:
+            batch.put(entity)
+            mutations = batch.mutations
+            mutation = mutations[0]
+            value_pb = mutation.upsert.properties.get_or_create('name-name')
+            value_pb.array_value.CopyFrom(entity_pb2.ArrayValue(values=[]))
+        client.get(key)
+
 
 class TestDatastoreTransaction(TestDatastore):
 

--- a/datastore/tests/unit/test_helpers.py
+++ b/datastore/tests/unit/test_helpers.py
@@ -147,10 +147,8 @@ class Test_entity_from_protobuf(unittest.TestCase):
         entity_pb.key.path.add(kind=_KIND, id=_ID)
 
         array_val_pb = _new_value_pb(entity_pb, 'baz')
-        array_pb = array_val_pb.array_value.values
         array_val_pb.array_value.CopyFrom(entity_pb2.ArrayValue(values=[]))
-        
-        unindexed_value_pb1 = array_pb.add()
+
         entity = self._call_fut(entity_pb)
         entity_dict = dict(entity)
         self.assertEqual(entity_dict['baz'], [])

--- a/datastore/tests/unit/test_helpers.py
+++ b/datastore/tests/unit/test_helpers.py
@@ -135,6 +135,26 @@ class Test_entity_from_protobuf(unittest.TestCase):
         with self.assertRaises(ValueError):
             self._call_fut(entity_pb)
 
+    def test_index_mismatch_ignores_empty_list(self):
+        from google.cloud.datastore_v1.proto import entity_pb2
+        from google.cloud.datastore.helpers import _new_value_pb
+
+        _PROJECT = 'PROJECT'
+        _KIND = 'KIND'
+        _ID = 1234
+        entity_pb = entity_pb2.Entity()
+        entity_pb.key.partition_id.project_id = _PROJECT
+        entity_pb.key.path.add(kind=_KIND, id=_ID)
+
+        array_val_pb = _new_value_pb(entity_pb, 'baz')
+        array_pb = array_val_pb.array_value.values
+        array_val_pb.array_value.CopyFrom(entity_pb2.ArrayValue(values=[]))
+        
+        unindexed_value_pb1 = array_pb.add()
+        entity = self._call_fut(entity_pb)
+        entity_dict = dict(entity)
+        self.assertEqual(entity_dict['baz'], [])
+
     def test_entity_no_key(self):
         from google.cloud.datastore_v1.proto import entity_pb2
 


### PR DESCRIPTION
Fixes #3152.

@lukesneeringer This was your fix, so I believe you should be able to get me an LGTM soon right?  :)

@dhermes I would like to ask that you are ok with it since I mostly referred to your test_system code.

@tseaver Do you mind looking it over just so I didn't miss anything?

I consolidated all of our responses and comments and made this pull request.

I backed out the code change and the errors happen. 

Separately, I have also investigated that
``` 
array_values{
  values{
  }
}
```
would `raise ValueError` when put into an entity.  It might be desired behavior, but we might need to deal with it at some point.  The issue is that `len(array_value.values)` is 1 and the result for this was not `[]` as I had expected in the following code:
```
        result = [_get_value_from_value_pb(value)
                  for value in value_pb.array_value.values]
```

Anyway, shall we get this merged soon please?