### PR TITLE
Allow listing/getting jobs even when there is an "invalid" job.

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1468,7 +1468,7 @@ class QueryJobConfig(object):
     @property
     def default_dataset(self):
         """google.cloud.bigquery.dataset.DatasetReference: the default dataset
-        to use for unqualified table names in the query.
+        to use for unqualified table names in the query or ``None`` if not set.
 
         See
         https://g.co/cloud/bigquery/docs/reference/v2/jobs#configuration.query.defaultDataset
@@ -1485,7 +1485,7 @@ class QueryJobConfig(object):
     @property
     def destination(self):
         """google.cloud.bigquery.table.TableReference: table where results are
-        written
+        written or ``None`` if not set.
 
         See
         https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationTable
@@ -1521,7 +1521,7 @@ class QueryJobConfig(object):
 
     @property
     def maximum_bytes_billed(self):
-        """int: Maximum bytes to be billed for this job.
+        """int: Maximum bytes to be billed for this job or ``None`` if not set.
 
         See
         https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.maximumBytesBilled
@@ -1595,7 +1595,7 @@ class QueryJobConfig(object):
     @property
     def table_definitions(self):
         """Dict[str, google.cloud.bigquery.external_config.ExternalConfig]:
-        Definitions for external tables.
+        Definitions for external tables or ``None`` if not set.
 
         See
         https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.tableDefinitions

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -26,7 +26,6 @@ from google.cloud.exceptions import NotFound
 from google.cloud._helpers import _datetime_from_microseconds
 from google.cloud.bigquery.dataset import DatasetReference
 from google.cloud.bigquery.external_config import ExternalConfig
-from google.cloud.bigquery.query import _AbstractQueryParameter
 from google.cloud.bigquery.query import _query_param_from_api_repr
 from google.cloud.bigquery.query import ArrayQueryParameter
 from google.cloud.bigquery.query import ScalarQueryParameter
@@ -1481,8 +1480,6 @@ class QueryJobConfig(object):
 
     @default_dataset.setter
     def default_dataset(self, value):
-        if value is not None and not isinstance(value, DatasetReference):
-            raise ValueError('Required type: DatasetReference')
         self._properties['defaultDataset'] = DatasetReference.to_api_repr(
             value)
 
@@ -1501,8 +1498,6 @@ class QueryJobConfig(object):
 
     @destination.setter
     def destination(self, value):
-        if value is not None and not isinstance(value, TableReference):
-            raise ValueError('Required type: TableReference')
         self._properties['destinationTable'] = TableReference.to_api_repr(
             value)
 
@@ -1540,8 +1535,6 @@ class QueryJobConfig(object):
 
     @maximum_bytes_billed.setter
     def maximum_bytes_billed(self, value):
-        if value is not None and not isinstance(value, int):
-            raise ValueError('Required type: int')
         self._properties['maximumBytesBilled'] = str(value)
 
     priority = QueryPriority('priority', 'priority')
@@ -1564,15 +1557,6 @@ class QueryJobConfig(object):
 
     @query_parameters.setter
     def query_parameters(self, values):
-        value_error_message = (
-            'Required type: list of ArrayQueryParameter, '
-            'ScalarQueryParameter, or StructQueryParameter. To unset, use '
-            'del or set to empty list')
-        if values is None:
-            raise ValueError(value_error_message)
-        if not all(
-                isinstance(item, _AbstractQueryParameter) for item in values):
-            raise ValueError(value_error_message)
         self._properties['queryParameters'] = _to_api_repr_query_parameters(
             values)
 
@@ -1589,13 +1573,6 @@ class QueryJobConfig(object):
 
     @udf_resources.setter
     def udf_resources(self, values):
-        value_error_message = (
-            'Required type: list of UDFResource. To unset, use del or set to '
-            'empty list')
-        if values is None:
-            raise ValueError(value_error_message)
-        if not all(isinstance(item, UDFResource) for item in values):
-            raise ValueError(value_error_message)
         self._properties['userDefinedFunctionResources'] = (
             _to_api_repr_udf_resources(values))
 
@@ -1632,8 +1609,6 @@ class QueryJobConfig(object):
 
     @table_definitions.setter
     def table_definitions(self, values):
-        if values is not None and not isinstance(values, dict):
-            raise ValueError('Required type: dict')
         self._properties['tableDefinitions'] = _to_api_repr_table_defs(values)
 
     _maximum_billing_tier = None

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -38,7 +38,6 @@ from google.cloud.bigquery.table import TableReference
 from google.cloud.bigquery.table import _build_schema_resource
 from google.cloud.bigquery.table import _parse_schema_resource
 from google.cloud.bigquery._helpers import _EnumApiResourceProperty
-from google.cloud.bigquery._helpers import _ListApiResourceProperty
 from google.cloud.bigquery._helpers import _TypedApiResourceProperty
 from google.cloud.bigquery._helpers import DEFAULT_RETRY
 from google.cloud.bigquery._helpers import _int_or_none
@@ -1390,9 +1389,6 @@ class QueryJobConfig(object):
     server defaults.
     """
 
-    _QUERY_PARAMETERS_KEY = 'queryParameters'
-    _UDF_RESOURCES_KEY = 'userDefinedFunctionResources'
-
     def __init__(self):
         self._properties = {}
 
@@ -1420,27 +1416,21 @@ class QueryJobConfig(object):
         self._properties['destinationEncryptionConfiguration'] = api_repr
 
     def to_api_repr(self):
-        """Build an API representation of the copy job config.
+        """Build an API representation of the query job config.
 
-        :rtype: dict
-        :returns: A dictionary in the format used by the BigQuery API.
+        Returns:
+            dict: A dictionary in the format used by the BigQuery API.
         """
         resource = copy.deepcopy(self._properties)
 
         # Query parameters have an addition property associated with them
         # to indicate if the query is using named or positional parameters.
-        query_parameters = resource.get(self._QUERY_PARAMETERS_KEY)
+        query_parameters = resource.get('queryParameters')
         if query_parameters:
-            if query_parameters[0].name is None:
+            if query_parameters[0].get('name') is None:
                 resource['parameterMode'] = 'POSITIONAL'
             else:
                 resource['parameterMode'] = 'NAMED'
-
-        for prop, convert in self._NESTED_PROPERTIES.items():
-            _, to_resource = convert
-            nested_resource = resource.get(prop)
-            if nested_resource is not None:
-                resource[prop] = to_resource(nested_resource)
 
         return resource
 
@@ -1448,22 +1438,16 @@ class QueryJobConfig(object):
     def from_api_repr(cls, resource):
         """Factory: construct a job configuration given its API representation
 
-        :type resource: dict
-        :param resource:
-            An extract job configuration in the same representation as is
-            returned from the API.
+        Args:
+            resource (dict): A query job configuration in the same
+                representation as is returned from the API.
 
-        :rtype: :class:`google.cloud.bigquery.job.QueryJobConfig`
-        :returns: Configuration parsed from ``resource``.
+        Returns:
+            :class:`~google.cloud.bigquery.job.QueryJobConfig`: Configuration
+                parsed from ``resource``.
         """
         config = cls()
         config._properties = copy.deepcopy(resource)
-
-        for prop, convert in cls._NESTED_PROPERTIES.items():
-            from_resource, _ = convert
-            nested_resource = resource.get(prop)
-            if nested_resource is not None:
-                config._properties[prop] = from_resource(nested_resource)
 
         return config
 
@@ -1481,20 +1465,45 @@ class QueryJobConfig(object):
     https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.createDisposition
     """
 
-    default_dataset = _TypedApiResourceProperty(
-        'default_dataset', 'defaultDataset', DatasetReference)
-    """See
-    https://g.co/cloud/bigquery/docs/reference/v2/jobs#configuration.query.defaultDataset
-    """
+    @property
+    def default_dataset(self):
+        """:class:`~google.cloud.bigquery.dataset.DatasetReference`: the
+        default dataset to use for unqualified table names in the query.
 
-    destination = _TypedApiResourceProperty(
-        'destination', 'destinationTable', TableReference)
-    """
-    google.cloud.bigquery.table.TableReference: table where results are written
+        See
+        https://g.co/cloud/bigquery/docs/reference/v2/jobs#configuration.query.defaultDataset
+        """
+        prop = self._properties.get('defaultDataset')
+        if prop is not None:
+            prop = DatasetReference.from_api_repr(prop)
+        return prop
 
-    See
-    https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationTable
-    """
+    @default_dataset.setter
+    def default_dataset(self, value):
+        if value is not None and not isinstance(value, DatasetReference):
+            raise ValueError('Required type: DatasetReference')
+        self._properties['defaultDataset'] = DatasetReference.to_api_repr(
+            value)
+
+    @property
+    def destination(self):
+        """:class:`~google.cloud.bigquery.table.TableReference`: table where results
+        are written
+
+        See
+        https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationTable
+        """
+        prop = self._properties.get('destinationTable')
+        if prop is not None:
+            prop = TableReference.from_api_repr(prop)
+        return prop
+
+    @destination.setter
+    def destination(self, value):
+        if value is not None and not isinstance(value, TableReference):
+            raise ValueError('Required type: TableReference')
+        self._properties['destinationTable'] = TableReference.to_api_repr(
+            value)
 
     dry_run = _TypedApiResourceProperty('dry_run', 'dryRun', bool)
     """
@@ -1516,39 +1525,78 @@ class QueryJobConfig(object):
     https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.maximumBillingTier
     """
 
-    maximum_bytes_billed = _TypedApiResourceProperty(
-        'maximum_bytes_billed', 'maximumBytesBilled', int)
-    """See
-    https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.maximumBytesBilled
-    """
+    @property
+    def maximum_bytes_billed(self):
+        """`int`: Maximum bytes to be billed for this job.
+
+        See
+        https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.maximumBytesBilled
+        """
+        prop = self._properties.get('maximumBytesBilled')
+        if prop is not None:
+            prop = int(prop)
+        return prop
+
+    @maximum_bytes_billed.setter
+    def maximum_bytes_billed(self, value):
+        if value is not None and not isinstance(value, int):
+            raise ValueError('Required type: int')
+        self._properties['maximumBytesBilled'] = str(value)
 
     priority = QueryPriority('priority', 'priority')
     """See
     https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.priority
     """
 
-    query_parameters = _ListApiResourceProperty(
-        'query_parameters', _QUERY_PARAMETERS_KEY, _AbstractQueryParameter)
-    """
-    A list of
-    :class:`google.cloud.bigquery.ArrayQueryParameter`,
-    :class:`google.cloud.bigquery.ScalarQueryParameter`, or
-    :class:`google.cloud.bigquery.StructQueryParameter`
-    (empty by default)
+    @property
+    def query_parameters(self):
+        """list(:class:`~google.cloud.bigquery.query.ArrayQueryParameter`,
+        :class:`~google.cloud.bigquery.query.ScalarQueryParameter`,
+        or :class:`~google.cloud.bigquery.query.StructQueryParameter`): list
+        of parameters for parameterized query (empty by default)
 
-    See:
-    https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.queryParameters
-    """
+        See:
+        https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.queryParameters
+        """
+        prop = self._properties.get('queryParameters', [])
+        return _from_api_repr_query_parameters(prop)
 
-    udf_resources = _ListApiResourceProperty(
-        'udf_resources', _UDF_RESOURCES_KEY, UDFResource)
-    """
-    A list of :class:`google.cloud.bigquery.UDFResource` (empty
-    by default)
+    @query_parameters.setter
+    def query_parameters(self, value):
+        value_error_message = (
+            'Required type: list of ArrayQueryParameter, '
+            'ScalarQueryParameter, or StructQueryParameter. To unset, use '
+            'del or set to empty list')
+        if value is None:
+            raise ValueError(value_error_message)
+        if not all(
+                isinstance(item, _AbstractQueryParameter) for item in value):
+            raise ValueError(value_error_message)
+        self._properties['queryParameters'] = _to_api_repr_query_parameters(
+            value)
 
-    See:
-    https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.userDefinedFunctionResources
-    """
+    @property
+    def udf_resources(self):
+        """list(:class:`~google.cloud.bigquery.query.UDFResource`): user
+        defined function resources (empty by default)
+
+        See:
+        https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.userDefinedFunctionResources
+        """
+        prop = self._properties.get('userDefinedFunctionResources', [])
+        return _from_api_repr_udf_resources(prop)
+
+    @udf_resources.setter
+    def udf_resources(self, value):
+        value_error_message = (
+            'Required type: list of UDFResource. To unset, use del or set to '
+            'empty list')
+        if value is None:
+            raise ValueError(value_error_message)
+        if not all(isinstance(item, UDFResource) for item in value):
+            raise ValueError(value_error_message)
+        self._properties['userDefinedFunctionResources'] = (
+            _to_api_repr_udf_resources(value))
 
     use_legacy_sql = _TypedApiResourceProperty(
         'use_legacy_sql', 'useLegacySql', bool)
@@ -1568,32 +1616,28 @@ class QueryJobConfig(object):
     https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.writeDisposition
     """
 
-    table_definitions = _TypedApiResourceProperty(
-        'table_definitions', 'tableDefinitions', dict)
-    """
-    Definitions for external tables. A dictionary from table names (strings)
-    to :class:`google.cloud.bigquery.ExternalConfig`.
+    @property
+    def table_definitions(self):
+        """dict{`str`,
+        :class:`~google.cloud.bigquery.external_config.ExternalConfig`}:
+        Definitions for external tables.
 
-    See
-    https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.tableDefinitions
-    """
+        See
+        https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.tableDefinitions
+        """
+        prop = self._properties.get('tableDefinitions')
+        if prop is not None:
+            prop = _from_api_repr_table_defs(prop)
+        return prop
+
+    @table_definitions.setter
+    def table_definitions(self, value):
+        if value is not None and not isinstance(value, dict):
+            raise ValueError('Required type: dict')
+        self._properties['tableDefinitions'] = _to_api_repr_table_defs(value)
 
     _maximum_billing_tier = None
     _maximum_bytes_billed = None
-
-    _NESTED_PROPERTIES = {
-        'defaultDataset': (
-            DatasetReference.from_api_repr, DatasetReference.to_api_repr),
-        'destinationTable': (
-            TableReference.from_api_repr, TableReference.to_api_repr),
-        'maximumBytesBilled': (int, str),
-        'tableDefinitions': (_from_api_repr_table_defs,
-                             _to_api_repr_table_defs),
-        _QUERY_PARAMETERS_KEY: (
-            _from_api_repr_query_parameters, _to_api_repr_query_parameters),
-        _UDF_RESOURCES_KEY: (
-            _from_api_repr_udf_resources, _to_api_repr_udf_resources),
-    }
 
 
 class QueryJob(_AsyncJob):

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1562,18 +1562,18 @@ class QueryJobConfig(object):
         return _from_api_repr_query_parameters(prop)
 
     @query_parameters.setter
-    def query_parameters(self, value):
+    def query_parameters(self, values):
         value_error_message = (
             'Required type: list of ArrayQueryParameter, '
             'ScalarQueryParameter, or StructQueryParameter. To unset, use '
             'del or set to empty list')
-        if value is None:
+        if values is None:
             raise ValueError(value_error_message)
         if not all(
-                isinstance(item, _AbstractQueryParameter) for item in value):
+                isinstance(item, _AbstractQueryParameter) for item in values):
             raise ValueError(value_error_message)
         self._properties['queryParameters'] = _to_api_repr_query_parameters(
-            value)
+            values)
 
     @property
     def udf_resources(self):
@@ -1587,16 +1587,16 @@ class QueryJobConfig(object):
         return _from_api_repr_udf_resources(prop)
 
     @udf_resources.setter
-    def udf_resources(self, value):
+    def udf_resources(self, values):
         value_error_message = (
             'Required type: list of UDFResource. To unset, use del or set to '
             'empty list')
-        if value is None:
+        if values is None:
             raise ValueError(value_error_message)
-        if not all(isinstance(item, UDFResource) for item in value):
+        if not all(isinstance(item, UDFResource) for item in values):
             raise ValueError(value_error_message)
         self._properties['userDefinedFunctionResources'] = (
-            _to_api_repr_udf_resources(value))
+            _to_api_repr_udf_resources(values))
 
     use_legacy_sql = _TypedApiResourceProperty(
         'use_legacy_sql', 'useLegacySql', bool)
@@ -1631,10 +1631,10 @@ class QueryJobConfig(object):
         return prop
 
     @table_definitions.setter
-    def table_definitions(self, value):
-        if value is not None and not isinstance(value, dict):
+    def table_definitions(self, values):
+        if values is not None and not isinstance(values, dict):
             raise ValueError('Required type: dict')
-        self._properties['tableDefinitions'] = _to_api_repr_table_defs(value)
+        self._properties['tableDefinitions'] = _to_api_repr_table_defs(values)
 
     _maximum_billing_tier = None
     _maximum_bytes_billed = None

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1480,8 +1480,7 @@ class QueryJobConfig(object):
 
     @default_dataset.setter
     def default_dataset(self, value):
-        self._properties['defaultDataset'] = DatasetReference.to_api_repr(
-            value)
+        self._properties['defaultDataset'] = value.to_api_repr()
 
     @property
     def destination(self):
@@ -1498,8 +1497,7 @@ class QueryJobConfig(object):
 
     @destination.setter
     def destination(self, value):
-        self._properties['destinationTable'] = TableReference.to_api_repr(
-            value)
+        self._properties['destinationTable'] = value.to_api_repr()
 
     dry_run = _TypedApiResourceProperty('dry_run', 'dryRun', bool)
     """

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1439,12 +1439,13 @@ class QueryJobConfig(object):
         """Factory: construct a job configuration given its API representation
 
         Args:
-            resource (dict): A query job configuration in the same
-                representation as is returned from the API.
+            resource (dict):
+                A query job configuration in the same representation as is
+                returned from the API.
 
         Returns:
-            :class:`~google.cloud.bigquery.job.QueryJobConfig`: Configuration
-                parsed from ``resource``.
+            ~google.cloud.bigquery.job.QueryJobConfig:
+                Configuration parsed from ``resource``.
         """
         config = cls()
         config._properties = copy.deepcopy(resource)
@@ -1467,8 +1468,8 @@ class QueryJobConfig(object):
 
     @property
     def default_dataset(self):
-        """:class:`~google.cloud.bigquery.dataset.DatasetReference`: the
-        default dataset to use for unqualified table names in the query.
+        """google.cloud.bigquery.dataset.DatasetReference: the default dataset
+        to use for unqualified table names in the query.
 
         See
         https://g.co/cloud/bigquery/docs/reference/v2/jobs#configuration.query.defaultDataset
@@ -1487,8 +1488,8 @@ class QueryJobConfig(object):
 
     @property
     def destination(self):
-        """:class:`~google.cloud.bigquery.table.TableReference`: table where results
-        are written
+        """google.cloud.bigquery.table.TableReference: table where results are
+        written
 
         See
         https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationTable
@@ -1527,7 +1528,7 @@ class QueryJobConfig(object):
 
     @property
     def maximum_bytes_billed(self):
-        """`int`: Maximum bytes to be billed for this job.
+        """int: Maximum bytes to be billed for this job.
 
         See
         https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.maximumBytesBilled
@@ -1550,10 +1551,10 @@ class QueryJobConfig(object):
 
     @property
     def query_parameters(self):
-        """list(:class:`~google.cloud.bigquery.query.ArrayQueryParameter`,
-        :class:`~google.cloud.bigquery.query.ScalarQueryParameter`,
-        or :class:`~google.cloud.bigquery.query.StructQueryParameter`): list
-        of parameters for parameterized query (empty by default)
+        """List[Union[google.cloud.bigquery.query.ArrayQueryParameter, \
+        google.cloud.bigquery.query.ScalarQueryParameter, \
+        google.cloud.bigquery.query.StructQueryParameter]]: list of parameters
+        for parameterized query (empty by default)
 
         See:
         https://g.co/cloud/bigquery/docs/reference/rest/v2/jobs#configuration.query.queryParameters
@@ -1577,7 +1578,7 @@ class QueryJobConfig(object):
 
     @property
     def udf_resources(self):
-        """list(:class:`~google.cloud.bigquery.query.UDFResource`): user
+        """List[google.cloud.bigquery.query.UDFResource]: user
         defined function resources (empty by default)
 
         See:
@@ -1618,8 +1619,7 @@ class QueryJobConfig(object):
 
     @property
     def table_definitions(self):
-        """dict{`str`,
-        :class:`~google.cloud.bigquery.external_config.ExternalConfig`}:
+        """Dict[str, google.cloud.bigquery.external_config.ExternalConfig]:
         Definitions for external tables.
 
         See

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -748,6 +748,8 @@ class TestBigQuery(unittest.TestCase):
 
     def test_get_failed_job(self):
         # issue 4246
+        from google.api_core.exceptions import BadRequest
+
         JOB_ID = 'invalid_{}'.format(str(uuid.uuid4()))
         QUERY = 'SELECT TIMESTAMP_ADD(@ts_value, INTERVAL 1 HOUR);'
         PARAM = bigquery.ScalarQueryParameter(
@@ -756,11 +758,14 @@ class TestBigQuery(unittest.TestCase):
         job_config = bigquery.QueryJobConfig()
         job_config.query_parameters = [PARAM]
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(BadRequest):
             Config.CLIENT.query(
                 QUERY, job_id=JOB_ID, job_config=job_config).result()
 
         job = Config.CLIENT.get_job(JOB_ID)
+
+        with self.assertRaises(ValueError):
+            job.query_parameters
 
     def test_query_w_legacy_sql_types(self):
         naive = datetime.datetime(2016, 12, 5, 12, 41, 9)

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -746,6 +746,22 @@ class TestBigQuery(unittest.TestCase):
         # raise an error, and that the job completed (in the `retry()`
         # above).
 
+    def test_get_failed_job(self):
+        # issue 4246
+        JOB_ID = 'invalid_{}'.format(str(uuid.uuid4()))
+        QUERY = 'SELECT TIMESTAMP_ADD(@ts_value, INTERVAL 1 HOUR);'
+        PARAM = bigquery.ScalarQueryParameter(
+            'ts_value', 'TIMESTAMP', 1.4810976E9)
+
+        job_config = bigquery.QueryJobConfig()
+        job_config.query_parameters = [PARAM]
+
+        with self.assertRaises(ValueError):
+            Config.CLIENT.query(
+                QUERY, job_id=JOB_ID, job_config=job_config).result()
+
+        job = Config.CLIENT.get_job(JOB_ID)
+
     def test_query_w_legacy_sql_types(self):
         naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
         stamp = '%s %s' % (naive.date().isoformat(), naive.time().isoformat())

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1684,6 +1684,7 @@ class TestQueryJobConfig(unittest.TestCase, _Base):
         self.assertIsNone(config.dry_run)
         self.assertIsNone(config.use_legacy_sql)
         self.assertIsNone(config.default_dataset)
+        self.assertIsNone(config.destination)
         self.assertIsNone(config.destination_encryption_configuration)
 
     def test_from_api_repr_normal(self):
@@ -1760,6 +1761,33 @@ class TestQueryJobConfig(unittest.TestCase, _Base):
         self.assertEqual(
             config.destination_encryption_configuration.kms_key_name,
             self.KMS_KEY_NAME)
+
+    def test_validation_on_property_setters(self):
+        config = self._make_one()
+
+        with self.assertRaises(ValueError):
+            config.default_dataset = 'foo'
+
+        with self.assertRaises(ValueError):
+            config.destination = 'foo'
+
+        with self.assertRaises(ValueError):
+            config.maximum_bytes_billed = 'foo'
+
+        with self.assertRaises(ValueError):
+            config.table_definitions = 'foo'
+
+        with self.assertRaises(ValueError):
+            config.query_parameters = None
+
+        with self.assertRaises(ValueError):
+            config.query_parameters = ['foo']
+
+        with self.assertRaises(ValueError):
+            config.udf_resources = None
+
+        with self.assertRaises(ValueError):
+            config.udf_resources = ['foo']
 
 
 class TestQueryJob(unittest.TestCase, _Base):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -1762,33 +1762,6 @@ class TestQueryJobConfig(unittest.TestCase, _Base):
             config.destination_encryption_configuration.kms_key_name,
             self.KMS_KEY_NAME)
 
-    def test_validation_on_property_setters(self):
-        config = self._make_one()
-
-        with self.assertRaises(ValueError):
-            config.default_dataset = 'foo'
-
-        with self.assertRaises(ValueError):
-            config.destination = 'foo'
-
-        with self.assertRaises(ValueError):
-            config.maximum_bytes_billed = 'foo'
-
-        with self.assertRaises(ValueError):
-            config.table_definitions = 'foo'
-
-        with self.assertRaises(ValueError):
-            config.query_parameters = None
-
-        with self.assertRaises(ValueError):
-            config.query_parameters = ['foo']
-
-        with self.assertRaises(ValueError):
-            config.udf_resources = None
-
-        with self.assertRaises(ValueError):
-            config.udf_resources = ['foo']
-
 
 class TestQueryJob(unittest.TestCase, _Base):
     JOB_TYPE = 'query'


### PR DESCRIPTION
Resolves https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4246 by bypassing property validation in `QueryJobConfig.from_api_repr()`. A `QueryJobConfig` object can be created for an invalid job retrieved from the API, but validation will still occur when assigning invalid property values through the setters.