### PR TITLE
Allow datastore client to connect to emulator host.

### DIFF
--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -28,7 +28,6 @@ from google.cloud.datastore.query import Query
 from google.cloud.datastore.transaction import Transaction
 from google.cloud.environment_vars import DISABLE_GRPC
 from google.cloud.environment_vars import GCD_DATASET
-from google.cloud.environment_vars import GCD_HOST
 
 try:
     from google.cloud.datastore._gax import make_datastore_api

--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -201,8 +201,16 @@ class Client(ClientWithProject):
 
     def __init__(self, project=None, namespace=None,
                  credentials=None, _http=None, _use_grpc=None):
+
+        gcd_host = os.environ.get('GCD_HOST')
+        datastore_emulator_host = os.environ.get('DATASTORE_EMULATOR_HOST')
+
+        if gcd_host or datastore_emulator_host:
+            project = project or 'emulated'
+
         super(Client, self).__init__(
             project=project, credentials=credentials, _http=_http)
+
         self.namespace = namespace
         self._batch_stack = _LocalStack()
         self._datastore_api_internal = None
@@ -210,10 +218,12 @@ class Client(ClientWithProject):
             self._use_grpc = _USE_GRPC
         else:
             self._use_grpc = _use_grpc
-        try:
-            host = os.environ[GCD_HOST]
-            self._base_url = 'http://' + host
-        except KeyError:
+
+        if gcd_host:
+            self._base_url = 'http://{}'.format(gcd_host)
+        elif datastore_emulator_host:
+            self._base_url = 'http://{}'.format(datastore_emulator_host)
+        else:
             self._base_url = _DATASTORE_BASE_URL
 
     @staticmethod

--- a/datastore/tests/unit/test_client.py
+++ b/datastore/tests/unit/test_client.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import unittest
-
+import os
+import copy
 import mock
 
 
@@ -135,6 +136,10 @@ class TestClient(unittest.TestCase):
                                         _use_grpc=_use_grpc)
 
     def test_constructor_w_project_no_environ(self):
+        # Get rid of any environment overrides to the datastore base url
+        old_env = copy.deepcopy(os.environ)
+        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
+
         # Some environments (e.g. AppVeyor CI) run in GCE, so
         # this test would fail artificially.
         patch = mock.patch(
@@ -143,8 +148,13 @@ class TestClient(unittest.TestCase):
         with patch:
             self.assertRaises(EnvironmentError, self._make_one, None)
 
+        os.environ = old_env
+
     def test_constructor_w_implicit_inputs(self):
         from google.cloud.datastore.client import _DATASTORE_BASE_URL
+        # Get rid of any environment overrides to the datastore base url
+        old_env = copy.deepcopy(os.environ)
+        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
 
         other = 'other'
         creds = _make_credentials()
@@ -172,8 +182,83 @@ class TestClient(unittest.TestCase):
         default.assert_called_once_with()
         _determine_default_project.assert_called_once_with(None)
 
+        os.environ = old_env
+
+    def test_constructor_w_implicit_inputs_and_gcd_host(self):
+        # Get rid of any environment overrides to the datastore base url
+        old_env = copy.deepcopy(os.environ)
+        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
+        # Re-assign GCD_HOST with something testable
+        os.environ['GCD_HOST'] = 'something-testable'
+
+        other = 'other'
+        creds = _make_credentials()
+
+        klass = self._get_target_class()
+        patch1 = mock.patch(
+            'google.cloud.datastore.client._determine_default_project',
+            return_value=other)
+        patch2 = mock.patch(
+            'google.auth.default', return_value=(creds, None))
+
+        with patch1 as _determine_default_project:
+            with patch2 as default:
+                client = klass()
+
+        self.assertEqual(client.project, other)
+        self.assertIsNone(client.namespace)
+        self.assertIs(client._credentials, creds)
+        self.assertIsNone(client._http_internal)
+        self.assertEqual(client._base_url, 'http://something-testable')
+
+        self.assertIsNone(client.current_batch)
+        self.assertIsNone(client.current_transaction)
+
+        default.assert_called_once_with()
+        _determine_default_project.assert_called_once_with('emulated')
+
+        os.environ = old_env
+
+    def test_constructor_w_implicit_inputs_and_datastore_emulator_host(self):
+        # Get rid of any environment overrides to the datastore base url
+        old_env = copy.deepcopy(os.environ)
+        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
+        # Re-assign DATASTORE_EMULATOR_HOST with something testable
+        os.environ['DATASTORE_EMULATOR_HOST'] = 'something-testable'
+
+        other = 'other'
+        creds = _make_credentials()
+
+        klass = self._get_target_class()
+        patch1 = mock.patch(
+            'google.cloud.datastore.client._determine_default_project',
+            return_value=other)
+        patch2 = mock.patch(
+            'google.auth.default', return_value=(creds, None))
+
+        with patch1 as _determine_default_project:
+            with patch2 as default:
+                client = klass()
+
+        self.assertEqual(client.project, other)
+        self.assertIsNone(client.namespace)
+        self.assertIs(client._credentials, creds)
+        self.assertIsNone(client._http_internal)
+        self.assertEqual(client._base_url, 'http://something-testable')
+
+        self.assertIsNone(client.current_batch)
+        self.assertIsNone(client.current_transaction)
+
+        default.assert_called_once_with()
+        _determine_default_project.assert_called_once_with('emulated')
+
+        os.environ = old_env
+
     def test_constructor_w_explicit_inputs(self):
         from google.cloud.datastore.client import _DATASTORE_BASE_URL
+        # Get rid of any environment overrides to the datastore base url
+        old_env = copy.deepcopy(os.environ)
+        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
 
         other = 'other'
         namespace = 'namespace'
@@ -190,6 +275,58 @@ class TestClient(unittest.TestCase):
         self.assertIsNone(client.current_batch)
         self.assertEqual(list(client._batch_stack), [])
         self.assertEqual(client._base_url, _DATASTORE_BASE_URL)
+
+        os.environ = old_env
+
+    def test_constructor_w_explicit_inputs_and_gcd_host(self):
+        # Get rid of any environment overrides to the datastore base url
+        old_env = copy.deepcopy(os.environ)
+        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
+        # Re-assign GCD_HOST to something testable
+        os.environ['GCD_HOST'] = 'something-testable'
+
+        other = 'other'
+        namespace = 'namespace'
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(project=other,
+                                namespace=namespace,
+                                credentials=creds,
+                                _http=http)
+        self.assertEqual(client.project, other)
+        self.assertEqual(client.namespace, namespace)
+        self.assertIs(client._credentials, creds)
+        self.assertIs(client._http_internal, http)
+        self.assertIsNone(client.current_batch)
+        self.assertEqual(list(client._batch_stack), [])
+        self.assertEqual(client._base_url, 'http://something-testable')
+
+        os.environ = old_env
+
+    def test_constructor_w_explicit_inputs_and_datastore_emulator_host(self):
+        # Get rid of any environment overrides to the datastore base url
+        old_env = copy.deepcopy(os.environ)
+        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
+        # Re-assign DATASTORE_EMULATOR_HOST to something testable
+        os.environ['DATASTORE_EMULATOR_HOST'] = 'something-testable'
+
+        other = 'other'
+        namespace = 'namespace'
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(project=other,
+                                namespace=namespace,
+                                credentials=creds,
+                                _http=http)
+        self.assertEqual(client.project, other)
+        self.assertEqual(client.namespace, namespace)
+        self.assertIs(client._credentials, creds)
+        self.assertIs(client._http_internal, http)
+        self.assertIsNone(client.current_batch)
+        self.assertEqual(list(client._batch_stack), [])
+        self.assertEqual(client._base_url, 'http://something-testable')
+
+        os.environ = old_env
 
     def test_constructor_use_grpc_default(self):
         import google.cloud.datastore.client as MUT
@@ -1047,6 +1184,32 @@ class TestClient(unittest.TestCase):
             self.assertIs(query, mock_klass.return_value)
             mock_klass.assert_called_once_with(
                 client, project=self.PROJECT, namespace=namespace2, kind=kind)
+
+    def test_can_instantiate_without_project_when_datastore_emulator_host_is_set(self):
+        from google.cloud.datastore import Client
+        # Get rid of any environment overrides to the datastore base url
+        old_env = copy.deepcopy(os.environ)
+        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
+        # Re-assign DATASTORE_EMULATOR_HOST to something testable
+        os.environ['DATASTORE_EMULATOR_HOST'] = 'something-testable'
+        try:
+            client = Client()
+        except Exception as e:
+            raise AssertionError('datastore client failed to instantiate. {}'.format(e.message))
+        os.environ = old_env
+
+    def test_can_instantiate_without_project_when_gcd_host_is_set(self):
+        from google.cloud.datastore import Client
+        # Get rid of any environment overrides to the datastore base url
+        old_env = copy.deepcopy(os.environ)
+        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
+        # Re-assign GCD_HOST to something testable
+        os.environ['GCD_HOST'] = 'something-testable'
+        try:
+            client = Client()
+        except Exception as e:
+            raise AssertionError('datastore client failed to instantiate. {}'.format(e.message))
+        os.environ = old_env
 
 
 class _NoCommitBatch(object):

--- a/datastore/tests/unit/test_client.py
+++ b/datastore/tests/unit/test_client.py
@@ -1154,13 +1154,13 @@ class TestClient(unittest.TestCase):
 
     def test_can_instantiate_without_project_when_datastore_emulator_host_is_set(self):
         # Set DATASTORE_EMULATOR_HOST to something testable
-        with mock.patch.dict('os.environ', {'DATASTORE_EMULATOR_HOST': 'something-testable'}):
-            client = self._get_target_class()()
+        with mock.patch.object(os, 'environ', {'DATASTORE_EMULATOR_HOST': 'something-testable'}):
+            self._get_target_class()()
 
     def test_can_instantiate_without_project_when_gcd_host_is_set(self):
         # Set GCD_HOST to something testable
-        with mock.patch.dict('os.environ', {'GCD_HOST': 'something-testable'}):
-            client = self._get_target_class()()
+        with mock.patch.object(os, 'environ', {'GCD_HOST': 'something-testable'}):
+            self._get_target_class()()
 
 
 class _NoCommitBatch(object):

--- a/datastore/tests/unit/test_client.py
+++ b/datastore/tests/unit/test_client.py
@@ -152,181 +152,148 @@ class TestClient(unittest.TestCase):
 
     def test_constructor_w_implicit_inputs(self):
         from google.cloud.datastore.client import _DATASTORE_BASE_URL
-        # Get rid of any environment overrides to the datastore base url
-        old_env = copy.deepcopy(os.environ)
-        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
 
-        other = 'other'
-        creds = _make_credentials()
+        with mock.patch.dict('os.environ', {}):
+            other = 'other'
+            creds = _make_credentials()
 
-        klass = self._get_target_class()
-        patch1 = mock.patch(
-            'google.cloud.datastore.client._determine_default_project',
-            return_value=other)
-        patch2 = mock.patch(
-            'google.auth.default', return_value=(creds, None))
+            klass = self._get_target_class()
+            patch1 = mock.patch(
+                'google.cloud.datastore.client._determine_default_project',
+                return_value=other)
+            patch2 = mock.patch(
+                'google.auth.default', return_value=(creds, None))
 
-        with patch1 as _determine_default_project:
-            with patch2 as default:
-                client = klass()
+            with patch1 as _determine_default_project:
+                with patch2 as default:
+                    client = klass()
 
-        self.assertEqual(client.project, other)
-        self.assertIsNone(client.namespace)
-        self.assertIs(client._credentials, creds)
-        self.assertIsNone(client._http_internal)
-        self.assertEqual(client._base_url, _DATASTORE_BASE_URL)
+            self.assertEqual(client.project, other)
+            self.assertIsNone(client.namespace)
+            self.assertIs(client._credentials, creds)
+            self.assertIsNone(client._http_internal)
+            self.assertEqual(client._base_url, _DATASTORE_BASE_URL)
 
-        self.assertIsNone(client.current_batch)
-        self.assertIsNone(client.current_transaction)
+            self.assertIsNone(client.current_batch)
+            self.assertIsNone(client.current_transaction)
 
-        default.assert_called_once_with()
-        _determine_default_project.assert_called_once_with(None)
-
-        os.environ = old_env
+            default.assert_called_once_with()
+            _determine_default_project.assert_called_once_with(None)
 
     def test_constructor_w_implicit_inputs_and_gcd_host(self):
-        # Get rid of any environment overrides to the datastore base url
-        old_env = copy.deepcopy(os.environ)
-        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
         # Re-assign GCD_HOST with something testable
-        os.environ['GCD_HOST'] = 'something-testable'
+        with mock.patch.dict('os.environ', {'GCD_HOST': 'something-testable'}):
+            other = 'other'
+            creds = _make_credentials()
 
-        other = 'other'
-        creds = _make_credentials()
+            klass = self._get_target_class()
+            patch1 = mock.patch(
+                'google.cloud.datastore.client._determine_default_project',
+                return_value=other)
+            patch2 = mock.patch(
+                'google.auth.default', return_value=(creds, None))
 
-        klass = self._get_target_class()
-        patch1 = mock.patch(
-            'google.cloud.datastore.client._determine_default_project',
-            return_value=other)
-        patch2 = mock.patch(
-            'google.auth.default', return_value=(creds, None))
+            with patch1 as _determine_default_project:
+                with patch2 as default:
+                    client = klass()
 
-        with patch1 as _determine_default_project:
-            with patch2 as default:
-                client = klass()
+            self.assertEqual(client.project, other)
+            self.assertIsNone(client.namespace)
+            self.assertIs(client._credentials, creds)
+            self.assertIsNone(client._http_internal)
+            self.assertEqual(client._base_url, 'http://something-testable')
 
-        self.assertEqual(client.project, other)
-        self.assertIsNone(client.namespace)
-        self.assertIs(client._credentials, creds)
-        self.assertIsNone(client._http_internal)
-        self.assertEqual(client._base_url, 'http://something-testable')
+            self.assertIsNone(client.current_batch)
+            self.assertIsNone(client.current_transaction)
 
-        self.assertIsNone(client.current_batch)
-        self.assertIsNone(client.current_transaction)
-
-        default.assert_called_once_with()
-        _determine_default_project.assert_called_once_with('emulated')
-
-        os.environ = old_env
+            default.assert_called_once_with()
+            _determine_default_project.assert_called_once_with('emulated')
 
     def test_constructor_w_implicit_inputs_and_datastore_emulator_host(self):
-        # Get rid of any environment overrides to the datastore base url
-        old_env = copy.deepcopy(os.environ)
-        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
-        # Re-assign DATASTORE_EMULATOR_HOST with something testable
-        os.environ['DATASTORE_EMULATOR_HOST'] = 'something-testable'
+        # Set DATASTORE_EMULATOR_HOST with something testable
+        with mock.patch.dict('os.environ', {'DATASTORE_EMULATOR_HOST': 'something-testable'}):
+            other = 'other'
+            creds = _make_credentials()
 
-        other = 'other'
-        creds = _make_credentials()
+            klass = self._get_target_class()
+            patch1 = mock.patch(
+                'google.cloud.datastore.client._determine_default_project',
+                return_value=other)
+            patch2 = mock.patch(
+                'google.auth.default', return_value=(creds, None))
 
-        klass = self._get_target_class()
-        patch1 = mock.patch(
-            'google.cloud.datastore.client._determine_default_project',
-            return_value=other)
-        patch2 = mock.patch(
-            'google.auth.default', return_value=(creds, None))
+            with patch1 as _determine_default_project:
+                with patch2 as default:
+                    client = klass()
 
-        with patch1 as _determine_default_project:
-            with patch2 as default:
-                client = klass()
+            self.assertEqual(client.project, other)
+            self.assertIsNone(client.namespace)
+            self.assertIs(client._credentials, creds)
+            self.assertIsNone(client._http_internal)
+            self.assertEqual(client._base_url, 'http://something-testable')
 
-        self.assertEqual(client.project, other)
-        self.assertIsNone(client.namespace)
-        self.assertIs(client._credentials, creds)
-        self.assertIsNone(client._http_internal)
-        self.assertEqual(client._base_url, 'http://something-testable')
+            self.assertIsNone(client.current_batch)
+            self.assertIsNone(client.current_transaction)
 
-        self.assertIsNone(client.current_batch)
-        self.assertIsNone(client.current_transaction)
-
-        default.assert_called_once_with()
-        _determine_default_project.assert_called_once_with('emulated')
-
-        os.environ = old_env
+            default.assert_called_once_with()
+            _determine_default_project.assert_called_once_with('emulated')
 
     def test_constructor_w_explicit_inputs(self):
         from google.cloud.datastore.client import _DATASTORE_BASE_URL
-        # Get rid of any environment overrides to the datastore base url
-        old_env = copy.deepcopy(os.environ)
-        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
-
-        other = 'other'
-        namespace = 'namespace'
-        creds = _make_credentials()
-        http = object()
-        client = self._make_one(project=other,
-                                namespace=namespace,
-                                credentials=creds,
-                                _http=http)
-        self.assertEqual(client.project, other)
-        self.assertEqual(client.namespace, namespace)
-        self.assertIs(client._credentials, creds)
-        self.assertIs(client._http_internal, http)
-        self.assertIsNone(client.current_batch)
-        self.assertEqual(list(client._batch_stack), [])
-        self.assertEqual(client._base_url, _DATASTORE_BASE_URL)
-
-        os.environ = old_env
+        with mock.patch.dict('os.environ', {}):
+            other = 'other'
+            namespace = 'namespace'
+            creds = _make_credentials()
+            http = object()
+            client = self._make_one(project=other,
+                                    namespace=namespace,
+                                    credentials=creds,
+                                    _http=http)
+            self.assertEqual(client.project, other)
+            self.assertEqual(client.namespace, namespace)
+            self.assertIs(client._credentials, creds)
+            self.assertIs(client._http_internal, http)
+            self.assertIsNone(client.current_batch)
+            self.assertEqual(list(client._batch_stack), [])
+            self.assertEqual(client._base_url, _DATASTORE_BASE_URL)
 
     def test_constructor_w_explicit_inputs_and_gcd_host(self):
-        # Get rid of any environment overrides to the datastore base url
-        old_env = copy.deepcopy(os.environ)
-        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
         # Re-assign GCD_HOST to something testable
-        os.environ['GCD_HOST'] = 'something-testable'
-
-        other = 'other'
-        namespace = 'namespace'
-        creds = _make_credentials()
-        http = object()
-        client = self._make_one(project=other,
-                                namespace=namespace,
-                                credentials=creds,
-                                _http=http)
-        self.assertEqual(client.project, other)
-        self.assertEqual(client.namespace, namespace)
-        self.assertIs(client._credentials, creds)
-        self.assertIs(client._http_internal, http)
-        self.assertIsNone(client.current_batch)
-        self.assertEqual(list(client._batch_stack), [])
-        self.assertEqual(client._base_url, 'http://something-testable')
-
-        os.environ = old_env
+        with mock.patch.dict('os.environ', {'GCD_HOST': 'something-testable'}):
+            other = 'other'
+            namespace = 'namespace'
+            creds = _make_credentials()
+            http = object()
+            client = self._make_one(project=other,
+                                    namespace=namespace,
+                                    credentials=creds,
+                                    _http=http)
+            self.assertEqual(client.project, other)
+            self.assertEqual(client.namespace, namespace)
+            self.assertIs(client._credentials, creds)
+            self.assertIs(client._http_internal, http)
+            self.assertIsNone(client.current_batch)
+            self.assertEqual(list(client._batch_stack), [])
+            self.assertEqual(client._base_url, 'http://something-testable')
 
     def test_constructor_w_explicit_inputs_and_datastore_emulator_host(self):
-        # Get rid of any environment overrides to the datastore base url
-        old_env = copy.deepcopy(os.environ)
-        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
-        # Re-assign DATASTORE_EMULATOR_HOST to something testable
-        os.environ['DATASTORE_EMULATOR_HOST'] = 'something-testable'
-
-        other = 'other'
-        namespace = 'namespace'
-        creds = _make_credentials()
-        http = object()
-        client = self._make_one(project=other,
-                                namespace=namespace,
-                                credentials=creds,
-                                _http=http)
-        self.assertEqual(client.project, other)
-        self.assertEqual(client.namespace, namespace)
-        self.assertIs(client._credentials, creds)
-        self.assertIs(client._http_internal, http)
-        self.assertIsNone(client.current_batch)
-        self.assertEqual(list(client._batch_stack), [])
-        self.assertEqual(client._base_url, 'http://something-testable')
-
-        os.environ = old_env
+        # Set DATASTORE_EMULATOR_HOST to something testable
+        with mock.patch.dict('os.environ', {'DATASTORE_EMULATOR_HOST': 'something-testable'}):
+            other = 'other'
+            namespace = 'namespace'
+            creds = _make_credentials()
+            http = object()
+            client = self._make_one(project=other,
+                                    namespace=namespace,
+                                    credentials=creds,
+                                    _http=http)
+            self.assertEqual(client.project, other)
+            self.assertEqual(client.namespace, namespace)
+            self.assertIs(client._credentials, creds)
+            self.assertIs(client._http_internal, http)
+            self.assertIsNone(client.current_batch)
+            self.assertEqual(list(client._batch_stack), [])
+            self.assertEqual(client._base_url, 'http://something-testable')
 
     def test_constructor_use_grpc_default(self):
         import google.cloud.datastore.client as MUT
@@ -1187,29 +1154,25 @@ class TestClient(unittest.TestCase):
 
     def test_can_instantiate_without_project_when_datastore_emulator_host_is_set(self):
         from google.cloud.datastore import Client
-        # Get rid of any environment overrides to the datastore base url
-        old_env = copy.deepcopy(os.environ)
-        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
-        # Re-assign DATASTORE_EMULATOR_HOST to something testable
-        os.environ['DATASTORE_EMULATOR_HOST'] = 'something-testable'
-        try:
-            client = Client()
-        except Exception as e:
-            raise AssertionError('datastore client failed to instantiate. {}'.format(e.message))
-        os.environ = old_env
+        from google.auth.exceptions import DefaultCredentialsError
+        # Set DATASTORE_EMULATOR_HOST to something testable
+        with mock.patch.dict('os.environ', {'DATASTORE_EMULATOR_HOST': 'something-testable'}):
+            try:
+                client = Client()
+            except DefaultCredentialsError as e:
+                raise AssertionError('datastore client failed to instantiate. {}'.format('DefaultCredentialsError'))
+        # os.environ = old_env
 
     def test_can_instantiate_without_project_when_gcd_host_is_set(self):
         from google.cloud.datastore import Client
-        # Get rid of any environment overrides to the datastore base url
-        old_env = copy.deepcopy(os.environ)
-        os.environ = {k: v for k, v in os.environ.items() if k not in ['GCD_HOST', 'DATASTORE_EMULATOR_HOST']}
-        # Re-assign GCD_HOST to something testable
-        os.environ['GCD_HOST'] = 'something-testable'
-        try:
-            client = Client()
-        except Exception as e:
-            raise AssertionError('datastore client failed to instantiate. {}'.format(e.message))
-        os.environ = old_env
+        from google.auth.exceptions import DefaultCredentialsError
+
+        # Set GCD_HOST to something testable
+        with mock.patch.dict('os.environ', {'GCD_HOST': 'something-testable'}):
+            try:
+                client = Client()
+            except DefaultCredentialsError as e:
+                raise AssertionError('datastore client failed to instantiate. {}'.format('DefaultCredentialsError'))
 
 
 class _NoCommitBatch(object):

--- a/datastore/tests/unit/test_client.py
+++ b/datastore/tests/unit/test_client.py
@@ -1153,26 +1153,14 @@ class TestClient(unittest.TestCase):
                 client, project=self.PROJECT, namespace=namespace2, kind=kind)
 
     def test_can_instantiate_without_project_when_datastore_emulator_host_is_set(self):
-        from google.cloud.datastore import Client
-        from google.auth.exceptions import DefaultCredentialsError
         # Set DATASTORE_EMULATOR_HOST to something testable
         with mock.patch.dict('os.environ', {'DATASTORE_EMULATOR_HOST': 'something-testable'}):
-            try:
-                client = Client()
-            except DefaultCredentialsError as e:
-                raise AssertionError('datastore client failed to instantiate. {}'.format('DefaultCredentialsError'))
-        # os.environ = old_env
+            client = self._get_target_class()()
 
     def test_can_instantiate_without_project_when_gcd_host_is_set(self):
-        from google.cloud.datastore import Client
-        from google.auth.exceptions import DefaultCredentialsError
-
         # Set GCD_HOST to something testable
         with mock.patch.dict('os.environ', {'GCD_HOST': 'something-testable'}):
-            try:
-                client = Client()
-            except DefaultCredentialsError as e:
-                raise AssertionError('datastore client failed to instantiate. {}'.format('DefaultCredentialsError'))
+            client = self._get_target_class()()
 
 
 class _NoCommitBatch(object):


### PR DESCRIPTION
Fix for issue #3920 
Updated PR for #4794 

Code Example:

```python
# This assumes you have the datastore emulator running on localhost:8081
from google.cloud import datastore

import os
os.environ['DATASTORE_EMULATOR_HOST'] = 'localhost:8081'

ds_client = datastore.Client()
key = ds_client.key('Testing', 'test')
entity = datastore.Entity(key)
entity.update({
    'hello': 'world'
})

ds_client.put(entity)
print(ds_client.get(key))
```