### PR TITLE
Fix for DS client not connecting to DS emulator host via env var.

### DIFF
--- a/datastore/google/cloud/datastore/client.py
+++ b/datastore/google/cloud/datastore/client.py
@@ -163,10 +163,12 @@ class EmulatorCreds(Credentials):
     """
     A mock credential object.
 
-    Used to avoid unnecessary token refreshing or reliance on the network when using an emulator.
+    Used to avoid unnecessary token refreshing or reliance on the network
+    when using an emulator.
     """
     # Credit to https://github.com/patrick91.
-    # Taken from https://github.com/GoogleCloudPlatform/google-cloud-python/issues/3920#issuecomment-327315159
+    # Taken from https://github.com/GoogleCloudPlatform/google-cloud-python
+    # /issues/3920#issuecomment-327315159
 
     def __init__(self):
         super(EmulatorCreds, self).__init__()

--- a/datastore/tests/unit/test_client.py
+++ b/datastore/tests/unit/test_client.py
@@ -1067,6 +1067,19 @@ class TestClient(unittest.TestCase):
         self.assertIsNone(client.current_transaction)
 
 
+class TestEmulatorCreds(unittest.TestCase):
+
+    def setUp(self):
+        from google.cloud.datastore.client import EmulatorCreds
+        self.creds = EmulatorCreds()
+
+    def test_valid_always_returns_true(self):
+        self.assertTrue(self.creds.valid)
+
+    def test_refresh_raises(self):
+        self.assertRaises(RuntimeError, self.creds.refresh, None)
+
+
 class _NoCommitBatch(object):
 
     def __init__(self, client):

--- a/datastore/tests/unit/test_client.py
+++ b/datastore/tests/unit/test_client.py
@@ -1048,6 +1048,24 @@ class TestClient(unittest.TestCase):
             mock_klass.assert_called_once_with(
                 client, project=self.PROJECT, namespace=namespace2, kind=kind)
 
+    def test_can_instantiate_client_with_gcd_host(self):
+        import os
+        from google.cloud.datastore.client import EmulatorCreds
+
+        klass = self._get_target_class()
+
+        with mock.patch.object(os, 'environ', {'DATASTORE_EMULATOR_HOST': 'localhost:8081'}):
+            client = klass()
+
+        self.assertEqual(client.project, 'other')
+        self.assertIsNone(client.namespace)
+        self.assertIsInstance(client._credentials, EmulatorCreds)
+        self.assertIsNone(client._http_internal)
+        self.assertEqual(client._base_url, 'http://localhost:8081')
+
+        self.assertIsNone(client.current_batch)
+        self.assertIsNone(client.current_transaction)
+
 
 class _NoCommitBatch(object):
 


### PR DESCRIPTION
Fix for issue #3920
Updated PR for #4795

Code Example:

```python
# This assumes you have the datastore emulator running on localhost:8081
from google.cloud import datastore

import os
os.environ['DATASTORE_EMULATOR_HOST'] = 'localhost:8081'

ds_client = datastore.Client()
key = ds_client.key('Testing', 'test')
entity = datastore.Entity(key)
entity.update({
    'hello': 'world'
})

ds_client.put(entity)
print(ds_client.get(key))
```