### PR TITLE
Fix speech helpers to properly pass retry and timeout args

### DIFF
--- a/speech/google/cloud/speech_v1/helpers.py
+++ b/speech/google/cloud/speech_v1/helpers.py
@@ -14,6 +14,8 @@
 
 from __future__ import absolute_import
 
+import google.api_core.gapic_v1.method
+
 
 class SpeechHelpers(object):
     """A set of convenience methods to make the Speech client easier to use.
@@ -22,7 +24,10 @@ class SpeechHelpers(object):
     in a multiple-inheritance construction alongside the applicable GAPIC.
     See the :class:`~google.cloud.speech_v1.SpeechClient`.
     """
-    def streaming_recognize(self, config, requests, options=None):
+    def streaming_recognize(
+            self, config, requests,
+            retry=google.api_core.gapic_v1.method.DEFAULT,
+            timeout=google.api_core.gapic_v1.method.DEFAULT):
         """Perform bi-directional speech recognition.
 
         This method allows you to receive results while sending audio;
@@ -66,7 +71,7 @@ class SpeechHelpers(object):
         """
         return self._streaming_recognize(
             self._streaming_request_iterable(config, requests),
-            options,
+            retry=retry, timeout=timeout
         )
 
     def _streaming_request_iterable(self, config, requests):

--- a/speech/tests/unit/gapic/v1/test_helpers.py
+++ b/speech/tests/unit/gapic/v1/test_helpers.py
@@ -36,7 +36,8 @@ class TestSpeechClient(unittest.TestCase):
 
         config = types.RecognitionConfig(encoding='FLAC')
         audio = types.RecognitionAudio(uri='http://foo.com/bar.wav')
-        with mock.patch.object(client, '_recognize') as recognize:
+        patch = mock.patch.object(client, '_recognize', autospec=True)
+        with patch as recognize:
             client.recognize(config, audio)
 
             # Assert that the underlying GAPIC method was called as expected.
@@ -54,7 +55,9 @@ class TestSpeechClient(unittest.TestCase):
 
         config = types.StreamingRecognitionConfig()
         requests = [types.StreamingRecognizeRequest(audio_content=b'...')]
-        with mock.patch.object(client, '_streaming_recognize') as sr:
+        patch = mock.patch.object(
+            client, '_streaming_recognize', autospec=True)
+        with patch as sr:
             client.streaming_recognize(config, requests)
 
             # Assert that we called streaming recognize with an iterable


### PR DESCRIPTION
Actual fix for #4820 (caused by regenerating the gapic layer)