### PR TITLE
BigQuery: Use constant strings for job properties

### DIFF
--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -394,6 +394,9 @@ class TestBigQuery(unittest.TestCase):
 
     def test_load_table_from_local_file_then_dump_table(self):
         from google.cloud._testing import _NamedTemporaryFile
+        from google.cloud.bigquery.job import CreateDisposition
+        from google.cloud.bigquery.job import SourceFormat
+        from google.cloud.bigquery.job import WriteDisposition
 
         TABLE_NAME = 'test_table'
 
@@ -411,10 +414,10 @@ class TestBigQuery(unittest.TestCase):
 
             with open(temp.name, 'rb') as csv_read:
                 config = bigquery.LoadJobConfig()
-                config.source_format = 'CSV'
+                config.source_format = SourceFormat.CSV
                 config.skip_leading_rows = 1
-                config.create_disposition = 'CREATE_NEVER'
-                config.write_disposition = 'WRITE_EMPTY'
+                config.create_disposition = CreateDisposition.CREATE_NEVER
+                config.write_disposition = WriteDisposition.WRITE_EMPTY
                 config.schema = table.schema
                 job = Config.CLIENT.load_table_from_file(
                     csv_read, table_ref, job_config=config)
@@ -431,6 +434,8 @@ class TestBigQuery(unittest.TestCase):
                          sorted(ROWS, key=by_age))
 
     def test_load_table_from_local_avro_file_then_dump_table(self):
+        from google.cloud.bigquery.job import SourceFormat
+        from google.cloud.bigquery.job import WriteDisposition
         TABLE_NAME = 'test_table_avro'
         ROWS = [
             ("violet", 400),
@@ -448,8 +453,8 @@ class TestBigQuery(unittest.TestCase):
 
         with open(os.path.join(WHERE, 'data', 'colors.avro'), 'rb') as avrof:
             config = bigquery.LoadJobConfig()
-            config.source_format = 'AVRO'
-            config.write_disposition = 'WRITE_TRUNCATE'
+            config.source_format = SourceFormat.AVRO
+            config.write_disposition = WriteDisposition.WRITE_TRUNCATE
             job = Config.CLIENT.load_table_from_file(
                 avrof, table_ref, job_config=config)
         # Retry until done.
@@ -465,6 +470,9 @@ class TestBigQuery(unittest.TestCase):
                          sorted(ROWS, key=by_wavelength))
 
     def test_load_avro_from_uri_then_dump_table(self):
+        from google.cloud.bigquery.job import CreateDisposition
+        from google.cloud.bigquery.job import SourceFormat
+        from google.cloud.bigquery.job import WriteDisposition
         table_name = 'test_table'
         rows = [
             ("violet", 400),
@@ -485,9 +493,9 @@ class TestBigQuery(unittest.TestCase):
         self.to_delete.insert(0, table)
 
         config = bigquery.LoadJobConfig()
-        config.create_disposition = 'CREATE_NEVER'
-        config.source_format = 'AVRO'
-        config.write_disposition = 'WRITE_EMPTY'
+        config.create_disposition = CreateDisposition.CREATE_NEVER
+        config.source_format = SourceFormat.AVRO
+        config.write_disposition = WriteDisposition.WRITE_EMPTY
         job = Config.CLIENT.load_table_from_uri(
             GS_URL, table_arg, job_config=config)
         job.result(timeout=JOB_TIMEOUT)
@@ -500,6 +508,10 @@ class TestBigQuery(unittest.TestCase):
                          sorted(rows, key=lambda x: x[1]))
 
     def test_load_table_from_uri_then_dump_table(self):
+        from google.cloud.bigquery.job import CreateDisposition
+        from google.cloud.bigquery.job import SourceFormat
+        from google.cloud.bigquery.job import WriteDisposition
+
         TABLE_ID = 'test_table'
         GS_URL = self._write_csv_to_storage(
             'bq_load_test' + unique_resource_id(), 'person_ages.csv',
@@ -512,10 +524,10 @@ class TestBigQuery(unittest.TestCase):
         self.to_delete.insert(0, table)
 
         config = bigquery.LoadJobConfig()
-        config.create_disposition = 'CREATE_NEVER'
+        config.create_disposition = CreateDisposition.CREATE_NEVER
         config.skip_leading_rows = 1
-        config.source_format = 'CSV'
-        config.write_disposition = 'WRITE_EMPTY'
+        config.source_format = SourceFormat.CSV
+        config.write_disposition = WriteDisposition.WRITE_EMPTY
         job = Config.CLIENT.load_table_from_uri(
             GS_URL, dataset.table(TABLE_ID), job_config=config)
 
@@ -674,6 +686,7 @@ class TestBigQuery(unittest.TestCase):
 
     def test_extract_table_w_job_config(self):
         from google.cloud.storage import Client as StorageClient
+        from google.cloud.bigquery.job import DestinationFormat
 
         storage_client = StorageClient()
         local_id = unique_resource_id()
@@ -691,10 +704,10 @@ class TestBigQuery(unittest.TestCase):
         destination = bucket.blob(destination_blob_name)
         destination_uri = 'gs://{}/person_ages_out.csv'.format(bucket_name)
 
-        job_config = bigquery.ExtractJobConfig()
-        job_config.destination_format = 'NEWLINE_DELIMITED_JSON'
+        config = bigquery.ExtractJobConfig()
+        config.destination_format = DestinationFormat.NEWLINE_DELIMITED_JSON
         job = Config.CLIENT.extract_table(
-            table, destination_uri, job_config=job_config)
+            table, destination_uri, job_config=config)
         job.result()
 
         self.to_delete.insert(0, destination)
@@ -926,6 +939,9 @@ class TestBigQuery(unittest.TestCase):
 
     def _load_table_for_dml(self, rows, dataset_id, table_id):
         from google.cloud._testing import _NamedTemporaryFile
+        from google.cloud.bigquery.job import CreateDisposition
+        from google.cloud.bigquery.job import SourceFormat
+        from google.cloud.bigquery.job import WriteDisposition
 
         dataset = self.temp_dataset(dataset_id)
         greeting = bigquery.SchemaField(
@@ -943,10 +959,10 @@ class TestBigQuery(unittest.TestCase):
 
             with open(temp.name, 'rb') as csv_read:
                 config = bigquery.LoadJobConfig()
-                config.source_format = 'CSV'
+                config.source_format = SourceFormat.CSV
                 config.skip_leading_rows = 1
-                config.create_disposition = 'CREATE_NEVER'
-                config.write_disposition = 'WRITE_EMPTY'
+                config.create_disposition = CreateDisposition.CREATE_NEVER
+                config.write_disposition = WriteDisposition.WRITE_EMPTY
                 job = Config.CLIENT.load_table_from_file(
                     csv_read, table_ref, job_config=config)
 
@@ -1519,6 +1535,9 @@ class TestBigQuery(unittest.TestCase):
 
     @unittest.skipIf(pandas is None, 'Requires `pandas`')
     def test_nested_table_to_dataframe(self):
+        from google.cloud.bigquery.job import SourceFormat
+        from google.cloud.bigquery.job import WriteDisposition
+
         SF = bigquery.SchemaField
         schema = [
             SF('string_col', 'STRING', mode='NULLABLE'),
@@ -1545,8 +1564,8 @@ class TestBigQuery(unittest.TestCase):
         table = dataset.table(table_id)
         self.to_delete.insert(0, table)
         job_config = bigquery.LoadJobConfig()
-        job_config.write_disposition = 'WRITE_TRUNCATE'
-        job_config.source_format = 'NEWLINE_DELIMITED_JSON'
+        job_config.write_disposition = WriteDisposition.WRITE_TRUNCATE
+        job_config.source_format = SourceFormat.NEWLINE_DELIMITED_JSON
         job_config.schema = schema
         # Load a table using a local JSON file from memory.
         Config.CLIENT.load_table_from_file(

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -566,8 +566,9 @@ class TestClient(unittest.TestCase):
         self.assertEqual(got.view_query, query)
 
     def test_create_table_w_external(self):
-        from google.cloud.bigquery.table import Table
         from google.cloud.bigquery.external_config import ExternalConfig
+        from google.cloud.bigquery.job import SourceFormat
+        from google.cloud.bigquery.table import Table
 
         path = 'projects/%s/datasets/%s/tables' % (
             self.PROJECT, self.DS_ID)
@@ -581,7 +582,7 @@ class TestClient(unittest.TestCase):
                 'tableId': self.TABLE_ID
             },
             'externalDataConfiguration': {
-                'sourceFormat': 'CSV',
+                'sourceFormat': SourceFormat.CSV,
                 'autodetect': True,
             },
         }
@@ -604,7 +605,7 @@ class TestClient(unittest.TestCase):
                 'tableId': self.TABLE_ID,
             },
             'externalDataConfiguration': {
-                'sourceFormat': 'CSV',
+                'sourceFormat': SourceFormat.CSV,
                 'autodetect': True,
             },
             'labels': {},
@@ -613,7 +614,8 @@ class TestClient(unittest.TestCase):
         self.assertEqual(got.table_id, self.TABLE_ID)
         self.assertEqual(got.project, self.PROJECT)
         self.assertEqual(got.dataset_id, self.DS_ID)
-        self.assertEqual(got.external_data_configuration.source_format, 'CSV')
+        self.assertEqual(got.external_data_configuration.source_format,
+                         SourceFormat.CSV)
         self.assertEqual(got.external_data_configuration.autodetect, True)
 
     def test_get_table(self):
@@ -1188,7 +1190,9 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], {'projection': 'full'})
 
     def test_get_job_hit(self):
+        from google.cloud.bigquery.job import CreateDisposition
         from google.cloud.bigquery.job import QueryJob
+        from google.cloud.bigquery.job import WriteDisposition
 
         JOB_ID = 'query_job'
         QUERY_DESTINATION_TABLE = 'query_destination_table'
@@ -1208,8 +1212,8 @@ class TestClient(unittest.TestCase):
                         'datasetId': self.DS_ID,
                         'tableId': QUERY_DESTINATION_TABLE,
                     },
-                    'createDisposition': 'CREATE_IF_NEEDED',
-                    'writeDisposition': 'WRITE_TRUNCATE',
+                    'createDisposition': CreateDisposition.CREATE_IF_NEEDED,
+                    'writeDisposition': WriteDisposition.WRITE_TRUNCATE,
                 }
             },
         }
@@ -1221,8 +1225,10 @@ class TestClient(unittest.TestCase):
 
         self.assertIsInstance(job, QueryJob)
         self.assertEqual(job.job_id, JOB_ID)
-        self.assertEqual(job.create_disposition, 'CREATE_IF_NEEDED')
-        self.assertEqual(job.write_disposition, 'WRITE_TRUNCATE')
+        self.assertEqual(job.create_disposition,
+                         CreateDisposition.CREATE_IF_NEEDED)
+        self.assertEqual(job.write_disposition,
+                         WriteDisposition.WRITE_TRUNCATE)
 
         self.assertEqual(len(conn._requested), 1)
         req = conn._requested[0]
@@ -1288,10 +1294,12 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req['query_params'], {'projection': 'full'})
 
     def test_list_jobs_defaults(self):
-        from google.cloud.bigquery.job import LoadJob
         from google.cloud.bigquery.job import CopyJob
+        from google.cloud.bigquery.job import CreateDisposition
         from google.cloud.bigquery.job import ExtractJob
+        from google.cloud.bigquery.job import LoadJob
         from google.cloud.bigquery.job import QueryJob
+        from google.cloud.bigquery.job import WriteDisposition
 
         SOURCE_TABLE = 'source_table'
         DESTINATION_TABLE = 'destination_table'
@@ -1322,8 +1330,8 @@ class TestClient(unittest.TestCase):
                         'datasetId': self.DS_ID,
                         'tableId': QUERY_DESTINATION_TABLE,
                     },
-                    'createDisposition': 'CREATE_IF_NEEDED',
-                    'writeDisposition': 'WRITE_TRUNCATE',
+                    'createDisposition': CreateDisposition.CREATE_IF_NEEDED,
+                    'writeDisposition': WriteDisposition.WRITE_TRUNCATE,
                 }
             },
         }
@@ -1568,7 +1576,9 @@ class TestClient(unittest.TestCase):
         from google.cloud.bigquery.client import _DEFAULT_CHUNKSIZE
         from google.cloud.bigquery.client import _GENERIC_CONTENT_TYPE
         from google.cloud.bigquery.client import _get_upload_headers
-        from google.cloud.bigquery.job import LoadJob, LoadJobConfig
+        from google.cloud.bigquery.job import LoadJob
+        from google.cloud.bigquery.job import LoadJobConfig
+        from google.cloud.bigquery.job import SourceFormat
 
         # Create mocks to be checked for doing transport.
         resumable_url = 'http://test.invalid?upload_id=hey-you'
@@ -1582,7 +1592,7 @@ class TestClient(unittest.TestCase):
         data = b'goodbye gudbi gootbee'
         stream = io.BytesIO(data)
         config = LoadJobConfig()
-        config.source_format = 'CSV'
+        config.source_format = SourceFormat.CSV
         job = LoadJob(None, None, self.TABLE_REF, client, job_config=config)
         metadata = job._build_resource()
         upload, transport = client._initiate_resumable_upload(
@@ -1635,7 +1645,9 @@ class TestClient(unittest.TestCase):
     def _do_multipart_upload_success_helper(
             self, get_boundary, num_retries=None):
         from google.cloud.bigquery.client import _get_upload_headers
-        from google.cloud.bigquery.job import LoadJob, LoadJobConfig
+        from google.cloud.bigquery.job import LoadJob
+        from google.cloud.bigquery.job import LoadJobConfig
+        from google.cloud.bigquery.job import SourceFormat
 
         fake_transport = self._mock_transport(http_client.OK, {})
         client = self._make_one(project=self.PROJECT, _http=fake_transport)
@@ -1645,7 +1657,7 @@ class TestClient(unittest.TestCase):
         data = b'Bzzzz-zap \x00\x01\xf4'
         stream = io.BytesIO(data)
         config = LoadJobConfig()
-        config.source_format = 'CSV'
+        config.source_format = SourceFormat.CSV
         job = LoadJob(None, None, self.TABLE_REF, client, job_config=config)
         metadata = job._build_resource()
         size = len(data)
@@ -2798,7 +2810,7 @@ class TestClientUpload(object):
     # NOTE: This is a "partner" to `TestClient` meant to test some of the
     #       "load_table_from_file" portions of `Client`. It also uses
     #       `pytest`-style tests rather than `unittest`-style.
-
+    from google.cloud.bigquery.job import SourceFormat
     TABLE_REF = DatasetReference(
         'project_id', 'test_dataset').table('test_table')
 
@@ -2841,7 +2853,7 @@ class TestClientUpload(object):
         'jobReference': {'projectId': 'project_id', 'jobId': 'job_id'},
         'configuration': {
             'load': {
-                'sourceFormat': 'CSV',
+                'sourceFormat': SourceFormat.CSV,
                 'destinationTable': {
                     'projectId': 'project_id',
                     'datasetId': 'test_dataset',
@@ -2858,9 +2870,10 @@ class TestClientUpload(object):
     @staticmethod
     def _make_config():
         from google.cloud.bigquery.job import LoadJobConfig
+        from google.cloud.bigquery.job import SourceFormat
 
         config = LoadJobConfig()
-        config.source_format = 'CSV'
+        config.source_format = SourceFormat.CSV
         return config
 
     # High-level tests
@@ -2885,6 +2898,8 @@ class TestClientUpload(object):
 
     def test_load_table_from_file_resumable_metadata(self):
         from google.cloud.bigquery.client import _DEFAULT_NUM_RETRIES
+        from google.cloud.bigquery.job import CreateDisposition
+        from google.cloud.bigquery.job import WriteDisposition
 
         client = self._make_client()
         file_obj = self._make_file_obj()
@@ -2892,14 +2907,14 @@ class TestClientUpload(object):
         config = self._make_config()
         config.allow_jagged_rows = False
         config.allow_quoted_newlines = False
-        config.create_disposition = 'CREATE_IF_NEEDED'
+        config.create_disposition = CreateDisposition.CREATE_IF_NEEDED
         config.encoding = 'utf8'
         config.field_delimiter = ','
         config.ignore_unknown_values = False
         config.max_bad_records = 0
         config.quote_character = '"'
         config.skip_leading_rows = 1
-        config.write_disposition = 'WRITE_APPEND'
+        config.write_disposition = WriteDisposition.WRITE_APPEND
         config.null_marker = r'\N'
 
         expected_config = {

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -20,8 +20,8 @@ try:
     import pandas
 except (ImportError, AttributeError):  # pragma: NO COVER
     pandas = None
-
-from google.cloud.bigquery.job import ExtractJobConfig, CopyJobConfig
+from google.cloud.bigquery.job import CopyJobConfig
+from google.cloud.bigquery.job import ExtractJobConfig
 from google.cloud.bigquery.job import LoadJobConfig
 from google.cloud.bigquery.dataset import DatasetReference
 
@@ -575,10 +575,12 @@ class TestLoadJob(unittest.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
     def test_from_api_repr_w_properties(self):
+        from google.cloud.bigquery.job import CreateDisposition
+
         client = _make_client(project=self.PROJECT)
         RESOURCE = self._make_resource()
         load_config = RESOURCE['configuration']['load']
-        load_config['createDisposition'] = 'CREATE_IF_NEEDED'
+        load_config['createDisposition'] = CreateDisposition.CREATE_IF_NEEDED
         klass = self._get_target_class()
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
@@ -675,6 +677,8 @@ class TestLoadJob(unittest.TestCase, _Base):
         self._verifyResourceProperties(job, resource)
 
     def test_begin_w_alternate_client(self):
+        from google.cloud.bigquery.job import CreateDisposition
+        from google.cloud.bigquery.job import WriteDisposition
         from google.cloud.bigquery.schema import SchemaField
 
         PATH = '/projects/%s/jobs' % (self.PROJECT,)
@@ -688,7 +692,7 @@ class TestLoadJob(unittest.TestCase, _Base):
             },
             'allowJaggedRows': True,
             'allowQuotedNewlines': True,
-            'createDisposition': 'CREATE_NEVER',
+            'createDisposition': CreateDisposition.CREATE_NEVER,
             'encoding': 'ISO-8559-1',
             'fieldDelimiter': '|',
             'ignoreUnknownValues': True,
@@ -697,7 +701,7 @@ class TestLoadJob(unittest.TestCase, _Base):
             'quote': "'",
             'skipLeadingRows': '1',
             'sourceFormat': 'CSV',
-            'writeDisposition': 'WRITE_TRUNCATE',
+            'writeDisposition': WriteDisposition.WRITE_TRUNCATE,
             'schema': {'fields': [
                 {'name': 'full_name', 'type': 'STRING', 'mode': 'REQUIRED'},
                 {'name': 'age', 'type': 'INTEGER', 'mode': 'REQUIRED'},
@@ -716,7 +720,7 @@ class TestLoadJob(unittest.TestCase, _Base):
                              client1, config)
         config.allow_jagged_rows = True
         config.allow_quoted_newlines = True
-        config.create_disposition = 'CREATE_NEVER'
+        config.create_disposition = CreateDisposition.CREATE_NEVER
         config.encoding = 'ISO-8559-1'
         config.field_delimiter = '|'
         config.ignore_unknown_values = True
@@ -725,7 +729,7 @@ class TestLoadJob(unittest.TestCase, _Base):
         config.quote_character = "'"
         config.skip_leading_rows = 1
         config.source_format = 'CSV'
-        config.write_disposition = 'WRITE_TRUNCATE'
+        config.write_disposition = WriteDisposition.WRITE_TRUNCATE
 
         job._begin(client=client2)
 
@@ -1035,10 +1039,11 @@ class TestCopyJob(unittest.TestCase, _Base):
             klass.from_api_repr(RESOURCE, client=client)
 
     def test_from_api_repr_w_properties(self):
+        from google.cloud.bigquery.job import CreateDisposition
         client = _make_client(project=self.PROJECT)
         RESOURCE = self._make_resource()
         copy_config = RESOURCE['configuration']['copy']
-        copy_config['createDisposition'] = 'CREATE_IF_NEEDED'
+        copy_config['createDisposition'] = CreateDisposition.CREATE_IF_NEEDED
         klass = self._get_target_class()
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
@@ -1088,6 +1093,8 @@ class TestCopyJob(unittest.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
     def test_begin_w_alternate_client(self):
+        from google.cloud.bigquery.job import CreateDisposition
+        from google.cloud.bigquery.job import WriteDisposition
         PATH = '/projects/%s/jobs' % (self.PROJECT,)
         RESOURCE = self._make_resource(ended=True)
         COPY_CONFIGURATION = {
@@ -1101,8 +1108,8 @@ class TestCopyJob(unittest.TestCase, _Base):
                 'datasetId': self.DS_ID,
                 'tableId': self.DESTINATION_TABLE,
             },
-            'createDisposition': 'CREATE_NEVER',
-            'writeDisposition': 'WRITE_TRUNCATE',
+            'createDisposition': CreateDisposition.CREATE_NEVER,
+            'writeDisposition': WriteDisposition.WRITE_TRUNCATE,
         }
         RESOURCE['configuration']['copy'] = COPY_CONFIGURATION
         conn1 = _Connection()
@@ -1112,8 +1119,8 @@ class TestCopyJob(unittest.TestCase, _Base):
         source = self._table_ref(self.SOURCE_TABLE)
         destination = self._table_ref(self.DESTINATION_TABLE)
         config = CopyJobConfig()
-        config.create_disposition = 'CREATE_NEVER'
-        config.write_disposition = 'WRITE_TRUNCATE'
+        config.create_disposition = CreateDisposition.CREATE_NEVER
+        config.write_disposition = WriteDisposition.WRITE_TRUNCATE
         job = self._make_one(self.JOB_ID, [source], destination, client1,
                              config)
         job._begin(client=client2)
@@ -1354,10 +1361,11 @@ class TestExtractJob(unittest.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
     def test_from_api_repr_w_properties(self):
+        from google.cloud.bigquery.job import Compression
         client = _make_client(project=self.PROJECT)
         RESOURCE = self._make_resource()
         extract_config = RESOURCE['configuration']['extract']
-        extract_config['compression'] = 'GZIP'
+        extract_config['compression'] = Compression.GZIP
         klass = self._get_target_class()
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
@@ -1404,6 +1412,9 @@ class TestExtractJob(unittest.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
     def test_begin_w_alternate_client(self):
+        from google.cloud.bigquery.job import Compression
+        from google.cloud.bigquery.job import DestinationFormat
+
         PATH = '/projects/%s/jobs' % (self.PROJECT,)
         RESOURCE = self._make_resource(ended=True)
         EXTRACT_CONFIGURATION = {
@@ -1413,8 +1424,8 @@ class TestExtractJob(unittest.TestCase, _Base):
                 'tableId': self.SOURCE_TABLE,
             },
             'destinationUris': [self.DESTINATION_URI],
-            'compression': 'GZIP',
-            'destinationFormat': 'NEWLINE_DELIMITED_JSON',
+            'compression': Compression.GZIP,
+            'destinationFormat': DestinationFormat.NEWLINE_DELIMITED_JSON,
             'fieldDelimiter': '|',
             'printHeader': False,
         }
@@ -1425,13 +1436,13 @@ class TestExtractJob(unittest.TestCase, _Base):
         client2 = _make_client(project=self.PROJECT, connection=conn2)
         source_dataset = DatasetReference(self.PROJECT, self.DS_ID)
         source = source_dataset.table(self.SOURCE_TABLE)
-        job_config = ExtractJobConfig()
-        job_config.compression = 'GZIP'
-        job_config.destination_format = 'NEWLINE_DELIMITED_JSON'
-        job_config.field_delimiter = '|'
-        job_config.print_header = False
+        config = ExtractJobConfig()
+        config.compression = Compression.GZIP
+        config.destination_format = DestinationFormat.NEWLINE_DELIMITED_JSON
+        config.field_delimiter = '|'
+        config.print_header = False
         job = self._make_one(self.JOB_ID, source, [self.DESTINATION_URI],
-                             client1, job_config)
+                             client1, config)
 
         job._begin(client=client2)
 
@@ -1826,11 +1837,14 @@ class TestQueryJob(unittest.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
     def test_from_api_repr_w_properties(self):
+        from google.cloud.bigquery.job import CreateDisposition
+        from google.cloud.bigquery.job import WriteDisposition
+
         client = _make_client(project=self.PROJECT)
         RESOURCE = self._make_resource()
         query_config = RESOURCE['configuration']['query']
-        query_config['createDisposition'] = 'CREATE_IF_NEEDED'
-        query_config['writeDisposition'] = 'WRITE_TRUNCATE'
+        query_config['createDisposition'] = CreateDisposition.CREATE_IF_NEEDED
+        query_config['writeDisposition'] = WriteDisposition.WRITE_TRUNCATE
         query_config['destinationTable'] = {
             'projectId': self.PROJECT,
             'datasetId': self.DS_ID,
@@ -2277,7 +2291,10 @@ class TestQueryJob(unittest.TestCase, _Base):
 
     def test_begin_w_alternate_client(self):
         from google.cloud.bigquery.dataset import DatasetReference
+        from google.cloud.bigquery.job import CreateDisposition
         from google.cloud.bigquery.job import QueryJobConfig
+        from google.cloud.bigquery.job import QueryPriority
+        from google.cloud.bigquery.job import WriteDisposition
 
         PATH = '/projects/%s/jobs' % (self.PROJECT,)
         TABLE = 'TABLE'
@@ -2286,7 +2303,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         QUERY_CONFIGURATION = {
             'query': self.QUERY,
             'allowLargeResults': True,
-            'createDisposition': 'CREATE_NEVER',
+            'createDisposition': CreateDisposition.CREATE_NEVER,
             'defaultDataset': {
                 'projectId': self.PROJECT,
                 'datasetId': DS_ID,
@@ -2297,10 +2314,10 @@ class TestQueryJob(unittest.TestCase, _Base):
                 'tableId': TABLE,
             },
             'flattenResults': True,
-            'priority': 'INTERACTIVE',
+            'priority': QueryPriority.INTERACTIVE,
             'useQueryCache': True,
             'useLegacySql': True,
-            'writeDisposition': 'WRITE_TRUNCATE',
+            'writeDisposition': WriteDisposition.WRITE_TRUNCATE,
             'maximumBillingTier': 4,
             'maximumBytesBilled': '123456'
         }
@@ -2315,16 +2332,16 @@ class TestQueryJob(unittest.TestCase, _Base):
 
         config = QueryJobConfig()
         config.allow_large_results = True
-        config.create_disposition = 'CREATE_NEVER'
+        config.create_disposition = CreateDisposition.CREATE_NEVER
         config.default_dataset = dataset_ref
         config.destination = table_ref
         config.dry_run = True
         config.flatten_results = True
         config.maximum_billing_tier = 4
-        config.priority = 'INTERACTIVE'
+        config.priority = QueryPriority.INTERACTIVE
         config.use_legacy_sql = True
         config.use_query_cache = True
-        config.write_disposition = 'WRITE_TRUNCATE'
+        config.write_disposition = WriteDisposition.WRITE_TRUNCATE
         config.maximum_bytes_billed = 123456
         job = self._make_one(
             self.JOB_ID, self.QUERY, client1, job_config=config)


### PR DESCRIPTION
Towards #4793 
