### PR TITLE
Pubsub: ignore creds kwarg if passed in for emulator

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/publisher/client.py
+++ b/pubsub/google/cloud/pubsub_v1/publisher/client.py
@@ -67,6 +67,10 @@ class Client(object):
             kwargs['channel'] = grpc.insecure_channel(
                 target=os.environ.get('PUBSUB_EMULATOR_HOST'),
             )
+            # We can either provide a channel or credentials but not
+            # both when creating a publisher_client.PublisherClient
+            kwargs.pop('credentials', None)
+
 
         # Use a custom channel.
         # We need this in order to set appropriate default message size and

--- a/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -51,6 +51,20 @@ def test_init_emulator(monkeypatch):
     assert channel.target().decode('utf8') == '/foo/bar/'
 
 
+def test_init_emulator_ignore_credentials(monkeypatch):
+    monkeypatch.setenv('PUBSUB_EMULATOR_HOST', '/foo/bar/')
+    # NOTE: throw away credentials if given while using emulator
+    creds = mock.Mock(spec=credentials.Credentials)
+    client = publisher.Client(credentials=creds)
+
+    # Establish that a gRPC request would attempt to hit the emulator host.
+    #
+    # Sadly, there seems to be no good way to do this without poking at
+    # the private API of gRPC.
+    channel = client.api.publisher_stub.Publish._channel
+    assert channel.target().decode('utf8') == '/foo/bar/'
+
+
 def test_batch_create():
     creds = mock.Mock(spec=credentials.Credentials)
     client = publisher.Client(credentials=creds)


### PR DESCRIPTION
Hey folks -

Developing on pubsub and running against the emulator, I noticed that pubsub client instantiation complains about both a channel and a credentials object being given. I'd prefer not to have to do the if/then dance within my own application code, so I hope y'all don't mind something like this in here.

LMK your thoughts! Thanks!
