### PR TITLE
Add support for EncryptionConfiguration

### DIFF
--- a/bigquery/google/cloud/bigquery/__init__.py
+++ b/bigquery/google/cloud/bigquery/__init__.py
@@ -49,6 +49,7 @@ from google.cloud.bigquery.query import ScalarQueryParameter
 from google.cloud.bigquery.query import StructQueryParameter
 from google.cloud.bigquery.query import UDFResource
 from google.cloud.bigquery.schema import SchemaField
+from google.cloud.bigquery.table import EncryptionConfigurations
 from google.cloud.bigquery.table import Table
 from google.cloud.bigquery.table import TableReference
 from google.cloud.bigquery.table import Row
@@ -73,6 +74,7 @@ __all__ = [
     'DatasetReference',
     'AccessEntry',
     # Tables
+    'EncryptionConfiguration',
     'Table',
     'TableReference',
     'Row',

--- a/bigquery/google/cloud/bigquery/__init__.py
+++ b/bigquery/google/cloud/bigquery/__init__.py
@@ -49,7 +49,7 @@ from google.cloud.bigquery.query import ScalarQueryParameter
 from google.cloud.bigquery.query import StructQueryParameter
 from google.cloud.bigquery.query import UDFResource
 from google.cloud.bigquery.schema import SchemaField
-from google.cloud.bigquery.table import EncryptionConfigurations
+from google.cloud.bigquery.table import EncryptionConfiguration
 from google.cloud.bigquery.table import Table
 from google.cloud.bigquery.table import TableReference
 from google.cloud.bigquery.table import Row

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -659,8 +659,10 @@ class LoadJobConfig(object):
 
     @destination_encryption_configuration.setter
     def destination_encryption_configuration(self, value):
-        self._properties[
-            'destinationEncryptionConfiguration'] = value.to_api_repr()
+        api_repr = value
+        if value is not None:
+            api_repr = value.to_api_repr()
+        self._properties['destinationEncryptionConfiguration'] = api_repr
 
     def to_api_repr(self):
         """Build an API representation of the load job config.
@@ -985,8 +987,10 @@ class CopyJobConfig(object):
 
     @destination_encryption_configuration.setter
     def destination_encryption_configuration(self, value):
-        self._properties[
-            'destinationEncryptionConfiguration'] = value.to_api_repr()
+        api_repr = value
+        if value is not None:
+            api_repr = value.to_api_repr()
+        self._properties['destinationEncryptionConfiguration'] = api_repr
 
     def to_api_repr(self):
         """Build an API representation of the copy job config.
@@ -1410,8 +1414,10 @@ class QueryJobConfig(object):
 
     @destination_encryption_configuration.setter
     def destination_encryption_configuration(self, value):
-        self._properties[
-            'destinationEncryptionConfiguration'] = value.to_api_repr()
+        api_repr = value
+        if value is not None:
+            api_repr = value.to_api_repr()
+        self._properties['destinationEncryptionConfiguration'] = api_repr
 
     def to_api_repr(self):
         """Build an API representation of the copy job config.

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -693,10 +693,11 @@ class LoadJobConfig(object):
         config.skip_leading_rows = _int_or_none(slr)
         if config.skip_leading_rows is None:
             del config.skip_leading_rows
-        if 'destinationEncryptionConfiguration' in resource:
-            key = resource['destinationEncryptionConfiguration']['kmsKeyName']
-            if key is not None:
-                config.kms_key_name = str(key)
+        if ('destinationEncryptionConfiguration' in resource
+            and 'kmsKeyName' in resource[
+                'destinationEncryptionConfiguration']):
+            config.kms_key_name = str(
+                resource['destinationEncryptionConfiguration']['kmsKeyName'])
         return config
 
 
@@ -999,10 +1000,11 @@ class CopyJobConfig(object):
         """
         config = cls()
         config._properties = copy.deepcopy(resource)
-        if 'destinationEncryptionConfiguration' in resource:
-            key = resource['destinationEncryptionConfiguration']['kmsKeyName']
-            if key is not None:
-                config.kms_key_name = str(key)
+        if ('destinationEncryptionConfiguration' in resource
+            and 'kmsKeyName' in resource[
+                'destinationEncryptionConfiguration']):
+            config.kms_key_name = str(
+                resource['destinationEncryptionConfiguration']['kmsKeyName'])
         return config
 
 
@@ -1443,10 +1445,11 @@ class QueryJobConfig(object):
             if nested_resource is not None:
                 config._properties[prop] = from_resource(nested_resource)
 
-        if 'destinationEncryptionConfiguration' in resource:
-            key = resource['destinationEncryptionConfiguration']['kmsKeyName']
-            if key is not None:
-                config.kms_key_name = str(key)
+        if ('destinationEncryptionConfiguration' in resource
+            and 'kmsKeyName' in resource[
+                'destinationEncryptionConfiguration']):
+            config.kms_key_name = str(
+                resource['destinationEncryptionConfiguration']['kmsKeyName'])
 
         return config
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -645,12 +645,12 @@ class LoadJobConfig(object):
     def kms_key_name(self):
         """ Resource ID of Cloud KMS key
 
+        See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationEncryptionConfiguration.kmsKeyName
+
         :rtype: str or None
         :returns: Resource ID of Cloud KMS key to encrypt destination table
                   or ``None`` if using default encryption.
-
-        See
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationEncryptionConfiguration.kmsKeyName
         """
         return self._kms_key_name
 
@@ -849,11 +849,12 @@ class LoadJob(_AsyncJob):
     def kms_key_name(self):
         """ Resource ID of Cloud KMS key
 
+        See
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
+
         :rtype str or None
         :returns Resource ID of Cloud KMS key to encrypt destination table
                  or ``None`` if using default encryption.
-        See
-        :attr:`google.cloud.bigquery.job.LoadJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
         """
         return self._configuration.kms_key_name
 
@@ -981,12 +982,12 @@ class CopyJobConfig(object):
     def kms_key_name(self):
         """ Resource ID of Cloud KMS key
 
+        See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy.destinationEncryptionConfiguration.kmsKeyName
+
         :rtype: str or None
         :returns: Resource ID of Cloud KMS key to encrypt destination table
                   or ``None`` if using default encryption.
-
-        See
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy.destinationEncryptionConfiguration.kmsKeyName
         """
         return self._kms_key_name
 
@@ -1085,12 +1086,12 @@ class CopyJob(_AsyncJob):
     def kms_key_name(self):
         """ Resource ID of Cloud KMS key
 
+        See
+        :attr:`google.cloud.bigquery.job.CopyJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
+
         :rtype: str or None
         :returns: Resource ID of Cloud KMS key to encrypt destination table
                   or ``None`` if using default encryption.
-
-        See
-        :attr:`google.cloud.bigquery.job.CopyJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
         """
         return self._configuration.kms_key_name
 
@@ -1419,12 +1420,12 @@ class QueryJobConfig(object):
     def kms_key_name(self):
         """ Resource ID of Cloud KMS key
 
+        See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationEncryptionConfiguration.kmsKeyName
+
         :rtype: str or None
         :returns: Resource ID of Cloud KMS key to encrypt destination table
                   or ``None`` if using default encryption.
-
-        See
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationEncryptionConfiguration.kmsKeyName
         """
         return self._kms_key_name
 
@@ -1691,12 +1692,12 @@ class QueryJob(_AsyncJob):
     def kms_key_name(self):
         """ Resource ID of Cloud KMS key
 
+        See
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
+
         :rtype: str or None
         :returns: Resource ID of Cloud KMS key to encrypt destination table
                   or ``None`` if using default encryption.
-
-        See
-        :attr:`google.cloud.bigquery.job.QueryJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
         """
         return self._configuration.kms_key_name
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -643,25 +643,18 @@ class LoadJobConfig(object):
 
     @property
     def kms_key_name(self):
-        """Resource ID of Cloud KMS key
+        """str: Resource ID of Cloud KMS key
+
+        Resource ID of Cloud KMS key to encrypt destination table or ``None``
+        if using default encryption.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationEncryptionConfiguration.kmsKeyName
-
-        :rtype: str or None
-        :returns: Resource ID of Cloud KMS key to encrypt destination table
-                  or ``None`` if using default encryption.
         """
         return self._kms_key_name
 
     @kms_key_name.setter
     def kms_key_name(self, value):
-        """
-        :type value: str or None
-        :param value: Resource ID of Cloud KMS key to encrypt destination table
-                      or ``None`` if using default encryption.
-        :raises: ValueError for invalid value types.
-        """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("kms_key_name should be a string, or None")
         self._kms_key_name = value
@@ -848,14 +841,13 @@ class LoadJob(_AsyncJob):
 
     @property
     def kms_key_name(self):
-        """Resource ID of Cloud KMS key
+        """str: Resource ID of Cloud KMS key
+
+        Resource ID of Cloud KMS key to encrypt destination table
+        or ``None`` if using default encryption.
 
         See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
-
-        :rtype str or None
-        :returns Resource ID of Cloud KMS key to encrypt destination table
-                 or ``None`` if using default encryption.
         """
         return self._configuration.kms_key_name
 
@@ -982,25 +974,18 @@ class CopyJobConfig(object):
 
     @property
     def kms_key_name(self):
-        """Resource ID of Cloud KMS key
+        """str: Resource ID of Cloud KMS key
+
+        Resource ID of Cloud KMS key to encrypt destination table or ``None``
+        if using default encryption.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy.destinationEncryptionConfiguration.kmsKeyName
-
-        :rtype: str or None
-        :returns: Resource ID of Cloud KMS key to encrypt destination table
-                  or ``None`` if using default encryption.
         """
         return self._kms_key_name
 
     @kms_key_name.setter
     def kms_key_name(self, value):
-        """
-        :type value: str or None
-        :param value: Resource ID of Cloud KMS key to encrypt destination table
-                      or ``None`` if using default encryption.
-        :raises: ValueError for invalid value types.
-        """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("kms_key_name should be a string, or None")
         self._kms_key_name = value
@@ -1087,14 +1072,13 @@ class CopyJob(_AsyncJob):
 
     @property
     def kms_key_name(self):
-        """Resource ID of Cloud KMS key
+        """str: Resource ID of Cloud KMS key
+
+        Resource ID of Cloud KMS key to encrypt destination table or ``None``
+        if using default encryption.
 
         See
         :attr:`google.cloud.bigquery.job.CopyJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
-
-        :rtype: str or None
-        :returns: Resource ID of Cloud KMS key to encrypt destination table
-                  or ``None`` if using default encryption.
         """
         return self._configuration.kms_key_name
 
@@ -1421,25 +1405,18 @@ class QueryJobConfig(object):
 
     @property
     def kms_key_name(self):
-        """Resource ID of Cloud KMS key
+        """str: Resource ID of Cloud KMS key
+
+        Resource ID of Cloud KMS key to encrypt destination table or ``None``
+        if using default encryption.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationEncryptionConfiguration.kmsKeyName
-
-        :rtype: str or None
-        :returns: Resource ID of Cloud KMS key to encrypt destination table
-                  or ``None`` if using default encryption.
         """
         return self._kms_key_name
 
     @kms_key_name.setter
     def kms_key_name(self, value):
-        """
-        :type value: str or None
-        :param value: Resource ID of Cloud KMS key to encrypt destination table
-                      or ``None`` if using default encryption.
-        :raises: ValueError for invalid value types.
-        """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("kms_key_name should be a string, or None")
         self._kms_key_name = value
@@ -1694,14 +1671,13 @@ class QueryJob(_AsyncJob):
 
     @property
     def kms_key_name(self):
-        """Resource ID of Cloud KMS key
+        """str: Resource ID of Cloud KMS key
+
+        Resource ID of Cloud KMS key to encrypt destination table or ``None``
+        if using default encryption.
 
         See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
-
-        :rtype: str or None
-        :returns: Resource ID of Cloud KMS key to encrypt destination table
-                  or ``None`` if using default encryption.
         """
         return self._configuration.kms_key_name
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -551,6 +551,7 @@ class LoadJobConfig(object):
     def __init__(self):
         self._properties = {}
         self._schema = ()
+        self._kms_key_name = None
 
     allow_jagged_rows = _TypedApiResourceProperty(
         'allow_jagged_rows', 'allowJaggedRows', bool)
@@ -640,6 +641,19 @@ class LoadJobConfig(object):
             raise ValueError('Schema items must be fields')
         self._schema = tuple(value)
 
+    @property
+    def kms_key_name(self):
+        """See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationEncryptionConfiguration.kmsKeyName
+        """
+        return self._kms_key_name
+
+    @kms_key_name.setter
+    def kms_key_name(self, value):
+        if not isinstance(value, six.string_types) and value is not None:
+            raise ValueError("Pass a string, or None")
+        self._kms_key_name = value
+
     def to_api_repr(self):
         """Build an API representation of the load job config.
 
@@ -654,6 +668,9 @@ class LoadJobConfig(object):
         slr = config.get('skipLeadingRows')
         if slr is not None:
             config['skipLeadingRows'] = str(slr)
+        if self._kms_key_name is not None:
+            config['destinationEncryptionConfiguration'] = {
+                'kmsKeyName': self._kms_key_name}
         return config
 
     @classmethod
@@ -676,6 +693,10 @@ class LoadJobConfig(object):
         config.skip_leading_rows = _int_or_none(slr)
         if config.skip_leading_rows is None:
             del config.skip_leading_rows
+        if 'destinationEncryptionConfiguration' in resource:
+            key = resource['destinationEncryptionConfiguration']['kmsKeyName']
+            if key is not None:
+                config.kms_key_name = str(key)
         return config
 
 
@@ -813,6 +834,13 @@ class LoadJob(_AsyncJob):
         return self._configuration.schema
 
     @property
+    def kms_key_name(self):
+        """See
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
+        """
+        return self._configuration.kms_key_name
+
+    @property
     def input_file_bytes(self):
         """Count of bytes loaded from source files.
 
@@ -918,6 +946,7 @@ class CopyJobConfig(object):
 
     def __init__(self):
         self._properties = {}
+        self._kms_key_name = None
 
     create_disposition = CreateDisposition('create_disposition',
                                            'createDisposition')
@@ -931,13 +960,30 @@ class CopyJobConfig(object):
     https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy.writeDisposition
     """
 
+    @property
+    def kms_key_name(self):
+        """See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy.destinationEncryptionConfiguration.kmsKeyName
+        """
+        return self._kms_key_name
+
+    @kms_key_name.setter
+    def kms_key_name(self, value):
+        if not isinstance(value, six.string_types) and value is not None:
+            raise ValueError("Pass a string, or None")
+        self._kms_key_name = value
+
     def to_api_repr(self):
         """Build an API representation of the copy job config.
 
         :rtype: dict
         :returns: A dictionary in the format used by the BigQuery API.
         """
-        return copy.deepcopy(self._properties)
+        config = copy.deepcopy(self._properties)
+        if self._kms_key_name is not None:
+            config['destinationEncryptionConfiguration'] = {
+                'kmsKeyName': self._kms_key_name}
+        return config
 
     @classmethod
     def from_api_repr(cls, resource):
@@ -953,6 +999,10 @@ class CopyJobConfig(object):
         """
         config = cls()
         config._properties = copy.deepcopy(resource)
+        if 'destinationEncryptionConfiguration' in resource:
+            key = resource['destinationEncryptionConfiguration']['kmsKeyName']
+            if key is not None:
+                config.kms_key_name = str(key)
         return config
 
 
@@ -1001,6 +1051,13 @@ class CopyJob(_AsyncJob):
         :attr:`google.cloud.bigquery.job.CopyJobConfig.write_disposition`.
         """
         return self._configuration.write_disposition
+
+    @property
+    def kms_key_name(self):
+        """See
+        :attr:`google.cloud.bigquery.job.CopyJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
+        """
+        return self._configuration.kms_key_name
 
     def _build_resource(self):
         """Generate a resource for :meth:`begin`."""
@@ -1321,6 +1378,20 @@ class QueryJobConfig(object):
 
     def __init__(self):
         self._properties = {}
+        self._kms_key_name = None
+
+    @property
+    def kms_key_name(self):
+        """See
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationEncryptionConfiguration.kmsKeyName
+        """
+        return self._kms_key_name
+
+    @kms_key_name.setter
+    def kms_key_name(self, value):
+        if not isinstance(value, six.string_types) and value is not None:
+            raise ValueError("Pass a string, or None")
+        self._kms_key_name = value
 
     def to_api_repr(self):
         """Build an API representation of the copy job config.
@@ -1345,6 +1416,10 @@ class QueryJobConfig(object):
             if nested_resource is not None:
                 resource[prop] = to_resource(nested_resource)
 
+        if self._kms_key_name is not None:
+            resource['destinationEncryptionConfiguration'] = {
+                'kmsKeyName': self._kms_key_name}
+
         return resource
 
     @classmethod
@@ -1367,6 +1442,12 @@ class QueryJobConfig(object):
             nested_resource = resource.get(prop)
             if nested_resource is not None:
                 config._properties[prop] = from_resource(nested_resource)
+
+        if 'destinationEncryptionConfiguration' in resource:
+            key = resource['destinationEncryptionConfiguration']['kmsKeyName']
+            print key
+            if key is not None:
+                config.kms_key_name = str(key)
 
         return config
 
@@ -1559,6 +1640,13 @@ class QueryJob(_AsyncJob):
         :attr:`google.cloud.bigquery.job.QueryJobConfig.destination`.
         """
         return self._configuration.destination
+
+    @property
+    def kms_key_name(self):
+        """See
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
+        """
+        return self._configuration.kms_key_name
 
     @property
     def dry_run(self):

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -643,7 +643,8 @@ class LoadJobConfig(object):
 
     @property
     def destination_encryption_configuration(self):
-        """Destination encryption configuration
+        """google.cloud.bigquery.table.EncryptionConfiguration: Custom
+        encryption configuration for the destination table.
 
         Custom encryption configuration (e.g., Cloud KMS keys) or ``None``
         if using default encryption.
@@ -835,7 +836,8 @@ class LoadJob(_AsyncJob):
 
     @property
     def destination_encryption_configuration(self):
-        """Destination encryption configuration
+        """google.cloud.bigquery.table.EncryptionConfiguration: Custom
+        encryption configuration for the destination table.
 
         Custom encryption configuration (e.g., Cloud KMS keys)
         or ``None`` if using default encryption.
@@ -967,7 +969,8 @@ class CopyJobConfig(object):
 
     @property
     def destination_encryption_configuration(self):
-        """Destination encryption configuration
+        """google.cloud.bigquery.table.EncryptionConfiguration: Custom
+        encryption configuration for the destination table.
 
         Custom encryption configuration (e.g., Cloud KMS keys) or ``None``
         if using default encryption.
@@ -1058,7 +1061,8 @@ class CopyJob(_AsyncJob):
 
     @property
     def destination_encryption_configuration(self):
-        """Destination encryption configuration
+        """google.cloud.bigquery.table.EncryptionConfiguration: Custom
+        encryption configuration for the destination table.
 
         Custom encryption configuration (e.g., Cloud KMS keys) or ``None``
         if using default encryption.
@@ -1390,7 +1394,8 @@ class QueryJobConfig(object):
 
     @property
     def destination_encryption_configuration(self):
-        """Destination encryption configuration
+        """google.cloud.bigquery.table.EncryptionConfiguration: Custom
+        encryption configuration for the destination table.
 
         Custom encryption configuration (e.g., Cloud KMS keys) or ``None``
         if using default encryption.
@@ -1648,7 +1653,8 @@ class QueryJob(_AsyncJob):
 
     @property
     def destination_encryption_configuration(self):
-        """Destination encryption configuration
+        """google.cloud.bigquery.table.EncryptionConfiguration: Custom
+        encryption configuration for the destination table.
 
         Custom encryption configuration (e.g., Cloud KMS keys) or ``None``
         if using default encryption.

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -843,7 +843,7 @@ class LoadJob(_AsyncJob):
         or ``None`` if using default encryption.
 
         See
-        :attr:`google.cloud.bigquery.job.LoadJobConfig.destinationEncryptionConfiguration`.
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.destination_encryption_configuration`.
         """
         return self._configuration.destination_encryption_configuration
 
@@ -1068,7 +1068,7 @@ class CopyJob(_AsyncJob):
         if using default encryption.
 
         See
-        :attr:`google.cloud.bigquery.job.LoadJobConfig.destinationEncryptionConfiguration`.
+        :attr:`google.cloud.bigquery.job.CopyJobConfig.destination_encryption_configuration`.
         """
         return self._configuration.destination_encryption_configuration
 
@@ -1660,7 +1660,7 @@ class QueryJob(_AsyncJob):
         if using default encryption.
 
         See
-        :attr:`google.cloud.bigquery.job.LoadJobConfig.destinationEncryptionConfiguration`.
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.destination_encryption_configuration`.
         """
         return self._configuration.destination_encryption_configuration
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -643,7 +643,7 @@ class LoadJobConfig(object):
 
     @property
     def kms_key_name(self):
-        """ Resource ID of Cloud KMS key
+        """Resource ID of Cloud KMS key
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationEncryptionConfiguration.kmsKeyName
@@ -847,7 +847,7 @@ class LoadJob(_AsyncJob):
 
     @property
     def kms_key_name(self):
-        """ Resource ID of Cloud KMS key
+        """Resource ID of Cloud KMS key
 
         See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
@@ -980,7 +980,7 @@ class CopyJobConfig(object):
 
     @property
     def kms_key_name(self):
-        """ Resource ID of Cloud KMS key
+        """Resource ID of Cloud KMS key
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy.destinationEncryptionConfiguration.kmsKeyName
@@ -1084,7 +1084,7 @@ class CopyJob(_AsyncJob):
 
     @property
     def kms_key_name(self):
-        """ Resource ID of Cloud KMS key
+        """Resource ID of Cloud KMS key
 
         See
         :attr:`google.cloud.bigquery.job.CopyJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
@@ -1418,7 +1418,7 @@ class QueryJobConfig(object):
 
     @property
     def kms_key_name(self):
-        """ Resource ID of Cloud KMS key
+        """Resource ID of Cloud KMS key
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationEncryptionConfiguration.kmsKeyName
@@ -1690,7 +1690,7 @@ class QueryJob(_AsyncJob):
 
     @property
     def kms_key_name(self):
-        """ Resource ID of Cloud KMS key
+        """Resource ID of Cloud KMS key
 
         See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.destinationEncryptionConfiguration.kmsKeyName`.

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -1445,7 +1445,6 @@ class QueryJobConfig(object):
 
         if 'destinationEncryptionConfiguration' in resource:
             key = resource['destinationEncryptionConfiguration']['kmsKeyName']
-            print key
             if key is not None:
                 config.kms_key_name = str(key)
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -643,13 +643,24 @@ class LoadJobConfig(object):
 
     @property
     def kms_key_name(self):
-        """See
+        """ Resource ID of Cloud KMS key
+
+        :rtype: str or None
+        :returns: Resource ID of Cloud KMS key to encrypt destination table
+            or ``None`` if using default encryption.
+
+        See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationEncryptionConfiguration.kmsKeyName
         """
         return self._kms_key_name
 
     @kms_key_name.setter
     def kms_key_name(self, value):
+        """
+        :type value: str or None
+        :param value: Resource ID of Cloud KMS key to encrypt destination table
+            or ``None`` if using default encryption.
+        """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("Pass a string, or None")
         self._kms_key_name = value
@@ -836,7 +847,12 @@ class LoadJob(_AsyncJob):
 
     @property
     def kms_key_name(self):
-        """See
+        """ Resource ID of Cloud KMS key
+
+        :rtype str or None
+        :returns Resource ID of Cloud KMS key to encrypt destination table
+            or ``None`` if using default encryption.
+        See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
         """
         return self._configuration.kms_key_name
@@ -963,13 +979,24 @@ class CopyJobConfig(object):
 
     @property
     def kms_key_name(self):
-        """See
+        """ Resource ID of Cloud KMS key
+
+        :rtype: str or None
+        :returns: Resource ID of Cloud KMS key to encrypt destination table
+            or ``None`` if using default encryption.
+
+        See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy.destinationEncryptionConfiguration.kmsKeyName
         """
         return self._kms_key_name
 
     @kms_key_name.setter
     def kms_key_name(self, value):
+        """
+        :type value: str or None
+        :param value: Resource ID of Cloud KMS key to encrypt destination table
+            or ``None`` if using default encryption.
+        """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("Pass a string, or None")
         self._kms_key_name = value
@@ -1056,7 +1083,13 @@ class CopyJob(_AsyncJob):
 
     @property
     def kms_key_name(self):
-        """See
+        """ Resource ID of Cloud KMS key
+
+        :rtype: str or None
+        :returns: Resource ID of Cloud KMS key to encrypt destination table
+            or ``None`` if using default encryption.
+
+        See
         :attr:`google.cloud.bigquery.job.CopyJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
         """
         return self._configuration.kms_key_name
@@ -1384,13 +1417,24 @@ class QueryJobConfig(object):
 
     @property
     def kms_key_name(self):
-        """See
+        """ Resource ID of Cloud KMS key
+
+        :rtype: str or None
+        :returns: Resource ID of Cloud KMS key to encrypt destination table
+            or ``None`` if using default encryption.
+
+        See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationEncryptionConfiguration.kmsKeyName
         """
         return self._kms_key_name
 
     @kms_key_name.setter
     def kms_key_name(self, value):
+        """
+        :type value: str or None
+        :param value: Resource ID of Cloud KMS key to encrypt destination table
+            or ``None`` if using default encryption.
+        """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("Pass a string, or None")
         self._kms_key_name = value
@@ -1645,7 +1689,13 @@ class QueryJob(_AsyncJob):
 
     @property
     def kms_key_name(self):
-        """See
+        """ Resource ID of Cloud KMS key
+
+        :rtype: str or None
+        :returns: Resource ID of Cloud KMS key to encrypt destination table
+            or ``None`` if using default encryption.
+
+        See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
         """
         return self._configuration.kms_key_name

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -660,6 +660,7 @@ class LoadJobConfig(object):
         :type value: str or None
         :param value: Resource ID of Cloud KMS key to encrypt destination table
                       or ``None`` if using default encryption.
+        :raises: ValueError for invalid value types.
         """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("kms_key_name should be a string, or None")
@@ -705,7 +706,7 @@ class LoadJobConfig(object):
         if config.skip_leading_rows is None:
             del config.skip_leading_rows
         if ('destinationEncryptionConfiguration' in resource
-            and 'kmsKeyName' in resource[
+                and 'kmsKeyName' in resource[
                 'destinationEncryptionConfiguration']):
             config.kms_key_name = str(
                 resource['destinationEncryptionConfiguration']['kmsKeyName'])
@@ -864,6 +865,7 @@ class LoadJob(_AsyncJob):
 
         :rtype: int, or ``NoneType``
         :returns: the count (None until set from the server).
+        :raises: ValueError for invalid value types.
         """
         statistics = self._properties.get('statistics')
         if statistics is not None:
@@ -997,6 +999,7 @@ class CopyJobConfig(object):
         :type value: str or None
         :param value: Resource ID of Cloud KMS key to encrypt destination table
                       or ``None`` if using default encryption.
+        :raises: ValueError for invalid value types.
         """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("kms_key_name should be a string, or None")
@@ -1029,7 +1032,7 @@ class CopyJobConfig(object):
         config = cls()
         config._properties = copy.deepcopy(resource)
         if ('destinationEncryptionConfiguration' in resource
-            and 'kmsKeyName' in resource[
+                and 'kmsKeyName' in resource[
                 'destinationEncryptionConfiguration']):
             config.kms_key_name = str(
                 resource['destinationEncryptionConfiguration']['kmsKeyName'])
@@ -1435,6 +1438,7 @@ class QueryJobConfig(object):
         :type value: str or None
         :param value: Resource ID of Cloud KMS key to encrypt destination table
                       or ``None`` if using default encryption.
+        :raises: ValueError for invalid value types.
         """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("kms_key_name should be a string, or None")
@@ -1491,7 +1495,7 @@ class QueryJobConfig(object):
                 config._properties[prop] = from_resource(nested_resource)
 
         if ('destinationEncryptionConfiguration' in resource
-            and 'kmsKeyName' in resource[
+                and 'kmsKeyName' in resource[
                 'destinationEncryptionConfiguration']):
             config.kms_key_name = str(
                 resource['destinationEncryptionConfiguration']['kmsKeyName'])

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -647,7 +647,7 @@ class LoadJobConfig(object):
 
         :rtype: str or None
         :returns: Resource ID of Cloud KMS key to encrypt destination table
-            or ``None`` if using default encryption.
+                  or ``None`` if using default encryption.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.destinationEncryptionConfiguration.kmsKeyName
@@ -659,10 +659,10 @@ class LoadJobConfig(object):
         """
         :type value: str or None
         :param value: Resource ID of Cloud KMS key to encrypt destination table
-            or ``None`` if using default encryption.
+                      or ``None`` if using default encryption.
         """
         if not isinstance(value, six.string_types) and value is not None:
-            raise ValueError("Pass a string, or None")
+            raise ValueError("kms_key_name should be a string, or None")
         self._kms_key_name = value
 
     def to_api_repr(self):
@@ -851,7 +851,7 @@ class LoadJob(_AsyncJob):
 
         :rtype str or None
         :returns Resource ID of Cloud KMS key to encrypt destination table
-            or ``None`` if using default encryption.
+                 or ``None`` if using default encryption.
         See
         :attr:`google.cloud.bigquery.job.LoadJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
         """
@@ -983,7 +983,7 @@ class CopyJobConfig(object):
 
         :rtype: str or None
         :returns: Resource ID of Cloud KMS key to encrypt destination table
-            or ``None`` if using default encryption.
+                  or ``None`` if using default encryption.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.copy.destinationEncryptionConfiguration.kmsKeyName
@@ -995,10 +995,10 @@ class CopyJobConfig(object):
         """
         :type value: str or None
         :param value: Resource ID of Cloud KMS key to encrypt destination table
-            or ``None`` if using default encryption.
+                      or ``None`` if using default encryption.
         """
         if not isinstance(value, six.string_types) and value is not None:
-            raise ValueError("Pass a string, or None")
+            raise ValueError("kms_key_name should be a string, or None")
         self._kms_key_name = value
 
     def to_api_repr(self):
@@ -1087,7 +1087,7 @@ class CopyJob(_AsyncJob):
 
         :rtype: str or None
         :returns: Resource ID of Cloud KMS key to encrypt destination table
-            or ``None`` if using default encryption.
+                  or ``None`` if using default encryption.
 
         See
         :attr:`google.cloud.bigquery.job.CopyJobConfig.destinationEncryptionConfiguration.kmsKeyName`.
@@ -1421,7 +1421,7 @@ class QueryJobConfig(object):
 
         :rtype: str or None
         :returns: Resource ID of Cloud KMS key to encrypt destination table
-            or ``None`` if using default encryption.
+                  or ``None`` if using default encryption.
 
         See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.destinationEncryptionConfiguration.kmsKeyName
@@ -1433,10 +1433,10 @@ class QueryJobConfig(object):
         """
         :type value: str or None
         :param value: Resource ID of Cloud KMS key to encrypt destination table
-            or ``None`` if using default encryption.
+                      or ``None`` if using default encryption.
         """
         if not isinstance(value, six.string_types) and value is not None:
-            raise ValueError("Pass a string, or None")
+            raise ValueError("kms_key_name should be a string, or None")
         self._kms_key_name = value
 
     def to_api_repr(self):
@@ -1693,7 +1693,7 @@ class QueryJob(_AsyncJob):
 
         :rtype: str or None
         :returns: Resource ID of Cloud KMS key to encrypt destination table
-            or ``None`` if using default encryption.
+                  or ``None`` if using default encryption.
 
         See
         :attr:`google.cloud.bigquery.job.QueryJobConfig.destinationEncryptionConfiguration.kmsKeyName`.

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -92,9 +92,13 @@ class EncryptionConfiguration(object):
     def kms_key_name(self):
         """str: Resource ID of Cloud KMS key
 
-        Resource ID of Cloud KMS key ``None`` if using default encryption.
+        Resource ID of Cloud KMS key or ``None`` if using default encryption.
         """
         return self._properties.get('kmsKeyName')
+
+    @kms_key_name.setter
+    def kms_key_name(self, value):
+        self._properties['kmsKeyName'] = value
 
     @classmethod
     def from_api_repr(cls, resource):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -79,12 +79,14 @@ def _view_use_legacy_sql_getter(table):
 class EncryptionConfiguration(object):
     """Custom encryption configuration (e.g., Cloud KMS keys).
 
-    :type kms_key_name: str or ``None``
-    :param kms_key_name: resource ID of Cloud KMS key
+    Args:
+        kms_key_name (str): resource ID of Cloud KMS key used for encryption
     """
 
-    def __init__(self, kms_key_name=None):
-        self._kms_key_name = kms_key_name
+    def __init__(self, **kwargs):
+        self._properties = {}
+        if 'kms_key_name' in kwargs:
+            self._properties['kmsKeyName'] = kwargs['kms_key_name']
 
     @property
     def kms_key_name(self):
@@ -96,26 +98,28 @@ class EncryptionConfiguration(object):
 
     @classmethod
     def from_api_repr(cls, resource):
-        """Factory: construct an encryption configuration from API representation
+        """Construct an encryption configuration from its API representation
 
-        :type resource: dict
-        :param resource: encryption configuration representation returned
-                         from the API
+        Args:
+            resource (dict):
+                An encryption configuration representation as returned from
+                the API.
 
-        :rtype: :class:`google.cloud.bigquery.table.EncryptionConfiguration`
-        :returns: Encryption configuration parsed from ``resource``.
+        Returns:
+            google.cloud.bigquery.table.EncryptionConfiguration:
+                An encryption configuration parsed from ``resource``.
         """
-        return cls(resource['kmsKeyName'])
+        config = cls()
+        config._properties = copy.deepcopy(resource)
+        return config
 
     def to_api_repr(self):
-        """Construct the API resource representation of this encryption configuration.
+        """Construct the API resource representation of this
 
-        :rtype: dict
-        :returns: Encryption configuration as represented as an API resource
+        Returns:
+            dict: Encryption configuration as represented as an API resource
         """
-        return {
-            'kmsKeyName': self.kms_key_name
-        }
+        return copy.deepcopy(self._properties)
 
 
 class TableReference(object):
@@ -354,10 +358,15 @@ class Table(object):
 
     @property
     def encryption_configuration(self):
-        """Encryption configuration
+        """google.cloud.bigquery.table.EncryptionConfiguration: Custom
+        encryption configuration for the table.
 
         Custom encryption configuration (e.g., Cloud KMS keys) or ``None``
         if using default encryption.
+
+        See `protecting data with Cloud KMS keys
+        <https://cloud.google.com/bigquery/docs/customer-managed-encryption>`_
+        in the BigQuery documentation.
         """
         prop = self._properties.get('encryptionConfiguration')
         if prop is not None:

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -94,7 +94,7 @@ class EncryptionConfiguration(object):
 
         Resource ID of Cloud KMS key ``None`` if using default encryption.
         """
-        return self._kms_key_name
+        return self._properties['kmsKeyName']
 
     @classmethod
     def from_api_repr(cls, resource):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -326,6 +326,7 @@ class Table(object):
 
         :type value: str
         :param value: the resource ID of Cloud KMS key
+        :raises: ValueError for invalid value types.
         """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("kms_key_name should be a string, or None")

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -677,10 +677,11 @@ class Table(object):
 
         table = cls(dataset_ref.table(table_id))
         table._set_properties(resource)
-        if 'encryptionConfiguration' in resource:
-            key = resource['encryptionConfiguration']['kmsKeyName']
-            if key is not None:
-                table.kms_key_name = str(key)
+        if ('encryptionConfiguration' in resource and
+                'kmsKeyName' in resource['encryptionConfiguration']):
+            table.kms_key_name = str(
+                resource['encryptionConfiguration']['kmsKeyName'])
+
         return table
 
     def _set_properties(self, api_response):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -313,21 +313,15 @@ class Table(object):
 
     @property
     def kms_key_name(self):
-        """Tables encryption configuration.
+        """str: Resource ID of Cloud KMS key
 
-        :rtype: str or None
-        :returns: the resource ID of Cloud KMS key
+        Resource ID of Cloud KMS key to encrypt the table or ``None`` if
+        using default encryption.
         """
         return self._kms_key_name
 
     @kms_key_name.setter
     def kms_key_name(self, value):
-        """Updates encryption configuration of a table
-
-        :type value: str
-        :param value: the resource ID of Cloud KMS key
-        :raises: ValueError for invalid value types.
-        """
         if not isinstance(value, six.string_types) and value is not None:
             raise ValueError("kms_key_name should be a string, or None")
         self._kms_key_name = value

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -94,7 +94,7 @@ class EncryptionConfiguration(object):
 
         Resource ID of Cloud KMS key ``None`` if using default encryption.
         """
-        return self._properties['kmsKeyName']
+        return self._properties.get('kmsKeyName')
 
     @classmethod
     def from_api_repr(cls, resource):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -714,10 +714,6 @@ class Table(object):
 
         table = cls(dataset_ref.table(table_id))
         table._set_properties(resource)
-        if ('encryptionConfiguration' in resource and
-                'kmsKeyName' in resource['encryptionConfiguration']):
-            table.kms_key_name = str(
-                resource['encryptionConfiguration']['kmsKeyName'])
 
         return table
 

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -83,10 +83,10 @@ class EncryptionConfiguration(object):
         kms_key_name (str): resource ID of Cloud KMS key used for encryption
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, kms_key_name=None):
         self._properties = {}
-        if 'kms_key_name' in kwargs:
-            self._properties['kmsKeyName'] = kwargs['kms_key_name']
+        if kms_key_name is not None:
+            self._properties['kmsKeyName'] = kms_key_name
 
     @property
     def kms_key_name(self):
@@ -379,7 +379,10 @@ class Table(object):
 
     @encryption_configuration.setter
     def encryption_configuration(self, value):
-        self._properties['encryptionConfiguration'] = value.to_api_repr()
+        api_repr = value
+        if value is not None:
+            api_repr = value.to_api_repr()
+        self._properties['encryptionConfiguration'] = api_repr
 
     @property
     def created(self):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -735,7 +735,8 @@ class Table(object):
 
     def _populate_encryption_configuration(self, resource):
         if self.kms_key_name is not None:
-            resource['encryptionConfiguration'] = {'kmsKeyName': self.kms_key_name}
+            resource['encryptionConfiguration'] = {
+                'kmsKeyName': self.kms_key_name}
 
     def _populate_external_config(self, resource):
         if not self.external_data_configuration:

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -328,7 +328,7 @@ class Table(object):
         :param value: the resource ID of Cloud KMS key
         """
         if not isinstance(value, six.string_types) and value is not None:
-            raise ValueError("Pass a string, or None")
+            raise ValueError("kms_key_name should be a string, or None")
         self._kms_key_name = value
 
     @property

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -472,6 +472,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(got.table_id, self.TABLE_ID)
 
     def test_create_table_w_encryption_configuration(self):
+        from google.cloud.bigquery.table import EncryptionConfiguration
         from google.cloud.bigquery.table import Table
 
         path = 'projects/%s/datasets/%s/tables' % (
@@ -488,7 +489,8 @@ class TestClient(unittest.TestCase):
         }
         conn = client._connection = _Connection(resource)
         table = Table(self.TABLE_REF)
-        table.kms_key_name = self.KMS_KEY_NAME
+        table.encryption_configuration = EncryptionConfiguration(
+            self.KMS_KEY_NAME)
 
         got = client.create_table(table)
 

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -38,6 +38,7 @@ class TestClient(unittest.TestCase):
     DS_ID = 'DATASET_ID'
     TABLE_ID = 'TABLE_ID'
     TABLE_REF = DatasetReference(PROJECT, DS_ID).table(TABLE_ID)
+    KMS_KEY_NAME = 'projects/1/locations/global/keyRings/1/cryptoKeys/1'
 
     @staticmethod
     def _get_target_class():
@@ -468,6 +469,43 @@ class TestClient(unittest.TestCase):
         }
         self.assertEqual(req['data'], sent)
         self.assertEqual(table.partitioning_type, "DAY")
+        self.assertEqual(got.table_id, self.TABLE_ID)
+
+    def test_create_table_w_encryption_configuration(self):
+        from google.cloud.bigquery.table import Table
+
+        path = 'projects/%s/datasets/%s/tables' % (
+            self.PROJECT, self.DS_ID)
+        creds = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=creds)
+        resource = {
+            'id': '%s:%s:%s' % (self.PROJECT, self.DS_ID, self.TABLE_ID),
+            'tableReference': {
+                'projectId': self.PROJECT,
+                'datasetId': self.DS_ID,
+                'tableId': self.TABLE_ID
+            },
+        }
+        conn = client._connection = _Connection(resource)
+        table = Table(self.TABLE_REF)
+        table.kms_key_name = self.KMS_KEY_NAME
+
+        got = client.create_table(table)
+
+        self.assertEqual(len(conn._requested), 1)
+        req = conn._requested[0]
+        self.assertEqual(req['method'], 'POST')
+        self.assertEqual(req['path'], '/%s' % path)
+        sent = {
+            'tableReference': {
+                'projectId': self.PROJECT,
+                'datasetId': self.DS_ID,
+                'tableId': self.TABLE_ID
+            },
+            'labels': {},
+            'encryptionConfiguration': {'kmsKeyName': self.KMS_KEY_NAME},
+        }
+        self.assertEqual(req['data'], sent)
         self.assertEqual(got.table_id, self.TABLE_ID)
 
     def test_create_table_w_day_partition_and_expire(self):

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -490,7 +490,7 @@ class TestClient(unittest.TestCase):
         conn = client._connection = _Connection(resource)
         table = Table(self.TABLE_REF)
         table.encryption_configuration = EncryptionConfiguration(
-            self.KMS_KEY_NAME)
+            kms_key_name=self.KMS_KEY_NAME)
 
         got = client.create_table(table)
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -627,6 +627,7 @@ class TestLoadJob(unittest.TestCase, _Base):
         klass = self._get_target_class()
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
+        self._verifyResourceProperties(job, RESOURCE)
         self.assertEqual(job.kms_key_name, self.KMS_KEY_NAME)
 
     def test_from_api_repr_w_properties(self):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -368,7 +368,8 @@ class TestLoadJob(unittest.TestCase, _Base):
 
         if 'destinationEncryptionConfiguration' in config:
             self.assertEqual(job.kms_key_name,
-                             config['destinationEncryptionConfiguration']['kmsKeyName'])
+                             config['destinationEncryptionConfiguration'][
+                                 'kmsKeyName'])
         else:
             self.assertIsNone(job.kms_key_name)
 
@@ -952,7 +953,8 @@ class TestCopyJob(unittest.TestCase, _Base):
 
         if 'destinationEncryptionConfiguration' in config:
             self.assertEqual(job.kms_key_name,
-                             config['destinationEncryptionConfiguration']['kmsKeyName'])
+                             config['destinationEncryptionConfiguration'][
+                                 'kmsKeyName'])
         else:
             self.assertIsNone(job.kms_key_name)
 
@@ -1838,7 +1840,8 @@ class TestQueryJob(unittest.TestCase, _Base):
             self.assertIsNone(job.write_disposition)
         if 'destinationEncryptionConfiguration' in query_config:
             self.assertEqual(job.kms_key_name,
-                             query_config['destinationEncryptionConfiguration']['kmsKeyName'])
+                             query_config['destinationEncryptionConfiguration'][
+                                 'kmsKeyName'])
         else:
             self.assertIsNone(job.kms_key_name)
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -918,11 +918,11 @@ class TestLoadJob(unittest.TestCase, _Base):
 
 
 class TestCopyJobConfig(unittest.TestCase, _Base):
-    JOB_TYPE = 'load'
+    JOB_TYPE = 'copy'
 
     @staticmethod
     def _get_target_class():
-        from google.cloud.bigquery.job import LoadJobConfig
+        from google.cloud.bigquery.job import CopyJobConfig
         return CopyJobConfig
 
     def test_to_api_repr_with_encryption(self):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -628,6 +628,7 @@ class TestLoadJob(unittest.TestCase, _Base):
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
         self._verifyResourceProperties(job, RESOURCE)
+        self.assertEqual(job.kms_key_name, self.KMS_KEY_NAME)
 
     def test_from_api_repr_w_properties(self):
         client = _make_client(project=self.PROJECT)
@@ -1081,6 +1082,7 @@ class TestCopyJob(unittest.TestCase, _Base):
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
         self._verifyResourceProperties(job, RESOURCE)
+        self.assertEqual(job.kms_key_name, self.KMS_KEY_NAME)
 
     def test_from_api_repr_w_sourcetable(self):
         self._setUpConstants()
@@ -2009,6 +2011,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
         self._verifyResourceProperties(job, RESOURCE)
+        self.assertEqual(job.kms_key_name, self.KMS_KEY_NAME)
 
     def test_from_api_repr_w_properties(self):
         client = _make_client(project=self.PROJECT)

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -248,10 +248,15 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
     def test_to_api_repr_with_encryption(self):
         config = self._make_one()
         config.destination_encryption_configuration = EncryptionConfiguration(
-            self.KMS_KEY_NAME)
+            kms_key_name=self.KMS_KEY_NAME)
         resource = config.to_api_repr()
-        self.assertEqual(resource, {'destinationEncryptionConfiguration': {
-            'kmsKeyName': self.KMS_KEY_NAME}})
+        self.assertEqual(
+            resource,
+            {
+                'destinationEncryptionConfiguration': {
+                    'kmsKeyName': self.KMS_KEY_NAME,
+                },
+            })
 
 
 class TestLoadJob(unittest.TestCase, _Base):
@@ -1137,10 +1142,15 @@ class TestCopyJob(unittest.TestCase, _Base):
     def test_to_api_repr_with_encryption(self):
         config = CopyJobConfig()
         config.destination_encryption_configuration = EncryptionConfiguration(
-            self.KMS_KEY_NAME)
+            kms_key_name=self.KMS_KEY_NAME)
         resource = config.to_api_repr()
-        self.assertEqual(resource, {'destinationEncryptionConfiguration': {
-            'kmsKeyName': self.KMS_KEY_NAME}})
+        self.assertEqual(
+            resource,
+            {
+                'destinationEncryptionConfiguration': {
+                    'kmsKeyName': self.KMS_KEY_NAME,
+                }
+            })
 
     def test_begin_w_bound_client(self):
         PATH = '/projects/%s/jobs' % (self.PROJECT,)
@@ -1691,10 +1701,14 @@ class TestQueryJobConfig(unittest.TestCase, _Base):
     def test_to_api_repr_with_encryption(self):
         config = self._make_one()
         config.destination_encryption_configuration = EncryptionConfiguration(
-            self.KMS_KEY_NAME)
+            kms_key_name=self.KMS_KEY_NAME)
         resource = config.to_api_repr()
-        self.assertEqual(resource, {'destinationEncryptionConfiguration': {
-            'kmsKeyName': self.KMS_KEY_NAME}})
+        self.assertEqual(
+            resource, {
+                'destinationEncryptionConfiguration': {
+                    'kmsKeyName': self.KMS_KEY_NAME,
+                },
+            })
 
     def test_from_api_repr_with_encryption(self):
         resource = {

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -627,7 +627,6 @@ class TestLoadJob(unittest.TestCase, _Base):
         klass = self._get_target_class()
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
-        self._verifyResourceProperties(job, RESOURCE)
         self.assertEqual(job.kms_key_name, self.KMS_KEY_NAME)
 
     def test_from_api_repr_w_properties(self):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -258,6 +258,16 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
                 },
             })
 
+    def test_to_api_repr_with_encryption_none(self):
+        config = self._make_one()
+        config.destination_encryption_configuration = None
+        resource = config.to_api_repr()
+        self.assertEqual(
+            resource,
+            {
+                'destinationEncryptionConfiguration': None,
+            })
+
 
 class TestLoadJob(unittest.TestCase, _Base):
     JOB_TYPE = 'load'
@@ -907,6 +917,38 @@ class TestLoadJob(unittest.TestCase, _Base):
         self._verifyResourceProperties(job, RESOURCE)
 
 
+class TestCopyJobConfig(unittest.TestCase, _Base):
+    JOB_TYPE = 'load'
+
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.bigquery.job import LoadJobConfig
+        return CopyJobConfig
+
+    def test_to_api_repr_with_encryption(self):
+        config = self._make_one()
+        config.destination_encryption_configuration = EncryptionConfiguration(
+            kms_key_name=self.KMS_KEY_NAME)
+        resource = config.to_api_repr()
+        self.assertEqual(
+            resource,
+            {
+                'destinationEncryptionConfiguration': {
+                    'kmsKeyName': self.KMS_KEY_NAME,
+                }
+            })
+
+    def test_to_api_repr_with_encryption_none(self):
+        config = self._make_one()
+        config.destination_encryption_configuration = None
+        resource = config.to_api_repr()
+        self.assertEqual(
+            resource,
+            {
+                'destinationEncryptionConfiguration': None,
+            })
+
+
 class TestCopyJob(unittest.TestCase, _Base):
     JOB_TYPE = 'copy'
     SOURCE_TABLE = 'source_table'
@@ -1138,19 +1180,6 @@ class TestCopyJob(unittest.TestCase, _Base):
         job = klass.from_api_repr(RESOURCE, client=client)
         self.assertIs(job._client, client)
         self._verifyResourceProperties(job, RESOURCE)
-
-    def test_to_api_repr_with_encryption(self):
-        config = CopyJobConfig()
-        config.destination_encryption_configuration = EncryptionConfiguration(
-            kms_key_name=self.KMS_KEY_NAME)
-        resource = config.to_api_repr()
-        self.assertEqual(
-            resource,
-            {
-                'destinationEncryptionConfiguration': {
-                    'kmsKeyName': self.KMS_KEY_NAME,
-                }
-            })
 
     def test_begin_w_bound_client(self):
         PATH = '/projects/%s/jobs' % (self.PROJECT,)
@@ -1708,6 +1737,16 @@ class TestQueryJobConfig(unittest.TestCase, _Base):
                 'destinationEncryptionConfiguration': {
                     'kmsKeyName': self.KMS_KEY_NAME,
                 },
+            })
+
+    def test_to_api_repr_with_encryption_none(self):
+        config = self._make_one()
+        config.destination_encryption_configuration = None
+        resource = config.to_api_repr()
+        self.assertEqual(
+            resource,
+            {
+                'destinationEncryptionConfiguration': None,
             })
 
     def test_from_api_repr_with_encryption(self):

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -56,24 +56,24 @@ class TestEncryptionConfiguration(unittest.TestCase):
         self.assertIsNone(encryption_config.kms_key_name)
 
     def test_ctor_with_key(self):
-        encryption_config = self._make_one(self.KMS_KEY_NAME)
+        encryption_config = self._make_one(kms_key_name=self.KMS_KEY_NAME)
         self.assertEqual(encryption_config.kms_key_name, self.KMS_KEY_NAME)
 
     def test_from_api_repr(self):
         RESOURCE = {
-            'kmsKeyName': self.KMS_KEY_NAME
+            'kmsKeyName': self.KMS_KEY_NAME,
         }
         klass = self._get_target_class()
         encryption_config = klass.from_api_repr(RESOURCE)
         self.assertEqual(encryption_config.kms_key_name, self.KMS_KEY_NAME)
 
     def test_to_api_repr(self):
-        encryption_config = self._make_one(self.KMS_KEY_NAME)
+        encryption_config = self._make_one(kms_key_name=self.KMS_KEY_NAME)
         resource = encryption_config.to_api_repr()
         self.assertEqual(
             resource,
             {
-                'kmsKeyName': self.KMS_KEY_NAME
+                'kmsKeyName': self.KMS_KEY_NAME,
             })
 
 
@@ -765,7 +765,8 @@ class TestTable(unittest.TestCase, _SchemaBase):
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)
         table = self._make_one(table_ref)
-        encryption_configuration = EncryptionConfiguration(self.KMS_KEY_NAME)
+        encryption_configuration = EncryptionConfiguration(
+            kms_key_name=self.KMS_KEY_NAME)
         table.encryption_configuration = encryption_configuration
         self.assertEqual(table.encryption_configuration.kms_key_name,
                          self.KMS_KEY_NAME)

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -59,6 +59,12 @@ class TestEncryptionConfiguration(unittest.TestCase):
         encryption_config = self._make_one(kms_key_name=self.KMS_KEY_NAME)
         self.assertEqual(encryption_config.kms_key_name, self.KMS_KEY_NAME)
 
+    def test_kms_key_name_setter(self):
+        encryption_config = self._make_one()
+        self.assertIsNone(encryption_config.kms_key_name)
+        encryption_config.kms_key_name = self.KMS_KEY_NAME
+        self.assertEqual(encryption_config.kms_key_name, self.KMS_KEY_NAME)
+
     def test_from_api_repr(self):
         RESOURCE = {
             'kmsKeyName': self.KMS_KEY_NAME,

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -64,6 +64,8 @@ class TestEncryptionConfiguration(unittest.TestCase):
         self.assertIsNone(encryption_config.kms_key_name)
         encryption_config.kms_key_name = self.KMS_KEY_NAME
         self.assertEqual(encryption_config.kms_key_name, self.KMS_KEY_NAME)
+        encryption_config.kms_key_name = None
+        self.assertIsNone(encryption_config.kms_key_name)
 
     def test_from_api_repr(self):
         RESOURCE = {
@@ -776,6 +778,8 @@ class TestTable(unittest.TestCase, _SchemaBase):
         table.encryption_configuration = encryption_configuration
         self.assertEqual(table.encryption_configuration.kms_key_name,
                          self.KMS_KEY_NAME)
+        table.encryption_configuration = None
+        self.assertIsNone(table.encryption_configuration)
 
 
 class Test_row_from_mapping(unittest.TestCase, _SchemaBase):


### PR DESCRIPTION
As part of a query, load job, or create table request, you can specify the encryption configuration, which just consists of a single string field containing the KMS key to use.