### PR TITLE
Pub/Sub: Update default batch size to 10 MB

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/types.py
+++ b/pubsub/google/cloud/pubsub_v1/types.py
@@ -41,9 +41,9 @@ BatchSettings = collections.namedtuple(
     ['max_bytes', 'max_latency', 'max_messages'],
 )
 BatchSettings.__new__.__defaults__ = (
-    1024 * 1024 * 5,  # max_bytes: 5 MB
-    0.05,             # max_latency: 0.05 seconds
-    1000,             # max_messages: 1,000
+    1024 * 1024 * 10,  # max_bytes: 10 MB
+    0.05,              # max_latency: 0.05 seconds
+    1000,              # max_messages: 1,000
 )
 
 # Define the type class and default values for flow control settings.


### PR DESCRIPTION
The Pub/Sub default is 10 MB. This allows sending the max batch size unless the user intervenes.