### PR TITLE
Add client configuration from dictionary

### DIFF
--- a/core/google/cloud/client.py
+++ b/core/google/cloud/client.py
@@ -67,15 +67,40 @@ class _ClientFactoryMixin(object):
         :raises TypeError: if there is a conflict with the kwargs
                  and the credentials created by the factory.
         """
-        if 'credentials' in kwargs:
-            raise TypeError('credentials must not be in keyword arguments')
         with io.open(json_credentials_path, 'r', encoding='utf-8') as json_fi:
             credentials_info = json.load(json_fi)
+        return cls.from_dict(credentials_info, *args, **kwargs)
+
+    @classmethod
+    def from_dict(cls, service_account_dict, *args, **kwargs):
+        """Factory to retrieve credentials from a dictionary while creating a
+        client. Dictionary is assumed to be equivalent to a parsed service
+        account JSON.
+
+        :type service_account_dict: dict
+        :param service_account_dict: A dictionary equivalent to a private key
+                                     file. This dict must contain a private key
+                                     and other credentials information (see
+                                     from_service_account_json).
+
+        :type args: tuple
+        :param args: Remaining positional arguments to pass to constructor.
+
+        :type kwargs: dict
+        :param kwargs: Remaining keyword arguments to pass to constructor.
+
+        :rtype: :class:`_ClientFactoryMixin`
+        :returns: The client created with the retrieved JSON credentials.
+        :raises TypeError: if there is a conflict with the kwargs
+                 and the credentials created by the factory.
+                """
+        if 'credentials' in kwargs:
+            raise TypeError('credentials must not be in keyword arguments')
         credentials = service_account.Credentials.from_service_account_info(
-            credentials_info)
+            service_account_dict)
         if cls._SET_PROJECT:
             if 'project' not in kwargs:
-                kwargs['project'] = credentials_info.get('project_id')
+                kwargs['project'] = service_account_dict.get('project_id')
 
         kwargs['credentials'] = credentials
         return cls(*args, **kwargs)

--- a/core/tests/unit/test_client.py
+++ b/core/tests/unit/test_client.py
@@ -113,6 +113,25 @@ class TestClient(unittest.TestCase):
             mock.sentinel.filename, 'r', encoding='utf-8')
         constructor.assert_called_once_with(info)
 
+    def test_from_dict(self):
+        klass = self._get_target_class()
+
+        # Mock the credentials constructor.
+        info = {'dummy': 'value', 'valid': 'json'}
+        constructor_patch = mock.patch(
+            'google.oauth2.service_account.Credentials.'
+            'from_service_account_info',
+            return_value=_make_credentials()
+        )
+
+        with constructor_patch as constructor:
+            client_obj = klass.from_dict(info)
+
+        self.assertIs(client_obj._credentials, constructor.return_value)
+        self.assertIsNone(client_obj._http_internal)
+        # Check that mocks were called as expected.
+        constructor.assert_called_once_with(info)
+
     def test_from_service_account_json_bad_args(self):
         KLASS = self._get_target_class()
 


### PR DESCRIPTION
I've added this change that we implement in our own code, as it may be more broadly useful. As we don't store our service account JSON in plaintext, we can't use the `from_service_account_json` convenience method.

This PR separates out some of the logic from `from_service_account_json` into a separate `from_dict` convenience method.

- split `_ClientFactoryMixin.from_service_account_json`
    - add `from_dict` to offer users a hook in without needing to load from plaintext JSON
- add new test for completeness, though test coverage would be unaffected