### PR TITLE
Add ability for subscriber to batch requests.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/message.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/message.py
@@ -18,6 +18,8 @@ import json
 import math
 import time
 
+from google.cloud.pubsub_v1.subscriber.policy import base as base_policy
+
 
 _MESSAGE_REPR = """\
 Message {{
@@ -172,14 +174,11 @@ class Message(object):
         """
         time_to_ack = math.ceil(time.time() - self._received_timestamp)
         self._request_queue.put(
-            (
-                'ack',
-                {
-                    'ack_id': self._ack_id,
-                    'byte_size': self.size,
-                    'time_to_ack': time_to_ack,
-                },
-            ),
+            base_policy.AckRequest(
+                ack_id=self._ack_id,
+                byte_size=self.size,
+                time_to_ack=time_to_ack
+            )
         )
 
     def drop(self):
@@ -196,13 +195,10 @@ class Message(object):
             directly.
         """
         self._request_queue.put(
-            (
-                'drop',
-                {
-                    'ack_id': self._ack_id,
-                    'byte_size': self.size,
-                },
-            ),
+            base_policy.DropRequest(
+                ack_id=self._ack_id,
+                byte_size=self.size
+            )
         )
 
     def lease(self):
@@ -213,19 +209,16 @@ class Message(object):
             need to call it manually.
         """
         self._request_queue.put(
-            (
-                'lease',
-                {
-                    'ack_id': self._ack_id,
-                    'byte_size': self.size,
-                },
-            ),
+            base_policy.LeaseRequest(
+                ack_id=self._ack_id,
+                byte_size=self.size
+            )
         )
 
     def modify_ack_deadline(self, seconds):
         """Resets the deadline for acknowledgement.
-	
-	New deadline will be the given value of seconds from now.
+
+        New deadline will be the given value of seconds from now.
 
         The default implementation handles this for you; you should not need
         to manually deal with setting ack deadlines. The exception case is
@@ -238,13 +231,10 @@ class Message(object):
                 values below 10 are advised against.
         """
         self._request_queue.put(
-            (
-                'modify_ack_deadline',
-                {
-                    'ack_id': self._ack_id,
-                    'seconds': seconds,
-                },
-            ),
+            base_policy.ModAckRequest(
+                ack_id=self._ack_id,
+                seconds=seconds
+            )
         )
 
     def nack(self):
@@ -253,11 +243,8 @@ class Message(object):
         This will cause the message to be re-delivered to the subscription.
         """
         self._request_queue.put(
-            (
-                'nack',
-                {
-                    'ack_id': self._ack_id,
-                    'byte_size': self.size,
-                },
-            ),
+            base_policy.NackRequest(
+                ack_id=self._ack_id,
+                byte_size=self.size
+            )
         )

--- a/pubsub/google/cloud/pubsub_v1/types.py
+++ b/pubsub/google/cloud/pubsub_v1/types.py
@@ -53,13 +53,16 @@ BatchSettings.__new__.__defaults__ = (
 # The defaults should be fine for most use cases.
 FlowControl = collections.namedtuple(
     'FlowControl',
-    ['max_bytes', 'max_messages', 'resume_threshold', 'max_requests'],
+    ['max_bytes', 'max_messages', 'resume_threshold', 'max_requests',
+     'max_request_batch_size', 'max_request_batch_latency'],
 )
 FlowControl.__new__.__defaults__ = (
     psutil.virtual_memory().total * 0.2,  # max_bytes: 20% of total RAM
     float('inf'),                         # max_messages: no limit
     0.8,                                  # resume_threshold: 80%
     100,                                  # max_requests: 100
+    100,                                  # max_request_batch_size: 100
+    0.01,                                 # max_request_batch_latency: 0.01s
 )
 
 

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_message.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_message.py
@@ -19,6 +19,7 @@ from six.moves import queue
 
 from google.cloud.pubsub_v1 import types
 from google.cloud.pubsub_v1.subscriber import message
+from google.cloud.pubsub_v1.subscriber.policy import base
 
 
 def create_message(data, ack_id='ACKID', **attrs):
@@ -53,53 +54,52 @@ def test_publish_time():
 def test_ack():
     msg = create_message(b'foo', ack_id='bogus_ack_id')
     with mock.patch.object(msg._request_queue, 'put') as put:
-        with mock.patch.object(message.Message, 'drop') as drop:
-            msg.ack()
-            put.assert_called_once_with(('ack', {
-                'ack_id': 'bogus_ack_id',
-                'byte_size': 25,
-                'time_to_ack': mock.ANY,
-            }))
+        msg.ack()
+        put.assert_called_once_with(base.AckRequest(
+            ack_id='bogus_ack_id',
+            byte_size=25,
+            time_to_ack=mock.ANY,
+        ))
 
 
 def test_drop():
     msg = create_message(b'foo', ack_id='bogus_ack_id')
     with mock.patch.object(msg._request_queue, 'put') as put:
         msg.drop()
-        put.assert_called_once_with(('drop', {
-            'ack_id': 'bogus_ack_id',
-            'byte_size': 25,
-        }))
+        put.assert_called_once_with(base.DropRequest(
+            ack_id='bogus_ack_id',
+            byte_size=25,
+        ))
 
 
 def test_lease():
     msg = create_message(b'foo', ack_id='bogus_ack_id')
     with mock.patch.object(msg._request_queue, 'put') as put:
         msg.lease()
-        put.assert_called_once_with(('lease', {
-            'ack_id': 'bogus_ack_id',
-            'byte_size': 25,
-        }))
+        put.assert_called_once_with(base.LeaseRequest(
+            ack_id='bogus_ack_id',
+            byte_size=25,
+        ))
 
 
 def test_modify_ack_deadline():
-    msg = create_message(b'foo', ack_id='bogus_id')
+    msg = create_message(b'foo', ack_id='bogus_ack_id')
     with mock.patch.object(msg._request_queue, 'put') as put:
         msg.modify_ack_deadline(60)
-        put.assert_called_once_with(('modify_ack_deadline', {
-            'ack_id': 'bogus_id',
-            'seconds': 60,
-        }))
+        put.assert_called_once_with(base.ModAckRequest(
+            ack_id='bogus_ack_id',
+            seconds=60,
+        ))
 
 
 def test_nack():
-    msg = create_message(b'foo', ack_id='bogus_id')
+    msg = create_message(b'foo', ack_id='bogus_ack_id')
     with mock.patch.object(msg._request_queue, 'put') as put:
         msg.nack()
-        put.assert_called_once_with(('nack', {
-            'ack_id': 'bogus_id',
-            'byte_size': 25,
-        }))
+        put.assert_called_once_with(base.NackRequest(
+            ack_id='bogus_ack_id',
+            byte_size=25,
+        ))
 
 
 def test_repr():

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_message.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_message.py
@@ -51,6 +51,29 @@ def test_publish_time():
     assert msg.publish_time == types.Timestamp(seconds=1335020400 - 86400)
 
 
+def check_call_types(mock, *args, **kwargs):
+    """Checks a mock's call types.
+
+    Args:
+        mock: The mock to check.
+        args: The types of the positional arguments.
+        kwargs: The names of the keyword args to check and their respective
+            types.
+
+    Raises:
+        AssertionError: if any of the types don't match, or if the number of
+            arguments does not match.
+    """
+    for call in mock.mock_calls:
+        _, call_args, call_kwargs = call
+        assert len(call_args) == len(args)
+        for n, argtype in enumerate(args):
+            assert isinstance(call_args[n], argtype)
+        for argname, argtype in kwargs:
+            assert argname in call_kwargs
+            assert isinstance(call_kwargs[argname], argtype)
+
+
 def test_ack():
     msg = create_message(b'foo', ack_id='bogus_ack_id')
     with mock.patch.object(msg._request_queue, 'put') as put:
@@ -60,6 +83,7 @@ def test_ack():
             byte_size=25,
             time_to_ack=mock.ANY,
         ))
+        check_call_types(put, base.AckRequest)
 
 
 def test_drop():
@@ -70,6 +94,7 @@ def test_drop():
             ack_id='bogus_ack_id',
             byte_size=25,
         ))
+        check_call_types(put, base.DropRequest)
 
 
 def test_lease():
@@ -80,6 +105,7 @@ def test_lease():
             ack_id='bogus_ack_id',
             byte_size=25,
         ))
+        check_call_types(put, base.LeaseRequest)
 
 
 def test_modify_ack_deadline():
@@ -90,6 +116,7 @@ def test_modify_ack_deadline():
             ack_id='bogus_ack_id',
             seconds=60,
         ))
+        check_call_types(put, base.ModAckRequest)
 
 
 def test_nack():
@@ -100,6 +127,7 @@ def test_nack():
             ack_id='bogus_ack_id',
             byte_size=25,
         ))
+        check_call_types(put, base.NackRequest)
 
 
 def test_repr():

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_base.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_policy_base.py
@@ -87,7 +87,9 @@ def test_ack():
     policy = create_policy()
     policy._consumer._stopped.clear()
     with mock.patch.object(policy._consumer, 'send_request') as send_request:
-        policy.ack('ack_id_string', 20)
+        policy.ack([
+            base.AckRequest(
+                ack_id='ack_id_string', time_to_ack=20, byte_size=0)])
         send_request.assert_called_once_with(types.StreamingPullRequest(
             ack_ids=['ack_id_string'],
         ))
@@ -99,7 +101,8 @@ def test_ack_no_time():
     policy = create_policy()
     policy._consumer._stopped.clear()
     with mock.patch.object(policy._consumer, 'send_request') as send_request:
-        policy.ack('ack_id_string')
+        policy.ack([base.AckRequest(
+            'ack_id_string', time_to_ack=None, byte_size=0)])
         send_request.assert_called_once_with(types.StreamingPullRequest(
             ack_ids=['ack_id_string'],
         ))
@@ -112,7 +115,7 @@ def test_ack_paused():
     consumer._stopped.set()
     assert consumer.paused is True
 
-    policy.ack('ack_id_string')
+    policy.ack([base.AckRequest('ack_id_string', 0, 0)])
 
     assert consumer.paused is False
     assert 'ack_id_string' in policy._ack_on_resume
@@ -129,12 +132,12 @@ def test_drop():
     policy = create_policy()
     policy.managed_ack_ids.add('ack_id_string')
     policy._bytes = 20
-    policy.drop('ack_id_string', 20)
+    policy.drop([base.DropRequest(ack_id='ack_id_string', byte_size=20)])
     assert len(policy.managed_ack_ids) == 0
     assert policy._bytes == 0
 
     # Do this again to establish idempotency.
-    policy.drop('ack_id_string', 20)
+    policy.drop([base.DropRequest(ack_id='ack_id_string', byte_size=20)])
     assert len(policy.managed_ack_ids) == 0
     assert policy._bytes == 0
 
@@ -144,7 +147,7 @@ def test_drop_unexpected_negative(_LOGGER):
     policy = create_policy()
     policy.managed_ack_ids.add('ack_id_string')
     policy._bytes = 0
-    policy.drop('ack_id_string', 20)
+    policy.drop([base.DropRequest(ack_id='ack_id_string', byte_size=20)])
     assert len(policy.managed_ack_ids) == 0
     assert policy._bytes == 0
     _LOGGER.debug.assert_called_once_with(
@@ -164,7 +167,8 @@ def test_drop_below_threshold():
     consumer = policy._consumer
     assert consumer.paused is True
 
-    policy.drop(ack_id='ack_id_string', byte_size=num_bytes)
+    policy.drop([
+        base.DropRequest(ack_id='ack_id_string', byte_size=num_bytes)])
 
     assert consumer.paused is False
 
@@ -200,16 +204,16 @@ def test_load_w_lease():
     with mock.patch.object(consumer, 'pause') as pause:
         # This should mean that our messages count is at 10%, and our bytes
         # are at 15%; the ._load property should return the higher (0.15).
-        policy.lease(ack_id='one', byte_size=150)
+        policy.lease([base.LeaseRequest(ack_id='one', byte_size=150)])
         assert policy._load == 0.15
         pause.assert_not_called()
         # After this message is added, the messages should be higher at 20%
         # (versus 16% for bytes).
-        policy.lease(ack_id='two', byte_size=10)
+        policy.lease([base.LeaseRequest(ack_id='two', byte_size=10)])
         assert policy._load == 0.2
         pause.assert_not_called()
         # Returning a number above 100% is fine.
-        policy.lease(ack_id='three', byte_size=1000)
+        policy.lease([base.LeaseRequest(ack_id='three', byte_size=1000)])
         assert policy._load == 1.16
         pause.assert_called_once_with()
 
@@ -226,7 +230,6 @@ def test_load_w_requests():
         assert policy._load == 0
 
         pending_requests.return_value = 100
-        print(consumer.pending_requests)
         assert policy._load == 1
 
         # If bytes count is higher, it should return that.
@@ -237,7 +240,8 @@ def test_load_w_requests():
 def test_modify_ack_deadline():
     policy = create_policy()
     with mock.patch.object(policy._consumer, 'send_request') as send_request:
-        policy.modify_ack_deadline('ack_id_string', 60)
+        policy.modify_ack_deadline([
+            base.ModAckRequest(ack_id='ack_id_string', seconds=60)])
         send_request.assert_called_once_with(types.StreamingPullRequest(
             modify_deadline_ack_ids=['ack_id_string'],
             modify_deadline_seconds=[60],
@@ -253,7 +257,7 @@ def test_maintain_leases_inactive_consumer():
 def test_maintain_leases_ack_ids():
     policy = create_policy()
     policy._consumer._stopped.clear()
-    policy.lease('my ack id', 50)
+    policy.lease([base.LeaseRequest(ack_id='my ack id', byte_size=50)])
 
     # Mock the sleep object.
     with mock.patch.object(time, 'sleep', autospec=True) as sleep:
@@ -288,12 +292,12 @@ def test_maintain_leases_no_ack_ids():
 
 def test_lease():
     policy = create_policy()
-    policy.lease(ack_id='ack_id_string', byte_size=20)
+    policy.lease([base.LeaseRequest(ack_id='ack_id_string', byte_size=20)])
     assert len(policy.managed_ack_ids) == 1
     assert policy._bytes == 20
 
     # Do this again to prove idempotency.
-    policy.lease(ack_id='ack_id_string', byte_size=20)
+    policy.lease([base.LeaseRequest(ack_id='ack_id_string', byte_size=20)])
     assert len(policy.managed_ack_ids) == 1
     assert policy._bytes == 20
 
@@ -304,9 +308,9 @@ def test_lease_above_threshold():
     consumer = policy._consumer
 
     with mock.patch.object(consumer, 'pause') as pause:
-        policy.lease(ack_id='first_ack_id', byte_size=20)
+        policy.lease([base.LeaseRequest(ack_id='first_ack_id', byte_size=20)])
         pause.assert_not_called()
-        policy.lease(ack_id='second_ack_id', byte_size=25)
+        policy.lease([base.LeaseRequest(ack_id='second_ack_id', byte_size=25)])
         pause.assert_called_once_with()
 
 
@@ -314,6 +318,9 @@ def test_nack():
     policy = create_policy()
     with mock.patch.object(policy, 'modify_ack_deadline') as mad:
         with mock.patch.object(policy, 'drop') as drop:
-            policy.nack(ack_id='ack_id_string', byte_size=10)
-            drop.assert_called_once_with(ack_id='ack_id_string', byte_size=10)
-        mad.assert_called_once_with(ack_id='ack_id_string', seconds=0)
+            items = [base.NackRequest(ack_id='ack_id_string', byte_size=10)]
+            policy.nack(items)
+            drop.assert_called_once_with(
+                [base.DropRequest(ack_id='ack_id_string', byte_size=10)])
+        mad.assert_called_once_with(
+            [base.ModAckRequest(ack_id='ack_id_string', seconds=0)])


### PR DESCRIPTION
The size of the batches and the rate at which they are submitted is controlled by two new flow control settings, `max_request_batch_size` and `max_request_batch_latency`.

Closes #4893