### PR TITLE
Don't check 'exclude_from_indexes' for empty lists.

### DIFF
--- a/datastore/google/cloud/datastore/helpers.py
+++ b/datastore/google/cloud/datastore/helpers.py
@@ -134,7 +134,7 @@ def entity_from_protobuf(pb):
         # Check if ``value_pb`` was excluded from index. Lists need to be
         # special-cased and we require all ``exclude_from_indexes`` values
         # in a list agree.
-        if is_list:
+        if is_list and len(value) > 0:
             exclude_values = set(value_pb.exclude_from_indexes
                                  for value_pb in value_pb.array_value.values)
             if len(exclude_values) != 1:

--- a/datastore/tests/unit/test_helpers.py
+++ b/datastore/tests/unit/test_helpers.py
@@ -191,6 +191,28 @@ class Test_entity_from_protobuf(unittest.TestCase):
         self.assertEqual(len(inside_entity), 1)
         self.assertEqual(inside_entity[INSIDE_NAME], INSIDE_VALUE)
 
+    def test_index_mismatch_ignores_empty_list(self):
+        from google.cloud.datastore_v1.proto import entity_pb2
+
+        _PROJECT = 'PROJECT'
+        _KIND = 'KIND'
+        _ID = 1234
+
+        array_val_pb = entity_pb2.Value(
+            array_value=entity_pb2.ArrayValue(values=[]))
+
+        entity_pb = entity_pb2.Entity(
+            properties={
+                'baz': array_val_pb,
+            },
+        )
+        entity_pb.key.partition_id.project_id = _PROJECT
+        entity_pb.key.path.add(kind=_KIND, id=_ID)
+
+        entity = self._call_fut(entity_pb)
+        entity_dict = dict(entity)
+        self.assertEqual(entity_dict['baz'], [])
+
 
 class Test_entity_to_protobuf(unittest.TestCase):
 


### PR DESCRIPTION
Closes #3152.

Adds a breaking unit test for the bug in the first commit, and fixes it in the second commit.

Supersedes PRs #3767 and #4778 