### PR TITLE
Don't run tests for every package when api_core is modified

### DIFF
--- a/test_utils/scripts/get_target_packages.py
+++ b/test_utils/scripts/get_target_packages.py
@@ -37,7 +37,6 @@ TAG_RE = re.compile(r"""
 # As of this writing, the only "real" dependency is that of error_reporting
 # (on logging), the rest are just system test dependencies.
 PKG_DEPENDENCIES = {
-    'core': {'api_core'},
     'bigquery': {'storage'},
     'error_reporting': {'logging'},
     'language': {'storage'},
@@ -174,7 +173,7 @@ def get_changed_packages(file_list):
 
         # If there is a change in core, short-circuit now and return
         # everything.
-        if package in ('api_core', 'core'):
+        if package in ('core',):
             return all_packages
 
         # Add the package, as well as any dependencies this package has.


### PR DESCRIPTION
This is in preparation for both a repository split and for api_core v1.0.0. 