### PR TITLE
Update minimum api-core version to 1.0.0 for Datastore, BigQuery, Logging, Trace, and Spanner

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -30,7 +30,7 @@ version = '0.30.0'
 release_status = 'Development Status :: 4 - Beta'
 dependencies = [
     'google-cloud-core<0.29dev,>=0.28.0',
-    'google-api-core<2.0.0dev,>=0.1.5.dev1',
+    'google-api-core<2.0.0dev,>=1.0.0',
     'google-resumable-media>=0.2.1',
 ]
 extras = {

--- a/datastore/setup.py
+++ b/datastore/setup.py
@@ -30,7 +30,7 @@ version = '1.5.0'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
     'google-cloud-core<0.29dev,>=0.28.0',
-    'google-api-core[grpc]<2.0.0dev,>=0.1.5.dev1',
+    'google-api-core[grpc]<2.0.0dev,>=1.0.0',
 ]
 extras = {
 }

--- a/logging/setup.py
+++ b/logging/setup.py
@@ -30,7 +30,7 @@ version = '1.5.0'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
     'google-cloud-core<0.29dev,>=0.28.0',
-    'google-api-core[grpc]<2.0.0dev,>=0.1.1',
+    'google-api-core[grpc]<2.0.0dev,>=1.0.0',
 ]
 extras = {
 }

--- a/spanner/setup.py
+++ b/spanner/setup.py
@@ -30,7 +30,7 @@ version = '1.0.0'
 release_status = 'Development Status :: 4 - Beta'
 dependencies = [
     'google-cloud-core<0.29dev,>=0.28.0',
-    'google-api-core[grpc]<2.0.0dev,>=0.1.5.dev1',
+    'google-api-core[grpc]<2.0.0dev,>=1.0.0',
     'grpc-google-iam-v1<0.12dev,>=0.11.4',
 ]
 extras = {

--- a/trace/setup.py
+++ b/trace/setup.py
@@ -30,7 +30,7 @@ version = '0.18.0'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     'google-cloud-core<0.29dev,>=0.28.0',
-    'google-api-core[grpc]<2.0.0dev,>=0.1.1',
+    'google-api-core[grpc]<2.0.0dev,>=1.0.0',
 ]
 extras = {
 }


### PR DESCRIPTION
Note: has #4945 as a diffbase. Needs to be rebased before merging.