### PR TITLE
futures now install_requires

### DIFF
--- a/api_core/setup.py
+++ b/api_core/setup.py
@@ -36,10 +36,10 @@ dependencies = [
     'setuptools>=34.0.0',
     'six>=1.10.0',
     'pytz',
+    'futures>=3.2.0;python_version<"3.2"'
 ]
 extras = {
-    'grpc': 'grpcio>=1.8.2',
-    ':python_version < "3.2"': 'futures>=3.2.0',
+    'grpc': 'grpcio>=1.8.2'
 }
 
 

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -30,9 +30,9 @@ version = '0.30.1'
 release_status = 'Development Status :: 4 - Beta'
 dependencies = [
     'google-api-core[grpc]<2.0.0dev,>=0.1.0',
+    'enum34;python_version<"3.4"'
 ]
 extras = {
-    ':python_version < "3.4"': 'enum34',
 }
 
 


### PR DESCRIPTION
According to this [comment ]( https://github.com/pypa/pipenv/issues/1547#issuecomment-370778759) the current extras_require format to specify platform dependencies is deprecated, so moving it upwards
Also look here at the [documentation](http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies) and at [SO](https://stackoverflow.com/questions/21082091/install-requires-based-on-python-version)