### PR TITLE
Bigtable: TimestampRanges must be milliseconds granularity

### DIFF
--- a/bigtable/google/cloud/bigtable/row_filters.py
+++ b/bigtable/google/cloud/bigtable/row_filters.py
@@ -281,8 +281,10 @@ class TimestampRange(object):
             timestamp_range_kwargs['start_timestamp_micros'] = (
                 _microseconds_from_datetime(self.start) // 1000 * 1000)
         if self.end is not None:
-            timestamp_range_kwargs['end_timestamp_micros'] = (
-                _microseconds_from_datetime(self.end) // 1000 * 1000)
+            end_time = _microseconds_from_datetime(self.end)
+            if end_time % 1000 != 0:
+                end_time = end_time // 1000 * 1000 + 1000
+            timestamp_range_kwargs['end_timestamp_micros'] = end_time
         return data_v2_pb2.TimestampRange(**timestamp_range_kwargs)
 
 

--- a/bigtable/google/cloud/bigtable/row_filters.py
+++ b/bigtable/google/cloud/bigtable/row_filters.py
@@ -279,10 +279,10 @@ class TimestampRange(object):
         timestamp_range_kwargs = {}
         if self.start is not None:
             timestamp_range_kwargs['start_timestamp_micros'] = (
-                _microseconds_from_datetime(self.start))
+                _microseconds_from_datetime(self.start) // 1000 * 1000)
         if self.end is not None:
             timestamp_range_kwargs['end_timestamp_micros'] = (
-                _microseconds_from_datetime(self.end))
+                _microseconds_from_datetime(self.end) // 1000 * 1000)
         return data_v2_pb2.TimestampRange(**timestamp_range_kwargs)
 
 

--- a/bigtable/tests/system.py
+++ b/bigtable/tests/system.py
@@ -337,6 +337,16 @@ class TestDataAPI(unittest.TestCase):
         cell4 = Cell(CELL_VAL4, timestamp4_micros)
         return cell1, cell2, cell3, cell4
 
+    def test_timestamp_filter_millisecond_granularity(self):
+        from google.cloud.bigtable import row_filters
+
+        end = datetime.datetime.now()
+        start = end - datetime.timedelta(minutes=60)
+        timestamp_range = row_filters.TimestampRange(start=start, end=end)
+        timefilter = row_filters.TimestampRangeFilter(timestamp_range)
+        row_data = self._table.read_rows(filter_=timefilter)
+        row_data.consume_all()
+
     def test_mutate_rows(self):
         row1 = self._table.row(ROW_KEY)
         row1.set_cell(COLUMN_FAMILY_ID1, COL_NAME1, CELL_VAL1)

--- a/bigtable/tests/unit/test_row_filters.py
+++ b/bigtable/tests/unit/test_row_filters.py
@@ -295,10 +295,12 @@ class TestTimestampRange(unittest.TestCase):
         if start_micros is not None:
             start = _EPOCH + datetime.timedelta(microseconds=start_micros)
             pb_kwargs['start_timestamp_micros'] = start_micros
+            self.assertEqual(start_micros % 1000, 0)
         end = None
         if end_micros is not None:
             end = _EPOCH + datetime.timedelta(microseconds=end_micros)
             pb_kwargs['end_timestamp_micros'] = end_micros
+            self.assertEqual(end_micros % 1000, 0)
         time_range = self._make_one(start=start, end=end)
 
         expected_pb = _TimestampRangePB(**pb_kwargs)

--- a/bigtable/tests/unit/test_row_filters.py
+++ b/bigtable/tests/unit/test_row_filters.py
@@ -285,43 +285,53 @@ class TestTimestampRange(unittest.TestCase):
         comparison_val = (time_range1 != time_range2)
         self.assertFalse(comparison_val)
 
-    def _to_pb_helper(self, start_micros=None, end_micros=None):
+    def _to_pb_helper(self, pb_kwargs, start=None, end=None):
         import datetime
         from google.cloud._helpers import _EPOCH
-
-        pb_kwargs = {}
-
-        start = None
-        if start_micros is not None:
-            start = _EPOCH + datetime.timedelta(microseconds=start_micros)
-            pb_kwargs['start_timestamp_micros'] = start_micros
-            self.assertEqual(start_micros % 1000, 0)
-        end = None
-        if end_micros is not None:
-            end = _EPOCH + datetime.timedelta(microseconds=end_micros)
-            pb_kwargs['end_timestamp_micros'] = end_micros
-            self.assertEqual(end_micros % 1000, 0)
+        if start is not None:
+            start = _EPOCH + datetime.timedelta(microseconds=start)
+        if end is not None:
+            end = _EPOCH + datetime.timedelta(microseconds=end)
         time_range = self._make_one(start=start, end=end)
-
         expected_pb = _TimestampRangePB(**pb_kwargs)
-        self.assertEqual(time_range.to_pb(), expected_pb)
+        time_pb = time_range.to_pb()
+        self.assertEqual(
+            time_pb.start_timestamp_micros,
+            expected_pb.start_timestamp_micros)
+        self.assertEqual(
+            time_pb.end_timestamp_micros,
+            expected_pb.end_timestamp_micros)
+        self.assertEqual(time_pb, expected_pb)
 
     def test_to_pb(self):
-        # Makes sure already milliseconds granularity
-        start_micros = 30871000
-        end_micros = 12939371000
-        self._to_pb_helper(start_micros=start_micros,
-                           end_micros=end_micros)
+        start_micros = 30871234
+        end_micros = 12939371234
+        start_millis = start_micros // 1000 * 1000
+        self.assertEqual(start_millis, 30871000)
+        end_millis = end_micros // 1000 * 1000 + 1000
+        self.assertEqual(end_millis, 12939372000)
+        pb_kwargs = {}
+        pb_kwargs['start_timestamp_micros'] = start_millis
+        pb_kwargs['end_timestamp_micros'] = end_millis
+        self._to_pb_helper(pb_kwargs, start=start_micros, end=end_micros)
 
     def test_to_pb_start_only(self):
         # Makes sure already milliseconds granularity
         start_micros = 30871000
-        self._to_pb_helper(start_micros=start_micros)
+        start_millis = start_micros // 1000 * 1000
+        self.assertEqual(start_millis, 30871000)
+        pb_kwargs = {}
+        pb_kwargs['start_timestamp_micros'] = start_millis
+        self._to_pb_helper(pb_kwargs, start=start_micros, end=None)
 
     def test_to_pb_end_only(self):
         # Makes sure already milliseconds granularity
         end_micros = 12939371000
-        self._to_pb_helper(end_micros=end_micros)
+        end_millis = end_micros // 1000 * 1000
+        self.assertEqual(end_millis, 12939371000)
+        pb_kwargs = {}
+        pb_kwargs['end_timestamp_micros'] = end_millis
+        self._to_pb_helper(pb_kwargs, start=None, end=end_micros)
 
 
 class TestTimestampRangeFilter(unittest.TestCase):


### PR DESCRIPTION
Closes #4932. 

But.  @tswast Should we have this and change it if/when BigTable supports microseconds or should we have the users handle it themselves and just document?