### PR TITLE
Firestore: return non existent snapshot if document not found instead of raising NotFound exception

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/client.py
+++ b/firestore/google/cloud/firestore_v1beta1/client.py
@@ -582,8 +582,7 @@ def _parse_batch_get(get_doc_response, reference_map, client):
             a document factory.
 
     Returns:
-        Optional[.DocumentSnapshot]: The retrieved snapshot. If the
-        snapshot is :data:`None`, that means the document is ``missing``.
+        Optional[.DocumentSnapshot]: The retrieved snapshot.
 
     Raises:
         ValueError: If the response has a ``result`` field (a oneof) other
@@ -601,13 +600,19 @@ def _parse_batch_get(get_doc_response, reference_map, client):
             read_time=get_doc_response.read_time,
             create_time=get_doc_response.found.create_time,
             update_time=get_doc_response.found.update_time)
-        return snapshot
     elif result_type == 'missing':
-        return None
+        snapshot = DocumentSnapshot(
+            None,
+            None,
+            exists=False,
+            read_time=get_doc_response.read_time,
+            create_time=None,
+            update_time=None)
     else:
         raise ValueError(
             '`BatchGetDocumentsResponse.result` (a oneof) had a field other '
             'than `found` or `missing` set, or was unset')
+    return snapshot
 
 
 def _get_doc_mask(field_paths):

--- a/firestore/google/cloud/firestore_v1beta1/client.py
+++ b/firestore/google/cloud/firestore_v1beta1/client.py
@@ -582,7 +582,7 @@ def _parse_batch_get(get_doc_response, reference_map, client):
             a document factory.
 
     Returns:
-        Optional[.DocumentSnapshot]: The retrieved snapshot.
+       [.DocumentSnapshot]: The retrieved snapshot.
 
     Raises:
         ValueError: If the response has a ``result`` field (a oneof) other

--- a/firestore/google/cloud/firestore_v1beta1/document.py
+++ b/firestore/google/cloud/firestore_v1beta1/document.py
@@ -418,12 +418,14 @@ class DocumentReference(object):
 
         Returns:
             ~.firestore_v1beta1.document.DocumentSnapshot: A snapshot of
-            the current document.
+                the current document. If the document does not exist at
+                the time of `snapshot`, the snapshot `reference`, `data`,
+                `update_time`, and `create_time` attributes will all be
+                `None` and `exists` will be `False`.
         """
         snapshot_generator = self._client.get_all(
             [self], field_paths=field_paths, transaction=transaction)
-        snapshot = _consume_single_get(snapshot_generator)
-        return snapshot
+        return _consume_single_get(snapshot_generator)
 
 
 class DocumentSnapshot(object):

--- a/firestore/google/cloud/firestore_v1beta1/document.py
+++ b/firestore/google/cloud/firestore_v1beta1/document.py
@@ -17,7 +17,6 @@
 
 import copy
 
-from google.cloud import exceptions
 from google.cloud.firestore_v1beta1 import _helpers
 
 
@@ -420,17 +419,11 @@ class DocumentReference(object):
         Returns:
             ~.firestore_v1beta1.document.DocumentSnapshot: A snapshot of
             the current document.
-
-        Raises:
-            ~google.cloud.exceptions.NotFound: If the document does not exist.
         """
         snapshot_generator = self._client.get_all(
             [self], field_paths=field_paths, transaction=transaction)
         snapshot = _consume_single_get(snapshot_generator)
-        if snapshot is None:
-            raise exceptions.NotFound(self._document_path)
-        else:
-            return snapshot
+        return snapshot
 
 
 class DocumentSnapshot(object):
@@ -566,12 +559,16 @@ class DocumentSnapshot(object):
                 field names).
 
         Returns:
-            Any: (A copy of) the value stored for the ``field_path``.
+            Any or None:
+                (A copy of) the value stored for the ``field_path`` or
+                None if snapshot document does not exist.
 
         Raises:
             KeyError: If the ``field_path`` does not match nested data
                 in the snapshot.
         """
+        if not self._exists:
+            return None
         nested_data = _helpers.get_nested_value(field_path, self._data)
         return copy.deepcopy(nested_data)
 
@@ -582,8 +579,12 @@ class DocumentSnapshot(object):
         but the data stored in the snapshot must remain immutable.
 
         Returns:
-            Dict[str, Any]: The data in the snapshot.
+            Dict[str, Any] or None:
+                The data in the snapshot.  Returns None if reference
+                does not exist.
         """
+        if not self._exists:
+            return None
         return copy.deepcopy(self._data)
 
 

--- a/firestore/tests/unit/test_client.py
+++ b/firestore/tests/unit/test_client.py
@@ -378,7 +378,7 @@ class TestClient(unittest.TestCase):
         self.assertIs(snapshot2._reference, document1)
         self.assertEqual(snapshot2._data, data1)
 
-        self.assertIsNone(snapshots[2])
+        self.assertFalse(snapshots[2].exists)
 
         # Verify the call to the mock.
         doc_paths = [
@@ -669,7 +669,7 @@ class Test__parse_batch_get(unittest.TestCase):
         response_pb = _make_batch_response(missing=ref_string)
 
         snapshot = self._call_fut(response_pb, {})
-        self.assertIsNone(snapshot)
+        self.assertFalse(snapshot.exists)
 
     def test_unset_result_type(self):
         response_pb = _make_batch_response()

--- a/firestore/tests/unit/test_document.py
+++ b/firestore/tests/unit/test_document.py
@@ -449,8 +449,8 @@ class TestDocumentReference(unittest.TestCase):
 
         # Create a minimal fake client with a dummy response.
         read_time = 123
-        snapshot = DocumentSnapshot(None, None, False, read_time, None, None)
-        response_iterator = iter([snapshot])
+        expected = DocumentSnapshot(None, None, False, read_time, None, None)
+        response_iterator = iter([expected])
         client = mock.Mock(
             _database_string='sprinklez',
             spec=['_database_string', 'get_all'])
@@ -463,7 +463,7 @@ class TestDocumentReference(unittest.TestCase):
         self.assertIsNone(snapshot.reference)
         self.assertIsNone(snapshot._data)
         self.assertFalse(snapshot.exists)
-        self.assertEqual(snapshot.read_time, read_time)
+        self.assertEqual(snapshot.read_time, expected.read_time)
         self.assertIsNone(snapshot.create_time)
         self.assertIsNone(snapshot.update_time)
 


### PR DESCRIPTION
closes #4809 