### PR TITLE
Link out to requester pays docs.

### DIFF
--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -1078,7 +1078,8 @@ class Bucket(_PropertyMixin):
 
         .. note::
 
-           No public docs exist yet for the "requester pays" feature.
+        See https://cloud.google.com/storage/docs/requester-pays for
+        details.
 
         :setter: Update whether requester pays for this bucket.
         :getter: Query whether requester pays for this bucket.

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -1076,8 +1076,6 @@ class Bucket(_PropertyMixin):
     def requester_pays(self):
         """Does the requester pay for API requests for this bucket?
 
-        .. note::
-
         See https://cloud.google.com/storage/docs/requester-pays for
         details.
 


### PR DESCRIPTION
Link out to requester pays docs instead of stating there are no existing docs.