### PR TITLE
Add see also for Bucket.create method call for Client.create_bucket() documentation.

### DIFF
--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -242,7 +242,8 @@ class Client(ClientWithProject):
         If the bucket already exists, will raise
         :class:`google.cloud.exceptions.Conflict`.
 
-        See also: :meth:`~.storage.Bucket.create`
+        To set additional properties when creating a bucket such as
+        :attr:`~.storage.Bucket.location`, use :meth:`~.storage.Bucket.create`.
         
         :type bucket_name: str
         :param bucket_name: The bucket name to create.

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -242,6 +242,8 @@ class Client(ClientWithProject):
         If the bucket already exists, will raise
         :class:`google.cloud.exceptions.Conflict`.
 
+        See also: :meth:`~.storage.Bucket.create`
+        
         :type bucket_name: str
         :param bucket_name: The bucket name to create.
 


### PR DESCRIPTION
Raised by @tswast, users[1] are confused by this method when trying to define storage class and location. There's no clear way to define these properties using this method and adding a link to `Bucket.create` method call.

I added a short `see also` to documentation. I have the following two questions:
1. Is this an expected way to define links out to other methods (trying to understand Python documentation). 
2. How is documentation for this client library updated at https://googlecloudplatform.github.io/google-cloud-python/latest/storage/client.html#google.cloud.storage.client.Client.create_bucket? Is it automatic when merged?

References:
[1]: https://stackoverflow.com/questions/44019273/python-to-create-google-storage-buckets/44035030#44035030