### PR TITLE
Update doc reference links in GCS client documentation

### DIFF
--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -243,7 +243,7 @@ class Client(ClientWithProject):
         :class:`google.cloud.exceptions.Conflict`.
 
         To set additional properties when creating a bucket such as
-        :attr:`~.storage.Bucket.location`, use :meth:`~.storage.Bucket.create`.
+        :attr:`~.Bucket.location`, use :meth:`~.Bucket.create`.
         
         :type bucket_name: str
         :param bucket_name: The bucket name to create.


### PR DESCRIPTION
Update doc reference in GCS to correctly reference associated method and attribute.