### PR TITLE
Add missing monitoring dependency: pandas

### DIFF
--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -31,6 +31,7 @@ release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     'google-cloud-core<0.29dev,>=0.28.0',
     'google-api-core<2.0.0dev,>=0.1.1',
+    'pandas>=0.22.0',
 ]
 extras = {
 }


### PR DESCRIPTION
Adding missing dependency as per: 

google/cloud/monitoring/_dataframe.py
google/cloud/monitoring/client.py
google/cloud/monitoring/query.py