### PR TITLE
Add spanner commit timestamp support.

### DIFF
--- a/spanner/google/cloud/spanner.py
+++ b/spanner/google/cloud/spanner.py
@@ -20,6 +20,7 @@ from google.cloud.spanner_v1 import __version__
 from google.cloud.spanner_v1 import AbstractSessionPool
 from google.cloud.spanner_v1 import BurstyPool
 from google.cloud.spanner_v1 import Client
+from google.cloud.spanner_v1 import COMMIT_TIMESTAMP
 from google.cloud.spanner_v1 import enums
 from google.cloud.spanner_v1 import FixedSizePool
 from google.cloud.spanner_v1 import KeyRange
@@ -33,6 +34,7 @@ __all__ = (
     'AbstractSessionPool',
     'BurstyPool',
     'Client',
+    'COMMIT_TIMESTAMP',
     'enums',
     'FixedSizePool',
     'KeyRange',

--- a/spanner/google/cloud/spanner_v1/__init__.py
+++ b/spanner/google/cloud/spanner_v1/__init__.py
@@ -28,6 +28,14 @@ from google.cloud.spanner_v1.pool import BurstyPool
 from google.cloud.spanner_v1.pool import FixedSizePool
 
 
+COMMIT_TIMESTAMP = 'spanner.commit_timestamp()'
+"""Placeholder be used to store commit timestamp of a transaction in a column.
+
+This value can only be used for timestamp columns that have set the option 
+``(allow_commit_timestamp=true)`` in the schema.
+"""
+
+
 __all__ = (
     # google.cloud.spanner_v1
     '__version__',
@@ -48,4 +56,7 @@ __all__ = (
 
     # google.cloud.spanner_v1.gapic
     'enums',
+
+    # local
+    'COMMIT_TIMESTAMP',
 )

--- a/spanner/tests/_fixtures.py
+++ b/spanner/tests/_fixtures.py
@@ -48,6 +48,14 @@ CREATE TABLE string_plus_array_of_string (
     tags ARRAY<STRING(16)> )
     PRIMARY KEY (id);
 CREATE INDEX name ON contacts(first_name, last_name);
+CREATE TABLE users_history (
+     id INT64 NOT NULL,
+     commit_ts TIMESTAMP NOT NULL OPTIONS
+        (allow_commit_timestamp=true),
+     name STRING(MAX) NOT NULL,
+     email STRING(MAX),
+     deleted BOOL NOT NULL )
+     PRIMARY KEY(id, commit_ts DESC);
 """
 
 DDL_STATEMENTS = [stmt.strip() for stmt in DDL.split(';') if stmt.strip()]


### PR DESCRIPTION
/cc @vkedia

Export `COMMIT_TIMESTAMP` constant.

Magic string value for timestamp columns to be populated on the backend with the commit timestamp of the corresponding insert / update operation.

Add a system test which shows using it with a table whose `commit_ts` column supports it.