### PR TITLE
BigQuery: Limit number of jobs in list_jobs snippet.

### DIFF
--- a/docs/bigquery/snippets.py
+++ b/docs/bigquery/snippets.py
@@ -1767,8 +1767,9 @@ def test_client_list_jobs(client):
         pass
 
     # [START client_list_jobs]
-    job_iterator = client.list_jobs()  # API request(s)
-    for job in job_iterator:
+    job_iterator = client.list_jobs(
+        max_results=10)  # Optionally, limit the results to 10 jobs.
+    for job in job_iterator:  # API request(s) happen when iterating
         do_something_with(job)
     # [END client_list_jobs]
 


### PR DESCRIPTION
The `list_jobs` snippet was taking a very long time in the CI tests.
This should keep it from timing out.

Closes https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5095