### PR TITLE
BigQuery: Add dev version for 0.32.0 release

### DIFF
--- a/bigquery/setup.py
+++ b/bigquery/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = 'google-cloud-bigquery'
 description = 'Google BigQuery API client library'
-version = '0.31.0'
+version = '0.32.0.dev1'
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
This will allow downstream packages (like pandas-gbq) to check for this
version when using the package at HEAD in CI tests.

Specifically, I'm thinking about https://github.com/pydata/pandas-gbq/pull/152 which updates pandas-gbq to account for my breaking change in https://github.com/GoogleCloudPlatform/google-cloud-python/pull/5036