### PR TITLE
BigQuery: Make SchemaField be able to include description via from_api_repr method

### DIFF
--- a/bigquery/google/cloud/bigquery/schema.py
+++ b/bigquery/google/cloud/bigquery/schema.py
@@ -58,11 +58,13 @@ class SchemaField(object):
         """
         # Handle optional properties with default values
         mode = api_repr.get('mode', 'NULLABLE')
+        description = api_repr.get('description')
         fields = api_repr.get('fields', ())
         return cls(
             field_type=api_repr['type'].upper(),
             fields=[cls.from_api_repr(f) for f in fields],
             mode=mode.upper(),
+            description=description,
             name=api_repr['name'],
         )
 

--- a/bigquery/tests/unit/test_schema.py
+++ b/bigquery/tests/unit/test_schema.py
@@ -94,12 +94,14 @@ class TestSchemaField(unittest.TestCase):
                 'type': 'integer',
             }],
             'mode': 'required',
+            'description': 'test_description',
             'name': 'foo',
             'type': 'record',
         })
         self.assertEqual(field.name, 'foo')
         self.assertEqual(field.field_type, 'RECORD')
         self.assertEqual(field.mode, 'REQUIRED')
+        self.assertEqual(field.description, 'test_description')
         self.assertEqual(len(field.fields), 1)
         self.assertEqual(field.fields[0].name, 'bar')
         self.assertEqual(field.fields[0].field_type, 'INTEGER')
@@ -113,6 +115,7 @@ class TestSchemaField(unittest.TestCase):
         self.assertEqual(field.name, 'foo')
         self.assertEqual(field.field_type, 'RECORD')
         self.assertEqual(field.mode, 'NULLABLE')
+        self.assertEqual(field.description, None)
         self.assertEqual(len(field.fields), 0)
 
     def test_name_property(self):


### PR DESCRIPTION
Hi,
I fixed a problem that the description was not reflected in the `SchemaField` via `from_api_repr` method.
