### PR TITLE
Use bytes literals to initialize 'BytesIO'.

### DIFF
--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -381,7 +381,7 @@ class TestBigQuery(unittest.TestCase):
         config = bigquery.LoadJobConfig()
         config.schema = schema
         job = Config.CLIENT.load_table_from_file(
-            six.BytesIO(body), table_ref, job_config=config)
+            six.BytesIO(body.encode('ascii')), table_ref, job_config=config)
         job.result()
         return bigquery.Table(table_ref, schema=schema)
 
@@ -1707,7 +1707,7 @@ class TestBigQuery(unittest.TestCase):
             {'string_col': 'Some value', 'record_col': record},
         ]
         rows = [json.dumps(row) for row in to_insert]
-        body = six.BytesIO('{}\n'.format('\n'.join(rows)))
+        body = six.BytesIO('{}\n'.format('\n'.join(rows)).encode('ascii'))
         table_id = 'test_table'
         dataset = self.temp_dataset(_make_dataset_id('nested_df'))
         table = dataset.table(table_id)
@@ -1749,7 +1749,7 @@ class TestBigQuery(unittest.TestCase):
         schema = [SF('string_col', 'STRING', mode='NULLABLE')]
         to_insert = [{'string_col': 'item%d' % i} for i in range(num_items)]
         rows = [json.dumps(row) for row in to_insert]
-        body = six.BytesIO('{}\n'.format('\n'.join(rows)))
+        body = six.BytesIO('{}\n'.format('\n'.join(rows)).encode('ascii'))
 
         table_id = 'test_table'
         dataset = self.temp_dataset(_make_dataset_id('nested_df'))


### PR DESCRIPTION
See [CI failure](https://circleci.com/gh/GoogleCloudPlatform/google-cloud-python/6104) on Py3k.