### PR TITLE
BigQuery: Specifies IPython version when running Python 2.7 tests

### DIFF
--- a/bigquery/nox.py
+++ b/bigquery/nox.py
@@ -35,11 +35,19 @@ def default(session):
     run the tests.
     """
     # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', 'ipython', *LOCAL_DEPS)
+    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+
+    # Pandas does not support Python 3.4
     if session.interpreter == 'python3.4':
         session.install('-e', '.')
     else:
         session.install('-e', '.[pandas]')
+
+    # IPython does not support Python 2 after version 5.x
+    if session.interpreter == 'python2.7':
+        session.install('ipython==5.5')
+    else:
+        session.install('ipython')
 
     # Run py.test against the unit tests.
     session.run(
@@ -87,12 +95,18 @@ def system(session, py):
 
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
-    session.install('mock', 'pytest', 'ipython', *LOCAL_DEPS)
+    session.install('mock', 'pytest', *LOCAL_DEPS)
     session.install(
         os.path.join('..', 'storage'),
         os.path.join('..', 'test_utils'),
     )
     session.install('-e', '.[pandas]')
+
+    # IPython does not support Python 2 after version 5.x
+    if session.interpreter == 'python2.7':
+        session.install('ipython==5.5')
+    else:
+        session.install('ipython')
 
     # Run py.test against the system tests.
     session.run(


### PR DESCRIPTION
IPython no longer supports Python 2.7 after version 5.x. This PR updates the nox sessions to specify IPython version 5.5 for Python 2.7 tests, which is the latest version that passes the tests. Resolves the tests failures in https://github.com/GoogleCloudPlatform/google-cloud-python/pull/5143.