### PR TITLE
Allow uploading files larger than 2GB by using Resumable Media Requests

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -879,9 +879,9 @@ class Blob(_PropertyMixin):
                    size, num_retries, predefined_acl):
         """Determine an upload strategy and then perform the upload.
 
-        If the size of the data to be uploaded exceeds 5 MB, or the size is
-        unknown, a resumable media request will be used, otherwise the content
-        and the metadata will be uploaded in a single multipart upload request.
+        If the size of the data to be uploaded exceeds 5 MB a resumable media 
+        request will be used, otherwise the content and the metadata will be
+        uploaded in a single multipart upload request.
 
         The content type of the upload will be determined in order
         of precedence:

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -879,7 +879,7 @@ class Blob(_PropertyMixin):
                    size, num_retries, predefined_acl):
         """Determine an upload strategy and then perform the upload.
 
-        If the size of the data to be uploaded exceeds 5 MB a resumable media 
+        If the size of the data to be uploaded exceeds 5 MB a resumable media
         request will be used, otherwise the content and the metadata will be
         uploaded in a single multipart upload request.
 

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -94,7 +94,7 @@ _READ_LESS_THAN_SIZE = (
     'Size {:d} was specified but the file-like object only had '
     '{:d} bytes remaining.')
 _DEFAULT_CHUNKSIZE = 1048576  # 1024 * 1024 B = 1 MB
-_MAX_MULTIPART_SIZE = 5 * 1024 * 1024 # 5 MB
+_MAX_MULTIPART_SIZE = 5242880  # 5 MB
 
 
 class Blob(_PropertyMixin):
@@ -177,8 +177,8 @@ class Blob(_PropertyMixin):
                  multiple of 256 KB.
         """
         if value is not None and \
-            value > 0 and \
-            value % self._CHUNK_SIZE_MULTIPLE != 0:
+                value > 0 and \
+                value % self._CHUNK_SIZE_MULTIPLE != 0:
             raise ValueError('Chunk size must be a multiple of %d.' % (
                 self._CHUNK_SIZE_MULTIPLE,))
         self._chunk_size = value

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -93,8 +93,9 @@ _NUM_RETRIES_MESSAGE = (
 _READ_LESS_THAN_SIZE = (
     'Size {:d} was specified but the file-like object only had '
     '{:d} bytes remaining.')
-_DEFAULT_CHUNKSIZE = 1048576  # 1024 * 1024 B = 1 MB
-_MAX_MULTIPART_SIZE = 5242880  # 5 MB
+
+_DEFAULT_CHUNKSIZE = 104857600  # 1024 * 1024 B * 100 = 100 MB
+_MAX_MULTIPART_SIZE = 8388608  # 8 MB
 
 
 class Blob(_PropertyMixin):

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -121,7 +121,7 @@ class Blob(_PropertyMixin):
         See https://cloud.google.com/storage/docs/encryption#customer-supplied.
     """
 
-    _chunk_size = _DEFAULT_CHUNKSIZE  # Default value for each instance.
+    _chunk_size = None  # Default value for each instance.
     _CHUNK_SIZE_MULTIPLE = 256 * 1024
     """Number (256 KB, in bytes) that must divide the chunk size."""
 

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -1142,7 +1142,7 @@ class Test_Blob(unittest.TestCase):
         if chunk_size is None:
             if blob_chunk_size is None:
                 self.assertEqual(upload._chunk_size,
-                    google.cloud.storage.blob._DEFAULT_CHUNKSIZE)
+                                 google.cloud.storage.blob._DEFAULT_CHUNKSIZE)
             else:
                 self.assertEqual(upload._chunk_size, blob.chunk_size)
         else:

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -1383,8 +1383,9 @@ class Test_Blob(unittest.TestCase):
             size=google.cloud.storage.blob._MAX_MULTIPART_SIZE)
 
     def test__do_upload_uses_resumable(self):
-        chunk_size = 1024 * 1024 * 1024  # 1GB
-        self._do_upload_helper(chunk_size=chunk_size)
+        self._do_upload_helper(
+            chunk_size=256 * 1024, # 256KB 
+            size=google.cloud.storage.blob._MAX_MULTIPART_SIZE + 1)
 
     def test__do_upload_with_retry(self):
         self._do_upload_helper(num_retries=20)

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -1384,7 +1384,7 @@ class Test_Blob(unittest.TestCase):
 
     def test__do_upload_uses_resumable(self):
         self._do_upload_helper(
-            chunk_size=256 * 1024, # 256KB 
+            chunk_size=256 * 1024,  # 256KB
             size=google.cloud.storage.blob._MAX_MULTIPART_SIZE + 1)
 
     def test__do_upload_with_retry(self):

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -1328,7 +1328,7 @@ class Test_Blob(unittest.TestCase):
         self._do_resumable_helper(predefined_acl='private')
 
     def _do_upload_helper(
-            self, chunk_size=None, num_retries=None, predefined_acl=None, 
+            self, chunk_size=None, num_retries=None, predefined_acl=None,
             size=None):
         blob = self._make_one(u'blob-name', bucket=None)
 
@@ -1356,7 +1356,7 @@ class Test_Blob(unittest.TestCase):
         self.assertIs(created_json, mock.sentinel.json)
         response.json.assert_called_once_with()
         if size is not None and \
-                size <= google.cloud.storage.blob._MAX_MULTIPART_SIZE :
+                size <= google.cloud.storage.blob._MAX_MULTIPART_SIZE:
             blob._do_multipart_upload.assert_called_once_with(
                 client, stream, content_type, size, num_retries,
                 predefined_acl)

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -1327,7 +1327,7 @@ class Test_Blob(unittest.TestCase):
         self._do_resumable_helper(predefined_acl='private')
 
     def _do_upload_helper(
-            self, chunk_size=None, num_retries=None, predefined_acl=None):
+            self, chunk_size=None, num_retries=None, predefined_acl=None, size=None):
         blob = self._make_one(u'blob-name', bucket=None)
 
         # Create a fake response.
@@ -1346,14 +1346,14 @@ class Test_Blob(unittest.TestCase):
         client = mock.sentinel.client
         stream = mock.sentinel.stream
         content_type = u'video/mp4'
-        size = 12345654321
+        if size is None:
+            size = 12345654321
         # Make the request and check the mocks.
         created_json = blob._do_upload(
             client, stream, content_type, size, num_retries, predefined_acl)
         self.assertIs(created_json, mock.sentinel.json)
         response.json.assert_called_once_with()
-        if chunk_size is None:
-
+        if size is not None and size < 1024*1024*5:
             blob._do_multipart_upload.assert_called_once_with(
                 client, stream, content_type, size, num_retries,
                 predefined_acl)
@@ -1364,8 +1364,8 @@ class Test_Blob(unittest.TestCase):
                 client, stream, content_type, size, num_retries,
                 predefined_acl)
 
-    def test__do_upload_without_chunk_size(self):
-        self._do_upload_helper()
+    def test__do_upload_small_file(self):
+        self._do_upload_helper(size=100)
 
     def test__do_upload_with_chunk_size(self):
         chunk_size = 1024 * 1024 * 1024  # 1GB


### PR DESCRIPTION
Change the logic to elect to use multipart or resumable media for upload requests.
