### PR TITLE
BigQuery: Adds samples from python-docs-samples

### DIFF
--- a/docs/bigquery/snippets.py
+++ b/docs/bigquery/snippets.py
@@ -851,7 +851,8 @@ def test_load_table_from_file(client, to_delete):
 
     job.result()  # Waits for table load to complete.
 
-    print('Job {} completed.'.format(job.job_id))
+    print('Loaded {} rows into {}:{}.'.format(
+        job.output_rows, dataset_id, table_id))
     # [END bigquery_load_from_file]
 
     table = client.get_table(table_ref)
@@ -1508,10 +1509,13 @@ def test_extract_table(client, to_delete):
     # from google.cloud import bigquery
     # client = bigquery.Client()
     # bucket_name = 'my-bucket'
+    project = 'bigquery-public-data'
+    dataset_id = 'samples'
+    table_id = 'shakespeare'
 
     destination_uri = 'gs://{}/{}'.format(bucket_name, 'shakespeare.csv')
-    dataset_ref = client.dataset('samples', project='bigquery-public-data')
-    table_ref = dataset_ref.table('shakespeare')
+    dataset_ref = client.dataset(dataset_id, project=project)
+    table_ref = dataset_ref.table(table_id)
 
     extract_job = client.extract_table(
         table_ref,
@@ -1519,6 +1523,9 @@ def test_extract_table(client, to_delete):
         # Location must match that of the source table.
         location='US')  # API request
     extract_job.result()  # Waits for job to complete.
+
+    print('Exported {}:{}.{} to {}'.format(
+        project, dataset_id, table_id, destination_uri))
     # [END bigquery_extract_table]
 
     blob = bucket.get_blob('shakespeare.csv')

--- a/docs/bigquery/snippets.py
+++ b/docs/bigquery/snippets.py
@@ -26,6 +26,7 @@ need to be deleted during teardown.
 import os
 import time
 
+import mock
 import pytest
 import six
 try:
@@ -88,6 +89,40 @@ class _CloseOnDelete(object):
 
     def delete(self):
         self._wrapped.close()
+
+
+def test_create_client_default_credentials():
+    """Create a BigQuery client with Application Default Credentials"""
+
+    # [START bigquery_client_default_credentials]
+    from google.cloud import bigquery
+
+    # If you don't specify credentials when constructing the client, the
+    # client library will look for credentials in the environment.
+    client = bigquery.Client()
+    # [END bigquery_client_default_credentials]
+
+    assert client is not None
+
+
+def test_create_client_json_credentials():
+    """Create a BigQuery client with Application Default Credentials"""
+    with open(os.environ['GOOGLE_APPLICATION_CREDENTIALS']) as creds_file:
+        creds_file_data = creds_file.read()
+
+    open_mock = mock.mock_open(read_data=creds_file_data)
+
+    with mock.patch('io.open', open_mock):
+        # [START bigquery_client_json_credentials]
+        from google.cloud import bigquery
+
+        # Explicitly use service account credentials by specifying the private
+        # key file. All clients in google-cloud-python have this helper.
+        client = bigquery.Client.from_service_account_json(
+            'path/to/service_account.json')
+        # [END bigquery_client_json_credentials]
+
+    assert client is not None
 
 
 def test_list_datasets(client):

--- a/docs/bigquery/snippets.py
+++ b/docs/bigquery/snippets.py
@@ -1723,8 +1723,8 @@ def test_client_query_w_params(client):
         AND word_count >= @min_word_count
         ORDER BY word_count DESC;
     """
-    corpus = 'hamlet'
-    min_word_count = 100
+    corpus = 'romeoandjuliet'
+    min_word_count = 250
     query_params = [
         bigquery.ScalarQueryParameter('corpus', 'STRING', corpus),
         bigquery.ScalarQueryParameter(

--- a/docs/bigquery/snippets.py
+++ b/docs/bigquery/snippets.py
@@ -1653,7 +1653,37 @@ def test_client_query(client):
     for row in query_job:  # API request - fetches results
         # Row values can be accessed by field name or index
         assert row[0] == row.name == row['name']
+        print(row)
     # [END bigquery_query]
+
+
+def test_client_query_standard_sql(client):
+    """Run a query with Standard SQL explicitly set"""
+    # [START bigquery_query_standard]
+    # from google.cloud import bigquery
+    # client = bigquery.Client()
+
+    query = (
+        'SELECT name FROM `bigquery-public-data.usa_names.usa_1910_2013` '
+        'WHERE state = "TX" '
+        'LIMIT 100')
+
+    # Set use_legacy_sql to False to use standard SQL syntax.
+    # Note that queries run through the Python Client Library are set to use
+    # standard SQL by default.
+    job_config = bigquery.QueryJobConfig()
+    job_config.use_legacy_sql = False
+
+    query_job = client.query(
+        query,
+        # Location must match that of the dataset(s) referenced in the query.
+        location='US',
+        job_config=job_config)  # API request - starts the query
+
+    # Print the results.
+    for row in query_job:  # API request - fetches results
+        print(row)
+    # [END bigquery_query_standard]
 
 
 def test_client_query_destination_table(client, to_delete):
@@ -1680,7 +1710,7 @@ def test_client_query_destination_table(client, to_delete):
     # The write_disposition specifies the behavior when writing query results
     # to a table that already exists. With WRITE_TRUNCATE, any existing rows
     # in the table are overwritten by the query results.
-    job_config.write_disposition = 'WRITE_TRUNCATE'
+    job_config.write_disposition = bigquery.WriteDisposition.WRITE_TRUNCATE
 
     # Start the query, passing in the extra configuration.
     query_job = client.query(

--- a/docs/bigquery/usage.rst
+++ b/docs/bigquery/usage.rst
@@ -344,8 +344,8 @@ See BigQuery documentation for more information on
 `parameterized queries <https://cloud.google.com/bigquery/docs/parameterized-queries>`_.
 
 .. literalinclude:: snippets.py
-  :start-after: [START bigquery_query_params]
-  :end-before: [END bigquery_query_params]
+  :start-after: [START bigquery_query_params_named]
+  :end-before: [END bigquery_query_params_named]
 
 
 List jobs for a project


### PR DESCRIPTION
There were many redundant samples between google-cloud-python and python-docs-samples. This repo is the primary source of code samples and only had a few missing that were still being sourced from python-docs-samples. This PR adds those few remaining samples so that all samples except quickstart, simple app, and user credentials can be deleted from python-docs-samples.