### PR TITLE
Don't suppress 'dots' output for snippets tests.

### DIFF
--- a/bigquery/nox.py
+++ b/bigquery/nox.py
@@ -144,7 +144,6 @@ def snippets(session, py):
     # Run py.test against the system tests.
     session.run(
         'py.test',
-        '--quiet',
         os.path.join(os.pardir, 'docs', 'bigquery', 'snippets.py'),
         *session.posargs
     )


### PR DESCRIPTION
CI aborts the run if the test goes longer than 10 minutes without emitting any output.

This change also eases running with verbose output for debugging long-running tests, e.g., `nox -e snippets -- --verbose`.

See #5003.