### PR TITLE
BigQuery: Fix typo in Encoding.ISO_8859_1 enum value

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -131,13 +131,13 @@ class DestinationFormat(object):
 class Encoding(object):
     """The character encoding of the data. The supported values
     are `UTF_8` corresponding to `'UTF-8'` or `ISO_8859_1` corresponding to
-    `'ISO-8559-1'`. The default value is `UTF_8`.
+    `'ISO-8859-1'`. The default value is `UTF_8`.
 
     BigQuery decodes the data after the raw, binary data has been
     split using the values of the quote and fieldDelimiter properties.
     """
     UTF_8 = 'UTF-8'
-    ISO_8559_1 = 'ISO-8559-1'
+    ISO_8859_1 = 'ISO-8859-1'
 
 
 class QueryPriority(object):


### PR DESCRIPTION
Per https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.encoding the encoding value should be ISO-8859-1 ("Latin alphabet no. 1"). It was ISO-8559-1 ("anthropometric measurements that can be used for the creation of size and shape profiles and their application in the field of clothing").

cc @mtai