### PR TITLE
BigQuery: add from_string factory methods to Dataset and Table

### DIFF
--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -210,6 +210,37 @@ class DatasetReference(object):
         dataset_id = resource['datasetId']
         return cls(project, dataset_id)
 
+    @classmethod
+    def from_string(cls, full_dataset_id):
+        """Construct a dataset reference from fully-qualified dataset ID.
+
+        Args:
+            full_dataset_id (str):
+                A fully-qualified dataset ID in standard SQL format. Must
+                included both the project ID and the dataset ID, separated by
+                ``.``.
+
+        Returns:
+            DatasetReference:
+                Dataset reference parsed from ``full_dataset_id``.
+
+        Examples:
+            >>> DatasetReference.from_string('my-project-id.some_dataset')
+            DatasetReference('my-project-id', 'some_dataset')
+
+        Raises:
+            ValueError:
+                If ``full_dataset_id`` is not a fully-qualified dataset ID in
+                standard SQL format.
+        """
+        parts = full_dataset_id.split('.')
+        if len(parts) != 2:
+            raise ValueError(
+                'full_dataset_id must be a fully-qualified dataset ID in '
+                'standard SQL format. e.g. "project.dataset_id", got '
+                '{}'.format(full_dataset_id))
+        return cls(parts[0], parts[1])
+
     def to_api_repr(self):
         """Construct the API resource representation of this dataset reference
 
@@ -451,6 +482,31 @@ class Dataset(object):
         self._properties['labels'] = value
 
     @classmethod
+    def from_string(cls, full_dataset_id):
+        """Construct a dataset from fully-qualified dataset ID.
+
+        Args:
+            full_dataset_id (str):
+                A fully-qualified dataset ID in standard SQL format. Must
+                included both the project ID and the dataset ID, separated by
+                ``.``.
+
+        Returns:
+            Dataset: Dataset parsed from ``full_dataset_id``.
+
+        Examples:
+            >>> Dataset.from_string('my-project-id.some_dataset')
+            Dataset(DatasetReference('my-project-id', 'some_dataset'))
+
+        Raises:
+            ValueError:
+                If ``full_dataset_id`` is not a fully-qualified dataset ID in
+                standard SQL format.
+        """
+        dataset_ref = DatasetReference.from_string(full_dataset_id)
+        return cls(dataset_ref)
+
+    @classmethod
     def from_api_repr(cls, resource):
         """Factory: construct a dataset given its API representation
 
@@ -507,6 +563,9 @@ class Dataset(object):
                 A TableReference for a table in this dataset.
         """
         return TableReference(self.reference, table_id)
+
+    def __repr__(self):
+        return 'Dataset({})'.format(repr(self.reference))
 
 
 class DatasetListItem(object):

--- a/bigquery/google/cloud/bigquery/dataset.py
+++ b/bigquery/google/cloud/bigquery/dataset.py
@@ -239,7 +239,7 @@ class DatasetReference(object):
                 'full_dataset_id must be a fully-qualified dataset ID in '
                 'standard SQL format. e.g. "project.dataset_id", got '
                 '{}'.format(full_dataset_id))
-        return cls(parts[0], parts[1])
+        return cls(*parts)
 
     def to_api_repr(self):
         """Construct the API resource representation of this dataset reference
@@ -503,8 +503,7 @@ class Dataset(object):
                 If ``full_dataset_id`` is not a fully-qualified dataset ID in
                 standard SQL format.
         """
-        dataset_ref = DatasetReference.from_string(full_dataset_id)
-        return cls(dataset_ref)
+        return cls(DatasetReference.from_string(full_dataset_id))
 
     @classmethod
     def from_api_repr(cls, resource):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -667,8 +667,7 @@ class Table(object):
                 If ``full_table_id`` is not a fully-qualified table ID in
                 standard SQL format.
         """
-        table_ref = TableReference.from_string(full_table_id)
-        return cls(table_ref)
+        return cls(TableReference.from_string(full_table_id))
 
     @classmethod
     def from_api_repr(cls, resource):

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -165,16 +165,27 @@ class TestDatasetReference(unittest.TestCase):
             })
 
     def test_from_api_repr(self):
-        from google.cloud.bigquery.dataset import DatasetReference
+        cls = self._get_target_class()
         expected = self._make_one('project_1', 'dataset_1')
 
-        got = DatasetReference.from_api_repr(
+        got = cls.from_api_repr(
             {
                 'projectId': 'project_1',
                 'datasetId': 'dataset_1',
             })
 
         self.assertEqual(expected, got)
+
+    def test_from_string(self):
+        cls = self._get_target_class()
+        got = cls.from_string('string-project.string_dataset')
+        self.assertEqual(got.project, 'string-project')
+        self.assertEqual(got.dataset_id, 'string_dataset')
+
+    def test_from_string_legacy_string(self):
+        cls = self._get_target_class()
+        with self.assertRaises(ValueError):
+            cls.from_string('string-project:string_dataset')
 
     def test___eq___wrong_type(self):
         dataset = self._make_one('project_1', 'dataset_1')
@@ -484,6 +495,17 @@ class TestDataset(unittest.TestCase):
         }
         self.assertEqual(resource, exp_resource)
 
+    def test_from_string(self):
+        cls = self._get_target_class()
+        got = cls.from_string('string-project.string_dataset')
+        self.assertEqual(got.project, 'string-project')
+        self.assertEqual(got.dataset_id, 'string_dataset')
+
+    def test_from_string_legacy_string(self):
+        cls = self._get_target_class()
+        with self.assertRaises(ValueError):
+            cls.from_string('string-project:string_dataset')
+
     def test__build_resource_w_custom_field(self):
         dataset = self._make_one(self.DS_REF)
         dataset._properties['newAlphaProperty'] = 'unreleased property'
@@ -509,6 +531,13 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(table.table_id, 'table_id')
         self.assertEqual(table.dataset_id, self.DS_ID)
         self.assertEqual(table.project, self.PROJECT)
+
+    def test___repr__(self):
+        from google.cloud.bigquery.dataset import DatasetReference
+        dataset = self._make_one(DatasetReference('project1', 'dataset1'))
+        expected = "Dataset(DatasetReference('project1', 'dataset1'))"
+        self.assertEqual(repr(dataset), expected)
+
 
 
 class TestDatasetListItem(unittest.TestCase):

--- a/bigquery/tests/unit/test_dataset.py
+++ b/bigquery/tests/unit/test_dataset.py
@@ -539,7 +539,6 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(repr(dataset), expected)
 
 
-
 class TestDatasetListItem(unittest.TestCase):
 
     @staticmethod

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -134,6 +134,28 @@ class TestTableReference(unittest.TestCase):
 
         self.assertEqual(expected, got)
 
+    def test_from_string(self):
+        cls = self._get_target_class()
+        got = cls.from_string('string-project.string_dataset.string_table')
+        self.assertEqual(got.project, 'string-project')
+        self.assertEqual(got.dataset_id, 'string_dataset')
+        self.assertEqual(got.table_id, 'string_table')
+
+    def test_from_string_legacy_string(self):
+        cls = self._get_target_class()
+        with self.assertRaises(ValueError):
+            cls.from_string('string-project:string_dataset.string_table')
+
+    def test_from_string_not_fully_qualified(self):
+        cls = self._get_target_class()
+        with self.assertRaises(ValueError):
+            cls.from_string('string_dataset.string_table')
+
+    def test_from_string_legacy_string(self):
+        cls = self._get_target_class()
+        with self.assertRaises(ValueError):
+            cls.from_string('string-project:string_dataset')
+
     def test___eq___wrong_type(self):
         from google.cloud.bigquery.dataset import DatasetReference
         dataset_ref = DatasetReference('project_1', 'dataset_1')
@@ -193,7 +215,10 @@ class TestTableReference(unittest.TestCase):
     def test___repr__(self):
         dataset = DatasetReference('project1', 'dataset1')
         table1 = self._make_one(dataset, 'table1')
-        expected = "TableReference('project1', 'dataset1', 'table1')"
+        expected = (
+            "TableReference(DatasetReference('project1', 'dataset1'), "
+            "'table1')"
+        )
         self.assertEqual(repr(table1), expected)
 
 
@@ -634,6 +659,23 @@ class TestTable(unittest.TestCase, _SchemaBase):
         with self.assertRaises(ValueError):
             table.labels = 12345
 
+    def test_from_string(self):
+        cls = self._get_target_class()
+        got = cls.from_string('string-project.string_dataset.string_table')
+        self.assertEqual(got.project, 'string-project')
+        self.assertEqual(got.dataset_id, 'string_dataset')
+        self.assertEqual(got.table_id, 'string_table')
+
+    def test_from_string_legacy_string(self):
+        cls = self._get_target_class()
+        with self.assertRaises(ValueError):
+            cls.from_string('string-project:string_dataset.string_table')
+
+    def test_from_string_not_fully_qualified(self):
+        cls = self._get_target_class()
+        with self.assertRaises(ValueError):
+            cls.from_string('string_dataset.string_table')
+
     def test_from_api_repr_missing_identity(self):
         self._setUpConstants()
         RESOURCE = {}
@@ -836,6 +878,17 @@ class TestTable(unittest.TestCase, _SchemaBase):
                          self.KMS_KEY_NAME)
         table.encryption_configuration = None
         self.assertIsNone(table.encryption_configuration)
+
+    def test___repr__(self):
+        from google.cloud.bigquery.table import TableReference
+        dataset = DatasetReference('project1', 'dataset1')
+        table1 = self._make_one(TableReference(dataset, 'table1'))
+        expected = (
+            "Table(TableReference("
+            "DatasetReference('project1', 'dataset1'), "
+            "'table1'))"
+        )
+        self.assertEqual(repr(table1), expected)
 
 
 class Test_row_from_mapping(unittest.TestCase, _SchemaBase):

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -151,11 +151,6 @@ class TestTableReference(unittest.TestCase):
         with self.assertRaises(ValueError):
             cls.from_string('string_dataset.string_table')
 
-    def test_from_string_legacy_string(self):
-        cls = self._get_target_class()
-        with self.assertRaises(ValueError):
-            cls.from_string('string-project:string_dataset')
-
     def test___eq___wrong_type(self):
         from google.cloud.bigquery.dataset import DatasetReference
         dataset_ref = DatasetReference('project_1', 'dataset_1')


### PR DESCRIPTION
To make it easier to construct Datasets and Tables when the
full-qualified ID is known ahead of time, this PR adds helper methods
called `from_string` to Dataset, DatasetReference, Table, and
TableReference. In each case, the expected format is a fully-qualified
ID (including the project ID) in standard SQL format.

```
dataset = client.create_dataset(
    bigquery.Dataset(
        client.dataset('mydataset', project='other-project')
    )
)
```

becomes

```
dataset = client.create_dataset(
    bigquery.Dataset.from_string('other-project.mydataset')
)
```

Also, while writing doctests/examples, I noticed `__repr__` was
inconsistent with the actual constructor on some of these classes. I
fixed that while I was here so those string representations don't cause
confusion.

/cc @maxim-lian