### PR TITLE
Storage: add support for KMS keys

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -126,7 +126,6 @@ class Blob(_PropertyMixin):
     :param kms_key_name:
         Optional resource name of Cloud KMS key used to encrypt the blob's
         contents.
-        See https://cloud.google.com/storage/docs/encryption#kms.
     """
 
     _chunk_size = None  # Default value for each instance.
@@ -1718,8 +1717,6 @@ class Blob(_PropertyMixin):
     @property
     def kms_key_name(self):
         """Resource name of Cloud KMS key used to encrypt the blob's contents.
-
-        See https://cloud.google.com/storage/docs/encryption#kms.
 
         :rtype: str or ``NoneType``
         :returns:

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -121,6 +121,12 @@ class Blob(_PropertyMixin):
     :param encryption_key:
         Optional 32 byte encryption key for customer-supplied encryption.
         See https://cloud.google.com/storage/docs/encryption#customer-supplied.
+
+    :type kms_key_name: str
+    :param kms_key_name:
+        Optional resource name of Cloud KMS key used to encrypt the blob's
+        contents.
+        See https://cloud.google.com/storage/docs/encryption#kms.
     """
 
     _chunk_size = None  # Default value for each instance.
@@ -150,14 +156,21 @@ class Blob(_PropertyMixin):
        set as their 'storage_class'.
     """
 
-    def __init__(self, name, bucket, chunk_size=None, encryption_key=None):
+    def __init__(self, name, bucket, chunk_size=None,
+                 encryption_key=None, kms_key_name=None):
         name = _bytes_to_unicode(name)
         super(Blob, self).__init__(name=name)
 
         self.chunk_size = chunk_size  # Check that setter accepts value.
         self.bucket = bucket
         self._acl = ObjectACL(self)
+        if encryption_key is not None and kms_key_name is not None:
+            raise ValueError(
+                "Pass at most one of 'encryption_key' "
+                "and 'kms_key_name'")
+
         self._encryption_key = encryption_key
+        self._kms_key_name = kms_key_name
 
     @property
     def chunk_size(self):
@@ -727,6 +740,10 @@ class Blob(_PropertyMixin):
 
         if self.user_project is not None:
             name_value_pairs.append(('userProject', self.user_project))
+
+        if self._kms_key_name is not None:
+            name_value_pairs.append(('kmsKeyName', self._kms_key_name))
+
         if predefined_acl is not None:
             name_value_pairs.append(('predefinedAcl', predefined_acl))
 
@@ -813,6 +830,10 @@ class Blob(_PropertyMixin):
 
         if self.user_project is not None:
             name_value_pairs.append(('userProject', self.user_project))
+
+        if self._kms_key_name is not None:
+            name_value_pairs.append(('kmsKeyName', self._kms_key_name))
+
         if predefined_acl is not None:
             name_value_pairs.append(('predefinedAcl', predefined_acl))
 
@@ -1400,6 +1421,9 @@ class Blob(_PropertyMixin):
 
         if self.user_project is not None:
             query_params['userProject'] = self.user_project
+
+        if self._kms_key_name is not None:
+            query_params['destinationKmsKeyName'] = self._kms_key_name
 
         api_response = client._connection.api_request(
             method='POST',

--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -170,7 +170,9 @@ class Blob(_PropertyMixin):
                 "and 'kms_key_name'")
 
         self._encryption_key = encryption_key
-        self._kms_key_name = kms_key_name
+
+        if kms_key_name is not None:
+            self._properties['kmsKeyName'] = kms_key_name
 
     @property
     def chunk_size(self):
@@ -741,8 +743,8 @@ class Blob(_PropertyMixin):
         if self.user_project is not None:
             name_value_pairs.append(('userProject', self.user_project))
 
-        if self._kms_key_name is not None:
-            name_value_pairs.append(('kmsKeyName', self._kms_key_name))
+        if self.kms_key_name is not None:
+            name_value_pairs.append(('kmsKeyName', self.kms_key_name))
 
         if predefined_acl is not None:
             name_value_pairs.append(('predefinedAcl', predefined_acl))
@@ -831,8 +833,8 @@ class Blob(_PropertyMixin):
         if self.user_project is not None:
             name_value_pairs.append(('userProject', self.user_project))
 
-        if self._kms_key_name is not None:
-            name_value_pairs.append(('kmsKeyName', self._kms_key_name))
+        if self.kms_key_name is not None:
+            name_value_pairs.append(('kmsKeyName', self.kms_key_name))
 
         if predefined_acl is not None:
             name_value_pairs.append(('predefinedAcl', predefined_acl))
@@ -1422,8 +1424,8 @@ class Blob(_PropertyMixin):
         if self.user_project is not None:
             query_params['userProject'] = self.user_project
 
-        if self._kms_key_name is not None:
-            query_params['destinationKmsKeyName'] = self._kms_key_name
+        if self.kms_key_name is not None:
+            query_params['destinationKmsKeyName'] = self.kms_key_name
 
         api_response = client._connection.api_request(
             method='POST',
@@ -1712,6 +1714,18 @@ class Blob(_PropertyMixin):
         size = self._properties.get('size')
         if size is not None:
             return int(size)
+
+    @property
+    def kms_key_name(self):
+        """Resource name of Cloud KMS key used to encrypt the blob's contents.
+
+        See https://cloud.google.com/storage/docs/encryption#kms.
+
+        :rtype: str or ``NoneType``
+        :returns:
+            The resource name or ``None`` if the property is not set locally.
+        """
+        return self._properties.get('kmsKeyName')
 
     storage_class = _scalar_property('storageClass')
     """Retrieve the storage class for the object.

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -787,6 +787,32 @@ class Bucket(_PropertyMixin):
         self._patch_property('cors', entries)
 
     @property
+    def default_kms_key_name(self):
+        """Retrieve / set default KMS encryption key for objects in the bucket.
+
+        See https://cloud.google.com/storage/docs/json_api/v1/buckets
+
+        :setter: Set default KMS encryption key for items in this bucket.
+        :getter: Get default KMS encryption key for items in this bucket.
+
+        :rtype: str
+        :returns: Default KMS encryption key, or ``None`` if not set.
+        """
+        encryption_config = self._properties.get('encryption', {})
+        return encryption_config.get('defaultKmsKeyName')
+
+    @default_kms_key_name.setter
+    def default_kms_key_name(self, value):
+        """Set default KMS encryption key for objects in the bucket.
+
+        :type value: str or None
+        :param value: new KMS key name (None to clear any existing key).
+        """
+        encryption_config = self._properties.get('encryption', {})
+        encryption_config['defaultKmsKeyName'] = value
+        self._patch_property('encryption', encryption_config)
+
+    @property
     def labels(self):
         """Retrieve or set labels assigned to this bucket.
 

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -171,7 +171,8 @@ class Bucket(_PropertyMixin):
         """
         return self._user_project
 
-    def blob(self, blob_name, chunk_size=None, encryption_key=None):
+    def blob(self, blob_name, chunk_size=None,
+             encryption_key=None, kms_key_name=None):
         """Factory constructor for blob object.
 
         .. note::
@@ -190,11 +191,15 @@ class Bucket(_PropertyMixin):
         :param encryption_key:
             Optional 32 byte encryption key for customer-supplied encryption.
 
+        :type kms_key_name: str
+        :param kms_key_name:
+            Optional resource name of KMS key used to encrypt blob's content.
+
         :rtype: :class:`google.cloud.storage.blob.Blob`
         :returns: The blob object created.
         """
         return Blob(name=blob_name, bucket=self, chunk_size=chunk_size,
-                    encryption_key=encryption_key)
+                    encryption_key=encryption_key, kms_key_name=kms_key_name)
 
     def notification(self, topic_name,
                      topic_project=None,

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -990,3 +990,131 @@ class TestAnonymousClient(unittest.TestCase):
         blob, = bucket.list_blobs(max_results=1)
         with tempfile.TemporaryFile() as stream:
             blob.download_to_file(stream)
+
+
+class TestKMSIntegration(TestStorageFiles):
+
+    FILENAMES = (
+        'file01.txt',
+    )
+
+    KEYRING_NAME = 'gcs-test'
+    KEY_NAME = 'gcs-test'
+    ALT_KEY_NAME = 'gcs-test-alternate'
+
+    def _kms_key_name(self, key_name=None):
+        if key_name is None:
+            key_name = self.KEY_NAME
+
+        return (
+            "projects/{}/"
+            "locations/{}/"
+            "keyRings/{}/"
+            "cryptoKeys/{}"
+        ).format(
+            Config.CLIENT.project,
+            'global',  # will be 'self.bucket.location' after launch
+            self.KEYRING_NAME,
+            key_name,
+        )
+
+    def test_blob_w_explicit_kms_key_name(self):
+        BLOB_NAME = 'explicit-kms-key-name'
+        file_data = self.FILES['simple']
+        kms_key_name = self._kms_key_name()
+        blob = self.bucket.blob(BLOB_NAME, kms_key_name=kms_key_name)
+        blob.upload_from_filename(file_data['path'])
+        self.case_blobs_to_delete.append(blob)
+        with open(file_data['path'], 'rb') as _file_data:
+            self.assertEqual(blob.download_as_string(), _file_data.read())
+        # We don't know the current version of the key.
+        self.assertTrue(blob.kms_key_name.startswith(kms_key_name))
+
+    def test_bucket_w_default_kms_key_name(self):
+        BLOB_NAME = 'default-kms-key-name'
+        OVERRIDE_BLOB_NAME = 'override-default-kms-key-name'
+        ALT_BLOB_NAME = 'alt-default-kms-key-name'
+        CLEARTEXT_BLOB_NAME = 'cleartext'
+
+        file_data = self.FILES['simple']
+
+        with open(file_data['path'], 'rb') as _file_data:
+            contents = _file_data.read()
+
+        kms_key_name = self._kms_key_name()
+        self.bucket.default_kms_key_name = kms_key_name
+        self.bucket.patch()
+        self.assertEqual(self.bucket.default_kms_key_name, kms_key_name)
+
+        defaulted_blob = self.bucket.blob(BLOB_NAME)
+        defaulted_blob.upload_from_filename(file_data['path'])
+        self.case_blobs_to_delete.append(defaulted_blob)
+
+        self.assertEqual(defaulted_blob.download_as_string(), contents)
+        # We don't know the current version of the key.
+        self.assertTrue(defaulted_blob.kms_key_name.startswith(kms_key_name))
+
+        alt_kms_key_name = self._kms_key_name(self.ALT_KEY_NAME)
+
+        override_blob = self.bucket.blob(
+            OVERRIDE_BLOB_NAME, kms_key_name=alt_kms_key_name)
+        override_blob.upload_from_filename(file_data['path'])
+        self.case_blobs_to_delete.append(override_blob)
+
+        self.assertEqual(override_blob.download_as_string(), contents)
+        # We don't know the current version of the key.
+        self.assertTrue(
+            override_blob.kms_key_name.startswith(alt_kms_key_name))
+
+        self.bucket.default_kms_key_name = alt_kms_key_name
+        self.bucket.patch()
+
+        alt_blob = self.bucket.blob(ALT_BLOB_NAME)
+        alt_blob.upload_from_filename(file_data['path'])
+        self.case_blobs_to_delete.append(alt_blob)
+
+        self.assertEqual(alt_blob.download_as_string(), contents)
+        # We don't know the current version of the key.
+        self.assertTrue(alt_blob.kms_key_name.startswith(alt_kms_key_name))
+
+        self.bucket.default_kms_key_name = None
+        self.bucket.patch()
+
+        cleartext_blob = self.bucket.blob(CLEARTEXT_BLOB_NAME)
+        cleartext_blob.upload_from_filename(file_data['path'])
+        self.case_blobs_to_delete.append(cleartext_blob)
+
+        self.assertEqual(cleartext_blob.download_as_string(), contents)
+        self.assertIsNone(cleartext_blob.kms_key_name)
+
+    def test_rewrite_rotate_csek_to_cmek(self):
+        BLOB_NAME = 'rotating-keys'
+        file_data = self.FILES['simple']
+
+        SOURCE_KEY = os.urandom(32)
+        source = self.bucket.blob(BLOB_NAME, encryption_key=SOURCE_KEY)
+        source.upload_from_filename(file_data['path'])
+        self.case_blobs_to_delete.append(source)
+        source_data = source.download_as_string()
+
+        kms_key_name = self._kms_key_name()
+
+        # We can't verify it, but ideally we would check that the following
+        # URL was resolvable with our credentals
+        # KEY_URL = 'https://cloudkms.googleapis.com/v1/{}'.format(
+        #     kms_key_name)
+
+        dest = self.bucket.blob(BLOB_NAME, kms_key_name=kms_key_name)
+        token, rewritten, total = dest.rewrite(source)
+
+        while token is not None:
+            token, rewritten, total = dest.rewrite(source, token=token)
+
+        # Not adding 'dest' to 'self.case_blobs_to_delete':  it is the
+        # same object as 'source'.
+
+        self.assertIsNone(token)
+        self.assertEqual(rewritten, len(source_data))
+        self.assertEqual(total, len(source_data))
+
+        self.assertEqual(dest.download_as_string(), source_data)

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1030,6 +1030,9 @@ class TestKMSIntegration(TestStorageFiles):
         # We don't know the current version of the key.
         self.assertTrue(blob.kms_key_name.startswith(kms_key_name))
 
+        listed, = list(self.bucket.list_blobs())
+        self.assertTrue(listed.kms_key_name.startswith(kms_key_name))
+
     def test_bucket_w_default_kms_key_name(self):
         BLOB_NAME = 'default-kms-key-name'
         OVERRIDE_BLOB_NAME = 'override-default-kms-key-name'

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -1013,7 +1013,7 @@ class TestKMSIntegration(TestStorageFiles):
             "cryptoKeys/{}"
         ).format(
             Config.CLIENT.project,
-            'global',  # will be 'self.bucket.location' after launch
+            self.bucket.location.lower(),
             self.KEYRING_NAME,
             key_name,
         )

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -79,7 +79,7 @@ class Test_Blob(unittest.TestCase):
             "projects/test-project-123/"
             "locations/us/"
             "keyRings/test-ring/"
-            "cryptoKeys/test-key/"
+            "cryptoKeys/test-key"
         )
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
@@ -95,7 +95,7 @@ class Test_Blob(unittest.TestCase):
             "projects/test-project-123/"
             "locations/us/"
             "keyRings/test-ring/"
-            "cryptoKeys/test-key/"
+            "cryptoKeys/test-key"
         )
         BLOB_NAME = 'blob-name'
         bucket = _Bucket()
@@ -196,7 +196,7 @@ class Test_Blob(unittest.TestCase):
             "projects/test-project-123/"
             "locations/us/"
             "keyRings/test-ring/"
-            "cryptoKeys/test-key/"
+            "cryptoKeys/test-key"
         )
         self._set_properties_helper(kms_key_name=kms_resource)
 
@@ -593,7 +593,7 @@ class Test_Blob(unittest.TestCase):
             "projects/test-project-123/"
             "locations/us/"
             "keyRings/test-ring/"
-            "cryptoKeys/test-key/"
+            "cryptoKeys/test-key"
         )
         blob_name = 'bzzz-fly.txt'
         bucket = _Bucket(name='buhkit')
@@ -1230,7 +1230,7 @@ class Test_Blob(unittest.TestCase):
             "projects/test-project-123/"
             "locations/us/"
             "keyRings/test-ring/"
-            "cryptoKeys/test-key/"
+            "cryptoKeys/test-key"
         )
         self._do_multipart_success(
             mock_get_boundary, kms_key_name=kms_resource)
@@ -1377,7 +1377,7 @@ class Test_Blob(unittest.TestCase):
             "projects/test-project-123/"
             "locations/us/"
             "keyRings/test-ring/"
-            "cryptoKeys/test-key/"
+            "cryptoKeys/test-key"
         )
         self._initiate_resumable_helper(kms_key_name=kms_resource)
 
@@ -2352,7 +2352,7 @@ class Test_Blob(unittest.TestCase):
             "projects/test-project-123/"
             "locations/us/"
             "keyRings/test-ring/"
-            "cryptoKeys/test-key/"
+            "cryptoKeys/test-key"
         )
         BLOB_NAME = 'blob'
         RESPONSE = {

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -39,9 +39,9 @@ class Test_Blob(unittest.TestCase):
     def _make_one(*args, **kw):
         from google.cloud.storage.blob import Blob
 
-        properties = kw.pop('properties', None)
+        properties = kw.pop('properties', {})
         blob = Blob(*args, **kw)
-        blob._properties = properties or {}
+        blob._properties.update(properties)
         return blob
 
     def test_ctor_wo_encryption_key(self):
@@ -55,7 +55,7 @@ class Test_Blob(unittest.TestCase):
         self.assertFalse(blob._acl.loaded)
         self.assertIs(blob._acl.blob, blob)
         self.assertEqual(blob._encryption_key, None)
-        self.assertEqual(blob._kms_key_name, None)
+        self.assertEqual(blob.kms_key_name, None)
 
     def test_ctor_with_encoded_unicode(self):
         blob_name = b'wet \xe2\x9b\xb5'
@@ -71,7 +71,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         blob = self._make_one(BLOB_NAME, bucket=bucket, encryption_key=KEY)
         self.assertEqual(blob._encryption_key, KEY)
-        self.assertEqual(blob._kms_key_name, None)
+        self.assertEqual(blob.kms_key_name, None)
 
     def test_ctor_w_kms_key_name_and_encryption_key(self):
         KEY = b'01234567890123456789012345678901'  # 32 bytes
@@ -102,7 +102,103 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(
             BLOB_NAME, bucket=bucket, kms_key_name=KMS_RESOURCE)
         self.assertEqual(blob._encryption_key, None)
-        self.assertEqual(blob._kms_key_name, KMS_RESOURCE)
+        self.assertEqual(blob.kms_key_name, KMS_RESOURCE)
+
+    def _set_properties_helper(self, kms_key_name=None):
+        import datetime
+        from google.cloud._helpers import UTC
+        from google.cloud._helpers import _RFC3339_MICROS
+        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        NOW = now.strftime(_RFC3339_MICROS)
+        BLOB_NAME = 'blob-name'
+        GENERATION = 12345
+        BLOB_ID = 'name/{}/{}'.format(BLOB_NAME, GENERATION)
+        SELF_LINK = 'http://example.com/self/'
+        METAGENERATION = 23456
+        SIZE = 12345
+        MD5_HASH = 'DEADBEEF'
+        MEDIA_LINK = 'http://example.com/media/'
+        ENTITY = 'project-owner-12345'
+        ENTITY_ID = '23456'
+        CRC32C = 'FACE0DAC'
+        COMPONENT_COUNT = 2
+        ETAG = 'ETAG'
+        resource = {
+            'id': BLOB_ID,
+            'selfLink': SELF_LINK,
+            'generation': GENERATION,
+            'metageneration': METAGENERATION,
+            'contentType': 'text/plain',
+            'timeCreated': NOW,
+            'updated': NOW,
+            'timeDeleted': NOW,
+            'storageClass': 'NEARLINE',
+            'timeStorageClassUpdated': NOW,
+            'size': SIZE,
+            'md5Hash': MD5_HASH,
+            'mediaLink': MEDIA_LINK,
+            'contentEncoding': 'gzip',
+            'contentDisposition': 'inline',
+            'contentLanguage': 'en-US',
+            'cacheControl': 'private',
+            'metadata': {
+                'foo': 'Foo',
+            },
+            'owner': {
+                'entity': ENTITY,
+                'entityId': ENTITY_ID,
+            },
+            'crc32c': CRC32C,
+            'componentCount': COMPONENT_COUNT,
+            'etag': ETAG,
+        }
+
+        if kms_key_name is not None:
+            resource['kmsKeyName'] = kms_key_name
+
+        bucket = _Bucket()
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
+
+        blob._set_properties(resource)
+
+        self.assertEqual(blob.id, BLOB_ID)
+        self.assertEqual(blob.self_link, SELF_LINK)
+        self.assertEqual(blob.generation, GENERATION)
+        self.assertEqual(blob.metageneration, METAGENERATION)
+        self.assertEqual(blob.content_type, 'text/plain')
+        self.assertEqual(blob.time_created, now)
+        self.assertEqual(blob.updated, now)
+        self.assertEqual(blob.time_deleted, now)
+        self.assertEqual(blob.storage_class, 'NEARLINE')
+        self.assertEqual(blob.size, SIZE)
+        self.assertEqual(blob.md5_hash, MD5_HASH)
+        self.assertEqual(blob.media_link, MEDIA_LINK)
+        self.assertEqual(blob.content_encoding, 'gzip')
+        self.assertEqual(blob.content_disposition, 'inline')
+        self.assertEqual(blob.content_language, 'en-US')
+        self.assertEqual(blob.cache_control, 'private')
+        self.assertEqual(blob.metadata, {'foo': 'Foo'})
+        self.assertEqual(blob.owner, {'entity': ENTITY, 'entityId': ENTITY_ID})
+        self.assertEqual(blob.crc32c, CRC32C)
+        self.assertEqual(blob.component_count, COMPONENT_COUNT)
+        self.assertEqual(blob.etag, ETAG)
+
+        if kms_key_name is not None:
+            self.assertEqual(blob.kms_key_name, kms_key_name)
+        else:
+            self.assertIsNone(blob.kms_key_name)
+
+    def test__set_properties_wo_kms_key_name(self):
+        self._set_properties_helper()
+
+    def test__set_properties_w_kms_key_name(self):
+        kms_resource = (
+            "projects/test-project-123/"
+            "locations/global/"
+            "keyRings/test-ring/"
+            "cryptoKeys/test-key/"
+        )
+        self._set_properties_helper(kms_key_name=kms_resource)
 
     def test_chunk_size_ctor(self):
         from google.cloud.storage.blob import Blob
@@ -2287,7 +2383,9 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['path'], PATH)
         self.assertEqual(kw[0]['query_params'],
                          {'destinationKmsKeyName': DEST_KMS_RESOURCE})
-        SENT = {}
+        SENT = {
+            'kmsKeyName': DEST_KMS_RESOURCE,
+        }
         self.assertEqual(kw[0]['data'], SENT)
 
         headers = {

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -604,7 +604,7 @@ class Test_Blob(unittest.TestCase):
         download_url = blob._get_download_url()
         expected_url = (
             'https://www.googleapis.com/download/storage/v1/b/'
-            'buhkit/o/bzzz-fly.txt?alt=media')  # kmsKeyName *not* expected
+            'buhkit/o/bzzz-fly.txt?alt=media')
         self.assertEqual(download_url, expected_url)
 
     @staticmethod

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -77,7 +77,7 @@ class Test_Blob(unittest.TestCase):
         KEY = b'01234567890123456789012345678901'  # 32 bytes
         KMS_RESOURCE = (
             "projects/test-project-123/"
-            "locations/global/"
+            "locations/us/"
             "keyRings/test-ring/"
             "cryptoKeys/test-key/"
         )
@@ -93,7 +93,7 @@ class Test_Blob(unittest.TestCase):
     def test_ctor_w_kms_key_name(self):
         KMS_RESOURCE = (
             "projects/test-project-123/"
-            "locations/global/"
+            "locations/us/"
             "keyRings/test-ring/"
             "cryptoKeys/test-key/"
         )
@@ -194,7 +194,7 @@ class Test_Blob(unittest.TestCase):
     def test__set_properties_w_kms_key_name(self):
         kms_resource = (
             "projects/test-project-123/"
-            "locations/global/"
+            "locations/us/"
             "keyRings/test-ring/"
             "cryptoKeys/test-key/"
         )
@@ -591,7 +591,7 @@ class Test_Blob(unittest.TestCase):
     def test__get_download_url_on_the_fly_with_kms_key_name(self):
         kms_resource = (
             "projects/test-project-123/"
-            "locations/global/"
+            "locations/us/"
             "keyRings/test-ring/"
             "cryptoKeys/test-key/"
         )
@@ -1228,7 +1228,7 @@ class Test_Blob(unittest.TestCase):
     def test__do_multipart_upload_with_kms(self, mock_get_boundary):
         kms_resource = (
             "projects/test-project-123/"
-            "locations/global/"
+            "locations/us/"
             "keyRings/test-ring/"
             "cryptoKeys/test-key/"
         )
@@ -1375,7 +1375,7 @@ class Test_Blob(unittest.TestCase):
     def test__initiate_resumable_upload_with_kms(self):
         kms_resource = (
             "projects/test-project-123/"
-            "locations/global/"
+            "locations/us/"
             "keyRings/test-ring/"
             "cryptoKeys/test-key/"
         )
@@ -2350,7 +2350,7 @@ class Test_Blob(unittest.TestCase):
             SOURCE_KEY_HASH).rstrip().decode('ascii')
         DEST_KMS_RESOURCE = (
             "projects/test-project-123/"
-            "locations/global/"
+            "locations/us/"
             "keyRings/test-ring/"
             "cryptoKeys/test-key/"
         )

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -122,7 +122,7 @@ class Test_Bucket(unittest.TestCase):
         CHUNK_SIZE = 1024 * 1024
         KMS_RESOURCE = (
             "projects/test-project-123/"
-            "locations/global/"
+            "locations/us/"
             "keyRings/test-ring/"
             "cryptoKeys/test-key/"
         )
@@ -965,7 +965,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         KMS_RESOURCE = (
             'projects/test-project-123/'
-            'locations/global/'
+            'locations/us/'
             'keyRings/test-ring/'
             'cryptoKeys/test-key'
         )
@@ -981,7 +981,7 @@ class Test_Bucket(unittest.TestCase):
         NAME = 'name'
         KMS_RESOURCE = (
             'projects/test-project-123/'
-            'locations/global/'
+            'locations/us/'
             'keyRings/test-ring/'
             'cryptoKeys/test-key'
         )

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -77,7 +77,25 @@ class Test_Bucket(unittest.TestCase):
         self.assertFalse(bucket._default_object_acl.loaded)
         self.assertIs(bucket._default_object_acl.bucket, bucket)
 
-    def test_blob(self):
+    def test_blob_wo_keys(self):
+        from google.cloud.storage.blob import Blob
+
+        BUCKET_NAME = 'BUCKET_NAME'
+        BLOB_NAME = 'BLOB_NAME'
+        CHUNK_SIZE = 1024 * 1024
+
+        bucket = self._make_one(name=BUCKET_NAME)
+        blob = bucket.blob(
+            BLOB_NAME, chunk_size=CHUNK_SIZE)
+        self.assertIsInstance(blob, Blob)
+        self.assertIs(blob.bucket, bucket)
+        self.assertIs(blob.client, bucket.client)
+        self.assertEqual(blob.name, BLOB_NAME)
+        self.assertEqual(blob.chunk_size, CHUNK_SIZE)
+        self.assertIsNone(blob._encryption_key)
+        self.assertIsNone(blob.kms_key_name)
+
+    def test_blob_w_encryption_key(self):
         from google.cloud.storage.blob import Blob
 
         BUCKET_NAME = 'BUCKET_NAME'
@@ -94,6 +112,31 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(blob.name, BLOB_NAME)
         self.assertEqual(blob.chunk_size, CHUNK_SIZE)
         self.assertEqual(blob._encryption_key, KEY)
+        self.assertIsNone(blob.kms_key_name)
+
+    def test_blob_w_kms_key_name(self):
+        from google.cloud.storage.blob import Blob
+
+        BUCKET_NAME = 'BUCKET_NAME'
+        BLOB_NAME = 'BLOB_NAME'
+        CHUNK_SIZE = 1024 * 1024
+        KMS_RESOURCE = (
+            "projects/test-project-123/"
+            "locations/global/"
+            "keyRings/test-ring/"
+            "cryptoKeys/test-key/"
+        )
+
+        bucket = self._make_one(name=BUCKET_NAME)
+        blob = bucket.blob(
+            BLOB_NAME, chunk_size=CHUNK_SIZE, kms_key_name=KMS_RESOURCE)
+        self.assertIsInstance(blob, Blob)
+        self.assertIs(blob.bucket, bucket)
+        self.assertIs(blob.client, bucket.client)
+        self.assertEqual(blob.name, BLOB_NAME)
+        self.assertEqual(blob.chunk_size, CHUNK_SIZE)
+        self.assertIsNone(blob._encryption_key)
+        self.assertEqual(blob.kms_key_name, KMS_RESOURCE)
 
     def test_notification_defaults(self):
         from google.cloud.storage.notification import BucketNotification

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -124,7 +124,7 @@ class Test_Bucket(unittest.TestCase):
             "projects/test-project-123/"
             "locations/us/"
             "keyRings/test-ring/"
-            "cryptoKeys/test-key/"
+            "cryptoKeys/test-key"
         )
 
         bucket = self._make_one(name=BUCKET_NAME)

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -918,6 +918,39 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(bucket.cors, [CORS_ENTRY])
         self.assertTrue('cors' in bucket._changes)
 
+    def test_default_kms_key_name_getter(self):
+        NAME = 'name'
+        KMS_RESOURCE = (
+            'projects/test-project-123/'
+            'locations/global/'
+            'keyRings/test-ring/'
+            'cryptoKeys/test-key'
+        )
+        ENCRYPTION_CONFIG = {
+            'defaultKmsKeyName': KMS_RESOURCE,
+        }
+        bucket = self._make_one(name=NAME)
+        self.assertIsNone(bucket.default_kms_key_name)
+        bucket._properties['encryption'] = ENCRYPTION_CONFIG
+        self.assertEqual(bucket.default_kms_key_name, KMS_RESOURCE)
+
+    def test_default_kms_key_name_setter(self):
+        NAME = 'name'
+        KMS_RESOURCE = (
+            'projects/test-project-123/'
+            'locations/global/'
+            'keyRings/test-ring/'
+            'cryptoKeys/test-key'
+        )
+        ENCRYPTION_CONFIG = {
+            'defaultKmsKeyName': KMS_RESOURCE,
+        }
+        bucket = self._make_one(name=NAME)
+        bucket.default_kms_key_name = KMS_RESOURCE
+        self.assertEqual(
+            bucket._properties['encryption'], ENCRYPTION_CONFIG)
+        self.assertTrue('encryption' in bucket._changes)
+
     def test_labels_getter(self):
         NAME = 'name'
         LABELS = {'color': 'red', 'flavor': 'cherry'}


### PR DESCRIPTION
Merge is blocked for public beta of the KMS support.  We will need to adjust the system tests at that time to switch from using keys in the `global` location to keys in the same location as the bucket.