### PR TITLE
Drop systest dependency expansion for bigquery/storage.

### DIFF
--- a/test_utils/scripts/get_target_packages.py
+++ b/test_utils/scripts/get_target_packages.py
@@ -37,12 +37,8 @@ TAG_RE = re.compile(r"""
 # As of this writing, the only "real" dependency is that of error_reporting
 # (on logging), the rest are just system test dependencies.
 PKG_DEPENDENCIES = {
-    'bigquery': {'storage'},
     'error_reporting': {'logging'},
-    'language': {'storage'},
-    'logging': {'bigquery', 'pubsub', 'storage'},
-    'speech': {'storage'},
-    'vision': {'storage'},
+    'logging': {'pubsub'},
 }
 
 


### PR DESCRIPTION
`storage` and `bigquery` are both GA:  we should be able to rely on testing against released versions.

Closes #5253.