### PR TITLE
Update docstring to reflect correct units

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -112,8 +112,9 @@ class Blob(_PropertyMixin):
     :param bucket: The bucket to which this blob belongs.
 
     :type chunk_size: int
-    :param chunk_size: The size of a chunk of data whenever iterating (1 MB).
-                       This must be a multiple of 256 KB per the API
+
+    :param chunk_size: The size of a chunk of data whenever iterating (in
+                       bytes). This must be a multiple of 256 KB per the API
                        specification.
 
     :type encryption_key: bytes

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -183,8 +183,8 @@ class Bucket(_PropertyMixin):
 
         :type chunk_size: int
         :param chunk_size: The size of a chunk of data whenever iterating
-                           (1 MB). This must be a multiple of 256 KB per the
-                           API specification.
+                           (in bytes). This must be a multiple of 256 KB per
+                           the API specification.
 
         :type encryption_key: bytes
         :param encryption_key:


### PR DESCRIPTION
I am not sure if 1 MB was an old default or the units, but I think it's a typo either way? The current default seems to be `None` (which shows up in the generated docs), and I believe the unit is bytes, correct?