### PR TITLE
Remove unused var (flake8 warning)

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -548,7 +548,7 @@ class Blob(_PropertyMixin):
             with open(filename, 'wb') as file_obj:
                 self.download_to_file(
                     file_obj, client=client, start=start, end=end)
-        except resumable_media.DataCorruption as exc:
+        except resumable_media.DataCorruption:
             # Delete the corrupt downloaded file.
             os.remove(filename)
             raise


### PR DESCRIPTION
This showed up in a flake8 warning when I was looking at #5277 
Let me know if this is right vs. using `_raise_from_invalid_response()`.