### PR TITLE
Add Test runs for Python 3.7 and remove 3.4

### DIFF
--- a/api_core/nox.py
+++ b/api_core/nox.py
@@ -52,7 +52,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/api_core/nox.py
+++ b/api_core/nox.py
@@ -52,7 +52,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/bigquery/nox.py
+++ b/bigquery/nox.py
@@ -65,7 +65,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/bigquery_datatransfer/nox.py
+++ b/bigquery_datatransfer/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/bigquery_datatransfer/nox.py
+++ b/bigquery_datatransfer/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/bigtable/nox.py
+++ b/bigtable/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/bigtable/nox.py
+++ b/bigtable/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/container/nox.py
+++ b/container/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/container/nox.py
+++ b/container/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/core/nox.py
+++ b/core/nox.py
@@ -58,7 +58,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/core/nox.py
+++ b/core/nox.py
@@ -58,7 +58,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/dataproc/nox.py
+++ b/dataproc/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/dataproc/nox.py
+++ b/dataproc/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/datastore/nox.py
+++ b/datastore/nox.py
@@ -54,7 +54,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/datastore/nox.py
+++ b/datastore/nox.py
@@ -54,7 +54,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/dlp/nox.py
+++ b/dlp/nox.py
@@ -50,7 +50,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/dlp/nox.py
+++ b/dlp/nox.py
@@ -50,7 +50,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/dns/nox.py
+++ b/dns/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/dns/nox.py
+++ b/dns/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -54,7 +54,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -54,7 +54,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/firestore/nox.py
+++ b/firestore/nox.py
@@ -56,7 +56,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/firestore/nox.py
+++ b/firestore/nox.py
@@ -56,7 +56,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/language/nox.py
+++ b/language/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/language/nox.py
+++ b/language/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/logging/nox.py
+++ b/logging/nox.py
@@ -72,7 +72,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/logging/nox.py
+++ b/logging/nox.py
@@ -72,7 +72,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/monitoring/nox.py
+++ b/monitoring/nox.py
@@ -58,7 +58,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/oslogin/nox.py
+++ b/oslogin/nox.py
@@ -24,7 +24,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/oslogin/nox.py
+++ b/oslogin/nox.py
@@ -24,7 +24,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/pubsub/google/cloud/pubsub_v1/subscriber/scheduler.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/scheduler.py
@@ -118,5 +118,9 @@ class ThreadScheduler(object):
         # Drop all pending item from the executor. Without this, the executor
         # will block until all pending items are complete, which is
         # undesirable.
-        self._executor._work_queue.queue.clear()
+        try:
+            while True:
+                self._executor._work_queue.get(block=False)
+        except queue.Empty:
+            pass
         self._executor.shutdown()

--- a/pubsub/nox.py
+++ b/pubsub/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/pubsub/nox.py
+++ b/pubsub/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/resource_manager/nox.py
+++ b/resource_manager/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/resource_manager/nox.py
+++ b/resource_manager/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/runtimeconfig/nox.py
+++ b/runtimeconfig/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/runtimeconfig/nox.py
+++ b/runtimeconfig/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/speech/nox.py
+++ b/speech/nox.py
@@ -51,7 +51,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/speech/nox.py
+++ b/speech/nox.py
@@ -51,7 +51,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/storage/nox.py
+++ b/storage/nox.py
@@ -54,7 +54,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/storage/nox.py
+++ b/storage/nox.py
@@ -54,7 +54,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/texttospeech/nox.py
+++ b/texttospeech/nox.py
@@ -24,7 +24,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/texttospeech/nox.py
+++ b/texttospeech/nox.py
@@ -24,7 +24,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/trace/nox.py
+++ b/trace/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/trace/nox.py
+++ b/trace/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/translate/nox.py
+++ b/translate/nox.py
@@ -48,7 +48,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/translate/nox.py
+++ b/translate/nox.py
@@ -48,7 +48,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/videointelligence/nox.py
+++ b/videointelligence/nox.py
@@ -35,7 +35,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/videointelligence/nox.py
+++ b/videointelligence/nox.py
@@ -35,7 +35,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/vision/nox.py
+++ b/vision/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/vision/nox.py
+++ b/vision/nox.py
@@ -53,7 +53,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/websecurityscanner/nox.py
+++ b/websecurityscanner/nox.py
@@ -51,7 +51,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6'])
 def unit(session, py):
     """Run the unit test suite."""
 

--- a/websecurityscanner/nox.py
+++ b/websecurityscanner/nox.py
@@ -51,7 +51,7 @@ def default(session):
 
 
 @nox.session
-@nox.parametrize('py', ['2.7', '3.5', '3.6'])
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
 def unit(session, py):
     """Run the unit test suite."""
 


### PR DESCRIPTION
There are *very* few people using 3.4 and 3.7 is coming up. A few of the packages cannot use 3.7 yet

PubSub: https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5292
Monitoring: https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5293
BigQuery: https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5294