### PR TITLE
BigQuery:  Add additional statistics to query plan stages.

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2483,11 +2483,44 @@ class QueryPlanEntry(object):
     :type entry_id: int
     :param entry_id: ID of the entry
 
+    :type start_ms: int
+    :param start_ms: start time for this stage of the query plan
+
+    :type end_ms: int
+    :param end_ms: end time for this stage of the query plan
+
+    :type input_stages: List(int)
+    :param input_stages: list of stage IDs that are inputs for this stage
+
+    :type parallel_inputs: int
+    :param completed_parallel_inputs: number of parallel input
+            segments in the stage
+
+    :type completed_parallel_inputs: int
+    :param completed_parallel_inputs: number of parallel input
+            segments completed
+
+    :type wait_ms_avg: int
+    :param wait_ms_avg: milliseconds the average shard spent
+            waiting to be scheduled
+
+    :type wait_ms_max: int
+    :param wait_ms_max: milliseconds the slowest shard spent
+            waiting to be scheduled
+
     :type wait_ratio_avg: float
     :param wait_ratio_avg: average wait ratio
 
     :type wait_ratio_max: float
     :param wait_ratio_max: maximum wait ratio
+
+    :type read_ms_avg: int
+    :param read_ms_avg: milliseconds the average shard spent
+            reading input
+
+    :type read_ms_max: int
+    :param read_ms_max: milliseconds the slowest shard spent
+            reading input
 
     :type read_ratio_avg: float
     :param read_ratio_avg: average read ratio
@@ -2495,11 +2528,27 @@ class QueryPlanEntry(object):
     :type read_ratio_max: float
     :param read_ratio_max: maximum read ratio
 
+    :type compute_ms_avg: int
+    :param compute_ms_avg: milliseconds the average shard spent
+            on cpu-bound tasks
+
+    :type compute_ms_max: int
+    :param compute_ms_max: milliseconds the slowest shard spent
+            on cpu-bound tasks
+
     :type compute_ratio_avg: float
     :param compute_ratio_avg: average compute ratio
 
     :type compute_ratio_max: float
     :param compute_ratio_max: maximum compute ratio
+
+    :type write_ms_avg: int
+    :param write_ms_avg: milliseconds the average shard spent
+            writing output
+
+    :type write_ms_max: int
+    :param write_ms_max: milliseconds the slowest shard spent
+            writing output
 
     :type write_ratio_avg: float
     :param write_ratio_avg: average write ratio
@@ -2516,37 +2565,74 @@ class QueryPlanEntry(object):
     :type status: str
     :param status: entry status
 
+    :type shuffle_output_bytes: int
+    :param shuffle_output_bytes: number of bytes written to shuffle
+
+    :type shuffle_output_bytes_spilled: int
+    :param shuffle_output_bytes_spilled: number of bytes written
+            to shuffle and spilled to disk
+
     :type steps: List(QueryPlanEntryStep)
     :param steps: steps in the entry
     """
     def __init__(self,
                  name,
                  entry_id,
+                 start_ms,
+                 end_ms,
+                 input_stages,
+                 parallel_inputs,
+                 completed_parallel_inputs,
+                 wait_ms_avg,
+                 wait_ms_max,
                  wait_ratio_avg,
                  wait_ratio_max,
+                 read_ms_avg,
+                 read_ms_max,
                  read_ratio_avg,
                  read_ratio_max,
+                 compute_ms_avg,
+                 compute_ms_max,
                  compute_ratio_avg,
                  compute_ratio_max,
+                 write_ms_avg,
+                 write_ms_max,
                  write_ratio_avg,
                  write_ratio_max,
                  records_read,
                  records_written,
                  status,
+                 shuffle_output_bytes,
+                 shuffle_output_bytes_spilled,
                  steps):
         self.name = name
         self.entry_id = entry_id
+        self.start_ms = start_ms
+        self.end_ms = end_ms
+        self.input_stages = input_stages
+        self.parallel_inputs = parallel_inputs
+        self.completed_parallel_inputs = completed_parallel_inputs
+        self.wait_ms_avg = wait_ms_avg
+        self.wait_ms_max = wait_ms_max
         self.wait_ratio_avg = wait_ratio_avg
         self.wait_ratio_max = wait_ratio_max
+        self.read_ms_avg = read_ms_avg
+        self.read_ms_max = read_ms_max
         self.read_ratio_avg = read_ratio_avg
         self.read_ratio_max = read_ratio_max
+        self.compute_ms_avg = compute_ms_avg
+        self.compute_ms_max = compute_ms_max
         self.compute_ratio_avg = compute_ratio_avg
         self.compute_ratio_max = compute_ratio_max
+        self.write_ms_avg = write_ms_avg
+        self.write_ms_max = write_ms_max
         self.write_ratio_avg = write_ratio_avg
         self.write_ratio_max = write_ratio_max
         self.records_read = records_read
         self.records_written = records_written
         self.status = status
+        self.shuffle_output_bytes = shuffle_output_bytes
+        self.shuffle_output_bytes_spilled = shuffle_output_bytes_spilled
         self.steps = steps
 
     @classmethod
@@ -2570,17 +2656,33 @@ class QueryPlanEntry(object):
         return cls(
             name=resource.get('name'),
             entry_id=resource.get('id'),
+            start_ms=resource.get('startMs'),
+            end_ms=resource.get('endMs'),
+            input_stages=resource.get('inputStages', []),
+            parallel_inputs=resource.get('parallelInputs'),
+            completed_parallel_inputs=resource.get('completedParallelInputs'),
+            wait_ms_avg=resource.get('waitMsAvg'),
+            wait_ms_max=resource.get('waitMsMax'),
             wait_ratio_avg=resource.get('waitRatioAvg'),
             wait_ratio_max=resource.get('waitRatioMax'),
+            read_ms_avg=resource.get('readMsAvg'),
+            read_ms_max=resource.get('readMsMax'),
             read_ratio_avg=resource.get('readRatioAvg'),
             read_ratio_max=resource.get('readRatioMax'),
+            compute_ms_avg=resource.get('computeMsAvg'),
+            compute_ms_max=resource.get('computeMsMax'),
             compute_ratio_avg=resource.get('computeRatioAvg'),
             compute_ratio_max=resource.get('computeRatioMax'),
+            write_ms_avg=resource.get('writeMsAvg'),
+            write_ms_max=resource.get('writeMsMax'),
             write_ratio_avg=resource.get('writeRatioAvg'),
             write_ratio_max=resource.get('writeRatioMax'),
             records_read=records_read,
             records_written=records_written,
             status=resource.get('status'),
+            shuffle_output_bytes=resource.get('shuffleOutputBytes'),
+            shuffle_output_bytes_spilled=resource.get(
+                    'shuffleOutputBytesSpilled'),
             steps=[QueryPlanEntryStep.from_api_repr(step)
                    for step in resource.get('steps', ())],
         )

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -2289,17 +2289,32 @@ class TestQueryJob(unittest.TestCase, _Base):
         plan_entries = [{
             'name': 'NAME',
             'id': 1234,
+            'inputStages': [88, 101],
+            'startMs': 1522540800000,
+            'endMs':   1522540804000,
+            'parallelInputs': 1000,
+            'completedParallelInputs': 5,
+            'waitMsAvg': 33,
+            'waitMsMax': 400,
             'waitRatioAvg': 2.71828,
             'waitRatioMax': 3.14159,
+            'readMsAvg': 45,
+            'readMsMax': 90,
             'readRatioAvg': 1.41421,
             'readRatioMax': 1.73205,
+            'computeMsAvg': 55,
+            'computeMsMax': 99,
             'computeRatioAvg': 0.69315,
             'computeRatioMax': 1.09861,
+            'writeMsAvg': 203,
+            'writeMsMax': 340,
             'writeRatioAvg': 3.32193,
             'writeRatioMax': 2.30258,
             'recordsRead': '100',
             'recordsWritten': '1',
             'status': 'STATUS',
+            'shuffleOutputBytes': 1024,
+            'shuffleOutputBytesSpilled': 1,
             'steps': [{
                 'kind': 'KIND',
                 'substeps': ['SUBSTEP1', 'SUBSTEP2'],
@@ -2322,14 +2337,36 @@ class TestQueryJob(unittest.TestCase, _Base):
             self.assertIsInstance(found, QueryPlanEntry)
             self.assertEqual(found.name, expected['name'])
             self.assertEqual(found.entry_id, expected['id'])
+            self.assertEqual(
+                    len(found.input_stages),
+                    len(expected['inputStages']))
+            for f_id in found.input_stages:
+                self.assertIn(f_id, expected['inputStages'])
+            self.assertEqual(found.start_ms, expected['startMs'])
+            self.assertEqual(found.end_ms, expected['endMs'])
+            self.assertEqual(
+                    found.parallel_inputs,
+                    expected['parallelInputs'])
+            self.assertEqual(
+                    found.completed_parallel_inputs,
+                    expected['completedParallelInputs'])
+            self.assertEqual(found.end_ms, expected['endMs'])
+            self.assertEqual(found.wait_ms_avg, expected['waitMsAvg'])
+            self.assertEqual(found.wait_ms_max, expected['waitMsMax'])
             self.assertEqual(found.wait_ratio_avg, expected['waitRatioAvg'])
             self.assertEqual(found.wait_ratio_max, expected['waitRatioMax'])
+            self.assertEqual(found.read_ms_avg, expected['readMsAvg'])
+            self.assertEqual(found.read_ms_max, expected['readMsMax'])
             self.assertEqual(found.read_ratio_avg, expected['readRatioAvg'])
             self.assertEqual(found.read_ratio_max, expected['readRatioMax'])
+            self.assertEqual(found.compute_ms_avg, expected['computeMsAvg'])
+            self.assertEqual(found.compute_ms_max, expected['computeMsMax'])
             self.assertEqual(
                 found.compute_ratio_avg, expected['computeRatioAvg'])
             self.assertEqual(
                 found.compute_ratio_max, expected['computeRatioMax'])
+            self.assertEqual(found.write_ms_avg, expected['writeMsAvg'])
+            self.assertEqual(found.write_ms_max, expected['writeMsMax'])
             self.assertEqual(found.write_ratio_avg, expected['writeRatioAvg'])
             self.assertEqual(found.write_ratio_max, expected['writeRatioMax'])
             self.assertEqual(
@@ -2337,6 +2374,12 @@ class TestQueryJob(unittest.TestCase, _Base):
             self.assertEqual(
                 found.records_written, int(expected['recordsWritten']))
             self.assertEqual(found.status, expected['status'])
+            self.assertEqual(
+                    found.shuffle_output_bytes,
+                    expected['shuffleOutputBytes'])
+            self.assertEqual(
+                    found.shuffle_output_bytes_spilled,
+                    expected['shuffleOutputBytesSpilled'])
 
             self.assertEqual(len(found.steps), len(expected['steps']))
             for f_step, e_step in zip(found.steps, expected['steps']):
@@ -3256,17 +3299,32 @@ class TestQueryPlanEntryStep(unittest.TestCase, _Base):
 class TestQueryPlanEntry(unittest.TestCase, _Base):
     NAME = 'NAME'
     ENTRY_ID = 1234
+    START_MS = 1522540800000
+    END_MS = 1522540804000
+    INPUT_STAGES = (88, 101)
+    PARALLEL_INPUTS = 1000
+    COMPLETED_PARALLEL_INPUTS = 5
+    WAIT_MS_AVG = 33
+    WAIT_MS_MAX = 400
     WAIT_RATIO_AVG = 2.71828
     WAIT_RATIO_MAX = 3.14159
+    READ_MS_AVG = 45
+    READ_MS_MAX = 90
     READ_RATIO_AVG = 1.41421
     READ_RATIO_MAX = 1.73205
+    COMPUTE_MS_AVG = 55
+    COMPUTE_MS_MAX = 99
     COMPUTE_RATIO_AVG = 0.69315
     COMPUTE_RATIO_MAX = 1.09861
+    WRITE_MS_AVG = 203
+    WRITE_MS_MAX = 340
     WRITE_RATIO_AVG = 3.32193
     WRITE_RATIO_MAX = 2.30258
     RECORDS_READ = 100
     RECORDS_WRITTEN = 1
     STATUS = 'STATUS'
+    SHUFFLE_OUTPUT_BYTES = 1024
+    SHUFFLE_OUTPUT_BYTES_SPILLED = 1
 
     @staticmethod
     def _get_target_class():
@@ -3286,32 +3344,67 @@ class TestQueryPlanEntry(unittest.TestCase, _Base):
         entry = self._make_one(
             name=self.NAME,
             entry_id=self.ENTRY_ID,
+            input_stages=self.INPUT_STAGES,
+            start_ms=self.START_MS,
+            end_ms=self.END_MS,
+            parallel_inputs=self.PARALLEL_INPUTS,
+            completed_parallel_inputs=self.COMPLETED_PARALLEL_INPUTS,
+            wait_ms_avg=self.WAIT_MS_AVG,
+            wait_ms_max=self.WAIT_MS_MAX,
             wait_ratio_avg=self.WAIT_RATIO_AVG,
             wait_ratio_max=self.WAIT_RATIO_MAX,
+            read_ms_avg=self.READ_MS_AVG,
+            read_ms_max=self.READ_MS_MAX,
             read_ratio_avg=self.READ_RATIO_AVG,
             read_ratio_max=self.READ_RATIO_MAX,
+            compute_ms_avg=self.COMPUTE_MS_AVG,
+            compute_ms_max=self.COMPUTE_MS_MAX,
             compute_ratio_avg=self.COMPUTE_RATIO_AVG,
             compute_ratio_max=self.COMPUTE_RATIO_MAX,
+            write_ms_avg=self.WRITE_MS_AVG,
+            write_ms_max=self.WRITE_MS_MAX,
             write_ratio_avg=self.WRITE_RATIO_AVG,
             write_ratio_max=self.WRITE_RATIO_MAX,
             records_read=self.RECORDS_READ,
             records_written=self.RECORDS_WRITTEN,
             status=self.STATUS,
             steps=steps,
+            shuffle_output_bytes=self.SHUFFLE_OUTPUT_BYTES,
+            shuffle_output_bytes_spilled=self.SHUFFLE_OUTPUT_BYTES_SPILLED,
         )
         self.assertEqual(entry.name, self.NAME)
         self.assertEqual(entry.entry_id, self.ENTRY_ID)
+        self.assertEqual(entry.input_stages, self.INPUT_STAGES)
+        self.assertEqual(entry.start_ms, self.START_MS)
+        self.assertEqual(entry.end_ms, self.END_MS)
+        self.assertEqual(entry.parallel_inputs, self.PARALLEL_INPUTS)
+        self.assertEqual(
+                entry.completed_parallel_inputs,
+                self.COMPLETED_PARALLEL_INPUTS)
+        self.assertEqual(entry.wait_ms_avg, self.WAIT_MS_AVG)
+        self.assertEqual(entry.wait_ms_max, self.WAIT_MS_MAX)
         self.assertEqual(entry.wait_ratio_avg, self.WAIT_RATIO_AVG)
         self.assertEqual(entry.wait_ratio_max, self.WAIT_RATIO_MAX)
+        self.assertEqual(entry.read_ms_avg, self.READ_MS_AVG)
+        self.assertEqual(entry.read_ms_max, self.READ_MS_MAX)
         self.assertEqual(entry.read_ratio_avg, self.READ_RATIO_AVG)
         self.assertEqual(entry.read_ratio_max, self.READ_RATIO_MAX)
+        self.assertEqual(entry.compute_ms_avg, self.COMPUTE_MS_AVG)
+        self.assertEqual(entry.compute_ms_max, self.COMPUTE_MS_MAX)
         self.assertEqual(entry.compute_ratio_avg, self.COMPUTE_RATIO_AVG)
         self.assertEqual(entry.compute_ratio_max, self.COMPUTE_RATIO_MAX)
+        self.assertEqual(entry.write_ms_avg, self.WRITE_MS_AVG)
+        self.assertEqual(entry.write_ms_max, self.WRITE_MS_MAX)
         self.assertEqual(entry.write_ratio_avg, self.WRITE_RATIO_AVG)
         self.assertEqual(entry.write_ratio_max, self.WRITE_RATIO_MAX)
         self.assertEqual(entry.records_read, self.RECORDS_READ)
         self.assertEqual(entry.records_written, self.RECORDS_WRITTEN)
         self.assertEqual(entry.status, self.STATUS)
+        self.assertEqual(entry.shuffle_output_bytes, self.SHUFFLE_OUTPUT_BYTES)
+        self.assertEqual(
+                entry.shuffle_output_bytes_spilled,
+                self.SHUFFLE_OUTPUT_BYTES_SPILLED)
+
         self.assertEqual(entry.steps, steps)
 
     def test_from_api_repr_empty(self):
@@ -3321,17 +3414,32 @@ class TestQueryPlanEntry(unittest.TestCase, _Base):
 
         self.assertIsNone(entry.name)
         self.assertIsNone(entry.entry_id)
+        self.assertEqual(entry.input_stages, [])
+        self.assertIsNone(entry.start_ms)
+        self.assertIsNone(entry.end_ms)
+        self.assertIsNone(entry.parallel_inputs)
+        self.assertIsNone(entry.completed_parallel_inputs)
+        self.assertIsNone(entry.wait_ms_avg)
+        self.assertIsNone(entry.wait_ms_max)
         self.assertIsNone(entry.wait_ratio_avg)
         self.assertIsNone(entry.wait_ratio_max)
+        self.assertIsNone(entry.read_ms_avg)
+        self.assertIsNone(entry.read_ms_max)
         self.assertIsNone(entry.read_ratio_avg)
         self.assertIsNone(entry.read_ratio_max)
+        self.assertIsNone(entry.compute_ms_avg)
+        self.assertIsNone(entry.compute_ms_max)
         self.assertIsNone(entry.compute_ratio_avg)
         self.assertIsNone(entry.compute_ratio_max)
+        self.assertIsNone(entry.write_ms_avg)
+        self.assertIsNone(entry.write_ms_max)
         self.assertIsNone(entry.write_ratio_avg)
         self.assertIsNone(entry.write_ratio_max)
         self.assertIsNone(entry.records_read)
         self.assertIsNone(entry.records_written)
         self.assertIsNone(entry.status)
+        self.assertIsNone(entry.shuffle_output_bytes)
+        self.assertIsNone(entry.shuffle_output_bytes_spilled)
         self.assertEqual(entry.steps, [])
 
     def test_from_api_repr_normal(self):
@@ -3343,17 +3451,30 @@ class TestQueryPlanEntry(unittest.TestCase, _Base):
         resource = {
             'name': self.NAME,
             'id': self.ENTRY_ID,
+            'inputStages': self.INPUT_STAGES,
+            'startMs': self.START_MS,
+            'endMs': self.END_MS,
+            'waitMsAvg': self.WAIT_MS_AVG,
+            'waitMsMax': self.WAIT_MS_MAX,
             'waitRatioAvg': self.WAIT_RATIO_AVG,
             'waitRatioMax': self.WAIT_RATIO_MAX,
+            'readMsAvg': self.READ_MS_AVG,
+            'readMsMax': self.READ_MS_MAX,
             'readRatioAvg': self.READ_RATIO_AVG,
             'readRatioMax': self.READ_RATIO_MAX,
+            'computeMsAvg': self.COMPUTE_MS_AVG,
+            'computeMsMax': self.COMPUTE_MS_MAX,
             'computeRatioAvg': self.COMPUTE_RATIO_AVG,
             'computeRatioMax': self.COMPUTE_RATIO_MAX,
+            'writeMsAvg': self.WRITE_MS_AVG,
+            'writeMsMax': self.WRITE_MS_MAX,
             'writeRatioAvg': self.WRITE_RATIO_AVG,
             'writeRatioMax': self.WRITE_RATIO_MAX,
             'recordsRead': str(self.RECORDS_READ),
             'recordsWritten': str(self.RECORDS_WRITTEN),
             'status': self.STATUS,
+            'shuffleOutputBytes': self.SHUFFLE_OUTPUT_BYTES,
+            'shuffleOutputBytesSpilled': self.SHUFFLE_OUTPUT_BYTES_SPILLED,
             'steps': [{
                 'kind': TestQueryPlanEntryStep.KIND,
                 'substeps': TestQueryPlanEntryStep.SUBSTEPS,


### PR DESCRIPTION
Part 1 of 2.  This plumbs through the additional statistics that are reported for each stage of query execution.   A followup change will introduce the timeline information.
