### PR TITLE
Add timeline and top-level slot-millis to query statistics.

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2285,7 +2285,7 @@ class QueryJob(_AsyncJob):
     @property
     def slot_millis(self):
         """Union[int, None]: Slot-milliseconds used by this query job."""
-        return self._job_statistics().get('totalSlotMs')
+        return _int_or_none(self._job_statistics().get('totalSlotMs'))
 
     @property
     def statement_type(self):
@@ -2531,7 +2531,7 @@ class QueryPlanEntry(object):
         if self._properties.get('startMs') is None:
             return None
         return _datetime_from_microseconds(
-                self._properties.get('startMs') * 1000.0)
+                int(self._properties.get('startMs')) * 1000.0)
 
     @property
     def end(self):
@@ -2539,38 +2539,41 @@ class QueryPlanEntry(object):
         if self._properties.get('endMs') is None:
             return None
         return _datetime_from_microseconds(
-                self._properties.get('endMs') * 1000.0)
+                int(self._properties.get('endMs')) * 1000.0)
 
     @property
     def input_stages(self):
         """List(int): Entry IDs for stages that were inputs for this stage."""
-        return self._properties.get('inputStages', [])
+        if self._properties.get('inputStages') is None:
+            return []
+        return [_int_or_none(entry)
+                for entry in self._properties.get('inputStages')]
 
     @property
     def parallel_inputs(self):
         """Union[int, None]: Number of parallel input segments within
         the stage.
         """
-        return self._properties.get('parallelInputs')
+        return _int_or_none(self._properties.get('parallelInputs'))
 
     @property
     def completed_parallel_inputs(self):
         """Union[int, None]: Number of parallel input segments completed."""
-        return self._properties.get('completedParallelInputs')
+        return _int_or_none(self._properties.get('completedParallelInputs'))
 
     @property
     def wait_ms_avg(self):
         """Union[int, None]: Milliseconds the average worker spent waiting to
         be scheduled.
         """
-        return self._properties.get('waitMsAvg')
+        return _int_or_none(self._properties.get('waitMsAvg'))
 
     @property
     def wait_ms_max(self):
         """Union[int, None]: Milliseconds the slowest worker spent waiting to
         be scheduled.
         """
-        return self._properties.get('waitMsMax')
+        return _int_or_none(self._properties.get('waitMsMax'))
 
     @property
     def wait_ratio_avg(self):
@@ -2593,14 +2596,14 @@ class QueryPlanEntry(object):
         """Union[int, None]: Milliseconds the average worker spent reading
         input.
         """
-        return self._properties.get('readMsAvg')
+        return _int_or_none(self._properties.get('readMsAvg'))
 
     @property
     def read_ms_max(self):
         """Union[int, None]: Milliseconds the slowest worker spent reading
         input.
         """
-        return self._properties.get('readMsMax')
+        return _int_or_none(self._properties.get('readMsMax'))
 
     @property
     def read_ratio_avg(self):
@@ -2623,14 +2626,14 @@ class QueryPlanEntry(object):
         """Union[int, None]: Milliseconds the average worker spent on CPU-bound
         processing.
         """
-        return self._properties.get('computeMsAvg')
+        return _int_or_none(self._properties.get('computeMsAvg'))
 
     @property
     def compute_ms_max(self):
         """Union[int, None]: Milliseconds the slowest worker spent on CPU-bound
         processing.
         """
-        return self._properties.get('computeMsMax')
+        return _int_or_none(self._properties.get('computeMsMax'))
 
     @property
     def compute_ratio_avg(self):
@@ -2653,14 +2656,14 @@ class QueryPlanEntry(object):
         """Union[int, None]: Milliseconds the average worker spent writing
         output data.
         """
-        return self._properties.get('writeMsAvg')
+        return _int_or_none(self._properties.get('writeMsAvg'))
 
     @property
     def write_ms_max(self):
         """Union[int, None]: Milliseconds the slowest worker spent writing
         output data.
         """
-        return self._properties.get('writeMsMax')
+        return _int_or_none(self._properties.get('writeMsMax'))
 
     @property
     def write_ratio_avg(self):
@@ -2681,12 +2684,12 @@ class QueryPlanEntry(object):
     @property
     def records_read(self):
         """Union[int, None]: Number of records read by this stage."""
-        return self._properties.get('recordsRead')
+        return _int_or_none(self._properties.get('recordsRead'))
 
     @property
     def records_written(self):
         """Union[int, None]: Number of records written by this stage."""
-        return self._properties.get('recordsWritten')
+        return _int_or_none(self._properties.get('recordsWritten'))
 
     @property
     def status(self):
@@ -2698,14 +2701,14 @@ class QueryPlanEntry(object):
         """Union[int, None]: Number of bytes written by this stage to
         intermediate shuffle.
         """
-        return self._properties.get('shuffleOutputBytes')
+        return _int_or_none(self._properties.get('shuffleOutputBytes'))
 
     @property
     def shuffle_output_bytes_spilled(self):
         """Union[int, None]: Number of bytes written by this stage to
         intermediate shuffle and spilled to disk.
         """
-        return self._properties.get('shuffleOutputBytesSpilled')
+        return _int_or_none(self._properties.get('shuffleOutputBytesSpilled'))
 
     @property
     def steps(self):
@@ -2749,31 +2752,31 @@ class TimelineEntry(object):
     def elapsed_ms(self):
         """Union[int, None]: Milliseconds elapsed since start of query
         execution."""
-        return self._properties.get('elapsedMs')
+        return _int_or_none(self._properties.get('elapsedMs'))
 
     @property
     def active_units(self):
         """Union[int, None]: Current number of input units being processed
         by workers, reported as largest value since the last sample."""
-        return self._properties.get('activeUnits')
+        return _int_or_none(self._properties.get('activeUnits'))
 
     @property
     def pending_units(self):
         """Union[int, None]: Current number of input units remaining for
         query stages active at this sample time."""
-        return self._properties.get('pendingUnits')
+        return _int_or_none(self._properties.get('pendingUnits'))
 
     @property
     def completed_units(self):
         """Union[int, None]: Current number of input units completed by
         this query."""
-        return self._properties.get('completedUnits')
+        return _int_or_none(self._properties.get('completedUnits'))
 
     @property
     def slot_millis(self):
         """Union[int, None]: Cumulative slot-milliseconds consumed by
         this query."""
-        return self._properties.get('totalSlotMs')
+        return _int_or_none(self._properties.get('totalSlotMs'))
 
 
 class UnknownJob(_AsyncJob):

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -1154,22 +1154,14 @@ class TestBigQuery(unittest.TestCase):
         self.assertGreater(first_stage.shuffle_output_bytes, 0)
         self.assertEqual(first_stage.status, 'COMPLETE')
 
-        # Query plan is a digraph, determine that there's a stage that's has
-        # the max ratio for an accounting type, and that not all nodes in the
-        # graphs recieve input from other stages.
+        # Query plan is a digraph.  Ensure it has inter-stage links,
+        # but not every stage has inputs.
         stages_with_inputs = 0
-        stages_with_max_ratio = 0
         for entry in plan:
             if len(entry.input_stages) > 0:
                 stages_with_inputs = stages_with_inputs + 1
-            if (entry.compute_ratio_max == 1.0 or
-                    entry.read_ratio_max == 1.0 or
-                    entry.wait_ratio_max == 1.0 or
-                    entry.write_ratio_max == 1.0):
-                stages_with_max_ratio = stages_with_max_ratio + 1
         self.assertGreater(stages_with_inputs, 0)
         self.assertGreater(len(plan), stages_with_inputs)
-        self.assertGreater(stages_with_max_ratio, 0)
 
     def test_dbapi_w_standard_sql_types(self):
         examples = self._generate_standard_sql_types_examples()

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -2289,33 +2289,33 @@ class TestQueryJob(unittest.TestCase, _Base):
 
         plan_entries = [{
             'name': 'NAME',
-            'id': 1234,
-            'inputStages': [88, 101],
-            'startMs': 1522540800000,
-            'endMs':   1522540804000,
-            'parallelInputs': 1000,
-            'completedParallelInputs': 5,
-            'waitMsAvg': 33,
-            'waitMsMax': 400,
+            'id': '1234',
+            'inputStages': ['88', '101'],
+            'startMs': '1522540800000',
+            'endMs':   '1522540804000',
+            'parallelInputs': '1000',
+            'completedParallelInputs': '5',
+            'waitMsAvg': '33',
+            'waitMsMax': '400',
             'waitRatioAvg': 2.71828,
             'waitRatioMax': 3.14159,
-            'readMsAvg': 45,
-            'readMsMax': 90,
+            'readMsAvg': '45',
+            'readMsMax': '90',
             'readRatioAvg': 1.41421,
             'readRatioMax': 1.73205,
-            'computeMsAvg': 55,
-            'computeMsMax': 99,
+            'computeMsAvg': '55',
+            'computeMsMax': '99',
             'computeRatioAvg': 0.69315,
             'computeRatioMax': 1.09861,
-            'writeMsAvg': 203,
-            'writeMsMax': 340,
+            'writeMsAvg': '203',
+            'writeMsMax': '340',
             'writeRatioAvg': 3.32193,
             'writeRatioMax': 2.30258,
             'recordsRead': '100',
             'recordsWritten': '1',
             'status': 'STATUS',
-            'shuffleOutputBytes': 1024,
-            'shuffleOutputBytesSpilled': 1,
+            'shuffleOutputBytes': '1024',
+            'shuffleOutputBytesSpilled': '1',
             'steps': [{
                 'kind': 'KIND',
                 'substeps': ['SUBSTEP1', 'SUBSTEP2'],
@@ -2342,7 +2342,7 @@ class TestQueryJob(unittest.TestCase, _Base):
                     len(found.input_stages),
                     len(expected['inputStages']))
             for f_id in found.input_stages:
-                self.assertIn(f_id, expected['inputStages'])
+                self.assertIn(f_id, [int(e) for e in expected['inputStages']])
             self.assertEqual(
                 found.start.strftime(_RFC3339_MICROS),
                 '2018-04-01T00:00:00.000000Z')
@@ -2351,39 +2351,43 @@ class TestQueryJob(unittest.TestCase, _Base):
                 '2018-04-01T00:00:04.000000Z')
             self.assertEqual(
                     found.parallel_inputs,
-                    expected['parallelInputs'])
+                    int(expected['parallelInputs']))
             self.assertEqual(
                     found.completed_parallel_inputs,
-                    expected['completedParallelInputs'])
-            self.assertEqual(found.wait_ms_avg, expected['waitMsAvg'])
-            self.assertEqual(found.wait_ms_max, expected['waitMsMax'])
+                    int(expected['completedParallelInputs']))
+            self.assertEqual(found.wait_ms_avg, int(expected['waitMsAvg']))
+            self.assertEqual(found.wait_ms_max, int(expected['waitMsMax']))
             self.assertEqual(found.wait_ratio_avg, expected['waitRatioAvg'])
             self.assertEqual(found.wait_ratio_max, expected['waitRatioMax'])
-            self.assertEqual(found.read_ms_avg, expected['readMsAvg'])
-            self.assertEqual(found.read_ms_max, expected['readMsMax'])
+            self.assertEqual(found.read_ms_avg, int(expected['readMsAvg']))
+            self.assertEqual(found.read_ms_max, int(expected['readMsMax']))
             self.assertEqual(found.read_ratio_avg, expected['readRatioAvg'])
             self.assertEqual(found.read_ratio_max, expected['readRatioMax'])
-            self.assertEqual(found.compute_ms_avg, expected['computeMsAvg'])
-            self.assertEqual(found.compute_ms_max, expected['computeMsMax'])
+            self.assertEqual(
+                found.compute_ms_avg,
+                int(expected['computeMsAvg']))
+            self.assertEqual(
+                found.compute_ms_max,
+                int(expected['computeMsMax']))
             self.assertEqual(
                 found.compute_ratio_avg, expected['computeRatioAvg'])
             self.assertEqual(
                 found.compute_ratio_max, expected['computeRatioMax'])
-            self.assertEqual(found.write_ms_avg, expected['writeMsAvg'])
-            self.assertEqual(found.write_ms_max, expected['writeMsMax'])
+            self.assertEqual(found.write_ms_avg, int(expected['writeMsAvg']))
+            self.assertEqual(found.write_ms_max, int(expected['writeMsMax']))
             self.assertEqual(found.write_ratio_avg, expected['writeRatioAvg'])
             self.assertEqual(found.write_ratio_max, expected['writeRatioMax'])
             self.assertEqual(
-                found.records_read, expected['recordsRead'])
+                found.records_read, int(expected['recordsRead']))
             self.assertEqual(
-                found.records_written, expected['recordsWritten'])
+                found.records_written, int(expected['recordsWritten']))
             self.assertEqual(found.status, expected['status'])
             self.assertEqual(
                     found.shuffle_output_bytes,
-                    expected['shuffleOutputBytes'])
+                    int(expected['shuffleOutputBytes']))
             self.assertEqual(
                     found.shuffle_output_bytes_spilled,
-                    expected['shuffleOutputBytesSpilled'])
+                    int(expected['shuffleOutputBytesSpilled']))
 
             self.assertEqual(len(found.steps), len(expected['steps']))
             for f_step, e_step in zip(found.steps, expected['steps']):


### PR DESCRIPTION
Part 2 of 2.  Expose the query timeline as a list of TimelineEntry objects.  Each sample provides progress information for a query query in terms of input units, as well as cumulative attribution of slot-millisecond resources.

Additionally, expose slot-milliseconds usage as a top-level field from the query statistics.