### PR TITLE
Added make_private to Storage bucket and blob

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -1346,6 +1346,18 @@ class Blob(_PropertyMixin):
         self.acl.all().grant_read()
         self.acl.save(client=client)
 
+    def make_private(self, client=None):
+        """Make this blob private by removing `allusers` read access.
+        Does not revoke access for anything other than the `allusers` group.
+
+        :type client: :class:`~google.cloud.storage.client.Client` or
+                      ``NoneType``
+        :param client: Optional. The client to use.  If not passed, falls back
+                       to the ``client`` stored on the blob's bucket.
+        """
+        self.acl.all().revoke_read()
+        self.acl.save(client=client)
+
     def compose(self, sources, client=None):
         """Concatenate source blobs into this one.
 

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -2062,6 +2062,24 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(kw[0]['data'], {'acl': permissive})
         self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
 
+    def test_make_private(self):
+        BLOB_NAME = 'blob-name'
+        no_permissions = []
+        after = ({'status': http_client.OK}, {'acl': no_permissions})
+        connection = _Connection(after)
+        client = _Client(connection)
+        bucket = _Bucket(client=client)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
+        blob.acl.loaded = True
+        blob.make_private()
+        self.assertEqual(list(blob.acl), no_permissions)
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/b/name/o/%s' % BLOB_NAME)
+        self.assertEqual(kw[0]['data'], {'acl': no_permissions})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+
     def test_compose_wo_content_type_set(self):
         SOURCE_1 = 'source-1'
         SOURCE_2 = 'source-2'
@@ -2103,7 +2121,7 @@ class Test_Blob(unittest.TestCase):
             'method': 'POST',
             'path': '/b/name/o/%s/compose' % DESTINATION,
             'query_params': {'userProject': USER_PROJECT},
-            'data':  {
+            'data': {
                 'sourceObjects': [
                     {'name': source_1.name},
                     {'name': source_2.name},
@@ -2143,7 +2161,7 @@ class Test_Blob(unittest.TestCase):
             'method': 'POST',
             'path': '/b/name/o/%s/compose' % DESTINATION,
             'query_params': {},
-            'data':  {
+            'data': {
                 'sourceObjects': [
                     {'name': source_1.name},
                     {'name': source_2.name},

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -1665,6 +1665,145 @@ class Test_Bucket(unittest.TestCase):
         bucket._MAX_OBJECTS_FOR_ITERATION = 1
         self.assertRaises(ValueError, bucket.make_public, recursive=True)
 
+    def test_make_private_defaults(self):
+        NAME = 'name'
+        no_permissions = []
+        after = {'acl': no_permissions, 'defaultObjectAcl': []}
+        connection = _Connection(after)
+        client = _Client(connection)
+        bucket = self._make_one(client=client, name=NAME)
+        bucket.acl.loaded = True
+        bucket.default_object_acl.loaded = True
+        bucket.make_private()
+        self.assertEqual(list(bucket.acl), no_permissions)
+        self.assertEqual(list(bucket.default_object_acl), [])
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
+        self.assertEqual(kw[0]['data'], {'acl': after['acl']})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+
+    def _make_private_w_future_helper(self, default_object_acl_loaded=True):
+        NAME = 'name'
+        no_permissions = []
+        after1 = {'acl': no_permissions, 'defaultObjectAcl': []}
+        after2 = {'acl': no_permissions, 'defaultObjectAcl': no_permissions}
+        if default_object_acl_loaded:
+            num_requests = 2
+            connection = _Connection(after1, after2)
+        else:
+            num_requests = 3
+            # We return the same value for default_object_acl.reload()
+            # to consume.
+            connection = _Connection(after1, after1, after2)
+        client = _Client(connection)
+        bucket = self._make_one(client=client, name=NAME)
+        bucket.acl.loaded = True
+        bucket.default_object_acl.loaded = default_object_acl_loaded
+        bucket.make_private(future=True)
+        self.assertEqual(list(bucket.acl), no_permissions)
+        self.assertEqual(list(bucket.default_object_acl), no_permissions)
+        kw = connection._requested
+        self.assertEqual(len(kw), num_requests)
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
+        self.assertEqual(kw[0]['data'], {'acl': no_permissions})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        if not default_object_acl_loaded:
+            self.assertEqual(kw[1]['method'], 'GET')
+            self.assertEqual(kw[1]['path'], '/b/%s/defaultObjectAcl' % NAME)
+        # Last could be 1 or 2 depending on `default_object_acl_loaded`.
+        self.assertEqual(kw[-1]['method'], 'PATCH')
+        self.assertEqual(kw[-1]['path'], '/b/%s' % NAME)
+        self.assertEqual(kw[-1]['data'], {'defaultObjectAcl': no_permissions})
+        self.assertEqual(kw[-1]['query_params'], {'projection': 'full'})
+
+    def test_make_private_w_future(self):
+        self._make_private_w_future_helper(default_object_acl_loaded=True)
+
+    def test_make_private_w_future_reload_default(self):
+        self._make_private_w_future_helper(default_object_acl_loaded=False)
+
+    def test_make_private_recursive(self):
+        _saved = []
+
+        class _Blob(object):
+            _granted = True
+
+            def __init__(self, bucket, name):
+                self._bucket = bucket
+                self._name = name
+
+            @property
+            def acl(self):
+                return self
+
+            # Faux ACL methods
+            def all(self):
+                return self
+
+            def revoke_read(self):
+                self._granted = False
+
+            def save(self, client=None):
+                _saved.append(
+                    (self._bucket, self._name, self._granted, client))
+
+        def item_to_blob(self, item):
+            return _Blob(self.bucket, item['name'])
+
+        NAME = 'name'
+        BLOB_NAME = 'blob-name'
+        no_permissions = []
+        after = {'acl': no_permissions, 'defaultObjectAcl': []}
+        connection = _Connection(after, {'items': [{'name': BLOB_NAME}]})
+        client = _Client(connection)
+        bucket = self._make_one(client=client, name=NAME)
+        bucket.acl.loaded = True
+        bucket.default_object_acl.loaded = True
+
+        with mock.patch('google.cloud.storage.bucket._item_to_blob',
+                        new=item_to_blob):
+            bucket.make_private(recursive=True)
+        self.assertEqual(list(bucket.acl), no_permissions)
+        self.assertEqual(list(bucket.default_object_acl), [])
+        self.assertEqual(_saved, [(bucket, BLOB_NAME, False, None)])
+        kw = connection._requested
+        self.assertEqual(len(kw), 2)
+        self.assertEqual(kw[0]['method'], 'PATCH')
+        self.assertEqual(kw[0]['path'], '/b/%s' % NAME)
+        self.assertEqual(kw[0]['data'], {'acl': no_permissions})
+        self.assertEqual(kw[0]['query_params'], {'projection': 'full'})
+        self.assertEqual(kw[1]['method'], 'GET')
+        self.assertEqual(kw[1]['path'], '/b/%s/o' % NAME)
+        max_results = bucket._MAX_OBJECTS_FOR_ITERATION + 1
+        self.assertEqual(kw[1]['query_params'],
+                         {'maxResults': max_results, 'projection': 'full'})
+
+    def test_make_private_recursive_too_many(self):
+        NO_PERMISSIONS = []
+        AFTER = {'acl': NO_PERMISSIONS, 'defaultObjectAcl': []}
+
+        NAME = 'name'
+        BLOB_NAME1 = 'blob-name1'
+        BLOB_NAME2 = 'blob-name2'
+        GET_BLOBS_RESP = {
+            'items': [
+                {'name': BLOB_NAME1},
+                {'name': BLOB_NAME2},
+            ],
+        }
+        connection = _Connection(AFTER, GET_BLOBS_RESP)
+        client = _Client(connection)
+        bucket = self._make_one(client=client, name=NAME)
+        bucket.acl.loaded = True
+        bucket.default_object_acl.loaded = True
+
+        # Make the Bucket refuse to make_private with 2 objects.
+        bucket._MAX_OBJECTS_FOR_ITERATION = 1
+        self.assertRaises(ValueError, bucket.make_private, recursive=True)
+
     def test_page_empty_response(self):
         from google.api_core import page_iterator
 

--- a/storage/tests/unit/test_notification.py
+++ b/storage/tests/unit/test_notification.py
@@ -36,7 +36,7 @@ class TestBucketNotification(unittest.TestCase):
     ETAG = 'DEADBEEF'
     CREATE_PATH = '/b/{}/notificationConfigs'.format(BUCKET_NAME)
     NOTIFICATION_PATH = '/b/{}/notificationConfigs/{}'.format(
-            BUCKET_NAME, NOTIFICATION_ID)
+        BUCKET_NAME, NOTIFICATION_ID)
 
     @staticmethod
     def event_types():


### PR DESCRIPTION
As the Storage UI on the console allows for easy toggling of public-private settings on objects and buckets, I figured it would be nice to add the support in the python package as well. 

This adds a new method to both storage's bucket and blob called `make_private` that undoes the actions of the `make_public` command.