### PR TITLE
BigQuery: use autosummary to split up API reference docs

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1084,8 +1084,6 @@ class RowIterator(HTTPIterator):
         page_size (int, optional): The number of items to return per page.
         extra_params (Dict[str, object]):
             Extra query string parameters for the API call.
-
-    .. autoattribute:: pages
     """
 
     def __init__(self, client, api_request, path, schema, page_token=None,

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,1 @@
+../../../third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/class.rst

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,0 +1,1 @@
+../../../third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/module.rst

--- a/docs/bigquery/.gitignore
+++ b/docs/bigquery/.gitignore
@@ -1,0 +1,1 @@
+reference/

--- a/docs/bigquery/.gitignore
+++ b/docs/bigquery/.gitignore
@@ -1,1 +1,1 @@
-reference/
+generated/

--- a/docs/bigquery/reference.rst
+++ b/docs/bigquery/reference.rst
@@ -1,68 +1,133 @@
 API Reference
 ~~~~~~~~~~~~~
 
-.. automodule:: google.cloud.bigquery
-  :no-members:
+.. currentmodule:: google.cloud.bigquery
+
+The main concepts with this API are:
+
+- :class:`~google.cloud.bigquery.client.Client` manages connections to the
+  BigQuery API. Use the client methods to run jobs (such as a
+  :class:`~google.cloud.bigquery.job.QueryJob` via
+  :meth:`~google.cloud.bigquery.client.Client.query`) and manage resources.
+
+- :class:`~google.cloud.bigquery.dataset.Dataset` represents a
+  collection of tables.
+
+- :class:`~google.cloud.bigquery.table.Table` represents a single "relation".
 
 Client
 ======
 
-.. automodule:: google.cloud.bigquery.client
-  :members:
-  :show-inheritance:
+.. autosummary::
+    :toctree: reference
 
+    client.Client
 
 Job
 ===
 
-.. automodule:: google.cloud.bigquery.job
-  :members:
-  :show-inheritance:
+Job Configuration
+-----------------
+
+.. autosummary::
+    :toctree: reference
+
+    job.QueryJobConfig
+    job.CopyJobConfig
+    job.LoadJobConfig
+    job.ExtractJobConfig
+
+Job Classes
+-----------
+
+.. autosummary::
+    :toctree: reference
+
+    job.QueryJob
+    job.CopyJob
+    job.LoadJob
+    job.ExtractJob
+    job.UnknownJob
+
+Job Resources
+-------------
+
+.. autosummary::
+    :toctree: reference
+
+    job.Compression
+    job.CreateDisposition
+    job.DestinationFormat
+    job.Encoding
+    job.QueryPriority
+    job.SourceFormat
+    job.WriteDisposition
 
 
 Dataset
 =======
 
-.. automodule:: google.cloud.bigquery.dataset
-  :members:
-  :show-inheritance:
+.. autosummary::
+    :toctree: reference
+
+    dataset.Dataset
+    dataset.DatasetReference
+    dataset.AccessEntry
 
 
 Table
 =====
 
-.. automodule:: google.cloud.bigquery.table
-  :members:
-  :show-inheritance:
+.. autosummary::
+    :toctree: reference
+
+    table.Table
+    table.TableReference
+    table.Row
+    table.EncryptionConfiguration
+    table.TimePartitioning
+    table.TimePartitioningType
 
 
 Schema
 ======
 
-.. automodule:: google.cloud.bigquery.schema
-  :members:
-  :show-inheritance:
+.. autosummary::
+    :toctree: reference
+
+    schema.SchemaField
 
 
 Query
 =====
 
-.. automodule:: google.cloud.bigquery.query
-  :members:
-  :show-inheritance:
+.. autosummary::
+    :toctree: reference
+
+    query.ArrayQueryParameter
+    query.ScalarQueryParameter
+    query.StructQueryParameter
+    query.UDFResource
 
 
 External Configuration
 ======================
 
-.. automodule:: google.cloud.bigquery.external_config
-  :members:
-  :show-inheritance:
+.. autosummary::
+    :toctree: reference
+
+    external_config.ExternalConfig
+    external_config.BigtableOptions
+    external_config.BigtableColumnFamily
+    external_config.BigtableColumn
+    external_config.CSVOptions
+    external_config.GoogleSheetsOptions
 
 
 Magics
 ======================
 
-.. automodule:: google.cloud.bigquery.magics
-  :members:
-  :show-inheritance:
+.. autosummary::
+    :toctree: reference
+
+    magics

--- a/docs/bigquery/reference.rst
+++ b/docs/bigquery/reference.rst
@@ -19,7 +19,7 @@ Client
 ======
 
 .. autosummary::
-    :toctree: reference
+    :toctree: generated
 
     client.Client
 
@@ -30,7 +30,7 @@ Job Configuration
 -----------------
 
 .. autosummary::
-    :toctree: reference
+    :toctree: generated
 
     job.QueryJobConfig
     job.CopyJobConfig
@@ -41,7 +41,7 @@ Job Classes
 -----------
 
 .. autosummary::
-    :toctree: reference
+    :toctree: generated
 
     job.QueryJob
     job.CopyJob
@@ -53,7 +53,7 @@ Job Resources
 -------------
 
 .. autosummary::
-    :toctree: reference
+    :toctree: generated
 
     job.Compression
     job.CreateDisposition
@@ -68,7 +68,7 @@ Dataset
 =======
 
 .. autosummary::
-    :toctree: reference
+    :toctree: generated
 
     dataset.Dataset
     dataset.DatasetReference
@@ -79,7 +79,7 @@ Table
 =====
 
 .. autosummary::
-    :toctree: reference
+    :toctree: generated
 
     table.Table
     table.TableReference
@@ -93,7 +93,7 @@ Schema
 ======
 
 .. autosummary::
-    :toctree: reference
+    :toctree: generated
 
     schema.SchemaField
 
@@ -102,7 +102,7 @@ Query
 =====
 
 .. autosummary::
-    :toctree: reference
+    :toctree: generated
 
     query.ArrayQueryParameter
     query.ScalarQueryParameter
@@ -114,7 +114,7 @@ External Configuration
 ======================
 
 .. autosummary::
-    :toctree: reference
+    :toctree: generated
 
     external_config.ExternalConfig
     external_config.BigtableOptions
@@ -128,6 +128,6 @@ Magics
 ======================
 
 .. autosummary::
-    :toctree: reference
+    :toctree: generated
 
     magics

--- a/docs/bigquery/reference.rst
+++ b/docs/bigquery/reference.rst
@@ -49,8 +49,8 @@ Job Classes
     job.ExtractJob
     job.UnknownJob
 
-Job Resources
--------------
+Job-Related Types
+-----------------
 
 .. autosummary::
     :toctree: generated
@@ -84,6 +84,7 @@ Table
     table.Table
     table.TableReference
     table.Row
+    table.RowIterator
     table.EncryptionConfiguration
     table.TimePartitioning
     table.TimePartitioningType

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = []
+templates_path = ['_templates']
 
 # Allow markdown includes (so releases.md can include CHANGLEOG.md)
 # http://www.sphinx-doc.org/en/master/markdown.html
@@ -305,6 +305,10 @@ texinfo_documents = [
 # This pulls class descriptions from the class docstring,
 # and parameter definitions from the __init__ docstring.
 autoclass_content = 'both'
+
+# Automatically generate API reference stubs from autosummary.
+# http://www.sphinx-doc.org/en/master/ext/autosummary.html#generating-stub-pages-automatically
+autosummary_generate = True
 
 # Configuration for intersphinx:
 intersphinx_mapping = {

--- a/test_utils/scripts/update_docs.sh
+++ b/test_utils/scripts/update_docs.sh
@@ -24,6 +24,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Function to build the docs.
 function build_docs {
     rm -rf docs/_build/
+    rm -rf docs/bigquery/generated
     sphinx-build -W -b html -d docs/_build/doctrees docs/ docs/_build/html/
     return $?
 }

--- a/third_party/sphinx/LICENSE
+++ b/third_party/sphinx/LICENSE
@@ -1,0 +1,280 @@
+License for Sphinx
+==================
+
+Copyright (c) 2007-2017 by the Sphinx team (see AUTHORS file).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Licenses for incorporated software
+==================================
+
+The pgen2 package, included in this distribution under the name
+sphinx.pycode.pgen2, is available in the Python 2.6 distribution under
+the PSF license agreement for Python:
+
+----------------------------------------------------------------------
+Copyright © 2001-2008 Python Software Foundation; All Rights Reserved.
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+   ("PSF"), and the Individual or Organization ("Licensee") accessing
+   and otherwise using Python 2.6 software in source or binary form
+   and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF
+   hereby grants Licensee a nonexclusive, royalty-free, world-wide
+   license to reproduce, analyze, test, perform and/or display
+   publicly, prepare derivative works, distribute, and otherwise use
+   Python 2.6 alone or in any derivative version, provided, however,
+   that PSF's License Agreement and PSF's notice of copyright, i.e.,
+   "Copyright © 2001-2008 Python Software Foundation; All Rights
+   Reserved" are retained in Python 2.6 alone or in any derivative
+   version prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+   or incorporates Python 2.6 or any part thereof, and wants to make
+   the derivative work available to others as provided herein, then
+   Licensee hereby agrees to include in any such work a brief summary
+   of the changes made to Python 2.6.
+
+4. PSF is making Python 2.6 available to Licensee on an "AS IS" basis.
+   PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY
+   WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY
+   REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY
+   PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 2.6 WILL NOT INFRINGE
+   ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+   2.6 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+   AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON
+   2.6, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY
+   THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+   breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+   relationship of agency, partnership, or joint venture between PSF
+   and Licensee.  This License Agreement does not grant permission to
+   use PSF trademarks or trade name in a trademark sense to endorse or
+   promote products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python 2.6, Licensee
+   agrees to be bound by the terms and conditions of this License
+   Agreement.
+----------------------------------------------------------------------
+
+The included smartypants module, included as sphinx.util.smartypants,
+is available under the following license:
+
+----------------------------------------------------------------------
+SmartyPants_ license::
+
+    Copyright (c) 2003 John Gruber
+    (http://daringfireball.net/)
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    *   Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+    *   Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials
+        provided with the distribution.
+
+    *   Neither the name "SmartyPants" nor the names of its
+        contributors may be used to endorse or promote products
+        derived from this software without specific prior written
+        permission.
+
+    This software is provided by the copyright holders and
+    contributors "as is" and any express or implied warranties,
+    including, but not limited to, the implied warranties of
+    merchantability and fitness for a particular purpose are
+    disclaimed. In no event shall the copyright owner or contributors
+    be liable for any direct, indirect, incidental, special,
+    exemplary, or consequential damages (including, but not limited
+    to, procurement of substitute goods or services; loss of use,
+    data, or profits; or business interruption) however caused and on
+    any theory of liability, whether in contract, strict liability, or
+    tort (including negligence or otherwise) arising in any way out of
+    the use of this software, even if advised of the possibility of
+    such damage.
+
+
+smartypants.py license::
+
+    smartypants.py is a derivative work of SmartyPants.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    *   Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+    *   Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials
+        provided with the distribution.
+
+    This software is provided by the copyright holders and
+    contributors "as is" and any express or implied warranties,
+    including, but not limited to, the implied warranties of
+    merchantability and fitness for a particular purpose are
+    disclaimed. In no event shall the copyright owner or contributors
+    be liable for any direct, indirect, incidental, special,
+    exemplary, or consequential damages (including, but not limited
+    to, procurement of substitute goods or services; loss of use,
+    data, or profits; or business interruption) however caused and on
+    any theory of liability, whether in contract, strict liability, or
+    tort (including negligence or otherwise) arising in any way out of
+    the use of this software, even if advised of the possibility of
+    such damage.
+----------------------------------------------------------------------
+
+The ElementTree package, included in this distribution in
+test/etree13, is available under the following license:
+
+----------------------------------------------------------------------
+The ElementTree toolkit is
+
+Copyright (c) 1999-2007 by Fredrik Lundh
+
+By obtaining, using, and/or copying this software and/or its
+associated documentation, you agree that you have read, understood,
+and will comply with the following terms and conditions:
+
+Permission to use, copy, modify, and distribute this software and its
+associated documentation for any purpose and without fee is hereby
+granted, provided that the above copyright notice appears in all
+copies, and that both that copyright notice and this permission notice
+appear in supporting documentation, and that the name of Secret Labs
+AB or the author not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior
+permission.
+
+SECRET LABS AB AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANT- ABILITY
+AND FITNESS.  IN NO EVENT SHALL SECRET LABS AB OR THE AUTHOR BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+----------------------------------------------------------------------
+
+The included JQuery JavaScript library is available under the MIT
+license:
+
+----------------------------------------------------------------------
+Copyright (c) 2008 John Resig, http://jquery.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+----------------------------------------------------------------------
+
+The included Underscore JavaScript library is available under the MIT
+license:
+
+----------------------------------------------------------------------
+Copyright (c) 2009 Jeremy Ashkenas, DocumentCloud
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+The included implementation of NumpyDocstring._parse_numpydoc_see_also_section
+was derived from code under the following license:
+
+-------------------------------------------------------------------------------
+
+Copyright (C) 2008 Stefan van der Walt <stefan@mentat.za.net>, Pauli Virtanen <pav@iki.fi>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------

--- a/third_party/sphinx/README.md
+++ b/third_party/sphinx/README.md
@@ -1,0 +1,2 @@
+Subset of [Sphinx](https://github.com/sphinx-doc/sphinx) to override built-in
+templates.

--- a/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/class.rst
+++ b/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/class.rst
@@ -10,6 +10,8 @@
    {% if methods %}
    .. rubric:: Methods
 
+   {# Customized from original by adding toctree. This generates docs for the
+   listed functions. #}
    .. autosummary::
       :toctree: .
    {% for item in methods %}

--- a/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/class.rst
+++ b/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/class.rst
@@ -1,0 +1,33 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: Methods
+
+   .. autosummary::
+      :toctree: .
+   {% for item in methods %}
+      {% if item != '__init__' %}
+      ~{{ name }}.{{ item }}
+      {% endif %}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: .
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/module.rst
+++ b/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/module.rst
@@ -1,0 +1,39 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: .
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: .
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: Exceptions
+
+   .. autosummary::
+      :toctree: .
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/module.rst
+++ b/third_party/sphinx/sphinx/ext/autosummary/templates/autosummary/module.rst
@@ -6,6 +6,8 @@
    {% if functions %}
    .. rubric:: Functions
 
+   {# Customized from original by adding toctree. This generates docs for the
+   listed functions. #}
    .. autosummary::
       :toctree: .
    {% for item in functions %}


### PR DESCRIPTION
@alixhami and I have heard from several folks that the [BigQuery API Reference docs](https://google-cloud-python.readthedocs.io/en/latest/bigquery/reference.html) are pretty impossible to navigate. This PR uses the [autosummary](http://www.sphinx-doc.org/en/master/ext/autosummary.html) module to split the docs into separate pages with an easier to browse summary table.