### PR TITLE
BigQuery: fix typo in Client docstrings

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -603,7 +603,7 @@ class Client(ClientWithProject):
         Returns:
             Union[google.cloud.bigquery.job.LoadJob, \
                   google.cloud.bigquery.job.CopyJob, \
-                  google.cloud.bigquery.job.ExtractJob \
+                  google.cloud.bigquery.job.ExtractJob, \
                   google.cloud.bigquery.job.QueryJob]:
                 Job instance, based on the resource returned by the API.
         """
@@ -642,7 +642,7 @@ class Client(ClientWithProject):
         Returns:
             Union[google.cloud.bigquery.job.LoadJob, \
                   google.cloud.bigquery.job.CopyJob, \
-                  google.cloud.bigquery.job.ExtractJob \
+                  google.cloud.bigquery.job.ExtractJob, \
                   google.cloud.bigquery.job.QueryJob]:
                 Job instance, based on the resource returned by the API.
         """


### PR DESCRIPTION
Was missing a comma between types in get_job and cancel_job functions.