### PR TITLE
make dependency on logging less restrictive in error_reporting

### DIFF
--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -29,7 +29,7 @@ version = '0.29.1'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    'google-cloud-logging<1.5dev,>=1.4.0',
+    'google-cloud-logging>=1.4.0',
 ]
 extras = {
 }

--- a/error_reporting/setup.py
+++ b/error_reporting/setup.py
@@ -29,7 +29,7 @@ version = '0.29.1'
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    'google-cloud-logging>=1.4.0',
+    'google-cloud-logging>=1.4.0, <2.0dev',
 ]
 extras = {
 }


### PR DESCRIPTION
This PR makes the dependency on `google-cloud-python` less restrictive in `google-cloud-error-reporting`. Currently, it is not possible to install `google-cloud-error-reporting` alongside other up-to-date `google-cloud-python` packages.

Of course, there may be great reasons why it was so restrictive in the first place, in which case I'd love for the author to explain the cause.

If this change is fine, it would be great if this was merged swiftly and published to PyPI with an updated version number.