### PR TITLE
Avoid overwriting '__module__' of messages from shared modules.

### DIFF
--- a/bigquery_datatransfer/google/cloud/bigquery_datatransfer_v1/types.py
+++ b/bigquery_datatransfer/google/cloud/bigquery_datatransfer_v1/types.py
@@ -15,11 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.bigquery_datatransfer_v1.proto import datatransfer_pb2
-from google.cloud.bigquery_datatransfer_v1.proto import transfer_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import duration_pb2
@@ -30,21 +26,38 @@ from google.protobuf import timestamp_pb2
 from google.protobuf import wrappers_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.bigquery_datatransfer_v1.proto import datatransfer_pb2
+from google.cloud.bigquery_datatransfer_v1.proto import transfer_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    struct_pb2,
+    timestamp_pb2,
+    wrappers_pb2,
+    status_pb2,
+]
+
+
+_local_modules = [
+    datatransfer_pb2,
+    transfer_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        datatransfer_pb2,
-        transfer_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        struct_pb2,
-        timestamp_pb2,
-        wrappers_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.bigquery_datatransfer_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/bigtable/google/cloud/bigtable_admin_v2/types.py
+++ b/bigtable/google/cloud/bigtable_admin_v2/types.py
@@ -15,13 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.bigtable_admin_v2.proto import bigtable_instance_admin_pb2
-from google.cloud.bigtable_admin_v2.proto import bigtable_table_admin_pb2
-from google.cloud.bigtable_admin_v2.proto import instance_pb2
-from google.cloud.bigtable_admin_v2.proto import table_pb2
 from google.iam.v1 import iam_policy_pb2
 from google.iam.v1 import policy_pb2
 from google.iam.v1.logging import audit_data_pb2
@@ -34,25 +28,43 @@ from google.protobuf import field_mask_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.bigtable_admin_v2.proto import bigtable_instance_admin_pb2
+from google.cloud.bigtable_admin_v2.proto import bigtable_table_admin_pb2
+from google.cloud.bigtable_admin_v2.proto import instance_pb2
+from google.cloud.bigtable_admin_v2.proto import table_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    iam_policy_pb2,
+    policy_pb2,
+    audit_data_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    bigtable_instance_admin_pb2,
+    bigtable_table_admin_pb2,
+    instance_pb2,
+    table_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        bigtable_instance_admin_pb2,
-        bigtable_table_admin_pb2,
-        instance_pb2,
-        table_pb2,
-        iam_policy_pb2,
-        policy_pb2,
-        audit_data_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.bigtable_admin_v2.types'
         setattr(sys.modules[__name__], name, message)

--- a/bigtable/google/cloud/bigtable_v2/types.py
+++ b/bigtable/google/cloud/bigtable_v2/types.py
@@ -15,26 +15,38 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.bigtable_v2.proto import bigtable_pb2
-from google.cloud.bigtable_v2.proto import data_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import wrappers_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.bigtable_v2.proto import bigtable_pb2
+from google.cloud.bigtable_v2.proto import data_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    any_pb2,
+    descriptor_pb2,
+    wrappers_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    bigtable_pb2,
+    data_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        bigtable_pb2,
-        data_pb2,
-        any_pb2,
-        descriptor_pb2,
-        wrappers_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.bigtable_v2.types'
         setattr(sys.modules[__name__], name, message)

--- a/container/google/cloud/container_v1/types.py
+++ b/container/google/cloud/container_v1/types.py
@@ -15,20 +15,32 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.container_v1.proto import cluster_service_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import empty_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.container_v1.proto import cluster_service_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    descriptor_pb2,
+    empty_pb2,
+]
+
+_local_modules = [
+    cluster_service_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        cluster_service_pb2,
-        descriptor_pb2,
-        empty_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.container_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/dataproc/google/cloud/dataproc_v1/types.py
+++ b/dataproc/google/cloud/dataproc_v1/types.py
@@ -15,12 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.dataproc_v1.proto import clusters_pb2
-from google.cloud.dataproc_v1.proto import jobs_pb2
-from google.cloud.dataproc_v1.proto import operations_pb2 as proto_operations_pb2
 from google.longrunning import operations_pb2 as longrunning_operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -30,21 +25,37 @@ from google.protobuf import field_mask_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.dataproc_v1.proto import clusters_pb2
+from google.cloud.dataproc_v1.proto import jobs_pb2
+from google.cloud.dataproc_v1.proto import operations_pb2 as proto_operations_pb2
+
+_shared_modules = [
+    http_pb2,
+    longrunning_operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    clusters_pb2,
+    jobs_pb2,
+    proto_operations_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        clusters_pb2,
-        jobs_pb2,
-        proto_operations_pb2,
-        longrunning_operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.dataproc_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/datastore/google/cloud/datastore_v1/types.py
+++ b/datastore/google/cloud/datastore_v1/types.py
@@ -15,30 +15,42 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.datastore_v1.proto import datastore_pb2
-from google.cloud.datastore_v1.proto import entity_pb2
-from google.cloud.datastore_v1.proto import query_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import struct_pb2
 from google.protobuf import timestamp_pb2
 from google.protobuf import wrappers_pb2
 from google.type import latlng_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.datastore_v1.proto import datastore_pb2
+from google.cloud.datastore_v1.proto import entity_pb2
+from google.cloud.datastore_v1.proto import query_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    descriptor_pb2,
+    struct_pb2,
+    timestamp_pb2,
+    wrappers_pb2,
+    latlng_pb2,
+]
+
+_local_modules = [
+    datastore_pb2,
+    entity_pb2,
+    query_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        datastore_pb2,
-        entity_pb2,
-        query_pb2,
-        descriptor_pb2,
-        struct_pb2,
-        timestamp_pb2,
-        wrappers_pb2,
-        latlng_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.datastore_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/dlp/google/cloud/dlp_v2/types.py
+++ b/dlp/google/cloud/dlp_v2/types.py
@@ -15,11 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.dlp_v2.proto import dlp_pb2
-from google.cloud.dlp_v2.proto import storage_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import duration_pb2
@@ -30,21 +26,37 @@ from google.rpc import status_pb2
 from google.type import date_pb2
 from google.type import timeofday_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.dlp_v2.proto import dlp_pb2
+from google.cloud.dlp_v2.proto import storage_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    timestamp_pb2,
+    status_pb2,
+    date_pb2,
+    timeofday_pb2,
+]
+
+_local_modules = [
+    dlp_pb2,
+    storage_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        dlp_pb2,
-        storage_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        timestamp_pb2,
-        status_pb2,
-        date_pb2,
-        timeofday_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.dlp_v2.types'
         setattr(sys.modules[__name__], name, message)

--- a/error_reporting/google/cloud/errorreporting_v1beta1/types.py
+++ b/error_reporting/google/cloud/errorreporting_v1beta1/types.py
@@ -15,32 +15,44 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
 from google.api import label_pb2
 from google.api import monitored_resource_pb2
-from google.cloud.errorreporting_v1beta1.proto import common_pb2
-from google.cloud.errorreporting_v1beta1.proto import error_group_service_pb2
-from google.cloud.errorreporting_v1beta1.proto import error_stats_service_pb2
-from google.cloud.errorreporting_v1beta1.proto import report_errors_service_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import duration_pb2
 from google.protobuf import timestamp_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.errorreporting_v1beta1.proto import common_pb2
+from google.cloud.errorreporting_v1beta1.proto import error_group_service_pb2
+from google.cloud.errorreporting_v1beta1.proto import error_stats_service_pb2
+from google.cloud.errorreporting_v1beta1.proto import report_errors_service_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    label_pb2,
+    monitored_resource_pb2,
+    report_errors_service_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    timestamp_pb2,
+]
+
+_local_modules = [
+    common_pb2,
+    error_group_service_pb2,
+    error_stats_service_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        label_pb2,
-        monitored_resource_pb2,
-        common_pb2,
-        error_group_service_pb2,
-        error_stats_service_pb2,
-        report_errors_service_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        timestamp_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.errorreporting_v1beta1.types'
         setattr(sys.modules[__name__], name, message)

--- a/firestore/google/cloud/firestore_v1beta1/types.py
+++ b/firestore/google/cloud/firestore_v1beta1/types.py
@@ -15,14 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.firestore_v1beta1.proto import common_pb2
-from google.cloud.firestore_v1beta1.proto import document_pb2
-from google.cloud.firestore_v1beta1.proto import firestore_pb2
-from google.cloud.firestore_v1beta1.proto import query_pb2
-from google.cloud.firestore_v1beta1.proto import write_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import empty_pb2
@@ -32,23 +25,42 @@ from google.protobuf import wrappers_pb2
 from google.rpc import status_pb2
 from google.type import latlng_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.firestore_v1beta1.proto import common_pb2
+from google.cloud.firestore_v1beta1.proto import document_pb2
+from google.cloud.firestore_v1beta1.proto import firestore_pb2
+from google.cloud.firestore_v1beta1.proto import query_pb2
+from google.cloud.firestore_v1beta1.proto import write_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    any_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    struct_pb2,
+    timestamp_pb2,
+    wrappers_pb2,
+    status_pb2,
+    latlng_pb2,
+]
+
+_local_modules = [
+    common_pb2,
+    document_pb2,
+    firestore_pb2,
+    query_pb2,
+    write_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        common_pb2,
-        document_pb2,
-        firestore_pb2,
-        query_pb2,
-        write_pb2,
-        any_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        struct_pb2,
-        timestamp_pb2,
-        wrappers_pb2,
-        status_pb2,
-        latlng_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.firestore_v1beta1.types'
         setattr(sys.modules[__name__], name, message)

--- a/language/google/cloud/language_v1/types.py
+++ b/language/google/cloud/language_v1/types.py
@@ -15,17 +15,30 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.language_v1.proto import language_service_pb2
 from google.protobuf import descriptor_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.language_v1.proto import language_service_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    descriptor_pb2,
+]
+
+_local_modules = [
+    language_service_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        language_service_pb2,
-        descriptor_pb2, ):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.language_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/language/google/cloud/language_v1beta2/types.py
+++ b/language/google/cloud/language_v1beta2/types.py
@@ -15,10 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.language_v1beta2.proto import language_service_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -26,16 +23,32 @@ from google.protobuf import empty_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.language_v1beta2.proto import language_service_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    language_service_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        language_service_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        timestamp_pb2,
-        status_pb2, ):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.language_v1beta2.types'
         setattr(sys.modules[__name__], name, message)

--- a/logging/google/cloud/logging_v2/types.py
+++ b/logging/google/cloud/logging_v2/types.py
@@ -15,17 +15,11 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import distribution_pb2
 from google.api import http_pb2
 from google.api import label_pb2
 from google.api import metric_pb2
 from google.api import monitored_resource_pb2
-from google.cloud.logging_v2.proto import log_entry_pb2
-from google.cloud.logging_v2.proto import logging_config_pb2
-from google.cloud.logging_v2.proto import logging_metrics_pb2
-from google.cloud.logging_v2.proto import logging_pb2
 from google.logging.type import http_request_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -36,27 +30,45 @@ from google.protobuf import struct_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.logging_v2.proto import log_entry_pb2
+from google.cloud.logging_v2.proto import logging_config_pb2
+from google.cloud.logging_v2.proto import logging_metrics_pb2
+from google.cloud.logging_v2.proto import logging_pb2
+
+
+_shared_modules = [
+    distribution_pb2,
+    http_pb2,
+    label_pb2,
+    metric_pb2,
+    monitored_resource_pb2,
+    http_request_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    struct_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    log_entry_pb2,
+    logging_config_pb2,
+    logging_metrics_pb2,
+    logging_pb2,
+]
+
 names = []
-for module in (
-        distribution_pb2,
-        http_pb2,
-        label_pb2,
-        metric_pb2,
-        monitored_resource_pb2,
-        log_entry_pb2,
-        logging_config_pb2,
-        logging_metrics_pb2,
-        logging_pb2,
-        http_request_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        struct_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.logging_v2.types'
         setattr(sys.modules[__name__], name, message)

--- a/monitoring/google/cloud/monitoring_v3/types.py
+++ b/monitoring/google/cloud/monitoring_v3/types.py
@@ -15,13 +15,21 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import distribution_pb2
 from google.api import http_pb2
 from google.api import label_pb2
 from google.api import metric_pb2 as api_metric_pb2
 from google.api import monitored_resource_pb2
+from google.protobuf import any_pb2
+from google.protobuf import descriptor_pb2
+from google.protobuf import duration_pb2
+from google.protobuf import empty_pb2
+from google.protobuf import field_mask_pb2
+from google.protobuf import timestamp_pb2
+from google.protobuf import wrappers_pb2
+from google.rpc import status_pb2
+
+from google.api_core.protobuf_helpers import get_messages
 from google.cloud.monitoring_v3.proto import alert_pb2
 from google.cloud.monitoring_v3.proto import alert_service_pb2
 from google.cloud.monitoring_v3.proto import common_pb2
@@ -34,43 +42,47 @@ from google.cloud.monitoring_v3.proto import notification_pb2
 from google.cloud.monitoring_v3.proto import notification_service_pb2
 from google.cloud.monitoring_v3.proto import uptime_pb2
 from google.cloud.monitoring_v3.proto import uptime_service_pb2
-from google.protobuf import any_pb2
-from google.protobuf import descriptor_pb2
-from google.protobuf import duration_pb2
-from google.protobuf import empty_pb2
-from google.protobuf import field_mask_pb2
-from google.protobuf import timestamp_pb2
-from google.protobuf import wrappers_pb2
-from google.rpc import status_pb2
+
+
+_shared_modules = [
+    distribution_pb2,
+    http_pb2,
+    label_pb2,
+    api_metric_pb2,
+    monitored_resource_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    timestamp_pb2,
+    wrappers_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    alert_pb2,
+    alert_service_pb2,
+    common_pb2,
+    group_pb2,
+    group_service_pb2,
+    proto_metric_pb2,
+    metric_service_pb2,
+    mutation_record_pb2,
+    notification_pb2,
+    notification_service_pb2,
+    uptime_pb2,
+    uptime_service_pb2,
+]
 
 names = []
-for module in (
-        distribution_pb2,
-        http_pb2,
-        label_pb2,
-        api_metric_pb2,
-        monitored_resource_pb2,
-        alert_pb2,
-        alert_service_pb2,
-        common_pb2,
-        group_pb2,
-        group_service_pb2,
-        proto_metric_pb2,
-        metric_service_pb2,
-        mutation_record_pb2,
-        notification_pb2,
-        notification_service_pb2,
-        uptime_pb2,
-        uptime_service_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        timestamp_pb2,
-        wrappers_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.monitoring_v3.types'
         setattr(sys.modules[__name__], name, message)

--- a/oslogin/google/cloud/oslogin_v1/types.py
+++ b/oslogin/google/cloud/oslogin_v1/types.py
@@ -15,24 +15,35 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.oslogin_v1.proto import common_pb2
-from google.cloud.oslogin_v1.proto import oslogin_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import empty_pb2
 from google.protobuf import field_mask_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.oslogin_v1.proto import common_pb2
+from google.cloud.oslogin_v1.proto import oslogin_pb2
+
+_shared_modules = [
+    http_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    field_mask_pb2,
+]
+
+_local_modules = [
+    common_pb2,
+    oslogin_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        common_pb2,
-        oslogin_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        field_mask_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.oslogin_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/pubsub/google/cloud/pubsub_v1/types.py
+++ b/pubsub/google/cloud/pubsub_v1/types.py
@@ -16,10 +16,7 @@ from __future__ import absolute_import
 import collections
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.pubsub_v1.proto import pubsub_pb2
 from google.iam.v1 import iam_policy_pb2
 from google.iam.v1 import policy_pb2
 from google.iam.v1.logging import audit_data_pb2
@@ -28,6 +25,9 @@ from google.protobuf import duration_pb2
 from google.protobuf import empty_pb2
 from google.protobuf import field_mask_pb2
 from google.protobuf import timestamp_pb2
+
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.pubsub_v1.proto import pubsub_pb2
 
 
 # Define the default values for batching.
@@ -67,24 +67,32 @@ FlowControl.__new__.__defaults__ = (
 )
 
 
+_shared_modules = [
+    http_pb2,
+    iam_policy_pb2,
+    policy_pb2,
+    audit_data_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    timestamp_pb2,
+]
+
+_local_modules = [
+    pubsub_pb2,
+]
+
+
 names = ['BatchSettings', 'FlowControl']
-for name, message in get_messages(pubsub_pb2).items():
-    message.__module__ = 'google.cloud.pubsub_v1.types'
-    setattr(sys.modules[__name__], name, message)
-    names.append(name)
 
 
-for module in (
-        http_pb2,
-        pubsub_pb2,
-        iam_policy_pb2,
-        policy_pb2,
-        audit_data_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        timestamp_pb2, ):
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.pubsub_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/redis/google/cloud/redis_v1beta1/types.py
+++ b/redis/google/cloud/redis_v1beta1/types.py
@@ -15,10 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.redis_v1beta1.proto import cloud_redis_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -27,18 +24,32 @@ from google.protobuf import field_mask_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.redis_v1beta1.proto import cloud_redis_pb2
+
+_shared_modules = [
+    http_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    cloud_redis_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        cloud_redis_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.redis_v1beta1.types'
         setattr(sys.modules[__name__], name, message)

--- a/spanner/google/cloud/spanner_admin_database_v1/types.py
+++ b/spanner/google/cloud/spanner_admin_database_v1/types.py
@@ -15,11 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.spanner_admin_database_v1.proto import (
-    spanner_database_admin_pb2)
 from google.iam.v1 import iam_policy_pb2
 from google.iam.v1 import policy_pb2
 from google.iam.v1.logging import audit_data_pb2
@@ -30,20 +26,36 @@ from google.protobuf import empty_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.spanner_admin_database_v1.proto import (
+    spanner_database_admin_pb2)
+
+
+_shared_modules = [
+    http_pb2,
+    iam_policy_pb2,
+    policy_pb2,
+    audit_data_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    spanner_database_admin_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        spanner_database_admin_pb2,
-        iam_policy_pb2,
-        policy_pb2,
-        audit_data_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.spanner_admin_database_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/spanner/google/cloud/spanner_admin_instance_v1/types.py
+++ b/spanner/google/cloud/spanner_admin_instance_v1/types.py
@@ -15,11 +15,8 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
 
 from google.api import http_pb2
-from google.cloud.spanner_admin_instance_v1.proto import (
-    spanner_instance_admin_pb2)
 from google.iam.v1 import iam_policy_pb2
 from google.iam.v1 import policy_pb2
 from google.iam.v1.logging import audit_data_pb2
@@ -31,21 +28,37 @@ from google.protobuf import field_mask_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.spanner_admin_instance_v1.proto import (
+    spanner_instance_admin_pb2)
+
+
+_shared_modules = [
+    http_pb2,
+    iam_policy_pb2,
+    policy_pb2,
+    audit_data_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    spanner_instance_admin_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        spanner_instance_admin_pb2,
-        iam_policy_pb2,
-        policy_pb2,
-        audit_data_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.spanner_admin_instance_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/spanner/google/cloud/spanner_v1/types.py
+++ b/spanner/google/cloud/spanner_v1/types.py
@@ -15,9 +15,14 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
+from google.protobuf import descriptor_pb2
+from google.protobuf import duration_pb2
+from google.protobuf import empty_pb2
+from google.protobuf import struct_pb2
+from google.protobuf import timestamp_pb2
+
+from google.api_core.protobuf_helpers import get_messages
 from google.cloud.spanner_v1.proto import keys_pb2
 from google.cloud.spanner_v1.proto import mutation_pb2
 from google.cloud.spanner_v1.proto import query_plan_pb2
@@ -25,28 +30,35 @@ from google.cloud.spanner_v1.proto import result_set_pb2
 from google.cloud.spanner_v1.proto import spanner_pb2
 from google.cloud.spanner_v1.proto import transaction_pb2
 from google.cloud.spanner_v1.proto import type_pb2
-from google.protobuf import descriptor_pb2
-from google.protobuf import duration_pb2
-from google.protobuf import empty_pb2
-from google.protobuf import struct_pb2
-from google.protobuf import timestamp_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    struct_pb2,
+    timestamp_pb2,
+]
+
+_local_modules = [
+    keys_pb2,
+    mutation_pb2,
+    query_plan_pb2,
+    result_set_pb2,
+    spanner_pb2,
+    transaction_pb2,
+    type_pb2,
+]
 
 names = []
-for module in (
-        http_pb2,
-        keys_pb2,
-        mutation_pb2,
-        query_plan_pb2,
-        result_set_pb2,
-        spanner_pb2,
-        transaction_pb2,
-        type_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        struct_pb2,
-        timestamp_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.spanner_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/speech/google/cloud/speech_v1/types.py
+++ b/speech/google/cloud/speech_v1/types.py
@@ -15,10 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.speech_v1.proto import cloud_speech_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -27,18 +24,33 @@ from google.protobuf import empty_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.speech_v1.proto import cloud_speech_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    cloud_speech_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        cloud_speech_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.speech_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/speech/google/cloud/speech_v1p1beta1/types.py
+++ b/speech/google/cloud/speech_v1p1beta1/types.py
@@ -15,10 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.speech_v1p1beta1.proto import cloud_speech_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -27,18 +24,33 @@ from google.protobuf import empty_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.speech_v1p1beta1.proto import cloud_speech_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    cloud_speech_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        cloud_speech_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.speech_v1p1beta1.types'
         setattr(sys.modules[__name__], name, message)

--- a/tasks/google/cloud/tasks_v2beta2/types.py
+++ b/tasks/google/cloud/tasks_v2beta2/types.py
@@ -15,13 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.tasks_v2beta2.proto import cloudtasks_pb2
-from google.cloud.tasks_v2beta2.proto import queue_pb2
-from google.cloud.tasks_v2beta2.proto import target_pb2
-from google.cloud.tasks_v2beta2.proto import task_pb2
 from google.iam.v1 import iam_policy_pb2
 from google.iam.v1 import policy_pb2
 from google.protobuf import any_pb2
@@ -32,23 +26,41 @@ from google.protobuf import field_mask_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.tasks_v2beta2.proto import cloudtasks_pb2
+from google.cloud.tasks_v2beta2.proto import queue_pb2
+from google.cloud.tasks_v2beta2.proto import target_pb2
+from google.cloud.tasks_v2beta2.proto import task_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    iam_policy_pb2,
+    policy_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    cloudtasks_pb2,
+    queue_pb2,
+    target_pb2,
+    task_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        cloudtasks_pb2,
-        queue_pb2,
-        target_pb2,
-        task_pb2,
-        iam_policy_pb2,
-        policy_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.tasks_v2beta2.types'
         setattr(sys.modules[__name__], name, message)

--- a/texttospeech/google/cloud/texttospeech_v1beta1/types.py
+++ b/texttospeech/google/cloud/texttospeech_v1beta1/types.py
@@ -15,18 +15,30 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.texttospeech_v1beta1.proto import cloud_tts_pb2
 from google.protobuf import descriptor_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.texttospeech_v1beta1.proto import cloud_tts_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    descriptor_pb2,
+]
+
+_local_modules = [
+    cloud_tts_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        cloud_tts_pb2,
-        descriptor_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.texttospeech_v1beta1.types'
         setattr(sys.modules[__name__], name, message)

--- a/trace/google/cloud/trace_v1/types.py
+++ b/trace/google/cloud/trace_v1/types.py
@@ -15,22 +15,34 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.trace_v1.proto import trace_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import empty_pb2
 from google.protobuf import timestamp_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.trace_v1.proto import trace_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    timestamp_pb2,
+]
+
+_local_modules = [
+    trace_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        trace_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        timestamp_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.trace_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/trace/google/cloud/trace_v2/types.py
+++ b/trace/google/cloud/trace_v2/types.py
@@ -15,11 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.trace_v2.proto import trace_pb2
-from google.cloud.trace_v2.proto import tracing_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import empty_pb2
@@ -27,18 +23,34 @@ from google.protobuf import timestamp_pb2
 from google.protobuf import wrappers_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.trace_v2.proto import trace_pb2
+from google.cloud.trace_v2.proto import tracing_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    any_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    timestamp_pb2,
+    wrappers_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    trace_pb2,
+    tracing_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        trace_pb2,
-        tracing_pb2,
-        any_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        timestamp_pb2,
-        wrappers_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.trace_v2.types'
         setattr(sys.modules[__name__], name, message)

--- a/videointelligence/google/cloud/videointelligence_v1/types.py
+++ b/videointelligence/google/cloud/videointelligence_v1/types.py
@@ -15,10 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.videointelligence_v1.proto import video_intelligence_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -27,18 +24,33 @@ from google.protobuf import empty_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.videointelligence_v1.proto import video_intelligence_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    video_intelligence_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        video_intelligence_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.videointelligence_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/videointelligence/google/cloud/videointelligence_v1beta1/types.py
+++ b/videointelligence/google/cloud/videointelligence_v1beta1/types.py
@@ -15,10 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.videointelligence_v1beta1.proto import video_intelligence_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -26,17 +23,32 @@ from google.protobuf import empty_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.videointelligence_v1beta1.proto import video_intelligence_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    video_intelligence_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        video_intelligence_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.videointelligence_v1beta1.types'
         setattr(sys.modules[__name__], name, message)

--- a/videointelligence/google/cloud/videointelligence_v1beta2/types.py
+++ b/videointelligence/google/cloud/videointelligence_v1beta2/types.py
@@ -15,10 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.videointelligence_v1beta2.proto import video_intelligence_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -27,18 +24,33 @@ from google.protobuf import empty_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.videointelligence_v1beta2.proto import video_intelligence_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    video_intelligence_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        video_intelligence_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.videointelligence_v1beta2.types'
         setattr(sys.modules[__name__], name, message)

--- a/videointelligence/google/cloud/videointelligence_v1p1beta1/types.py
+++ b/videointelligence/google/cloud/videointelligence_v1p1beta1/types.py
@@ -15,10 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.videointelligence_v1p1beta1.proto import video_intelligence_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -27,18 +24,34 @@ from google.protobuf import empty_pb2
 from google.protobuf import timestamp_pb2
 from google.rpc import status_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.videointelligence_v1p1beta1.proto import (
+    video_intelligence_pb2)
+
+
+_shared_modules = [
+    http_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    duration_pb2,
+    empty_pb2,
+    timestamp_pb2,
+    status_pb2,
+]
+
+_local_modules = [
+    video_intelligence_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        video_intelligence_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        duration_pb2,
-        empty_pb2,
-        timestamp_pb2,
-        status_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.videointelligence_v1p1beta1.types'
         setattr(sys.modules[__name__], name, message)

--- a/vision/google/cloud/vision_v1/types.py
+++ b/vision/google/cloud/vision_v1/types.py
@@ -15,13 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.vision_v1.proto import geometry_pb2
-from google.cloud.vision_v1.proto import image_annotator_pb2
-from google.cloud.vision_v1.proto import text_annotation_pb2
-from google.cloud.vision_v1.proto import web_detection_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import wrappers_pb2
@@ -29,20 +23,38 @@ from google.rpc import status_pb2
 from google.type import color_pb2
 from google.type import latlng_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.vision_v1.proto import geometry_pb2
+from google.cloud.vision_v1.proto import image_annotator_pb2
+from google.cloud.vision_v1.proto import text_annotation_pb2
+from google.cloud.vision_v1.proto import web_detection_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    any_pb2,
+    descriptor_pb2,
+    wrappers_pb2,
+    status_pb2,
+    color_pb2,
+    latlng_pb2,
+]
+
+_local_modules = [
+    geometry_pb2,
+    image_annotator_pb2,
+    text_annotation_pb2,
+    web_detection_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        geometry_pb2,
-        image_annotator_pb2,
-        text_annotation_pb2,
-        web_detection_pb2,
-        any_pb2,
-        descriptor_pb2,
-        wrappers_pb2,
-        status_pb2,
-        color_pb2,
-        latlng_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.vision_v1.types'
         setattr(sys.modules[__name__], name, message)

--- a/vision/google/cloud/vision_v1p1beta1/types.py
+++ b/vision/google/cloud/vision_v1p1beta1/types.py
@@ -15,13 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.vision_v1p1beta1.proto import geometry_pb2
-from google.cloud.vision_v1p1beta1.proto import image_annotator_pb2
-from google.cloud.vision_v1p1beta1.proto import text_annotation_pb2
-from google.cloud.vision_v1p1beta1.proto import web_detection_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import wrappers_pb2
@@ -29,20 +23,38 @@ from google.rpc import status_pb2
 from google.type import color_pb2
 from google.type import latlng_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.vision_v1p1beta1.proto import geometry_pb2
+from google.cloud.vision_v1p1beta1.proto import image_annotator_pb2
+from google.cloud.vision_v1p1beta1.proto import text_annotation_pb2
+from google.cloud.vision_v1p1beta1.proto import web_detection_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    any_pb2,
+    descriptor_pb2,
+    wrappers_pb2,
+    status_pb2,
+    color_pb2,
+    latlng_pb2,
+]
+
+_local_modules = [
+    geometry_pb2,
+    image_annotator_pb2,
+    text_annotation_pb2,
+    web_detection_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        geometry_pb2,
-        image_annotator_pb2,
-        text_annotation_pb2,
-        web_detection_pb2,
-        any_pb2,
-        descriptor_pb2,
-        wrappers_pb2,
-        status_pb2,
-        color_pb2,
-        latlng_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.vision_v1p1beta1.types'
         setattr(sys.modules[__name__], name, message)

--- a/vision/google/cloud/vision_v1p2beta1/types.py
+++ b/vision/google/cloud/vision_v1p2beta1/types.py
@@ -15,13 +15,7 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.vision_v1p2beta1.proto import geometry_pb2
-from google.cloud.vision_v1p2beta1.proto import image_annotator_pb2
-from google.cloud.vision_v1p2beta1.proto import text_annotation_pb2
-from google.cloud.vision_v1p2beta1.proto import web_detection_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2
@@ -32,23 +26,41 @@ from google.rpc import status_pb2
 from google.type import color_pb2
 from google.type import latlng_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.vision_v1p2beta1.proto import geometry_pb2
+from google.cloud.vision_v1p2beta1.proto import image_annotator_pb2
+from google.cloud.vision_v1p2beta1.proto import text_annotation_pb2
+from google.cloud.vision_v1p2beta1.proto import web_detection_pb2
+
+
+_shared_modules = [
+    http_pb2,
+    operations_pb2,
+    any_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    timestamp_pb2,
+    wrappers_pb2,
+    status_pb2,
+    color_pb2,
+    latlng_pb2,
+]
+
+_local_modules = [
+    geometry_pb2,
+    image_annotator_pb2,
+    text_annotation_pb2,
+    web_detection_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        geometry_pb2,
-        image_annotator_pb2,
-        text_annotation_pb2,
-        web_detection_pb2,
-        operations_pb2,
-        any_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        timestamp_pb2,
-        wrappers_pb2,
-        status_pb2,
-        color_pb2,
-        latlng_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.vision_v1p2beta1.types'
         setattr(sys.modules[__name__], name, message)

--- a/websecurityscanner/google/cloud/websecurityscanner_v1alpha/types.py
+++ b/websecurityscanner/google/cloud/websecurityscanner_v1alpha/types.py
@@ -15,38 +15,50 @@
 from __future__ import absolute_import
 import sys
 
-from google.api_core.protobuf_helpers import get_messages
-
 from google.api import http_pb2
-from google.cloud.websecurityscanner_v1alpha.proto import crawled_url_pb2
-from google.cloud.websecurityscanner_v1alpha.proto import finding_addon_pb2
-from google.cloud.websecurityscanner_v1alpha.proto import finding_pb2
-from google.cloud.websecurityscanner_v1alpha.proto import \
-    finding_type_stats_pb2
-from google.cloud.websecurityscanner_v1alpha.proto import scan_config_pb2
-from google.cloud.websecurityscanner_v1alpha.proto import scan_run_pb2
-from google.cloud.websecurityscanner_v1alpha.proto import \
-    web_security_scanner_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import empty_pb2
 from google.protobuf import field_mask_pb2
 from google.protobuf import timestamp_pb2
 
+from google.api_core.protobuf_helpers import get_messages
+from google.cloud.websecurityscanner_v1alpha.proto import crawled_url_pb2
+from google.cloud.websecurityscanner_v1alpha.proto import finding_addon_pb2
+from google.cloud.websecurityscanner_v1alpha.proto import finding_pb2
+from google.cloud.websecurityscanner_v1alpha.proto import (
+    finding_type_stats_pb2 )
+from google.cloud.websecurityscanner_v1alpha.proto import scan_config_pb2
+from google.cloud.websecurityscanner_v1alpha.proto import scan_run_pb2
+from google.cloud.websecurityscanner_v1alpha.proto import (
+    web_security_scanner_pb2 )
+
+
+_shared_modules = [
+    http_pb2,
+    descriptor_pb2,
+    empty_pb2,
+    field_mask_pb2,
+    timestamp_pb2,
+]
+
+_local_modules = [
+    crawled_url_pb2,
+    finding_addon_pb2,
+    finding_pb2,
+    finding_type_stats_pb2,
+    scan_config_pb2,
+    scan_run_pb2,
+    web_security_scanner_pb2,
+]
+
 names = []
-for module in (
-        http_pb2,
-        crawled_url_pb2,
-        finding_addon_pb2,
-        finding_pb2,
-        finding_type_stats_pb2,
-        scan_config_pb2,
-        scan_run_pb2,
-        web_security_scanner_pb2,
-        descriptor_pb2,
-        empty_pb2,
-        field_mask_pb2,
-        timestamp_pb2,
-):
+
+for module in _shared_modules:
+    for name, message in get_messages(module).items():
+        setattr(sys.modules[__name__], name, message)
+        names.append(name)
+
+for module in _local_modules:
     for name, message in get_messages(module).items():
         message.__module__ = 'google.cloud.websecurityscanner_v1alpha.types'
         setattr(sys.modules[__name__], name, message)


### PR DESCRIPTION
Note that we *are* still overwriting it for messages from modules defined within the current package.

See #4715.