### PR TITLE
Updated SubscriberClient docs

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/client.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/client.py
@@ -135,7 +135,7 @@ class Client(object):
                 print(message)
                 message.ack()
 
-            future = subscriber.subscribe_experimental(
+            future = subscriber.subscribe(
                 subscription, callback)
 
             try:


### PR DESCRIPTION
`subscribe_experimental` was promoted to `subscribe` but the docs for the `SubscriberClient` still suggested using `subscribe_experimental`