### PR TITLE
BigQuery: add ddl-related query stats.

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2267,6 +2267,29 @@ class QueryJob(_AsyncJob):
         return self._job_statistics().get('cacheHit')
 
     @property
+    def ddl_operation_performed(self):
+        """Union[str, None]: Return the DDL operation performed.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#statistics.query.ddlOperationPerformed
+
+        """
+        return self._job_statistics().get('ddlOperationPerformed')
+
+    @property
+    def ddl_target_table(self):
+        """Union[tablereference, None]: Return the DDL target table, present
+            for CREATE/DROP TABLE/VIEW queries.
+
+        See:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#statistics.query.ddlTargetTable
+        """
+        prop = self._job_statistics().get('ddlTargetTable')
+        if prop is not None:
+            prop = TableReference.from_api_repr(prop)
+        return prop
+
+    @property
     def num_dml_affected_rows(self):
         """Return the number of DML rows affected by the job.
 

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2268,7 +2268,7 @@ class QueryJob(_AsyncJob):
 
     @property
     def ddl_operation_performed(self):
-        """Union[str, None]: Return the DDL operation performed.
+        """Optional[str]: Return the DDL operation performed.
 
         See:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#statistics.query.ddlOperationPerformed
@@ -2278,7 +2278,7 @@ class QueryJob(_AsyncJob):
 
     @property
     def ddl_target_table(self):
-        """Union[tablereference, None]: Return the DDL target table, present
+        """Optional[TableReference]: Return the DDL target table, present
             for CREATE/DROP TABLE/VIEW queries.
 
         See:

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -409,6 +409,10 @@ class TestBigQuery(unittest.TestCase):
             """.format(dsname, table_id, colprojections, rowcount)
         query_job = Config.CLIENT.query(sql)
         query_job.result()
+        self.assertTrue(query_job.statement_type, 'CREATE_TABLE_AS_SELECT')
+        self.assertTrue(query_job.ddl_operation_performed, 'CREATE')
+        self.assertTrue(query_job.ddl_target_table, table_ref)
+
         return table_ref
 
     def test_query_many_columns(self):

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -409,9 +409,9 @@ class TestBigQuery(unittest.TestCase):
             """.format(dsname, table_id, colprojections, rowcount)
         query_job = Config.CLIENT.query(sql)
         query_job.result()
-        self.assertTrue(query_job.statement_type, 'CREATE_TABLE_AS_SELECT')
-        self.assertTrue(query_job.ddl_operation_performed, 'CREATE')
-        self.assertTrue(query_job.ddl_target_table, table_ref)
+        self.assertEqual(query_job.statement_type, 'CREATE_TABLE_AS_SELECT')
+        self.assertEqual(query_job.ddl_operation_performed, 'CREATE')
+        self.assertEqual(query_job.ddl_target_table, table_ref)
 
         return table_ref
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -2454,6 +2454,45 @@ class TestQueryJob(unittest.TestCase, _Base):
         query_stats['cacheHit'] = True
         self.assertTrue(job.cache_hit)
 
+    def test_ddl_operation_performed(self):
+        op = 'SKIP'
+        client = _make_client(project=self.PROJECT)
+        job = self._make_one(self.JOB_ID, self.QUERY, client)
+        self.assertIsNone(job.ddl_operation_performed)
+
+        statistics = job._properties['statistics'] = {}
+        self.assertIsNone(job.ddl_operation_performed)
+
+        query_stats = statistics['query'] = {}
+        self.assertIsNone(job.ddl_operation_performed)
+
+        query_stats['ddlOperationPerformed'] = op
+        self.assertEqual(job.ddl_operation_performed, op)
+
+    def test_ddl_target_table(self):
+        from google.cloud.bigquery.table import TableReference
+
+        ref_table = {
+            'projectId': self.PROJECT,
+            'datasetId': 'ddl_ds',
+            'tableId': 'targettable',
+        }
+        client = _make_client(project=self.PROJECT)
+        job = self._make_one(self.JOB_ID, self.QUERY, client)
+        self.assertIsNone(job.ddl_target_table)
+
+        statistics = job._properties['statistics'] = {}
+        self.assertIsNone(job.ddl_target_table)
+
+        query_stats = statistics['query'] = {}
+        self.assertIsNone(job.ddl_target_table)
+
+        query_stats['ddlTargetTable'] = ref_table
+        self.assertIsInstance(job.ddl_target_table, TableReference)
+        self.assertEqual(job.ddl_target_table.table_id, 'targettable')
+        self.assertEqual(job.ddl_target_table.dataset_id, 'ddl_ds')
+        self.assertEqual(job.ddl_target_table.project, self.PROJECT)
+
     def test_num_dml_affected_rows(self):
         num_rows = 1234
         client = _make_client(project=self.PROJECT)


### PR DESCRIPTION
python library already supported statement type, so its possible to determine if a query was a DDL statement based on the classification (e.g. CREATE_TABLE.
This adds ddl target table and operation performed.  The first identifies the resolved table being manipulated via a DDL statement, and the operation performed provides insight into whether that table was created, replaced, etc.

