### PR TITLE
ResourceManager: fix list_projects(filter_params)

### DIFF
--- a/resource_manager/google/cloud/resource_manager/client.py
+++ b/resource_manager/google/cloud/resource_manager/client.py
@@ -14,6 +14,7 @@
 
 """A Client for interacting with the Resource Manager API."""
 
+import six
 
 from google.api_core import page_iterator
 from google.cloud.client import Client as BaseClient
@@ -162,7 +163,10 @@ class Client(BaseClient):
             extra_params['pageSize'] = page_size
 
         if filter_params is not None:
-            extra_params['filter'] = filter_params
+            extra_params['filter'] = [
+                '{}:{}'.format(key, value)
+                for key, value in six.iteritems(filter_params)
+            ]
 
         return page_iterator.HTTPIterator(
             client=self,

--- a/resource_manager/tests/unit/test_client.py
+++ b/resource_manager/tests/unit/test_client.py
@@ -217,12 +217,13 @@ class TestClient(unittest.TestCase):
         self.assertEqual(project.status, STATUS)
 
         # Check that the filter made it in the request.
+        FLATTENED_FILTER_PARAMS = ['id:project-id']
         request, = client._connection._requested
         self.assertEqual(request, {
             'path': '/projects',
             'method': 'GET',
             'query_params': {
-                'filter': FILTER_PARAMS,
+                'filter': FLATTENED_FILTER_PARAMS,
             },
         })
 


### PR DESCRIPTION
The filter_params parameter of resource_manager.Client.list_projects is
a dict (of properties to filter on and the desired value for each property).
Prior to this commit, this dict was passed into the HTTPIterator constructor
in extra_params['filter'].

This didn't work, because extra_params values can't be dicts. They *can* be
iterables, but since the iterable of a dict is its keys, this resulted in only
the properties being sent along in the 'filter' query param, while the desired
values for those properties were discarded.

This commit transforms the filter_params dict into a simple list prior to
shoving it in extra_params, which fixes the bug.