### PR TITLE
fix docstring: str -> dict

### DIFF
--- a/translate/google/cloud/translate_v2/client.py
+++ b/translate/google/cloud/translate_v2/client.py
@@ -103,7 +103,7 @@ class Client(BaseClient):
         :param values: String or list of strings that will have
                        language detected.
 
-        :rtype: str or list
+        :rtype: dict or list
         :returns: A list of dictionaries for each queried value. Each
                   dictionary typically contains three keys
 


### PR DESCRIPTION
Fix error in documentation. In case of single value the function "detect_language" returns a dictionary (not a string).