### PR TITLE
Don't error out for empty response.

### DIFF
--- a/api_core/tests/unit/test_operation.py
+++ b/api_core/tests/unit/test_operation.py
@@ -127,13 +127,16 @@ def test_exception():
 def test_unexpected_result():
     responses = [
         make_operation_proto(),
-        # Second operation response is done, but has not error or response.
+        # Second operation response is done, but has no error or response.
         make_operation_proto(done=True)]
     future, _, _ = make_operation_future(responses)
 
     exception = future.exception()
+    result = future.result()
 
-    assert 'Unexpected state' in '{!r}'.format(exception)
+    assert exception is None
+    assert result == struct_pb2.Struct()
+    assert future.done()
 
 
 def test__refresh_http():


### PR DESCRIPTION
grpc will not set a field that's set to its default value. So, if the
api should be returning an empty string or an empty list, for example,
operation.py currently throws an error because the response isn't set.
In fact, though, the response is just set to the default value, which
doesn't get serialized over the wire.