### PR TITLE
BigQuery: Use datetime for jobs listing filter args.

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -28,6 +28,7 @@ from google.resumable_media.requests import MultipartUpload
 from google.resumable_media.requests import ResumableUpload
 
 from google.api_core import page_iterator
+import google.cloud._helpers
 from google.cloud import exceptions
 from google.cloud.client import ClientWithProject
 
@@ -692,14 +693,14 @@ class Client(ClientWithProject):
                     * ``"running"``
             retry (google.api_core.retry.Retry, optional):
                 How to retry the RPC.
-            min_creation_time (int, optional):
-                Min value for job creation time, in milliseconds since the
-                POSIX epoch. If set, only jobs created after or at this
-                timestamp are returned.
-            max_creation_time (int, optional):
-                Max value for job creation time, in milliseconds since the
-                POSIX epoch. If set, only jobs created before or at this
-                timestamp are returned.
+            min_creation_time (datetitme.datetime, optional):
+                Min value for job creation time. If set, only jobs created
+                after or at this timestamp are returned. If the datetime has
+                no time zone assumes UTC time.
+            max_creation_time (datetime.datetime, optional):
+                Max value for job creation time. If set, only jobs created
+                before or at this timestamp are returned. If the datetime has
+                no time zone assumes UTC time.
 
         Returns:
             google.api_core.page_iterator.Iterator:
@@ -708,8 +709,12 @@ class Client(ClientWithProject):
         extra_params = {
             'allUsers': all_users,
             'stateFilter': state_filter,
-            'minCreationTime': _str_or_none(min_creation_time),
-            'maxCreationTime': _str_or_none(max_creation_time),
+            'minCreationTime': _str_or_none(
+                google.cloud._helpers._millis_from_datetime(
+                    min_creation_time)),
+            'maxCreationTime': _str_or_none(
+                google.cloud._helpers._millis_from_datetime(
+                    max_creation_time)),
             'projection': 'full'
         }
 

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import datetime
 import decimal
 import email
 import io
@@ -1758,8 +1759,14 @@ class TestClient(unittest.TestCase):
         client = self._make_one(self.PROJECT, creds)
         conn = client._connection = _make_connection({})
 
+        # One millisecond after the unix epoch.
+        start_time = datetime.datetime(1970, 1, 1, 0, 0, 0, 1000)
+        # One millisecond after the the 2038 31-bit signed int rollover
+        end_time = datetime.datetime(2038, 1, 19, 3, 14, 7, 1000)
+        end_time_millis = (((2 ** 31) - 1) * 1000) + 1
+
         list(client.list_jobs(
-            min_creation_time=1, max_creation_time=1527874895820))
+            min_creation_time=start_time, max_creation_time=end_time))
 
         conn.api_request.assert_called_once_with(
             method='GET',
@@ -1767,7 +1774,7 @@ class TestClient(unittest.TestCase):
             query_params={
                 'projection': 'full',
                 'minCreationTime': '1',
-                'maxCreationTime': '1527874895820',
+                'maxCreationTime': str(end_time_millis),
             })
 
     def test_load_table_from_uri(self):


### PR DESCRIPTION
datetime.datetime will be easier to work with for filtering things like
"all the jobs run last month" or "all the jobs in the past 5 minutes".

Follow-up to https://github.com/GoogleCloudPlatform/google-cloud-python/pull/5429#discussion_r192791719

Addresses https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5067 further.

Note, I sent this PR ASAP because I got a [request for a BigQuery package release](https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5432) this (so numerics support can get out there) and I'd like to avoid any breaking changes.