### PR TITLE
Ensure that initial resume token is bytes, not text.

### DIFF
--- a/spanner/google/cloud/spanner_v1/snapshot.py
+++ b/spanner/google/cloud/spanner_v1/snapshot.py
@@ -36,7 +36,7 @@ def _restart_on_unavailable(restart):
     :type restart: callable
     :param restart: curried function returning iterator
     """
-    resume_token = ''
+    resume_token = b''
     item_buffer = []
     iterator = restart()
     while True:


### PR DESCRIPTION
Closes #5164.