### PR TITLE
Use subpackage installation instructions on main index.

### DIFF
--- a/docs/bigquery/usage.rst
+++ b/docs/bigquery/usage.rst
@@ -10,6 +10,15 @@ BigQuery
 
 .. contents:: :local:
 
+Installation
+------------
+
+Install the ``google-cloud-bigquery`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-bigquery
+
 .. note::
 
     This library changed significantly before the 1.0.0 release, especially

--- a/docs/bigtable/usage.rst
+++ b/docs/bigtable/usage.rst
@@ -19,6 +19,15 @@ Bigtable
   data-api
   changelog
 
+Installation
+------------
+
+Install the ``google-cloud-bigtable`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-bigtable
+
 API requests are sent to the `Google Cloud Bigtable`_ API via RPC over HTTP/2.
 In order to support this, we'll rely on `gRPC`_. We are working with the gRPC
 team to rapidly make the install story more user-friendly.

--- a/docs/datastore/usage.rst
+++ b/docs/datastore/usage.rst
@@ -13,6 +13,15 @@ Datastore
   batches
   helpers
 
+Installation
+------------
+
+Install the ``google-cloud-datastore`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-datastore
+
 Modules
 -------
 

--- a/docs/dns/usage.rst
+++ b/docs/dns/usage.rst
@@ -10,6 +10,15 @@ DNS
   resource-record-set
   changes
 
+Installation
+------------
+
+Install the ``google-cloud-dns`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-dns
+
 Client
 ------
 

--- a/docs/error-reporting/usage.rst
+++ b/docs/error-reporting/usage.rst
@@ -8,6 +8,15 @@ Stackdriver Error Reporting
   client
   util
 
+Installation
+------------
+
+Install the ``google-cloud-error-reporting`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-error-reporting
+
 Authentication and Configuration
 --------------------------------
 

--- a/docs/firestore/index.rst
+++ b/docs/firestore/index.rst
@@ -1,5 +1,5 @@
 Firestore
----------
+=========
 
 .. toctree::
   :maxdepth: 2
@@ -14,6 +14,18 @@ Firestore
   transaction
   types
   changelog
+
+Installation
+------------
+
+Install the ``google-cloud-firestore`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-firestore
+
+Usage
+-----
 
 .. automodule:: google.cloud.firestore_v1beta1
 .. autoclass:: google.cloud.firestore_v1beta1.GeoPoint

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,12 +36,6 @@ Google Cloud Client Library for Python
 Getting started
 ---------------
 
-The ``google-cloud`` library is ``pip`` install-able:
-
-.. code-block:: console
-
-    $ pip install google-cloud
-
 For more information on setting up your Python development environment,
 such as installing ``pip`` and ``virtualenv`` on your system, please refer
 to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
@@ -51,9 +45,19 @@ to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 Cloud Datastore
 ~~~~~~~~~~~~~~~
 
-`Google Cloud Datastore`_ is a fully managed, schemaless database for storing non-relational data.
+`Google Cloud Datastore`_ is a fully managed, schemaless database for storing
+non-relational data.
 
 .. _Google Cloud Datastore: https://cloud.google.com/datastore/
+
+Install the ``google-cloud-datastore`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-datastore
+
+Example
+^^^^^^^
 
 .. code-block:: python
 
@@ -73,6 +77,15 @@ Cloud Storage
 `Google Cloud Storage`_ allows you to store data on Google infrastructure.
 
 .. _Google Cloud Storage: https://cloud.google.com/storage/
+
+Install the ``google-cloud-storage`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-storage
+
+Example
+^^^^^^^
 
 .. code-block:: python
 

--- a/docs/language/usage.rst
+++ b/docs/language/usage.rst
@@ -13,6 +13,16 @@ with your document storage on Google Cloud Storage.
 
 .. _Google Natural Language: https://cloud.google.com/natural-language/docs/quickstart-client-libraries
 
+************
+Installation
+************
+
+Install the ``google-cloud-language`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-language
+
 
 ********************************
 Authentication and Configuration

--- a/docs/logging/usage.rst
+++ b/docs/logging/usage.rst
@@ -18,6 +18,15 @@ Stackdriver Logging
   transports-thread
   transports-base
 
+Installation
+------------
+
+Install the ``google-cloud-logging`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-logging
+
 Authentication and Configuration
 --------------------------------
 

--- a/docs/pubsub/index.rst
+++ b/docs/pubsub/index.rst
@@ -12,6 +12,16 @@ messages per second (and beyond).
 
 .. _Google Cloud Pub/Sub: https://cloud.google.com/pubsub/
 
+************
+Installation
+************
+
+Install the ``google-cloud-pubsub`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-pubsub
+
 ********************************
 Authentication and Configuration
 ********************************

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,8 +4,8 @@
 
 .. attention:: The ``google-cloud`` package is deprecated
 
-    The ``google-cloud`` package is no longer maintained or updated. Install
-    the ``google-cloud-*`` subpackages directly, instead.
+    The ``google-cloud`` package is no longer maintained or updated. Instead,
+    install the ``google-cloud-*`` subpackages directly.
 
 
 The ``google-cloud`` package (formerly ``gcloud``) contains

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -2,6 +2,12 @@
 ``google-cloud`` Releases
 #########################
 
+.. attention:: The ``google-cloud`` package is deprecated
+
+    The ``google-cloud`` package is no longer maintained or updated. Install
+    the ``google-cloud-*`` subpackages directly, instead.
+
+
 The ``google-cloud`` package (formerly ``gcloud``) contains
 **all** ``google-cloud-*`` subpackages.
 

--- a/docs/resource-manager/api.rst
+++ b/docs/resource-manager/api.rst
@@ -35,6 +35,18 @@ With this API, you can do the following:
 
 .. _projects.create() API method: https://cloud.google.com/resource-manager/docs/creating-project
 
+Installation
+------------
+
+Install the ``google-cloud-resource-manager`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-resource-manager
+
+Usage
+-----
+
 Here's a quick example of the full life-cycle:
 
 .. code-block:: python

--- a/docs/runtimeconfig/usage.rst
+++ b/docs/runtimeconfig/usage.rst
@@ -12,7 +12,7 @@ Runtimeconfig
 Installation
 ------------
 
-Install the ``google-cloud-resource-runtimeconfig`` library using ``pip``:
+Install the ``google-cloud-runtimeconfig`` library using ``pip``:
 
 .. code-block:: console
 

--- a/docs/runtimeconfig/usage.rst
+++ b/docs/runtimeconfig/usage.rst
@@ -9,6 +9,15 @@ Runtimeconfig
   config
   variable
 
+Installation
+------------
+
+Install the ``google-cloud-resource-runtimeconfig`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-runtimeconfig
+
 Modules
 -------
 

--- a/docs/spanner/usage.rst
+++ b/docs/spanner/usage.rst
@@ -24,6 +24,15 @@ workloads.
   advanced-session-pool-topics
   api-reference
 
+Installation
+============
+
+Install the ``google-cloud-spanner`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-spanner
+
 Spanner Client
 ==============
 

--- a/docs/speech/index.rst
+++ b/docs/speech/index.rst
@@ -8,6 +8,15 @@ base.
 
 .. _Google Speech: https://cloud.google.com/speech/docs/getting-started
 
+Installation
+------------
+
+Install the ``google-cloud-speech`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-speech
+
 
 Authentication and Configuration
 --------------------------------

--- a/docs/storage/client.rst
+++ b/docs/storage/client.rst
@@ -11,6 +11,17 @@ Storage
   batch
   changelog
 
+Installation
+------------
+
+Install the ``google-cloud-storage`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-storage
+
+Usage
+-----
 
 .. automodule:: google.cloud.storage.client
   :members:

--- a/docs/translate/usage.rst
+++ b/docs/translate/usage.rst
@@ -13,6 +13,15 @@ lets websites and programs integrate with Google Cloud Translation
 programmatically. Google Cloud Translation is available as a
 paid service. See the `Pricing`_ and `FAQ`_ pages for details.
 
+Installation
+------------
+
+Install the ``google-cloud-translate`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-translate
+
 Authentication / Configuration
 ------------------------------
 

--- a/docs/videointelligence/index.rst
+++ b/docs/videointelligence/index.rst
@@ -13,6 +13,16 @@ relevant information at the video, shot or per frame.
 .. _Google Cloud Video Intelligence: https://cloud.google.com/video-intelligence/
 .. _Google Cloud Storage: https://cloud.google.com/storage/
 
+************
+Installation
+************
+
+Install the ``google-cloud-videointelligence`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-videointelligence
+
 
 ********************************
 Authentication and Configuration

--- a/docs/vision/index.rst
+++ b/docs/vision/index.rst
@@ -16,6 +16,16 @@ Storage.
 .. _Vision: https://cloud.google.com/vision/
 .. _Vision API docs: https://cloud.google.com/vision/reference/rest/
 
+************
+Installation
+************
+
+Install the ``google-cloud-vision`` library using ``pip``:
+
+.. code-block:: console
+
+    $ pip install google-cloud-vision
+
 
 ********************************
 Authentication and Configuration


### PR DESCRIPTION
* Add installation instructions to subpackage pages that were missing them.
* Add deprecation notice to google-cloud releases page.

Closes https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5455