### PR TITLE
Add DatasetListItem and TableListItem back to docs.

### DIFF
--- a/docs/bigquery/reference.rst
+++ b/docs/bigquery/reference.rst
@@ -72,6 +72,7 @@ Dataset
     :toctree: generated
 
     dataset.Dataset
+    dataset.DatasetListItem
     dataset.DatasetReference
     dataset.AccessEntry
 
@@ -83,6 +84,7 @@ Table
     :toctree: generated
 
     table.Table
+    table.TableListItem
     table.TableReference
     table.Row
     table.RowIterator


### PR DESCRIPTION
I think I accidentally dropped these classes in https://github.com/GoogleCloudPlatform/google-cloud-python/pull/5340.