### PR TITLE
Redo 5018: run only needed systests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: googleapis/nox:0.18.2
+      - image: googleapis/nox:0.17.0
     steps:
       - checkout
       - run:
@@ -43,151 +43,151 @@ jobs:
       - run:
           name: Run tests - google.api_core
           command: |
-            if [[ -n $(grep api_core ~/target_packages) ]]; then
+            if [[ -n $(grep -x api_core ~/target_packages) ]]; then
               nox -f api_core/nox.py
             fi
       - run:
           name: Run tests - google.cloud.core
           command: |
-            if [[ -n $(grep core ~/target_packages) ]]; then
+            if [[ -n $(grep -x core ~/target_packages) ]]; then
               nox -f core/nox.py
             fi
       - run:
           name: Run tests - google.cloud.bigquery
           command: |
-            if [[ -n $(grep bigquery ~/target_packages) ]]; then
+            if [[ -n $(grep -x bigquery ~/target_packages) ]]; then
               nox -f bigquery/nox.py
             fi
       - run:
           name: Run tests - google.cloud.bigquery_datatransfer
           command: |
-            if [[ -n $(grep bigquery_datatransfer ~/target_packages) ]]; then
+            if [[ -n $(grep -x bigquery_datatransfer ~/target_packages) ]]; then
               nox -f bigquery_datatransfer/nox.py
             fi
       - run:
           name: Run tests - google.cloud.bigtable
           command: |
-            if [[ -n $(grep bigtable ~/target_packages) ]]; then
+            if [[ -n $(grep -x bigtable ~/target_packages) ]]; then
               nox -f bigtable/nox.py
             fi
       - run:
           name: Run tests - google.cloud.container
           command: |
-            if [[ -n $(grep container ~/target_packages) ]]; then
+            if [[ -n $(grep -x container ~/target_packages) ]]; then
               nox -f container/nox.py
             fi
       - run:
           name: Run tests - google.cloud.datastore
           command: |
-            if [[ -n $(grep datastore ~/target_packages) ]]; then
+            if [[ -n $(grep -x datastore ~/target_packages) ]]; then
               nox -f datastore/nox.py
             fi
       - run:
           name: Run tests - google.cloud.dataproc
           command: |
-            if [[ -n $(grep dataproc ~/target_packages) ]]; then
+            if [[ -n $(grep -x dataproc ~/target_packages) ]]; then
               nox -f dataproc/nox.py
             fi
       - run:
           name: Run tests - google.cloud.dlp
           command: |
-            if [[ -n $(grep dlp ~/target_packages) ]]; then
+            if [[ -n $(grep -x dlp ~/target_packages) ]]; then
               nox -f dlp/nox.py
             fi
       - run:
           name: Run tests - google.cloud.dns
           command: |
-            if [[ -n $(grep dns ~/target_packages) ]]; then
+            if [[ -n $(grep -x dns ~/target_packages) ]]; then
               nox -f dns/nox.py
             fi
       - run:
           name: Run tests - google.cloud.error_reporting
           command: |
-            if [[ -n $(grep error_reporting ~/target_packages) ]]; then
+            if [[ -n $(grep -x error_reporting ~/target_packages) ]]; then
               nox -f error_reporting/nox.py
             fi
       - run:
           name: Run tests - google.cloud.firestore
           command: |
-            if [[ -n $(grep firestore ~/target_packages) ]]; then
+            if [[ -n $(grep -x firestore ~/target_packages) ]]; then
               nox -f firestore/nox.py
             fi
       - run:
           name: Run tests - google.cloud.language
           command: |
-            if [[ -n $(grep language ~/target_packages) ]]; then
+            if [[ -n $(grep -x language ~/target_packages) ]]; then
               nox -f language/nox.py
             fi
       - run:
           name: Run tests - google.cloud.logging
           command: |
-            if [[ -n $(grep logging ~/target_packages) ]]; then
+            if [[ -n $(grep -x logging ~/target_packages) ]]; then
               nox -f logging/nox.py
             fi
       - run:
           name: Run tests - google.cloud.monitoring
           command: |
-            if [[ -n $(grep monitoring ~/target_packages) ]]; then
+            if [[ -n $(grep -x monitoring ~/target_packages) ]]; then
               nox -f monitoring/nox.py
             fi
       - run:
           name: Run tests - google.cloud.pubsub
           command: |
-            if [[ -n $(grep pubsub ~/target_packages) ]]; then
+            if [[ -n $(grep -x pubsub ~/target_packages) ]]; then
               nox -f pubsub/nox.py
             fi
       - run:
           name: Run tests - google.cloud.resource_manager
           command: |
-            if [[ -n $(grep resource_manager ~/target_packages) ]]; then
+            if [[ -n $(grep -x resource_manager ~/target_packages) ]]; then
               nox -f resource_manager/nox.py
             fi
       - run:
           name: Run tests - google.cloud.runtimeconfig
           command: |
-            if [[ -n $(grep runtimeconfig ~/target_packages) ]]; then
+            if [[ -n $(grep -x runtimeconfig ~/target_packages) ]]; then
               nox -f runtimeconfig/nox.py
             fi
       - run:
           name: Run tests - google.cloud.spanner
           command: |
-            if [[ -n $(grep spanner ~/target_packages) ]]; then
+            if [[ -n $(grep -x spanner ~/target_packages) ]]; then
               nox -f spanner/nox.py
             fi
       - run:
           name: Run tests - google.cloud.speech
           command: |
-            if [[ -n $(grep speech ~/target_packages) ]]; then
+            if [[ -n $(grep -x speech ~/target_packages) ]]; then
               nox -f speech/nox.py
             fi
       - run:
           name: Run tests - google.cloud.storage
           command: |
-            if [[ -n $(grep storage ~/target_packages) ]]; then
+            if [[ -n $(grep -x storage ~/target_packages) ]]; then
               nox -f storage/nox.py
             fi
       - run:
           name: Run tests - google.cloud.trace
           command: |
-            if [[ -n $(grep trace ~/target_packages) ]]; then
+            if [[ -n $(grep -x trace ~/target_packages) ]]; then
               nox -f trace/nox.py
             fi
       - run:
           name: Run tests - google.cloud.translate
           command: |
-            if [[ -n $(grep translate ~/target_packages) ]]; then
+            if [[ -n $(grep -x translate ~/target_packages) ]]; then
               nox -f translate/nox.py
             fi
       - run:
           name: Run tests - google.cloud.vision
           command: |
-            if [[ -n $(grep vision ~/target_packages) ]]; then
+            if [[ -n $(grep -x vision ~/target_packages) ]]; then
               nox -f vision/nox.py
             fi
       - run:
           name: Run tests - google.cloud.videointelligence
           command: |
-            if [[ -n $(grep videointelligence ~/target_packages) ]]; then
+            if [[ -n $(grep -x videointelligence ~/target_packages) ]]; then
               nox -f videointelligence/nox.py
             fi
       - run:

--- a/test_utils/scripts/get_target_packages.py
+++ b/test_utils/scripts/get_target_packages.py
@@ -23,7 +23,13 @@ import warnings
 CURRENT_DIR = os.path.realpath(os.path.dirname(__file__))
 BASE_DIR = os.path.realpath(os.path.join(CURRENT_DIR, '..', '..'))
 GITHUB_REPO = os.environ.get('GITHUB_REPO', 'google-cloud-python')
+CI = os.environ.get('CI', '')
+CI_BRANCH = os.environ.get('CIRCLE_BRANCH')
+CI_PR = os.environ.get('CIRCLE_PR_NUMBER')
 CIRCLE_TAG = os.environ.get('CIRCLE_TAG')
+MAJOR_DIV = '#' * 78
+MINOR_DIV = '#' + '-' * 77
+
 # NOTE: This reg-ex is copied from ``get_tagged_packages``.
 TAG_RE = re.compile(r"""
     ^
@@ -45,7 +51,8 @@ PKG_DEPENDENCIES = {
 def get_baseline():
     """Return the baseline commit.
 
-    On a pull request, or on a branch, return the master tip.
+    On a pull request, or on a branch, return the common parent revision
+    with the master branch.
 
     Locally, return a value pulled from environment variables, or None if
     the environment variables are not set.
@@ -53,16 +60,17 @@ def get_baseline():
     On a push to master, return None. This will effectively cause everything
     to be considered to be affected.
     """
-    ci_branch = os.environ.get('CIRCLE_BRANCH')
-    ci_pr = os.environ.get('CIRCLE_PR_NUMBER')
 
     # If this is a pull request or branch, return the tip for master.
     # We will test only packages which have changed since that point.
-    ci_non_master = os.environ.get('CI', '') == 'true' and any([
-        ci_branch != 'master',
-        ci_pr,
-    ])
+    ci_non_master = (CI == 'true') and any([CI_BRANCH != 'master', CI_PR])
+
     if ci_non_master:
+        if CI_BRANCH is not None:
+            output = subprocess.check_output(
+                ['git', 'merge-base', 'master', CI_BRANCH])
+            return output.strip().decode('ascii')
+
         repo_url = 'git@github.com:GoogleCloudPlatform/{}'.format(GITHUB_REPO)
         subprocess.run(['git', 'remote', 'add', 'baseline', repo_url],
                         stderr=subprocess.DEVNULL)
@@ -78,7 +86,7 @@ def get_baseline():
         return '%s/%s' % (remote, branch)
 
     # If we are not in CI and we got this far, issue a warning.
-    if not os.environ.get('CI', ''):
+    if not CI:
         warnings.warn('No baseline could be determined; this means tests '
                       'will run for every package. If this is local '
                       'development, set the $GOOGLE_CLOUD_TESTING_REMOTE '
@@ -95,6 +103,7 @@ def get_changed_files():
     """
     # Get the baseline, and fail quickly if there is no baseline.
     baseline = get_baseline()
+    print('# Baseline commit: {}'.format(baseline))
     if not baseline:
         return None
 
@@ -215,12 +224,36 @@ def get_target_packages():
     tagged_package = get_tagged_package()
     if tagged_package is None:
         file_list = get_changed_files()
+        print(MAJOR_DIV)
+        print('# Changed files:')
+        print(MINOR_DIV)
+        for file_ in file_list:
+            print('#  {}'.format(file_))
         for package in sorted(get_changed_packages(file_list)):
             yield package
     else:
         yield tagged_package
 
 
-if __name__ == '__main__':
-    for package in get_target_packages():
+def main():
+    print(MAJOR_DIV)
+    print('# Environment')
+    print(MINOR_DIV)
+    print('# CircleCI:        {}'.format(CI))
+    print('# CircleCI branch: {}'.format(CI_BRANCH))
+    print('# CircleCI pr:     {}'.format(CI_PR))
+    print('# CircleCI tag:    {}'.format(CIRCLE_TAG))
+    print(MAJOR_DIV)
+
+    packages = list(get_target_packages())
+
+    print(MAJOR_DIV)
+    print('# Target packages:')
+    print(MINOR_DIV)
+    for package in packages:
        print(package)
+    print(MAJOR_DIV)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This version emits debugging output from `get_target_packages.py`, in "comment" form.

It also updates the grep commands used to detect individual API packages to use whole-line matching only (`grep -x`).

See #5018, #5083