### PR TITLE
Fix docs links for TTS.

### DIFF
--- a/texttospeech/README.rst
+++ b/texttospeech/README.rst
@@ -9,7 +9,7 @@ models.
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Cloud Text-to-Speech API: https://cloud.google.com/texttospeech
-.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/texttospeech/usage.html
+.. _Client Library Documentation: https://google-cloud-python.readthedocs.io/en/latest/texttospeech/index.html
 .. _Product Documentation:  https://cloud.google.com/texttospeech
 
 Quick Start

--- a/texttospeech/docs/api.rst
+++ b/texttospeech/docs/api.rst
@@ -1,0 +1,31 @@
+API Reference
+=============
+
+APIs
+----
+
+.. autosummary::
+
+.. :toctree::
+
+   google.cloud.texttospeech_v1.trace_service_client
+
+
+API types
+~~~~~~~~~
+
+.. autosummary::
+.. :toctree::
+
+   google.cloud.trace_v1
+
+
+API types
+~~~~~~~~~
+
+.. autosummary::
+.. :toctree::
+
+   google.cloud.trace_v1.gapic.enums
+   google.cloud.trace_v1.gapic.types
+

--- a/texttospeech/docs/index.rst
+++ b/texttospeech/docs/index.rst
@@ -9,8 +9,8 @@ models.
 
 .. _Alpha: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/README.rst
 .. _Cloud Text-to-Speech API: https://cloud.google.com/texttospeech
-.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/texttospeech/usage.html
-.. _Product Documentation:  https://cloud.google.com/texttospeech
+.. _Client Library Documentation: https://googlecloudplatform.github.io/google-cloud-python/stable/texttospeech/api.html
+.. _Product Documentation: https://cloud.google.com/texttospeech
 
 Quick Start
 -----------
@@ -80,6 +80,7 @@ Api Reference
 .. toctree::
     :maxdepth: 2
 
+    api
     gapic/v1/api
     gapic/v1/types
     gapic/v1beta1/api


### PR DESCRIPTION
Add top-level 'api' page (to pick up the derived client, enums, and types).

Closes #5193.