### PR TITLE
Drop running 'error_reporting' tests for changes in 'logging'.

### DIFF
--- a/test_utils/scripts/get_target_packages.py
+++ b/test_utils/scripts/get_target_packages.py
@@ -48,7 +48,6 @@ TAG_RE = re.compile(r"""
 # As of this writing, the only "real" dependency is that of error_reporting
 # (on logging), the rest are just system test dependencies.
 PKG_DEPENDENCIES = {
-    'error_reporting': {'logging'},
     'logging': {'pubsub'},
 }
 


### PR DESCRIPTION
'logging' is GA.