### PR TITLE
Add `pip_install: true` to ReadTheDocs config.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,4 +2,5 @@ requirements_file: docs/requirements.txt
 build:
   image: latest
 python:
+  pip_install: true
   version: 3.6


### PR DESCRIPTION
This option fixed the docs build for `pandas-gbq`. I suspect it is needed for the docs here too.