### PR TITLE
#5024 Django Versioning Compatability for RequestMiddleware

### DIFF
--- a/logging/google/cloud/logging/handlers/middleware/request.py
+++ b/logging/google/cloud/logging/handlers/middleware/request.py
@@ -32,9 +32,20 @@ def _get_django_request():
     """
     return getattr(_thread_locals, 'request', None)
 
+try:
+    # Django >= 1.10
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object
 
-class RequestMiddleware(object):
+
+class RequestMiddleware(MiddlewareMixin):
     """Saves the request in thread local"""
+
+    def __init__(self, get_response=None):
+        self.get_response = get_response
 
     def process_request(self, request):
         """Called on each request, before Django decides which view to execute.

--- a/logging/google/cloud/logging/handlers/middleware/request.py
+++ b/logging/google/cloud/logging/handlers/middleware/request.py
@@ -32,6 +32,7 @@ def _get_django_request():
     """
     return getattr(_thread_locals, 'request', None)
 
+
 try:
     # Django >= 1.10
     from django.utils.deprecation import MiddlewareMixin

--- a/logging/nox.py
+++ b/logging/nox.py
@@ -35,7 +35,7 @@ UNIT_TEST_DEPS = (
 
 
 @nox.session
-def default(session):
+def default(session, django_dep=('django',)):
     """Default unit test session.
 
     This is intended to be run **without** an interpreter set, so
@@ -45,12 +45,11 @@ def default(session):
     """
     # Install all test dependencies, then install this package in-place.
     deps = UNIT_TEST_DEPS
-    if session.interpreter == 'python2.7':
-        deps += ('django >= 1.11.0, < 2.0.0dev',)
-    elif session.interpreter is None and sys.version_info[:2] == (2, 7):
+
+    if session.interpreter is None and sys.version_info[:2] == (2, 7):
         deps += ('django >= 1.11.0, < 2.0.0dev',)
     else:
-        deps += ('django',)
+        deps += django_dep
 
     deps += LOCAL_DEPS
     session.install(*deps)
@@ -82,7 +81,17 @@ def unit(session, py):
     # Set the virtualenv dirname.
     session.virtualenv_dirname = 'unit-' + py
 
-    default(session)
+    # Testing multiple version of django
+    # See https://www.djangoproject.com/download/ for supported version
+    django_deps_27 = [
+        ('django==1.8.19',),
+        ('django >= 1.11.0, < 2.0.0dev',),
+    ]
+
+    if session.interpreter == 'python2.7':
+        [default(session, django_dep=django) for django in django_deps_27]
+    else:
+        default(session)
 
 
 @nox.session


### PR DESCRIPTION
This commit allows the Django Request Middleware to be compatible with
all versions of Django.

This references the official upgrade Docs @
https://docs.djangoproject.com/en/2.0/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware

#5024