### PR TITLE
Link concrete entry classes into usage docs

### DIFF
--- a/docs/logging/usage.rst
+++ b/docs/logging/usage.rst
@@ -97,6 +97,16 @@ Fetch entries for the default project.
     :end-before: [END client_list_entries_default]
     :dedent: 4
 
+Entries returned by
+:meth:`Client.list_entries <google.cloud.logging.client.Client.list_entries>`
+or
+:meth:`Logger.list_entries <google.cloud.logging.logger.Logger.list_entries>`
+will be instances of one of the following classes:
+
+- :class:`~google.cloud.logging.entries.TextEntry`
+- :class:`~google.cloud.logging.entries.StructEntry`
+- :class:`~google.cloud.logging.entries.ProtobufEntry`
+
 Fetch entries across multiple projects.
 
 .. literalinclude:: snippets.py


### PR DESCRIPTION
Closes #4118.

Note that those API docs won't be as useful as they could be without either making `_BaseEntry` public (see #5511) or going to extra effort to propagate the signature docs for `__init__`.