### PR TITLE
Bigtable: Instance creation cleanup.

### DIFF
--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -36,7 +36,6 @@ from google.cloud import bigtable_admin_v2
 
 from google.cloud.bigtable import __version__
 from google.cloud.bigtable.instance import Instance
-from google.cloud.bigtable.instance import _EXISTING_INSTANCE_LOCATION_ID
 
 from google.cloud.client import ClientWithProject
 
@@ -196,17 +195,11 @@ class Client(ClientWithProject):
 
         return self._instance_admin_client
 
-    def instance(self, instance_id, location=_EXISTING_INSTANCE_LOCATION_ID,
-                 display_name=None):
+    def instance(self, instance_id, display_name=None):
         """Factory to create a instance associated with this client.
 
         :type instance_id: str
         :param instance_id: The ID of the instance.
-
-        :type location: str
-        :param location: location name, in form
-                         ``projects/<project>/locations/<location>``; used to
-                         set up the instance's cluster.
 
         :type display_name: str
         :param display_name: (Optional) The display name for the instance in
@@ -217,7 +210,7 @@ class Client(ClientWithProject):
         :rtype: :class:`~google.cloud.bigtable.instance.Instance`
         :returns: an instance owned by this client.
         """
-        return Instance(instance_id, self, location, display_name=display_name)
+        return Instance(instance_id, self, display_name=display_name)
 
     def list_instances(self):
         """List instances owned by the project.

--- a/bigtable/google/cloud/bigtable/instance.py
+++ b/bigtable/google/cloud/bigtable/instance.py
@@ -56,41 +56,17 @@ class Instance(object):
     :param client: The client that owns the instance. Provides
                    authorization and a project ID.
 
-    :type location_id: str
-    :param location_id: ID of the location in which the instance will be
-                        created.  Required for instances which do not yet
-                        exist.
-
     :type display_name: str
     :param display_name: (Optional) The display name for the instance in the
                          Cloud Console UI. (Must be between 4 and 30
                          characters.) If this value is not set in the
                          constructor, will fall back to the instance ID.
-
-    :type serve_nodes: int
-    :param serve_nodes: (Optional) The number of nodes in the instance's
-                        cluster; used to set up the instance's cluster.
-
-    :type default_storage_type: int
-    :param default_storage_type: (Optional) The default values are
-                                    STORAGE_TYPE_UNSPECIFIED = 0: The user did
-                                    not specify a storage type.
-                                    SSD = 1: Flash (SSD) storage should be
-                                    used.
-                                    HDD = 2: Magnetic drive (HDD) storage
-                                    should be used.
     """
 
-    def __init__(self, instance_id, client,
-                 location_id=_EXISTING_INSTANCE_LOCATION_ID,
-                 display_name=None, serve_nodes=DEFAULT_SERVE_NODES,
-                 default_storage_type=_STORAGE_TYPE_UNSPECIFIED):
+    def __init__(self, instance_id, client, display_name=None):
         self.instance_id = instance_id
         self.display_name = display_name or instance_id
-        self._cluster_location_id = location_id
-        self._cluster_serve_nodes = serve_nodes
         self._client = client
-        self._default_storage_type = default_storage_type
 
     @classmethod
     def from_pb(cls, instance_pb, client):
@@ -119,7 +95,7 @@ class Instance(object):
                              'project ID on the client')
         instance_id = match.group('instance_id')
 
-        result = cls(instance_id, client, _EXISTING_INSTANCE_LOCATION_ID)
+        result = cls(instance_id, client, display_name=instance_pb.display_name)
         return result
 
     def _update_from_pb(self, instance_pb):
@@ -172,7 +148,9 @@ class Instance(object):
         #       instance ID on the response match the request.
         self._update_from_pb(instance_pb)
 
-    def create(self):
+    def create(self, location_id=_EXISTING_INSTANCE_LOCATION_ID,
+                     serve_nodes=DEFAULT_SERVE_NODES,
+                     default_storage_type=_STORAGE_TYPE_UNSPECIFIED):
         """Create this instance.
 
         .. note::
@@ -188,6 +166,25 @@ class Instance(object):
 
             before calling :meth:`create`.
 
+        :type location_id: str
+        :param location_id: ID of the location in which the instance will be
+                            created.  Required for instances which do not yet
+                            exist.
+
+
+        :type serve_nodes: int
+        :param serve_nodes: (Optional) The number of nodes in the instance's
+                            cluster; used to set up the instance's cluster.
+
+        :type default_storage_type: int
+        :param default_storage_type: (Optional) The default values are
+                                        STORAGE_TYPE_UNSPECIFIED = 0: The user did
+                                        not specify a storage type.
+                                        SSD = 1: Flash (SSD) storage should be
+                                        used.
+                                        HDD = 2: Magnetic drive (HDD) storage
+                                        should be used.
+
         :rtype: :class:`~google.api_core.operation.Operation`
         :returns: The long-running operation corresponding to the create
                     operation.
@@ -197,11 +194,11 @@ class Instance(object):
         cluster_name = self._client.instance_admin_client.cluster_path(
             self._client.project, self.instance_id, cluster_id)
         location = self._client.instance_admin_client.location_path(
-            self._client.project, self._cluster_location_id)
+            self._client.project, location_id)
         cluster = instance_pb2.Cluster(
             name=cluster_name, location=location,
-            serve_nodes=self._cluster_serve_nodes,
-            default_storage_type=self._default_storage_type)
+            serve_nodes=serve_nodes,
+            default_storage_type=default_storage_type)
         instance = instance_pb2.Instance(
             display_name=self.display_name
         )

--- a/bigtable/google/cloud/bigtable/instance.py
+++ b/bigtable/google/cloud/bigtable/instance.py
@@ -95,7 +95,7 @@ class Instance(object):
                              'project ID on the client')
         instance_id = match.group('instance_id')
 
-        result = cls(instance_id, client, 
+        result = cls(instance_id, client,
                      display_name=instance_pb.display_name)
         return result
 

--- a/bigtable/google/cloud/bigtable/instance.py
+++ b/bigtable/google/cloud/bigtable/instance.py
@@ -95,7 +95,8 @@ class Instance(object):
                              'project ID on the client')
         instance_id = match.group('instance_id')
 
-        result = cls(instance_id, client, display_name=instance_pb.display_name)
+        result = cls(instance_id, client, 
+                     display_name=instance_pb.display_name)
         return result
 
     def _update_from_pb(self, instance_pb):
@@ -149,8 +150,8 @@ class Instance(object):
         self._update_from_pb(instance_pb)
 
     def create(self, location_id=_EXISTING_INSTANCE_LOCATION_ID,
-                     serve_nodes=DEFAULT_SERVE_NODES,
-                     default_storage_type=_STORAGE_TYPE_UNSPECIFIED):
+               serve_nodes=DEFAULT_SERVE_NODES,
+               default_storage_type=_STORAGE_TYPE_UNSPECIFIED):
         """Create this instance.
 
         .. note::
@@ -178,12 +179,12 @@ class Instance(object):
 
         :type default_storage_type: int
         :param default_storage_type: (Optional) The default values are
-                                        STORAGE_TYPE_UNSPECIFIED = 0: The user did
-                                        not specify a storage type.
-                                        SSD = 1: Flash (SSD) storage should be
-                                        used.
-                                        HDD = 2: Magnetic drive (HDD) storage
-                                        should be used.
+                                     STORAGE_TYPE_UNSPECIFIED = 0: The user
+                                     did not specify a storage type.
+                                     SSD = 1: Flash (SSD) storage should be
+                                     used.
+                                     HDD = 2: Magnetic drive (HDD) storage
+                                     should be used.
 
         :rtype: :class:`~google.api_core.operation.Operation`
         :returns: The long-running operation corresponding to the create

--- a/bigtable/tests/system.py
+++ b/bigtable/tests/system.py
@@ -84,7 +84,7 @@ def setUpModule():
     else:
         Config.CLIENT = Client(admin=True)
 
-    Config.INSTANCE = Config.CLIENT.instance(INSTANCE_ID, LOCATION_ID)
+    Config.INSTANCE = Config.CLIENT.instance(INSTANCE_ID)
 
     if not Config.IN_EMULATOR:
         retry = RetryErrors(GrpcRendezvous,
@@ -97,7 +97,7 @@ def setUpModule():
         EXISTING_INSTANCES[:] = instances
 
         # After listing, create the test instance.
-        created_op = Config.INSTANCE.create()
+        created_op = Config.INSTANCE.create(location_id=LOCATION_ID)
         created_op.result(timeout=10)
 
 
@@ -131,7 +131,7 @@ class TestInstanceAdminAPI(unittest.TestCase):
     def test_reload(self):
         # Use same arguments as Config.INSTANCE (created in `setUpModule`)
         # so we can use reload() on a fresh instance.
-        instance = Config.CLIENT.instance(INSTANCE_ID, LOCATION_ID)
+        instance = Config.CLIENT.instance(INSTANCE_ID)
         # Make sure metadata unset before reloading.
         instance.display_name = None
 
@@ -140,8 +140,8 @@ class TestInstanceAdminAPI(unittest.TestCase):
 
     def test_create_instance(self):
         ALT_INSTANCE_ID = 'new' + unique_resource_id('-')
-        instance = Config.CLIENT.instance(ALT_INSTANCE_ID, LOCATION_ID)
-        operation = instance.create()
+        instance = Config.CLIENT.instance(ALT_INSTANCE_ID)
+        operation = instance.create(location_id=LOCATION_ID)
         # Make sure this instance gets deleted after the test case.
         self.instances_to_delete.append(instance)
 
@@ -149,7 +149,7 @@ class TestInstanceAdminAPI(unittest.TestCase):
         operation.result(timeout=10)
 
         # Create a new instance instance and make sure it is the same.
-        instance_alt = Config.CLIENT.instance(ALT_INSTANCE_ID, LOCATION_ID)
+        instance_alt = Config.CLIENT.instance(ALT_INSTANCE_ID)
         instance_alt.reload()
 
         self.assertEqual(instance, instance_alt)
@@ -162,7 +162,7 @@ class TestInstanceAdminAPI(unittest.TestCase):
         Config.INSTANCE.update()
 
         # Create a new instance instance and reload it.
-        instance_alt = Config.CLIENT.instance(INSTANCE_ID, None)
+        instance_alt = Config.CLIENT.instance(INSTANCE_ID)
         self.assertNotEqual(instance_alt.display_name, NEW_DISPLAY_NAME)
         instance_alt.reload()
         self.assertEqual(instance_alt.display_name, NEW_DISPLAY_NAME)

--- a/bigtable/tests/unit/test_client.py
+++ b/bigtable/tests/unit/test_client.py
@@ -107,18 +107,15 @@ class TestClient(unittest.TestCase):
         PROJECT = 'PROJECT'
         INSTANCE_ID = 'instance-id'
         DISPLAY_NAME = 'display-name'
-        LOCATION_ID = 'locname'
         credentials = _make_credentials()
         client = self._make_one(
             project=PROJECT, credentials=credentials)
 
-        instance = client.instance(
-            INSTANCE_ID, display_name=DISPLAY_NAME, location=LOCATION_ID)
+        instance = client.instance(INSTANCE_ID, display_name=DISPLAY_NAME)
 
         self.assertIsInstance(instance, Instance)
         self.assertEqual(instance.instance_id, INSTANCE_ID)
         self.assertEqual(instance.display_name, DISPLAY_NAME)
-        self.assertEqual(instance._cluster_location_id, LOCATION_ID)
         self.assertIs(instance._client, client)
 
     def test_admin_client_w_value_error(self):

--- a/bigtable/tests/unit/test_instance.py
+++ b/bigtable/tests/unit/test_instance.py
@@ -94,7 +94,8 @@ class TestInstance(unittest.TestCase):
         display_name = 'display_name'
         client = object()
 
-        instance = self._make_one(self.INSTANCE_ID, client, display_name=display_name)
+        instance = self._make_one(self.INSTANCE_ID, client,
+                                  display_name=display_name)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
         self.assertEqual(instance.display_name, display_name)
         self.assertIs(instance._client, client)
@@ -273,7 +274,8 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, display_name=self.DISPLAY_NAME)
+        instance = self._make_one(self.INSTANCE_ID, client,
+                                  display_name=self.DISPLAY_NAME)
 
         # Create response_pb
         metadata = messages_v2_pb2.CreateInstanceMetadata(request_time=NOW_PB)
@@ -336,7 +338,8 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, display_name=self.DISPLAY_NAME)
+        instance = self._make_one(self.INSTANCE_ID, client,
+                                  display_name=self.DISPLAY_NAME)
 
         # Mock api calls
         client._instance_admin_client = api

--- a/bigtable/tests/unit/test_instance.py
+++ b/bigtable/tests/unit/test_instance.py
@@ -85,18 +85,16 @@ class TestInstance(unittest.TestCase):
     def test_constructor_defaults(self):
 
         client = object()
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
         self.assertEqual(instance.display_name, self.INSTANCE_ID)
         self.assertIs(instance._client, client)
-        self.assertEqual(instance._cluster_location_id, self.LOCATION_ID)
 
     def test_constructor_non_default(self):
         display_name = 'display_name'
         client = object()
 
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
-                                  display_name=display_name)
+        instance = self._make_one(self.INSTANCE_ID, client, display_name=display_name)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
         self.assertEqual(instance.display_name, display_name)
         self.assertIs(instance._client, client)
@@ -104,7 +102,7 @@ class TestInstance(unittest.TestCase):
     def test_table_factory(self):
         from google.cloud.bigtable.table import Table
 
-        instance = self._make_one(self.INSTANCE_ID, None, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, None)
 
         table = instance.table(self.TABLE_ID)
         self.assertIsInstance(table, Table)
@@ -120,7 +118,7 @@ class TestInstance(unittest.TestCase):
             display_name=display_name,
         )
 
-        instance = self._make_one(None, None, None, None)
+        instance = self._make_one(None, None)
         self.assertIsNone(instance.display_name)
         instance._update_from_pb(instance_pb)
         self.assertEqual(instance.display_name, display_name)
@@ -130,14 +128,12 @@ class TestInstance(unittest.TestCase):
             instance_pb2 as data_v2_pb2)
 
         instance_pb = data_v2_pb2.Instance()
-        instance = self._make_one(None, None, None, None)
+        instance = self._make_one(None, None)
         self.assertIsNone(instance.display_name)
         with self.assertRaises(ValueError):
             instance._update_from_pb(instance_pb)
 
     def test_from_pb_success(self):
-        from google.cloud.bigtable.instance import (
-            _EXISTING_INSTANCE_LOCATION_ID)
         from google.cloud.bigtable_admin_v2.proto import (
             instance_pb2 as data_v2_pb2)
 
@@ -153,8 +149,6 @@ class TestInstance(unittest.TestCase):
         self.assertIsInstance(instance, klass)
         self.assertEqual(instance._client, client)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
-        self.assertEqual(instance._cluster_location_id,
-                         _EXISTING_INSTANCE_LOCATION_ID)
 
     def test_from_pb_bad_instance_name(self):
         from google.cloud.bigtable_admin_v2.proto import (
@@ -195,31 +189,31 @@ class TestInstance(unittest.TestCase):
         # Patch the the API method.
         client._instance_admin_client = api
 
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
         self.assertEqual(instance.name, self.INSTANCE_NAME)
 
     def test___eq__(self):
         client = object()
-        instance1 = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
-        instance2 = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance1 = self._make_one(self.INSTANCE_ID, client)
+        instance2 = self._make_one(self.INSTANCE_ID, client)
         self.assertEqual(instance1, instance2)
 
     def test___eq__type_differ(self):
         client = object()
-        instance1 = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance1 = self._make_one(self.INSTANCE_ID, client)
         instance2 = object()
         self.assertNotEqual(instance1, instance2)
 
     def test___ne__same_value(self):
         client = object()
-        instance1 = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
-        instance2 = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance1 = self._make_one(self.INSTANCE_ID, client)
+        instance2 = self._make_one(self.INSTANCE_ID, client)
         comparison_val = (instance1 != instance2)
         self.assertFalse(comparison_val)
 
     def test___ne__(self):
-        instance1 = self._make_one('instance_id1', 'client1', self.LOCATION_ID)
-        instance2 = self._make_one('instance_id2', 'client2', self.LOCATION_ID)
+        instance1 = self._make_one('instance_id1', 'client1')
+        instance2 = self._make_one('instance_id2', 'client2')
         self.assertNotEqual(instance1, instance2)
 
     def test_reload(self):
@@ -233,7 +227,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         # Create response_pb
         DISPLAY_NAME = u'hey-hi-hello'
@@ -279,8 +273,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
-                                  display_name=self.DISPLAY_NAME)
+        instance = self._make_one(self.INSTANCE_ID, client, display_name=self.DISPLAY_NAME)
 
         # Create response_pb
         metadata = messages_v2_pb2.CreateInstanceMetadata(request_time=NOW_PB)
@@ -300,7 +293,7 @@ class TestInstance(unittest.TestCase):
         client._instance_admin_client.bigtable_instance_admin_stub = stub
 
         # Perform the method and check the result.
-        result = instance.create()
+        result = instance.create(location_id=self.LOCATION_ID)
 
         self.assertIsInstance(result, operation.Operation)
         # self.assertEqual(result.operation.name, self.OP_NAME)
@@ -319,7 +312,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         # Create response_pb
         response_pb = operations_pb2.Operation(name=self.OP_NAME)
@@ -330,7 +323,7 @@ class TestInstance(unittest.TestCase):
         client._instance_admin_client.bigtable_instance_admin_stub = stub
 
         # Perform the method and check the result.
-        result = instance.create()
+        result = instance.create(location_id=self.LOCATION_ID)
 
         self.assertIsInstance(result, operation.Operation)
 
@@ -343,8 +336,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID,
-                                  display_name=self.DISPLAY_NAME)
+        instance = self._make_one(self.INSTANCE_ID, client, display_name=self.DISPLAY_NAME)
 
         # Mock api calls
         client._instance_admin_client = api
@@ -366,7 +358,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         # Mock api calls
         client._instance_admin_client = api
@@ -395,7 +387,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         # Create response_pb
         if table_name is None:
@@ -442,7 +434,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         app_profile_id = 'appProfileId1262094415'
         update_mask = []
@@ -465,7 +457,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         description = 'description-1724546052'
         app_profile_id = 'appProfileId1262094415'
@@ -512,7 +504,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         description = 'description-1724546052'
         app_profile_id = 'appProfileId1262094415'
@@ -569,7 +561,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         name = 'name3373707'
         etag = 'etag3123477'
@@ -613,7 +605,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         # Setup Expected Response
         next_page_token = ''
@@ -657,7 +649,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         # Create response_pb
         NOW = datetime.datetime.utcnow()
@@ -706,7 +698,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         # Create response_pb
         NOW = datetime.datetime.utcnow()
@@ -748,7 +740,7 @@ class TestInstance(unittest.TestCase):
         credentials = _make_credentials()
         client = self._make_client(project=self.PROJECT,
                                    credentials=credentials, admin=True)
-        instance = self._make_one(self.INSTANCE_ID, client, self.LOCATION_ID)
+        instance = self._make_one(self.INSTANCE_ID, client)
 
         # Patch the stub used by the API method.
         client._instance_admin_client = instance_api


### PR DESCRIPTION
A Cloud Bigtable instance is a collection of clusters.  Each cluster has a node count and a location.  The python Cloud Bigtable client needs a bit of refactoring to better represent the distinction between instances and clusters.

Long term, Instance.create() should take in a complete set of variables required for creating an [instance](https://github.com/googleapis/googleapis/blob/c89b6330b6386298f8ea65e47e0b77b28294e3e7/google/bigtable/admin/v2/instance.proto#L34) and a collection of [cluster](https://github.com/googleapis/googleapis/blob/c89b6330b6386298f8ea65e47e0b77b28294e3e7/google/bigtable/admin/v2/instance.proto#L104)s.

This is PR is related to issue #5454