### PR TITLE
Connection management support (with optional grpc_gcp dependency)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ htmlcov
 # JetBrains
 .idea
 
+# VS Code
+.vscode
+
 # Built documentation
 docs/_build
 docs/_build_doc2dash

--- a/api_core/google/api_core/grpc_helpers.py
+++ b/api_core/google/api_core/grpc_helpers.py
@@ -157,7 +157,7 @@ def wrap_errors(callable_):
 def _create_secure_channel(
         credentials, request, target, ssl_credentials=None, **kwargs):
     """Creates a secure authorized gRPC channel.
-    
+
     This overwrites google.auth.transport.grpc.secure_authorized_channel to
     return a secure channel using grpc_gcp.secure_channel if grpc_gcp is
     available.
@@ -172,7 +172,8 @@ def _create_secure_channel(
         target (str): The host and port of the service.
         ssl_credentials (grpc.ChannelCredentials): Optional SSL channel
             credentials. This can be used to specify different certificates.
-        kwargs: Additional arguments to pass to :func:`grpc_gcp.secure_channel`.
+        kwargs: Additional arguments to pass to
+            :func:`grpc_gcp.secure_channel`.
 
     Returns:
         grpc_gcp.Channel: The created gRPC channel.
@@ -190,7 +191,7 @@ def _create_secure_channel(
     # Combine the ssl credentials and the authorization credentials.
     composite_credentials = grpc.composite_channel_credentials(
         ssl_credentials, google_auth_credentials)
-    
+
     if HAS_GRPC_GCP:
         # If grpc_gcp module is available use grpc_gcp.secure_channel,
         # otherwise, use grpc.secure_channel to create grpc channel.
@@ -221,7 +222,7 @@ def create_channel(target, credentials=None, scopes=None, **kwargs):
     else:
         credentials = google.auth.credentials.with_scopes_if_required(
             credentials, scopes)
- 
+
     request = google.auth.transport.requests.Request()
 
     return _create_secure_channel(credentials, request, target, **kwargs)

--- a/api_core/google/api_core/grpc_helpers.py
+++ b/api_core/google/api_core/grpc_helpers.py
@@ -169,6 +169,8 @@ def create_channel(target,
         scopes (Sequence[str]): A optional list of scopes needed for this
             service. These are only used when credentials are not specified and
             are passed to :func:`google.auth.default`.
+        ssl_credentials (grpc.ChannelCredentials): Optional SSL channel
+            credentials. This can be used to specify different certificates.
         kwargs: Additional key-word args passed to
             :func:`grpc_gcp.secure_channel` or :func:`grpc.secure_channel`.
 

--- a/api_core/nox.py
+++ b/api_core/nox.py
@@ -66,6 +66,17 @@ def unit(session, py):
 
 
 @nox.session
+@nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
+def unit_with_grpc_gcp(session, py):
+    """Run the unit test suite with grpcio-gcp installed."""
+
+    # Install grpcio-gcp
+    session.install('grpcio-gcp')
+
+    unit(session, py)
+
+
+@nox.session
 def lint(session):
     """Run linters.
 

--- a/api_core/nox.py
+++ b/api_core/nox.py
@@ -79,7 +79,7 @@ def unit_grpc_gcp(session, py):
     # Install grpcio-gcp
     session.install('grpcio-gcp')
 
-    default(session, py)
+    default(session)
 
 
 @nox.session

--- a/api_core/nox.py
+++ b/api_core/nox.py
@@ -67,13 +67,19 @@ def unit(session, py):
 
 @nox.session
 @nox.parametrize('py', ['2.7', '3.5', '3.6', '3.7'])
-def unit_with_grpc_gcp(session, py):
+def unit_grpc_gcp(session, py):
     """Run the unit test suite with grpcio-gcp installed."""
+
+    # Run unit tests against all supported versions of Python.
+    session.interpreter = 'python{}'.format(py)
+
+    # Set the virtualenv dirname.
+    session.virtualenv_dirname = 'unit-grpc-gcp-' + py
 
     # Install grpcio-gcp
     session.install('grpcio-gcp')
 
-    unit(session, py)
+    default(session, py)
 
 
 @nox.session

--- a/api_core/tests/unit/test_grpc_helpers.py
+++ b/api_core/tests/unit/test_grpc_helpers.py
@@ -190,8 +190,12 @@ def test_create_channel_implicit(
 
     assert channel is grpc_secure_channel.return_value
     default.assert_called_once_with(scopes=None)
-    grpc_secure_channel.assert_called_once_with(
-        target, composite_creds)
+    if (grpc_helpers.HAS_GRPC_GCP):
+        grpc_secure_channel.assert_called_once_with(
+            target, composite_creds, None)
+    else:
+        grpc_secure_channel.assert_called_once_with(
+            target, composite_creds)
 
 
 @mock.patch('grpc.composite_channel_credentials')
@@ -210,8 +214,12 @@ def test_create_channel_implicit_with_ssl_creds(
     default.assert_called_once_with(scopes=None)
     composite_creds_call.assert_called_once_with(ssl_creds, mock.ANY)
     composite_creds = composite_creds_call.return_value
-    grpc_secure_channel.assert_called_once_with(
-        target, composite_creds)
+    if (grpc_helpers.HAS_GRPC_GCP):
+        grpc_secure_channel.assert_called_once_with(
+            target, composite_creds, None)
+    else:
+        grpc_secure_channel.assert_called_once_with(
+            target, composite_creds)
 
 
 @mock.patch('grpc.composite_channel_credentials')
@@ -228,8 +236,12 @@ def test_create_channel_implicit_with_scopes(
 
     assert channel is grpc_secure_channel.return_value
     default.assert_called_once_with(scopes=['one', 'two'])
-    grpc_secure_channel.assert_called_once_with(
-        target, composite_creds)
+    if (grpc_helpers.HAS_GRPC_GCP):
+        grpc_secure_channel.assert_called_once_with(
+            target, composite_creds, None)
+    else:
+        grpc_secure_channel.assert_called_once_with(
+            target, composite_creds)
 
 
 @mock.patch('grpc.composite_channel_credentials')
@@ -245,8 +257,12 @@ def test_create_channel_explicit(
 
     auth_creds.assert_called_once_with(mock.sentinel.credentials, None)
     assert channel is grpc_secure_channel.return_value
-    grpc_secure_channel.assert_called_once_with(
-        target, composite_creds)
+    if (grpc_helpers.HAS_GRPC_GCP):
+        grpc_secure_channel.assert_called_once_with(
+            target, composite_creds, None)
+    else:
+        grpc_secure_channel.assert_called_once_with(
+            target, composite_creds)
 
 
 @mock.patch('grpc.composite_channel_credentials')
@@ -268,8 +284,12 @@ def test_create_channel_explicit_scoped(
 
     credentials.with_scopes.assert_called_once_with(scopes)
     assert channel is grpc_secure_channel.return_value
-    grpc_secure_channel.assert_called_once_with(
-        target, composite_creds)
+    if (grpc_helpers.HAS_GRPC_GCP):
+        grpc_secure_channel.assert_called_once_with(
+            target, composite_creds, None)
+    else:
+        grpc_secure_channel.assert_called_once_with(
+            target, composite_creds)
 
 
 @pytest.mark.skipif(not grpc_helpers.HAS_GRPC_GCP,

--- a/spanner/MANIFEST.in
+++ b/spanner/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.rst LICENSE
-recursive-include google *.json *.proto
+recursive-include google *.json *.proto *.config
 recursive-include tests *
 global-exclude *.pyc __pycache__

--- a/spanner/google/cloud/spanner_v1/gapic/spanner.grpc.config
+++ b/spanner/google/cloud/spanner_v1/gapic/spanner.grpc.config
@@ -1,0 +1,88 @@
+channel_pool: {
+  max_size: 10
+  max_concurrent_streams_low_watermark: 100
+}
+method: {
+  name: "/google.spanner.v1.Spanner/CreateSession"
+  affinity: {
+    command: BIND
+    affinity_key: "name"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/GetSession"
+  affinity: {
+    command: BOUND
+    affinity_key: "name"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/DeleteSession"
+  affinity: {
+    command: UNBIND
+    affinity_key: "name"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/ExecuteSql"
+  affinity: {
+    command: BOUND
+    affinity_key: "session"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/ExecuteStreamingSql"
+  affinity: {
+    command: BOUND
+    affinity_key: "session"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/Read"
+  affinity: {
+    command: BOUND
+    affinity_key: "session"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/StreamingRead"
+  affinity: {
+    command: BOUND
+    affinity_key: "session"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/BeginTransaction"
+  affinity: {
+    command: BOUND
+    affinity_key: "session"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/Commit"
+  affinity: {
+    command: BOUND
+    affinity_key: "session"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/Rollback"
+  affinity: {
+    command: BOUND
+    affinity_key: "session"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/PartitionQuery"
+  affinity: {
+    command: BOUND
+    affinity_key: "session"
+  }
+}
+method: {
+  name: "/google.spanner.v1.Spanner/PartitionRead"
+  affinity: {
+    command: BOUND
+    affinity_key: "session"
+  }
+}

--- a/spanner/google/cloud/spanner_v1/gapic/spanner_client.py
+++ b/spanner/google/cloud/spanner_v1/gapic/spanner_client.py
@@ -31,7 +31,6 @@ from google.cloud.spanner_v1.proto import mutation_pb2
 from google.cloud.spanner_v1.proto import spanner_pb2
 from google.cloud.spanner_v1.proto import transaction_pb2
 from google.protobuf import struct_pb2
-from google.protobuf import text_format
 
 try:
     import grpc_gcp
@@ -125,11 +124,9 @@ class SpannerClient(object):
 
             if HAS_GRPC_GCP:
                 # Initialize grpc gcp config for spanner api.
-                grpc_gcp_config = grpc_gcp.proto.grpc_gcp_pb2.ApiConfig()
-                text_format.Merge(
-                    pkg_resources.resource_string(__name__, _SPANNER_GRPC_CONFIG),
-                    grpc_gcp_config
-                )
+                grpc_gcp_config = grpc_gcp.api_config_from_text_pb(
+                    pkg_resources.resource_string(__name__,
+                                                  _SPANNER_GRPC_CONFIG))
                 options = [(grpc_gcp.API_CONFIG_CHANNEL_ARG, grpc_gcp_config)]
 
             channel = google.api_core.grpc_helpers.create_channel(

--- a/spanner/nox.py
+++ b/spanner/nox.py
@@ -67,6 +67,15 @@ def unit(session, py):
 
     default(session)
 
+@nox.session
+@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6', '3.7'])
+def unit_with_grpc_gcp(session, py):
+    """Run the unit test suite with grpcio-gcp installed."""
+
+    # Install grpcio-gcp
+    session.install('grpcio-gcp')
+
+    unit(session, py)
 
 @nox.session
 @nox.parametrize('py', ['2.7', '3.6'])

--- a/spanner/tests/unit/gapic/v1/test_spanner_client_v1.py
+++ b/spanner/tests/unit/gapic/v1/test_spanner_client_v1.py
@@ -26,11 +26,6 @@ from google.cloud.spanner_v1.proto import spanner_pb2
 from google.cloud.spanner_v1.proto import transaction_pb2
 from google.protobuf import empty_pb2
 
-try:
-    import grpc_gcp
-    HAS_GRPC_GCP = True
-except ImportError:
-    HAS_GRPC_GCP = False
 
 class MultiCallableStub(object):
     """Stub for the grpc.UnaryUnaryMultiCallable interface."""
@@ -561,7 +556,7 @@ class TestSpannerClient(object):
         with pytest.raises(CustomException):
             client.partition_read(session, table, key_set)
 
-    @pytest.mark.skipif(not HAS_GRPC_GCP,
+    @pytest.mark.skipif(not spanner_v1.HAS_GRPC_GCP,
                         reason='grpc_gcp module not available')
     @mock.patch('google.protobuf.text_format.Merge')
     @mock.patch('grpc_gcp.proto.grpc_gcp_pb2.ApiConfig',

--- a/spanner/tests/unit/gapic/v1/test_spanner_client_v1.py
+++ b/spanner/tests/unit/gapic/v1/test_spanner_client_v1.py
@@ -558,6 +558,9 @@ class TestSpannerClient(object):
 
     @pytest.mark.skipif(not spanner_v1.HAS_GRPC_GCP,
                         reason='grpc_gcp module not available')
+    @mock.patch(
+        'google.auth.default',
+        return_value=(mock.sentinel.credentials, mock.sentinel.projet))
     @mock.patch('google.protobuf.text_format.Merge')
     @mock.patch('grpc_gcp.proto.grpc_gcp_pb2.ApiConfig',
                 return_value=mock.sentinel.api_config)
@@ -565,7 +568,8 @@ class TestSpannerClient(object):
     def test_client_with_grpc_gcp_channel(self,
                                           grpc_gcp_secure_channel,
                                           api_config,
-                                          merge):
+                                          merge,
+                                          auth_default):
         spanner_target = 'spanner.googleapis.com:443'
         client = spanner_v1.SpannerClient()
         merge.assert_called_once_with(mock.ANY, mock.sentinel.api_config)


### PR DESCRIPTION
Add optional grpc_gcp dependency for api_core and spanner_v1. If user has installed grpcio-gcp, then the connection management feature will be enabled, and with the configuration specified in spanner.grpc.config . Otherwise, grpc_gcp won't be imported and everything works as usual. 