### PR TITLE
Bigtable: DirectRow without a table

### DIFF
--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -262,8 +262,8 @@ class DirectRow(_SetDeleteRow):
 
     :type table: :class:`Table <google.cloud.bigtable.table.Table>`
     :param table: (Optional) The table that owns the row. This is
-                  used for the :meth: `commit` only.  Alternatively, 
-                  DirectRows can be persisted via 
+                  used for the :meth: `commit` only.  Alternatively,
+                  DirectRows can be persisted via
                   :meth:`~google.cloud.bigtable.table.Table.mutate_rows`.
     """
 

--- a/bigtable/google/cloud/bigtable/row.py
+++ b/bigtable/google/cloud/bigtable/row.py
@@ -46,7 +46,7 @@ class Row(object):
     :param row_key: The key for the current row.
 
     :type table: :class:`Table <google.cloud.bigtable.table.Table>`
-    :param table: The table that owns the row.
+    :param table: (Optional) The table that owns the row.
     """
 
     def __init__(self, row_key, table=None):
@@ -261,7 +261,10 @@ class DirectRow(_SetDeleteRow):
     :param row_key: The key for the current row.
 
     :type table: :class:`Table <google.cloud.bigtable.table.Table>`
-    :param table: The table that owns the row.
+    :param table: (Optional) The table that owns the row. This is
+                  used for the :meth: `commit` only.  Alternatively, 
+                  DirectRows can be persisted via 
+                  :meth:`~google.cloud.bigtable.table.Table.mutate_rows`.
     """
 
     def __init__(self, row_key, table=None):

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -663,13 +663,9 @@ def _mutate_rows_request(table_name, rows, app_profile_id=None):
     for row in rows:
         _check_row_table_name(table_name, row)
         _check_row_type(row)
-        entry = request_pb.entries.add()
-        entry.row_key = row.row_key
-        # NOTE: Since `_check_row_type` has verified `row` is a `DirectRow`,
-        #  the mutations have no state.
-        for mutation in row._get_mutations(None):
-            mutations_count += 1
-            entry.mutations.add().CopyFrom(mutation)
+        mutations = row._get_mutations()
+        request_pb.entries.add(row_key=row.row_key, mutations=mutations)
+        mutations_count += len(mutations)
     if mutations_count > _MAX_BULK_MUTATIONS:
         raise TooManyMutationsError('Maximum number of mutations is %s' %
                                     (_MAX_BULK_MUTATIONS,))

--- a/bigtable/tests/unit/test_row.py
+++ b/bigtable/tests/unit/test_row.py
@@ -333,8 +333,6 @@ class TestDirectRow(unittest.TestCase):
         self.assertEqual(row._pb_mutations, [expected_pb1, expected_pb2])
 
     def test_commit(self):
-        from google.cloud.bigtable_v2.gapic import bigtable_client
-
         project_id = 'project-id'
         row_key = b'row_key'
         table_name = 'projects/more-stuff'

--- a/bigtable/tests/unit/test_row.py
+++ b/bigtable/tests/unit/test_row.py
@@ -333,7 +333,6 @@ class TestDirectRow(unittest.TestCase):
         self.assertEqual(row._pb_mutations, [expected_pb1, expected_pb2])
 
     def test_commit(self):
-        from google.protobuf import empty_pb2
         from google.cloud.bigtable_v2.gapic import bigtable_client
 
         project_id = 'project-id'
@@ -342,7 +341,6 @@ class TestDirectRow(unittest.TestCase):
         column_family_id = u'column_family_id'
         column = b'column'
 
-        api = bigtable_client.BigtableClient(mock.Mock())
         credentials = _make_credentials()
         client = self._make_client(project=project_id,
                                    credentials=credentials, admin=True)

--- a/bigtable/tests/unit/test_row.py
+++ b/bigtable/tests/unit/test_row.py
@@ -348,81 +348,12 @@ class TestDirectRow(unittest.TestCase):
                                    credentials=credentials, admin=True)
         table = _Table(table_name, client=client)
         row = self._make_one(row_key, table)
-
-        # Create request_pb
         value = b'bytes-value'
-
-        # Create response_pb
-        response_pb = empty_pb2.Empty()
-
-        # Patch the stub used by the API method.
-        client._table_data_client = api
-        bigtable_stub = client._table_data_client.bigtable_stub
-        bigtable_stub.MutateRow.side_effect = [response_pb]
-
-        # Create expected_result.
-        expected_result = None  # commit() has no return value when no filter.
 
         # Perform the method and check the result.
         row.set_cell(column_family_id, column, value)
-        result = row.commit()
-        self.assertEqual(result, expected_result)
-        self.assertEqual(row._pb_mutations, [])
-
-    def test_retry_commit_exception(self):
-        import grpc
-        import mock
-
-        from google.cloud.bigtable.row import _retry_commit_exception
-
-        class ErrorUnavailable(grpc.RpcError, grpc.Call):
-            """ErrorUnavailable exception"""
-
-        message = 'Endpoint read failed'
-        error = mock.create_autospec(ErrorUnavailable, instance=True)
-        error.code.return_value = grpc.StatusCode.UNAVAILABLE
-        error.details.return_value = message
-
-        result = _retry_commit_exception(error)
-        self.assertEqual(result, True)
-
-        result = _retry_commit_exception(ValueError)
-        self.assertNotEqual(result, True)
-
-    def test_commit_too_many_mutations(self):
-        from google.cloud._testing import _Monkey
-        from google.cloud.bigtable import row as MUT
-
-        row_key = b'row_key'
-        table = object()
-        row = self._make_one(row_key, table)
-        row._pb_mutations = [1, 2, 3]
-        num_mutations = len(row._pb_mutations)
-        with _Monkey(MUT, MAX_MUTATIONS=num_mutations - 1):
-            with self.assertRaises(ValueError):
-                row.commit()
-
-    def test_commit_no_mutations(self):
-        from tests.unit._testing import _FakeStub
-
-        project_id = 'project-id'
-        row_key = b'row_key'
-
-        credentials = _make_credentials()
-        client = self._make_client(project=project_id,
-                                   credentials=credentials, admin=True)
-        table = _Table(None, client=client)
-        row = self._make_one(row_key, table)
-        self.assertEqual(row._pb_mutations, [])
-
-        # Patch the stub used by the API method.
-        stub = _FakeStub()
-
-        # Perform the method and check the result.
-        result = row.commit()
-        self.assertIsNone(result)
-        # Make sure no request was sent.
-        self.assertEqual(stub.method_calls, [])
+        row.commit()
+        self.assertEqual(table.mutated_rows, [row])
 
 
 class TestConditionalRow(unittest.TestCase):
@@ -939,3 +870,7 @@ class _Table(object):
         self.name = name
         self._instance = _Instance(client)
         self.client = client
+        self.mutated_rows = []
+
+    def mutate_rows(self, rows):
+        self.mutated_rows.extend(rows)


### PR DESCRIPTION
Allowing `DirectRow`s to be created without a call to `table.row()` or without a table passed in the constructor. `DirectRow`s that are passed to `Table.mutate_rows()` don't need their own reference to a table.  More importantly, Dataflow needs the separation of concerns between the data that needs to be operated on, adn the Service which will perform operations.

This PR also changes the dynamics of how `DirectRow.commit()` is performed.  `DirectRow.commit()` now defers implementation details to `Table.mutate_rows()`.  Until now, there was validation duplication, as well as some duplication around complexities of retrying.  Validation and retries now only happen in `Table.mutate_rows()` simplifying the codebase.

This is a replacement for PR #5417.  The intent of the PRs are the same, but this PR reduces the amount of change required to achieve the same feature.