### PR TITLE
Allow listing rows on an empty table.

### DIFF
--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1400,6 +1400,8 @@ class Client(ClientWithProject):
         elif isinstance(table, TableReference):
             raise ValueError('need selected_fields with TableReference')
         elif isinstance(table, Table):
+            if len(table.schema) == 0 and table.created is None:
+                raise ValueError(_TABLE_HAS_NO_SCHEMA)
             schema = table.schema
         else:
             raise TypeError('table should be Table or TableReference')

--- a/bigquery/google/cloud/bigquery/client.py
+++ b/bigquery/google/cloud/bigquery/client.py
@@ -1400,8 +1400,6 @@ class Client(ClientWithProject):
         elif isinstance(table, TableReference):
             raise ValueError('need selected_fields with TableReference')
         elif isinstance(table, Table):
-            if len(table.schema) == 0:
-                raise ValueError(_TABLE_HAS_NO_SCHEMA)
             schema = table.schema
         else:
             raise TypeError('table should be Table or TableReference')

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -2508,6 +2508,9 @@ class QueryJob(_AsyncJob):
         schema = self._query_results.schema
         dest_table_ref = self.destination
         dest_table = Table(dest_table_ref, schema=schema)
+        # Set creation time to non-null to indicate this is actually the
+        # fetched schema to list_rows().
+        dest_table._properties['creationTime'] = '0'
         return self._client.list_rows(dest_table, retry=retry)
 
     def to_dataframe(self):

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -1720,6 +1720,20 @@ class TestBigQuery(unittest.TestCase):
             row['record_col']['nested_record']['nested_nested_string'],
             'some deep insight')
 
+    def test_list_rows_empty_table(self):
+        from google.cloud.bigquery.table import RowIterator
+
+        dataset_id = _make_dataset_id('empty_table')
+        dataset = self.temp_dataset(dataset_id)
+        table_ref = dataset.table('empty_table')
+        table = Config.CLIENT.create_table(bigquery.Table(table_ref))
+
+        # It's a bit silly to list rows for an empty table, but this does
+        # happen as the result of a DDL query from an IPython magic command.
+        rows = Config.CLIENT.list_rows(table)
+        self.assertIsInstance(rows, RowIterator)
+        self.assertEqual(tuple(rows), ())
+
     def test_list_rows_page_size(self):
         from google.cloud.bigquery.job import SourceFormat
         from google.cloud.bigquery.job import WriteDisposition

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -3079,6 +3079,25 @@ class TestClient(unittest.TestCase):
             path='/%s' % PATH,
             query_params={})
 
+    def test_list_rows_empty_table(self):
+        from google.cloud.bigquery.table import Table
+
+        response = {
+            'totalRows': '0',
+            'rows': [],
+        }
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(
+            project=self.PROJECT, credentials=creds, _http=http)
+        client._connection = _make_connection(response, response)
+
+        # Table that has no schema because it's an empty table.
+        table = Table(self.TABLE_REF)
+        table._properties['creationTime'] = '1234567890'
+        rows = tuple(client.list_rows(table))
+        self.assertEqual(rows, ())
+
     def test_list_rows_query_params(self):
         from google.cloud.bigquery.table import Table, SchemaField
 

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -2712,6 +2712,25 @@ class TestQueryJob(unittest.TestCase, _Base):
 
         self.assertEqual(list(result), [])
 
+    def test_result_w_empty_schema(self):
+        # Destination table may have no schema for some DDL and DML queries.
+        query_resource = {
+            'jobComplete': True,
+            'jobReference': {
+                'projectId': self.PROJECT,
+                'jobId': self.JOB_ID,
+            },
+            'schema': {'fields': []},
+        }
+        connection = _make_connection(query_resource, query_resource)
+        client = _make_client(self.PROJECT, connection=connection)
+        resource = self._make_resource(ended=True)
+        job = self._get_target_class().from_api_repr(resource, client)
+
+        result = job.result()
+
+        self.assertEqual(list(result), [])
+
     def test_result_invokes_begins(self):
         begun_resource = self._make_resource()
         incomplete_resource = {


### PR DESCRIPTION
Removes check for missing schema on Client.list_rows. This allows the
rows of an empty table to be listed. Such a table might be the
"destination table" for a DML or DDL query.

Closes https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5583