### PR TITLE
sample regen cloudtasks (do not merge)

### DIFF
--- a/tasks/README.rst
+++ b/tasks/README.rst
@@ -23,7 +23,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Tasks API.:  https://console.cloud.google.com/apis/library/cloudtasks.googleapis.com
+.. _Enable the Cloud Tasks API.:  https://cloud.google.com/tasks
 .. _Setup Authentication.: https://googlecloudplatform.github.io/google-cloud-python/stable/core/auth.html
 
 Installation

--- a/tasks/google/cloud/tasks_v2beta2/gapic/cloud_tasks_client.py
+++ b/tasks/google/cloud/tasks_v2beta2/gapic/cloud_tasks_client.py
@@ -381,7 +381,7 @@ class CloudTasksClient(object):
         WARNING: Using this method may have unintended side effects if you are
         using an App Engine ``queue.yaml`` or ``queue.xml`` file to manage your queues.
         Read
-        `Overview of Queue Management and queue.yaml <https://cloud.google.com/cloud-tasks/docs/queue-yaml>`_
+        `Overview of Queue Management and queue.yaml <https://cloud.google.com/tasks/docs/queue-yaml>`_
         before using this method.
 
         Example:
@@ -480,7 +480,7 @@ class CloudTasksClient(object):
         WARNING: Using this method may have unintended side effects if you are
         using an App Engine ``queue.yaml`` or ``queue.xml`` file to manage your queues.
         Read
-        `Overview of Queue Management and queue.yaml <https://cloud.google.com/cloud-tasks/docs/queue-yaml>`_
+        `Overview of Queue Management and queue.yaml <https://cloud.google.com/tasks/docs/queue-yaml>`_
         before using this method.
 
         Example:
@@ -575,7 +575,7 @@ class CloudTasksClient(object):
         WARNING: Using this method may have unintended side effects if you are
         using an App Engine ``queue.yaml`` or ``queue.xml`` file to manage your queues.
         Read
-        `Overview of Queue Management and queue.yaml <https://cloud.google.com/cloud-tasks/docs/queue-yaml>`_
+        `Overview of Queue Management and queue.yaml <https://cloud.google.com/tasks/docs/queue-yaml>`_
         before using this method.
 
         Example:
@@ -797,7 +797,7 @@ class CloudTasksClient(object):
         WARNING: Resuming many high-QPS queues at the same time can
         lead to target overloading. If you are resuming high-QPS
         queues, follow the 500/50/5 pattern described in
-        `Managing Cloud Tasks Scaling Risks <https://cloud.google.com/cloud-tasks/pdfs/managing-cloud-tasks-scaling-risks-2017-06-05.pdf>`_.
+        `Managing Cloud Tasks Scaling Risks <https://cloud.google.com/tasks/docs/manage-cloud-task-scaling>`_.
 
         Example:
             >>> from google.cloud import tasks_v2beta2
@@ -1110,7 +1110,6 @@ class CloudTasksClient(object):
     def list_tasks(self,
                    parent,
                    response_view=None,
-                   order_by=None,
                    page_size=None,
                    retry=google.api_core.gapic_v1.method.DEFAULT,
                    timeout=google.api_core.gapic_v1.method.DEFAULT,
@@ -1161,10 +1160,6 @@ class CloudTasksClient(object):
                 Authorization for ``FULL`` requires
                 ``cloudtasks.tasks.fullView`` `Google IAM <https://cloud.google.com/iam/>`_ permission on the
                 ``Task`` resource.
-            order_by (str): Sort order used for the query. The only fields supported for sorting
-                are ``schedule_time`` and ``pull_message.tag``. All results will be
-                returned in approximately ascending order. The default ordering is by
-                ``schedule_time``.
             page_size (int): The maximum number of resources contained in the
                 underlying API response. If page streaming is performed per-
                 resource, this parameter does not affect the return value. If page
@@ -1205,7 +1200,6 @@ class CloudTasksClient(object):
         request = cloudtasks_pb2.ListTasksRequest(
             parent=parent,
             response_view=response_view,
-            order_by=order_by,
             page_size=page_size,
         )
         if metadata is None:

--- a/tasks/google/cloud/tasks_v2beta2/gapic/cloud_tasks_client.py
+++ b/tasks/google/cloud/tasks_v2beta2/gapic/cloud_tasks_client.py
@@ -17,6 +17,7 @@ import functools
 import pkg_resources
 import warnings
 
+from google.oauth2 import service_account
 import google.api_core.gapic_v1.client_info
 import google.api_core.gapic_v1.config
 import google.api_core.gapic_v1.method
@@ -56,6 +57,27 @@ class CloudTasksClient(object):
     # The name of the interface for this client. This is the key used to
     # find the method configuration in the client_config dictionary.
     _INTERFACE_NAME = 'google.cloud.tasks.v2beta2.CloudTasks'
+
+    @classmethod
+    def from_service_account_file(cls, filename, *args, **kwargs):
+        """Creates an instance of this client using the provided credentials
+        file.
+
+        Args:
+            filename (str): The path to the service account private key json
+                file.
+            args: Additional arguments to pass to the constructor.
+            kwargs: Additional arguments to pass to the constructor.
+
+        Returns:
+            CloudTasksClient: The constructed client.
+        """
+        credentials = service_account.Credentials.from_service_account_file(
+            filename)
+        kwargs['credentials'] = credentials
+        return cls(*args, **kwargs)
+
+    from_service_account_json = from_service_account_file
 
     @classmethod
     def project_path(cls, project):

--- a/tasks/google/cloud/tasks_v2beta2/gapic/enums.py
+++ b/tasks/google/cloud/tasks_v2beta2/gapic/enums.py
@@ -190,6 +190,39 @@ class Code(enum.IntEnum):
     DATA_LOSS = 15
 
 
+class Task(object):
+    class View(enum.IntEnum):
+        """
+        The view specifies a subset of ``Task`` data.
+
+        When a task is returned in a response, not all
+        information is retrieved by default because some data, such as
+        payloads, might be desirable to return only when needed because
+        of its large size or because of the sensitivity of data that it
+        contains.
+
+        Attributes:
+          VIEW_UNSPECIFIED (int): Unspecified. Defaults to BASIC.
+          BASIC (int): The basic view omits fields which can be large or can contain
+          sensitive data.
+
+          This view does not include the
+          (``payload in AppEngineHttpRequest`` and
+          ``payload in PullMessage``). These payloads are
+          desirable to return only when needed, because they can be large
+          and because of the sensitivity of the data that you choose to
+          store in it.
+          FULL (int): All information is returned.
+
+          Authorization for ``FULL`` requires
+          ``cloudtasks.tasks.fullView`` `Google IAM <https://cloud.google.com/iam/>`_
+          permission on the ``Queue`` resource.
+        """
+        VIEW_UNSPECIFIED = 0
+        BASIC = 1
+        FULL = 2
+
+
 class Queue(object):
     class State(enum.IntEnum):
         """
@@ -229,36 +262,3 @@ class Queue(object):
         RUNNING = 1
         PAUSED = 2
         DISABLED = 3
-
-
-class Task(object):
-    class View(enum.IntEnum):
-        """
-        The view specifies a subset of ``Task`` data.
-
-        When a task is returned in a response, not all
-        information is retrieved by default because some data, such as
-        payloads, might be desirable to return only when needed because
-        of its large size or because of the sensitivity of data that it
-        contains.
-
-        Attributes:
-          VIEW_UNSPECIFIED (int): Unspecified. Defaults to BASIC.
-          BASIC (int): The basic view omits fields which can be large or can contain
-          sensitive data.
-
-          This view does not include the
-          (``payload in AppEngineHttpRequest`` and
-          ``payload in PullMessage``). These payloads are
-          desirable to return only when needed, because they can be large
-          and because of the sensitivity of the data that you choose to
-          store in it.
-          FULL (int): All information is returned.
-
-          Authorization for ``FULL`` requires
-          ``cloudtasks.tasks.fullView`` `Google IAM <https://cloud.google.com/iam/>`_
-          permission on the ``Queue`` resource.
-        """
-        VIEW_UNSPECIFIED = 0
-        BASIC = 1
-        FULL = 2

--- a/tasks/google/cloud/tasks_v2beta2/gapic/transports/cloud_tasks_grpc_transport.py
+++ b/tasks/google/cloud/tasks_v2beta2/gapic/transports/cloud_tasks_grpc_transport.py
@@ -130,7 +130,7 @@ class CloudTasksGrpcTransport(object):
         WARNING: Using this method may have unintended side effects if you are
         using an App Engine ``queue.yaml`` or ``queue.xml`` file to manage your queues.
         Read
-        `Overview of Queue Management and queue.yaml <https://cloud.google.com/cloud-tasks/docs/queue-yaml>`_
+        `Overview of Queue Management and queue.yaml <https://cloud.google.com/tasks/docs/queue-yaml>`_
         before using this method.
 
         Returns:
@@ -156,7 +156,7 @@ class CloudTasksGrpcTransport(object):
         WARNING: Using this method may have unintended side effects if you are
         using an App Engine ``queue.yaml`` or ``queue.xml`` file to manage your queues.
         Read
-        `Overview of Queue Management and queue.yaml <https://cloud.google.com/cloud-tasks/docs/queue-yaml>`_
+        `Overview of Queue Management and queue.yaml <https://cloud.google.com/tasks/docs/queue-yaml>`_
         before using this method.
 
         Returns:
@@ -180,7 +180,7 @@ class CloudTasksGrpcTransport(object):
         WARNING: Using this method may have unintended side effects if you are
         using an App Engine ``queue.yaml`` or ``queue.xml`` file to manage your queues.
         Read
-        `Overview of Queue Management and queue.yaml <https://cloud.google.com/cloud-tasks/docs/queue-yaml>`_
+        `Overview of Queue Management and queue.yaml <https://cloud.google.com/tasks/docs/queue-yaml>`_
         before using this method.
 
         Returns:
@@ -242,7 +242,7 @@ class CloudTasksGrpcTransport(object):
         WARNING: Resuming many high-QPS queues at the same time can
         lead to target overloading. If you are resuming high-QPS
         queues, follow the 500/50/5 pattern described in
-        `Managing Cloud Tasks Scaling Risks <https://cloud.google.com/cloud-tasks/pdfs/managing-cloud-tasks-scaling-risks-2017-06-05.pdf>`_.
+        `Managing Cloud Tasks Scaling Risks <https://cloud.google.com/tasks/docs/manage-cloud-task-scaling>`_.
 
         Returns:
             Callable: A callable which accepts the appropriate

--- a/tasks/google/cloud/tasks_v2beta2/proto/cloudtasks_pb2.py
+++ b/tasks/google/cloud/tasks_v2beta2/proto/cloudtasks_pb2.py
@@ -29,7 +29,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='google/cloud/tasks_v2beta2/proto/cloudtasks.proto',
   package='google.cloud.tasks.v2beta2',
   syntax='proto3',
-  serialized_pb=_b('\n1google/cloud/tasks_v2beta2/proto/cloudtasks.proto\x12\x1agoogle.cloud.tasks.v2beta2\x1a\x1cgoogle/api/annotations.proto\x1a,google/cloud/tasks_v2beta2/proto/queue.proto\x1a+google/cloud/tasks_v2beta2/proto/task.proto\x1a\x1egoogle/iam/v1/iam_policy.proto\x1a\x1agoogle/iam/v1/policy.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x15google/rpc/code.proto\"Z\n\x11ListQueuesRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\"`\n\x12ListQueuesResponse\x12\x31\n\x06queues\x18\x01 \x03(\x0b\x32!.google.cloud.tasks.v2beta2.Queue\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"\x1f\n\x0fGetQueueRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"V\n\x12\x43reateQueueRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x30\n\x05queue\x18\x02 \x01(\x0b\x32!.google.cloud.tasks.v2beta2.Queue\"w\n\x12UpdateQueueRequest\x12\x30\n\x05queue\x18\x01 \x01(\x0b\x32!.google.cloud.tasks.v2beta2.Queue\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\"\"\n\x12\x44\x65leteQueueRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"!\n\x11PurgeQueueRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"!\n\x11PauseQueueRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\"\n\x12ResumeQueueRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\x99\x01\n\x10ListTasksRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12<\n\rresponse_view\x18\x02 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\x12\x10\n\x08order_by\x18\x03 \x01(\t\x12\x11\n\tpage_size\x18\x04 \x01(\x05\x12\x12\n\npage_token\x18\x05 \x01(\t\"]\n\x11ListTasksResponse\x12/\n\x05tasks\x18\x01 \x03(\x0b\x32 .google.cloud.tasks.v2beta2.Task\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"\\\n\x0eGetTaskRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12<\n\rresponse_view\x18\x02 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\"\x91\x01\n\x11\x43reateTaskRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12.\n\x04task\x18\x02 \x01(\x0b\x32 .google.cloud.tasks.v2beta2.Task\x12<\n\rresponse_view\x18\x03 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\"!\n\x11\x44\x65leteTaskRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\xb7\x01\n\x11LeaseTasksRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x11\n\tmax_tasks\x18\x02 \x01(\x05\x12\x31\n\x0elease_duration\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12<\n\rresponse_view\x18\x04 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\x12\x0e\n\x06\x66ilter\x18\x05 \x01(\t\"E\n\x12LeaseTasksResponse\x12/\n\x05tasks\x18\x01 \x03(\x0b\x32 .google.cloud.tasks.v2beta2.Task\"Y\n\x16\x41\x63knowledgeTaskRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\rschedule_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xc5\x01\n\x11RenewLeaseRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\rschedule_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x31\n\x0elease_duration\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12<\n\rresponse_view\x18\x04 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\"\x93\x01\n\x12\x43\x61ncelLeaseRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\rschedule_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12<\n\rresponse_view\x18\x03 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\"\\\n\x0eRunTaskRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12<\n\rresponse_view\x18\x02 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View2\xf0\x19\n\nCloudTasks\x12\xa4\x01\n\nListQueues\x12-.google.cloud.tasks.v2beta2.ListQueuesRequest\x1a..google.cloud.tasks.v2beta2.ListQueuesResponse\"7\x82\xd3\xe4\x93\x02\x31\x12//v2beta2/{parent=projects/*/locations/*}/queues\x12\x93\x01\n\x08GetQueue\x12+.google.cloud.tasks.v2beta2.GetQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\"7\x82\xd3\xe4\x93\x02\x31\x12//v2beta2/{name=projects/*/locations/*/queues/*}\x12\xa0\x01\n\x0b\x43reateQueue\x12..google.cloud.tasks.v2beta2.CreateQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\">\x82\xd3\xe4\x93\x02\x38\"//v2beta2/{parent=projects/*/locations/*}/queues:\x05queue\x12\xa6\x01\n\x0bUpdateQueue\x12..google.cloud.tasks.v2beta2.UpdateQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\"D\x82\xd3\xe4\x93\x02>25/v2beta2/{queue.name=projects/*/locations/*/queues/*}:\x05queue\x12\x8e\x01\n\x0b\x44\x65leteQueue\x12..google.cloud.tasks.v2beta2.DeleteQueueRequest\x1a\x16.google.protobuf.Empty\"7\x82\xd3\xe4\x93\x02\x31*//v2beta2/{name=projects/*/locations/*/queues/*}\x12\xa0\x01\n\nPurgeQueue\x12-.google.cloud.tasks.v2beta2.PurgeQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\"@\x82\xd3\xe4\x93\x02:\"5/v2beta2/{name=projects/*/locations/*/queues/*}:purge:\x01*\x12\xa0\x01\n\nPauseQueue\x12-.google.cloud.tasks.v2beta2.PauseQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\"@\x82\xd3\xe4\x93\x02:\"5/v2beta2/{name=projects/*/locations/*/queues/*}:pause:\x01*\x12\xa3\x01\n\x0bResumeQueue\x12..google.cloud.tasks.v2beta2.ResumeQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\"A\x82\xd3\xe4\x93\x02;\"6/v2beta2/{name=projects/*/locations/*/queues/*}:resume:\x01*\x12\x96\x01\n\x0cGetIamPolicy\x12\".google.iam.v1.GetIamPolicyRequest\x1a\x15.google.iam.v1.Policy\"K\x82\xd3\xe4\x93\x02\x45\"@/v2beta2/{resource=projects/*/locations/*/queues/*}:getIamPolicy:\x01*\x12\x96\x01\n\x0cSetIamPolicy\x12\".google.iam.v1.SetIamPolicyRequest\x1a\x15.google.iam.v1.Policy\"K\x82\xd3\xe4\x93\x02\x45\"@/v2beta2/{resource=projects/*/locations/*/queues/*}:setIamPolicy:\x01*\x12\xbc\x01\n\x12TestIamPermissions\x12(.google.iam.v1.TestIamPermissionsRequest\x1a).google.iam.v1.TestIamPermissionsResponse\"Q\x82\xd3\xe4\x93\x02K\"F/v2beta2/{resource=projects/*/locations/*/queues/*}:testIamPermissions:\x01*\x12\xa9\x01\n\tListTasks\x12,.google.cloud.tasks.v2beta2.ListTasksRequest\x1a-.google.cloud.tasks.v2beta2.ListTasksResponse\"?\x82\xd3\xe4\x93\x02\x39\x12\x37/v2beta2/{parent=projects/*/locations/*/queues/*}/tasks\x12\x98\x01\n\x07GetTask\x12*.google.cloud.tasks.v2beta2.GetTaskRequest\x1a .google.cloud.tasks.v2beta2.Task\"?\x82\xd3\xe4\x93\x02\x39\x12\x37/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}\x12\xa1\x01\n\nCreateTask\x12-.google.cloud.tasks.v2beta2.CreateTaskRequest\x1a .google.cloud.tasks.v2beta2.Task\"B\x82\xd3\xe4\x93\x02<\"7/v2beta2/{parent=projects/*/locations/*/queues/*}/tasks:\x01*\x12\x94\x01\n\nDeleteTask\x12-.google.cloud.tasks.v2beta2.DeleteTaskRequest\x1a\x16.google.protobuf.Empty\"?\x82\xd3\xe4\x93\x02\x39*7/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}\x12\xb5\x01\n\nLeaseTasks\x12-.google.cloud.tasks.v2beta2.LeaseTasksRequest\x1a..google.cloud.tasks.v2beta2.LeaseTasksResponse\"H\x82\xd3\xe4\x93\x02\x42\"=/v2beta2/{parent=projects/*/locations/*/queues/*}/tasks:lease:\x01*\x12\xad\x01\n\x0f\x41\x63knowledgeTask\x12\x32.google.cloud.tasks.v2beta2.AcknowledgeTaskRequest\x1a\x16.google.protobuf.Empty\"N\x82\xd3\xe4\x93\x02H\"C/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}:acknowledge:\x01*\x12\xac\x01\n\nRenewLease\x12-.google.cloud.tasks.v2beta2.RenewLeaseRequest\x1a .google.cloud.tasks.v2beta2.Task\"M\x82\xd3\xe4\x93\x02G\"B/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}:renewLease:\x01*\x12\xaf\x01\n\x0b\x43\x61ncelLease\x12..google.cloud.tasks.v2beta2.CancelLeaseRequest\x1a .google.cloud.tasks.v2beta2.Task\"N\x82\xd3\xe4\x93\x02H\"C/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}:cancelLease:\x01*\x12\x9f\x01\n\x07RunTask\x12*.google.cloud.tasks.v2beta2.RunTaskRequest\x1a .google.cloud.tasks.v2beta2.Task\"F\x82\xd3\xe4\x93\x02@\";/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}:run:\x01*B|\n\x1e\x63om.google.cloud.tasks.v2beta2B\x0f\x43loudTasksProtoP\x01Z?google.golang.org/genproto/googleapis/cloud/tasks/v2beta2;tasks\xa2\x02\x05TASKSb\x06proto3')
+  serialized_pb=_b('\n1google/cloud/tasks_v2beta2/proto/cloudtasks.proto\x12\x1agoogle.cloud.tasks.v2beta2\x1a\x1cgoogle/api/annotations.proto\x1a,google/cloud/tasks_v2beta2/proto/queue.proto\x1a+google/cloud/tasks_v2beta2/proto/task.proto\x1a\x1egoogle/iam/v1/iam_policy.proto\x1a\x1agoogle/iam/v1/policy.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x15google/rpc/code.proto\"Z\n\x11ListQueuesRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x0e\n\x06\x66ilter\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\"`\n\x12ListQueuesResponse\x12\x31\n\x06queues\x18\x01 \x03(\x0b\x32!.google.cloud.tasks.v2beta2.Queue\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"\x1f\n\x0fGetQueueRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"V\n\x12\x43reateQueueRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x30\n\x05queue\x18\x02 \x01(\x0b\x32!.google.cloud.tasks.v2beta2.Queue\"w\n\x12UpdateQueueRequest\x12\x30\n\x05queue\x18\x01 \x01(\x0b\x32!.google.cloud.tasks.v2beta2.Queue\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\"\"\n\x12\x44\x65leteQueueRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"!\n\x11PurgeQueueRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"!\n\x11PauseQueueRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\"\n\x12ResumeQueueRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\x87\x01\n\x10ListTasksRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12<\n\rresponse_view\x18\x02 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\x12\x11\n\tpage_size\x18\x04 \x01(\x05\x12\x12\n\npage_token\x18\x05 \x01(\t\"]\n\x11ListTasksResponse\x12/\n\x05tasks\x18\x01 \x03(\x0b\x32 .google.cloud.tasks.v2beta2.Task\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"\\\n\x0eGetTaskRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12<\n\rresponse_view\x18\x02 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\"\x91\x01\n\x11\x43reateTaskRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12.\n\x04task\x18\x02 \x01(\x0b\x32 .google.cloud.tasks.v2beta2.Task\x12<\n\rresponse_view\x18\x03 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\"!\n\x11\x44\x65leteTaskRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\xb7\x01\n\x11LeaseTasksRequest\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x11\n\tmax_tasks\x18\x02 \x01(\x05\x12\x31\n\x0elease_duration\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12<\n\rresponse_view\x18\x04 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\x12\x0e\n\x06\x66ilter\x18\x05 \x01(\t\"E\n\x12LeaseTasksResponse\x12/\n\x05tasks\x18\x01 \x03(\x0b\x32 .google.cloud.tasks.v2beta2.Task\"Y\n\x16\x41\x63knowledgeTaskRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\rschedule_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xc5\x01\n\x11RenewLeaseRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\rschedule_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x31\n\x0elease_duration\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12<\n\rresponse_view\x18\x04 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\"\x93\x01\n\x12\x43\x61ncelLeaseRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\rschedule_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12<\n\rresponse_view\x18\x03 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View\"\\\n\x0eRunTaskRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12<\n\rresponse_view\x18\x02 \x01(\x0e\x32%.google.cloud.tasks.v2beta2.Task.View2\xf0\x19\n\nCloudTasks\x12\xa4\x01\n\nListQueues\x12-.google.cloud.tasks.v2beta2.ListQueuesRequest\x1a..google.cloud.tasks.v2beta2.ListQueuesResponse\"7\x82\xd3\xe4\x93\x02\x31\x12//v2beta2/{parent=projects/*/locations/*}/queues\x12\x93\x01\n\x08GetQueue\x12+.google.cloud.tasks.v2beta2.GetQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\"7\x82\xd3\xe4\x93\x02\x31\x12//v2beta2/{name=projects/*/locations/*/queues/*}\x12\xa0\x01\n\x0b\x43reateQueue\x12..google.cloud.tasks.v2beta2.CreateQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\">\x82\xd3\xe4\x93\x02\x38\"//v2beta2/{parent=projects/*/locations/*}/queues:\x05queue\x12\xa6\x01\n\x0bUpdateQueue\x12..google.cloud.tasks.v2beta2.UpdateQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\"D\x82\xd3\xe4\x93\x02>25/v2beta2/{queue.name=projects/*/locations/*/queues/*}:\x05queue\x12\x8e\x01\n\x0b\x44\x65leteQueue\x12..google.cloud.tasks.v2beta2.DeleteQueueRequest\x1a\x16.google.protobuf.Empty\"7\x82\xd3\xe4\x93\x02\x31*//v2beta2/{name=projects/*/locations/*/queues/*}\x12\xa0\x01\n\nPurgeQueue\x12-.google.cloud.tasks.v2beta2.PurgeQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\"@\x82\xd3\xe4\x93\x02:\"5/v2beta2/{name=projects/*/locations/*/queues/*}:purge:\x01*\x12\xa0\x01\n\nPauseQueue\x12-.google.cloud.tasks.v2beta2.PauseQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\"@\x82\xd3\xe4\x93\x02:\"5/v2beta2/{name=projects/*/locations/*/queues/*}:pause:\x01*\x12\xa3\x01\n\x0bResumeQueue\x12..google.cloud.tasks.v2beta2.ResumeQueueRequest\x1a!.google.cloud.tasks.v2beta2.Queue\"A\x82\xd3\xe4\x93\x02;\"6/v2beta2/{name=projects/*/locations/*/queues/*}:resume:\x01*\x12\x96\x01\n\x0cGetIamPolicy\x12\".google.iam.v1.GetIamPolicyRequest\x1a\x15.google.iam.v1.Policy\"K\x82\xd3\xe4\x93\x02\x45\"@/v2beta2/{resource=projects/*/locations/*/queues/*}:getIamPolicy:\x01*\x12\x96\x01\n\x0cSetIamPolicy\x12\".google.iam.v1.SetIamPolicyRequest\x1a\x15.google.iam.v1.Policy\"K\x82\xd3\xe4\x93\x02\x45\"@/v2beta2/{resource=projects/*/locations/*/queues/*}:setIamPolicy:\x01*\x12\xbc\x01\n\x12TestIamPermissions\x12(.google.iam.v1.TestIamPermissionsRequest\x1a).google.iam.v1.TestIamPermissionsResponse\"Q\x82\xd3\xe4\x93\x02K\"F/v2beta2/{resource=projects/*/locations/*/queues/*}:testIamPermissions:\x01*\x12\xa9\x01\n\tListTasks\x12,.google.cloud.tasks.v2beta2.ListTasksRequest\x1a-.google.cloud.tasks.v2beta2.ListTasksResponse\"?\x82\xd3\xe4\x93\x02\x39\x12\x37/v2beta2/{parent=projects/*/locations/*/queues/*}/tasks\x12\x98\x01\n\x07GetTask\x12*.google.cloud.tasks.v2beta2.GetTaskRequest\x1a .google.cloud.tasks.v2beta2.Task\"?\x82\xd3\xe4\x93\x02\x39\x12\x37/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}\x12\xa1\x01\n\nCreateTask\x12-.google.cloud.tasks.v2beta2.CreateTaskRequest\x1a .google.cloud.tasks.v2beta2.Task\"B\x82\xd3\xe4\x93\x02<\"7/v2beta2/{parent=projects/*/locations/*/queues/*}/tasks:\x01*\x12\x94\x01\n\nDeleteTask\x12-.google.cloud.tasks.v2beta2.DeleteTaskRequest\x1a\x16.google.protobuf.Empty\"?\x82\xd3\xe4\x93\x02\x39*7/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}\x12\xb5\x01\n\nLeaseTasks\x12-.google.cloud.tasks.v2beta2.LeaseTasksRequest\x1a..google.cloud.tasks.v2beta2.LeaseTasksResponse\"H\x82\xd3\xe4\x93\x02\x42\"=/v2beta2/{parent=projects/*/locations/*/queues/*}/tasks:lease:\x01*\x12\xad\x01\n\x0f\x41\x63knowledgeTask\x12\x32.google.cloud.tasks.v2beta2.AcknowledgeTaskRequest\x1a\x16.google.protobuf.Empty\"N\x82\xd3\xe4\x93\x02H\"C/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}:acknowledge:\x01*\x12\xac\x01\n\nRenewLease\x12-.google.cloud.tasks.v2beta2.RenewLeaseRequest\x1a .google.cloud.tasks.v2beta2.Task\"M\x82\xd3\xe4\x93\x02G\"B/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}:renewLease:\x01*\x12\xaf\x01\n\x0b\x43\x61ncelLease\x12..google.cloud.tasks.v2beta2.CancelLeaseRequest\x1a .google.cloud.tasks.v2beta2.Task\"N\x82\xd3\xe4\x93\x02H\"C/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}:cancelLease:\x01*\x12\x9f\x01\n\x07RunTask\x12*.google.cloud.tasks.v2beta2.RunTaskRequest\x1a .google.cloud.tasks.v2beta2.Task\"F\x82\xd3\xe4\x93\x02@\";/v2beta2/{name=projects/*/locations/*/queues/*/tasks/*}:run:\x01*B|\n\x1e\x63om.google.cloud.tasks.v2beta2B\x0f\x43loudTasksProtoP\x01Z?google.golang.org/genproto/googleapis/cloud/tasks/v2beta2;tasks\xa2\x02\x05TASKSb\x06proto3')
   ,
   dependencies=[google_dot_api_dot_annotations__pb2.DESCRIPTOR,google_dot_cloud_dot_tasks__v2beta2_dot_proto_dot_queue__pb2.DESCRIPTOR,google_dot_cloud_dot_tasks__v2beta2_dot_proto_dot_task__pb2.DESCRIPTOR,google_dot_iam_dot_v1_dot_iam__policy__pb2.DESCRIPTOR,google_dot_iam_dot_v1_dot_policy__pb2.DESCRIPTOR,google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,google_dot_protobuf_dot_field__mask__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_rpc_dot_code__pb2.DESCRIPTOR,])
 
@@ -379,21 +379,14 @@ _LISTTASKSREQUEST = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='order_by', full_name='google.cloud.tasks.v2beta2.ListTasksRequest.order_by', index=2,
-      number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='page_size', full_name='google.cloud.tasks.v2beta2.ListTasksRequest.page_size', index=3,
+      name='page_size', full_name='google.cloud.tasks.v2beta2.ListTasksRequest.page_size', index=2,
       number=4, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='page_token', full_name='google.cloud.tasks.v2beta2.ListTasksRequest.page_token', index=4,
+      name='page_token', full_name='google.cloud.tasks.v2beta2.ListTasksRequest.page_token', index=3,
       number=5, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -412,7 +405,7 @@ _LISTTASKSREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=988,
-  serialized_end=1141,
+  serialized_end=1123,
 )
 
 
@@ -449,8 +442,8 @@ _LISTTASKSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1143,
-  serialized_end=1236,
+  serialized_start=1125,
+  serialized_end=1218,
 )
 
 
@@ -487,8 +480,8 @@ _GETTASKREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1238,
-  serialized_end=1330,
+  serialized_start=1220,
+  serialized_end=1312,
 )
 
 
@@ -532,8 +525,8 @@ _CREATETASKREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1333,
-  serialized_end=1478,
+  serialized_start=1315,
+  serialized_end=1460,
 )
 
 
@@ -563,8 +556,8 @@ _DELETETASKREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1480,
-  serialized_end=1513,
+  serialized_start=1462,
+  serialized_end=1495,
 )
 
 
@@ -622,8 +615,8 @@ _LEASETASKSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1516,
-  serialized_end=1699,
+  serialized_start=1498,
+  serialized_end=1681,
 )
 
 
@@ -653,8 +646,8 @@ _LEASETASKSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1701,
-  serialized_end=1770,
+  serialized_start=1683,
+  serialized_end=1752,
 )
 
 
@@ -691,8 +684,8 @@ _ACKNOWLEDGETASKREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1772,
-  serialized_end=1861,
+  serialized_start=1754,
+  serialized_end=1843,
 )
 
 
@@ -743,8 +736,8 @@ _RENEWLEASEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1864,
-  serialized_end=2061,
+  serialized_start=1846,
+  serialized_end=2043,
 )
 
 
@@ -788,8 +781,8 @@ _CANCELLEASEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2064,
-  serialized_end=2211,
+  serialized_start=2046,
+  serialized_end=2193,
 )
 
 
@@ -826,8 +819,8 @@ _RUNTASKREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2213,
-  serialized_end=2305,
+  serialized_start=2195,
+  serialized_end=2287,
 )
 
 _LISTQUEUESRESPONSE.fields_by_name['queues'].message_type = google_dot_cloud_dot_tasks__v2beta2_dot_proto_dot_queue__pb2._QUEUE
@@ -1099,11 +1092,6 @@ ListTasksRequest = _reflection.GeneratedProtocolMessageType('ListTasksRequest', 
           ``cloudtasks.tasks.fullView`` `Google IAM </iam/>`__
           permission on the [Task][google.cloud.tasks.v2beta2.Task]
           resource.
-      order_by:
-          Sort order used for the query. The only fields supported for
-          sorting are ``schedule_time`` and ``pull_message.tag``. All
-          results will be returned in approximately ascending order. The
-          default ordering is by ``schedule_time``.
       page_size:
           Requested page size. Fewer tasks than requested might be
           returned.  The maximum page size is 1000. If unspecified, the
@@ -1487,8 +1475,8 @@ _CLOUDTASKS = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=2308,
-  serialized_end=5620,
+  serialized_start=2290,
+  serialized_end=5602,
   methods=[
   _descriptor.MethodDescriptor(
     name='ListQueues',

--- a/tasks/google/cloud/tasks_v2beta2/proto/cloudtasks_pb2_grpc.py
+++ b/tasks/google/cloud/tasks_v2beta2/proto/cloudtasks_pb2_grpc.py
@@ -153,7 +153,7 @@ class CloudTasksServicer(object):
     WARNING: Using this method may have unintended side effects if you are
     using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
     Read
-    [Overview of Queue Management and queue.yaml](/cloud-tasks/docs/queue-yaml)
+    [Overview of Queue Management and queue.yaml](/tasks/docs/queue-yaml)
     before using this method.
     """
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -173,7 +173,7 @@ class CloudTasksServicer(object):
     WARNING: Using this method may have unintended side effects if you are
     using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
     Read
-    [Overview of Queue Management and queue.yaml](/cloud-tasks/docs/queue-yaml)
+    [Overview of Queue Management and queue.yaml](/tasks/docs/queue-yaml)
     before using this method.
     """
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -191,7 +191,7 @@ class CloudTasksServicer(object):
     WARNING: Using this method may have unintended side effects if you are
     using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
     Read
-    [Overview of Queue Management and queue.yaml](/cloud-tasks/docs/queue-yaml)
+    [Overview of Queue Management and queue.yaml](/tasks/docs/queue-yaml)
     before using this method.
     """
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -235,7 +235,7 @@ class CloudTasksServicer(object):
     WARNING: Resuming many high-QPS queues at the same time can
     lead to target overloading. If you are resuming high-QPS
     queues, follow the 500/50/5 pattern described in
-    [Managing Cloud Tasks Scaling Risks](/cloud-tasks/pdfs/managing-cloud-tasks-scaling-risks-2017-06-05.pdf).
+    [Managing Cloud Tasks Scaling Risks](/tasks/docs/manage-cloud-task-scaling).
     """
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
     context.set_details('Method not implemented!')

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -20,11 +20,10 @@ import setuptools
 name = 'google-cloud-tasks'
 description = 'Cloud Tasks API API client library'
 version = '0.1.0'
-release_status = 'Development Status :: 3 - Alpha'
+release_status = '3 - Alpha'
 dependencies = [
     'google-api-core[grpc] >= 1.1.0, < 2.0.0dev',
     'enum34; python_version < "3.4"',
-    'grpc-google-iam-v1<0.12dev,>=0.11.4',
 ]
 
 package_root = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Test PR for visualizing changes due to https://github.com/googleapis/gapic-generator/pull/2145

The first commit contains the regenerated cloud tasks with the master branch of toolkit. The cloudtasks team must have snuck in changes to their API after it had just been regenerated a day ago.

All commits after that have the regenerated cloud tasks client using the gapic-generator PR, so it is helpful to see the effect of that PR in the diff between the commits: https://github.com/GoogleCloudPlatform/google-cloud-python/pull/5595/commits/4ec17109ee783cda553697c8012cf0e96401bf46