### PR TITLE
Trace: Pass credentials into TraceServiceClient

### DIFF
--- a/trace/google/cloud/trace/__init__.py
+++ b/trace/google/cloud/trace/__init__.py
@@ -14,6 +14,9 @@
 
 from __future__ import absolute_import
 
+from pkg_resources import get_distribution
+__version__ = get_distribution('google-cloud-trace').version
+
 from google.cloud.trace.client import Client
 from google.cloud.trace_v2 import types
 from google.cloud.trace_v2.gapic import enums
@@ -26,6 +29,7 @@ class TraceServiceClient(trace_service_client.TraceServiceClient):
 
 
 __all__ = (
+    '__version__',
     'enums',
     'types',
     'TraceServiceClient',

--- a/trace/google/cloud/trace/_gapic.py
+++ b/trace/google/cloud/trace/_gapic.py
@@ -14,14 +14,20 @@
 
 """Wrapper for interacting with the Stackdriver Trace API."""
 
+from google.api_core.gapic_v1 import client_info
 from google.api_core.gapic_v1 import method
 from google.cloud._helpers import _datetime_to_pb_timestamp
+from google.cloud.trace import __version__
 from google.cloud.trace_v2.gapic import trace_service_client
 from google.cloud.trace_v2.proto import trace_pb2
 from google.protobuf.json_format import ParseDict
 from google.rpc import status_pb2 as google_dot_rpc_dot_status__pb2
 from google.protobuf import wrappers_pb2 as \
     google_dot_protobuf_dot_wrappers__pb2
+
+
+_CLIENT_INFO = client_info.ClientInfo(
+    client_library_version=__version__)
 
 
 class _TraceAPI(object):
@@ -316,5 +322,6 @@ def make_trace_api(client):
         A :class:`~google.cloud.trace_v2._gapic._TraceAPI` instance with the
         proper configurations.
     """
-    generated = trace_service_client.TraceServiceClient()
+    generated = trace_service_client.TraceServiceClient(
+        credentials=client._credentials, client_info=_CLIENT_INFO)
     return _TraceAPI(generated, client)

--- a/trace/google/cloud/trace/v1/_gapic.py
+++ b/trace/google/cloud/trace/v1/_gapic.py
@@ -14,10 +14,16 @@
 
 """Wrapper for interacting with the Stackdriver Trace API."""
 
+from google.api_core.gapic_v1 import client_info
+from google.cloud.trace import __version__
 from google.cloud.trace_v1.gapic import trace_service_client
 from google.cloud.trace_v1.proto import trace_pb2
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.json_format import ParseDict
+
+
+_CLIENT_INFO = client_info.ClientInfo(
+    client_library_version=__version__)
 
 
 class _TraceAPI(object):
@@ -169,7 +175,8 @@ def make_trace_api(client):
         A :class:`~google.cloud.trace._gapic._TraceAPI` instance with the
         proper configurations.
     """
-    generated = trace_service_client.TraceServiceClient()
+    generated = trace_service_client.TraceServiceClient(
+        credentials=client._credentials, client_info=_CLIENT_INFO)
     return _TraceAPI(generated, client)
 
 


### PR DESCRIPTION
`make_trace_api` currently ignores the credentials configured in the `Client`