### PR TITLE
Add 'internalError' to retryable error reasons.

### DIFF
--- a/bigquery/google/cloud/bigquery/retry.py
+++ b/bigquery/google/cloud/bigquery/retry.py
@@ -16,6 +16,13 @@
 from google.api_core import retry
 
 
+_RETRYABLE_REASONS = frozenset([
+    'backendError',
+    'rateLimitExceeded',
+    'internalError',
+])
+
+
 def _should_retry(exc):
     """Predicate for determining when to retry.
 
@@ -27,7 +34,7 @@ def _should_retry(exc):
     if len(exc.errors) == 0:
         return False
     reason = exc.errors[0]['reason']
-    return reason == 'backendError' or reason == 'rateLimitExceeded'
+    return reason in _RETRYABLE_REASONS
 
 
 DEFAULT_RETRY = retry.Retry(predicate=_should_retry)

--- a/bigquery/tests/unit/test_retry.py
+++ b/bigquery/tests/unit/test_retry.py
@@ -46,3 +46,8 @@ class Test_should_retry(unittest.TestCase):
         exc = mock.Mock(
             errors=[{'reason': 'rateLimitExceeded'}], spec=['errors'])
         self.assertTrue(self._call_fut(exc))
+
+    def test_w_internalError(self):
+        exc = mock.Mock(
+            errors=[{'reason': 'internalError'}], spec=['errors'])
+        self.assertTrue(self._call_fut(exc))


### PR DESCRIPTION
Closes #5547.