### PR TITLE
Don't raise exception when fetching CREATE VIEW query results

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -31,6 +31,7 @@ from google.cloud.bigquery.query import StructQueryParameter
 from google.cloud.bigquery.query import UDFResource
 from google.cloud.bigquery.retry import DEFAULT_RETRY
 from google.cloud.bigquery.schema import SchemaField
+from google.cloud.bigquery.table import _EmptyRowIterator
 from google.cloud.bigquery.table import EncryptionConfiguration
 from google.cloud.bigquery.table import TableReference
 from google.cloud.bigquery.table import Table
@@ -2505,12 +2506,17 @@ class QueryJob(_AsyncJob):
             self._query_results = self._client._get_query_results(
                 self.job_id, retry, project=self.project,
                 location=self.location)
+
+        # If the query job is complete but there are no query results, this was
+        # special job, such as a DDL query. Return an empty result set to
+        # indicate success and avoid calling tabledata.list on a table which
+        # can't be read (such as a view table).
+        if self._query_results.total_rows is None:
+            return _EmptyRowIterator()
+
         schema = self._query_results.schema
         dest_table_ref = self.destination
         dest_table = Table(dest_table_ref, schema=schema)
-        # Set creation time to non-null to indicate this is actually the
-        # fetched schema to list_rows().
-        dest_table._properties['creationTime'] = '0'
         return self._client.list_rows(dest_table, retry=retry)
 
     def to_dataframe(self):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -3312,6 +3312,7 @@ class TestQueryJob(unittest.TestCase, _Base):
                 'projectId': self.PROJECT,
                 'jobId': self.JOB_ID,
             },
+            'totalRows': '4',
             'schema': {
                 'fields': [
                     {'name': 'name', 'type': 'STRING', 'mode': 'NULLABLE'},
@@ -3348,6 +3349,7 @@ class TestQueryJob(unittest.TestCase, _Base):
                 'projectId': self.PROJECT,
                 'jobId': self.JOB_ID,
             },
+            'totalRows': '0',
             'schema': {'fields': [{'name': 'col1', 'type': 'STRING'}]},
         }
         done_resource = copy.deepcopy(begun_resource)

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -1123,6 +1123,24 @@ class TestRow(unittest.TestCase):
             row['z']
 
 
+class Test_EmptyRowIterator(unittest.TestCase):
+
+    @mock.patch('google.cloud.bigquery.table.pandas', new=None)
+    def test_to_dataframe_error_if_pandas_is_none(self):
+        from google.cloud.bigquery.table import _EmptyRowIterator
+        row_iterator = _EmptyRowIterator()
+        with self.assertRaises(ValueError):
+            row_iterator.to_dataframe()
+
+    @unittest.skipIf(pandas is None, 'Requires `pandas`')
+    def test_to_dataframe(self):
+        from google.cloud.bigquery.table import _EmptyRowIterator
+        row_iterator = _EmptyRowIterator()
+        df = row_iterator.to_dataframe()
+        self.assertIsInstance(df, pandas.DataFrame)
+        self.assertEqual(len(df), 0)  # verify the number of rows
+
+
 class TestRowIterator(unittest.TestCase):
 
     def test_constructor(self):


### PR DESCRIPTION
CREATE VIEW DDL queries set a "destination table" field, but that table
is actually a view. If you attempt to list rows on the view table, it
results in an error.

The fix is to avoid listing rows altogether if `getQueryResults()` says
that a query has completed but the number of rows in the result set is
undefined.