### PR TITLE
Add system test: signed URLs w/ non-ASCII blob name.

### DIFF
--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -674,6 +674,20 @@ class TestStorageSignURLs(TestStorageFiles):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, self.LOCAL_FILE)
 
+    def test_create_signed_read_url_w_non_ascii_name(self):
+        blob = self.bucket.blob(u'Caf\xe9.txt')
+        payload = b'Test signed URL for blob w/ non-ASCII name'
+        blob.upload_from_string(payload)
+        self.case_blobs_to_delete.append(blob)
+
+        expiration = int(time.time() + 10)
+        signed_url = blob.generate_signed_url(expiration, method='GET',
+                                              client=Config.CLIENT)
+
+        response = requests.get(signed_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, payload)
+
     def test_create_signed_delete_url(self):
         blob = self.bucket.blob('LogoToSign.jpg')
         expiration = int(time.time() + 283473274)


### PR DESCRIPTION
See #5625.