### PR TITLE
Refactors snippets to only delete datasets + contents rather than tables

### DIFF
--- a/docs/bigquery/snippets.py
+++ b/docs/bigquery/snippets.py
@@ -76,8 +76,6 @@ def to_delete(client):
     for item in doomed:
         if isinstance(item, (bigquery.Dataset, bigquery.DatasetReference)):
             client.delete_dataset(item, delete_contents=True)
-        elif isinstance(item, (bigquery.Table, bigquery.TableReference)):
-            client.delete_table(item)
         else:
             item.delete()
 
@@ -486,8 +484,6 @@ def test_list_tables(client, to_delete):
     assert tables[0].table_id == 'my_table'
     # [END bigquery_list_tables]
 
-    to_delete.insert(0, table)
-
 
 def test_create_table(client, to_delete):
     """Create a table."""
@@ -513,8 +509,6 @@ def test_create_table(client, to_delete):
     assert table.table_id == 'my_table'
     # [END bigquery_create_table]
 
-    to_delete.insert(0, table)
-
 
 @pytest.mark.skip(reason=(
     'update_table() is flaky '
@@ -538,9 +532,6 @@ def test_create_table_then_add_schema(client, to_delete):
 
     assert table.table_id == 'my_table'
     # [END bigquery_create_table_without_schema]
-
-    to_delete.insert(0, table)
-
     # [START bigquery_add_schema_to_empty]
     # from google.cloud import bigquery
     # client = bigquery.Client()
@@ -748,7 +739,6 @@ def test_get_table_information(client, to_delete):
     table = bigquery.Table(dataset.table(table_id), schema=SCHEMA)
     table.description = ORIGINAL_DESCRIPTION
     table = client.create_table(table)
-    to_delete.insert(0, table)
 
     # [START bigquery_get_table]
     # from google.cloud import bigquery
@@ -805,7 +795,6 @@ def test_table_exists(client, to_delete):
     table_ref = dataset.table(TABLE_ID)
     table = bigquery.Table(table_ref, schema=SCHEMA)
     table = client.create_table(table)
-    to_delete.insert(0, table)
 
     assert table_exists(client, table_ref)
     assert not table_exists(client, dataset.table('i_dont_exist'))
@@ -823,7 +812,6 @@ def test_manage_table_labels(client, to_delete):
 
     table = bigquery.Table(dataset.table(table_id), schema=SCHEMA)
     table = client.create_table(table)
-    to_delete.insert(0, table)
 
     # [START bigquery_label_table]
     # from google.cloud import bigquery
@@ -892,7 +880,6 @@ def test_update_table_description(client, to_delete):
     table = bigquery.Table(dataset.table(table_id), schema=SCHEMA)
     table.description = 'Original description.'
     table = client.create_table(table)
-    to_delete.insert(0, table)
 
     # [START bigquery_update_table_description]
     # from google.cloud import bigquery
@@ -922,7 +909,6 @@ def test_update_table_expiration(client, to_delete):
 
     table = bigquery.Table(dataset.table(table_id), schema=SCHEMA)
     table = client.create_table(table)
-    to_delete.insert(0, table)
 
     # [START bigquery_update_table_expiration]
     import datetime
@@ -959,7 +945,6 @@ def test_add_empty_column(client, to_delete):
 
     table = bigquery.Table(dataset.table(table_id), schema=SCHEMA)
     table = client.create_table(table)
-    to_delete.insert(0, table)
 
     # [START bigquery_add_empty_column]
     # from google.cloud import bigquery
@@ -1019,8 +1004,6 @@ def test_relax_column(client, to_delete):
     assert all(field.mode == 'NULLABLE' for field in table.schema)
     # [END bigquery_relax_column]
 
-    to_delete.insert(0, table)
-
 
 @pytest.mark.skip(reason=(
     'update_table() is flaky '
@@ -1040,7 +1023,6 @@ def test_update_table_cmek(client, to_delete):
     table.encryption_configuration = bigquery.EncryptionConfiguration(
         kms_key_name=original_kms_key_name)
     table = client.create_table(table)
-    to_delete.insert(0, table)
 
     # [START bigquery_update_table_cmek]
     # from google.cloud import bigquery
@@ -1239,7 +1221,6 @@ def test_table_insert_rows(client, to_delete):
 
     table = bigquery.Table(dataset.table(table_id), schema=SCHEMA)
     table = client.create_table(table)
-    to_delete.insert(0, table)
 
     # [START bigquery_table_insert_rows]
     # from google.cloud import bigquery
@@ -1296,7 +1277,6 @@ def test_load_table_from_file(client, to_delete):
     # [END bigquery_load_from_file]
 
     table = client.get_table(table_ref)
-    to_delete.insert(0, table)
     rows = list(client.list_rows(table))  # API request
 
     assert len(rows) == 2
@@ -1951,8 +1931,6 @@ def test_copy_table(client, to_delete):
     assert dest_table.num_rows > 0
     # [END bigquery_copy_table]
 
-    to_delete.insert(0, dest_table)
-
 
 def test_copy_table_multiple_source(client, to_delete):
     dest_dataset_id = 'dest_dataset_{}'.format(_millis())
@@ -1975,8 +1953,6 @@ def test_copy_table_multiple_source(client, to_delete):
     table_data = {'table1': b'Washington,WA', 'table2': b'California,CA'}
     for table_id, data in table_data.items():
         table_ref = source_dataset.table(table_id)
-        table = bigquery.Table(table_ref, schema=schema)
-        to_delete.insert(0, table)
         job_config = bigquery.LoadJobConfig()
         job_config.schema = schema
         body = six.BytesIO(data)
@@ -2010,7 +1986,6 @@ def test_copy_table_multiple_source(client, to_delete):
     # [END bigquery_copy_table_multiple_source]
 
     assert dest_table.num_rows == 2
-    to_delete.insert(0, dest_table)
 
 
 def test_copy_table_cmek(client, to_delete):
@@ -2053,8 +2028,6 @@ def test_copy_table_cmek(client, to_delete):
     dest_table = client.get_table(dest_table_ref)
     assert dest_table.encryption_configuration.kms_key_name == kms_key_name
     # [END bigquery_copy_table_cmek]
-
-    to_delete.insert(0, dest_table)
 
 
 def test_extract_table(client, to_delete):
@@ -2301,7 +2274,6 @@ def test_client_query_destination_table(client, to_delete):
     dataset = bigquery.Dataset(dataset_ref)
     dataset.location = 'US'
     client.create_dataset(dataset)
-    to_delete.insert(0, dataset_ref.table('your_table_id'))
 
     # [START bigquery_query_destination_table]
     # from google.cloud import bigquery
@@ -2377,7 +2349,6 @@ def test_client_query_destination_table_cmek(client, to_delete):
     dataset = bigquery.Dataset(dataset_ref)
     dataset.location = 'US'
     client.create_dataset(dataset)
-    to_delete.insert(0, dataset_ref.table('your_table_id'))
 
     # [START bigquery_query_destination_table_cmek]
     # from google.cloud import bigquery


### PR DESCRIPTION
`to_delete()` had already been updated to delete the Dataset as well as its contents. Therefore, deleting individual tables is unnecessary. This PR removes individual table deletion in order to simplify code and leave a good example for future tests.