### PR TITLE
 Add 'Table.clustering_fields' property.

### DIFF
--- a/bigquery/google/cloud/bigquery/_helpers.py
+++ b/bigquery/google/cloud/bigquery/_helpers.py
@@ -417,6 +417,42 @@ def _set_sub_prop(container, keys, value):
     sub_val[keys[-1]] = value
 
 
+def _del_sub_prop(container, keys):
+    """Remove a nested key fro a dictionary.
+
+    Arguments:
+        container (dict):
+            A dictionary which may contain other dictionaries as values.
+        keys (iterable):
+            A sequence of keys to attempt to clear the value for. Each item in
+            the sequence represents a deeper nesting. The first key is for
+            the top level. If there is a dictionary there, the second key
+            attempts to get the value within that, and so on.
+
+    Examples:
+        Remove a top-level value (equivalent to ``del container['key']``).
+
+        >>> container = {'key': 'value'}
+        >>> _del_sub_prop(container, ['key'])
+        >>> container
+        {}
+
+        Remove a nested value.
+
+        >>> container = {'key': {'subkey': 'value'}}
+        >>> _del_sub_prop(container, ['key', 'subkey'])
+        >>> container
+        {'key': {}}
+    """
+    sub_val = container
+    for key in keys[:-1]:
+        if key not in sub_val:
+            sub_val[key] = {}
+        sub_val = sub_val[key]
+    if keys[-1] in sub_val:
+        del sub_val[keys[-1]]
+
+
 def _int_or_none(value):
     """Helper: deserialize int value from JSON string."""
     if isinstance(value, int):

--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -748,6 +748,27 @@ class _JobConfig(object):
         """
         _helpers._set_sub_prop(self._properties, [self._job_type, key], value)
 
+    def _del_sub_prop(self, key):
+        """Reove ``key`` from the ``self._properties[self._job_type]`` dict.
+
+        Most job properties are inside the dictionary related to the job type
+        (e.g. 'copy', 'extract', 'load', 'query'). Use this method to clear
+        those properties::
+
+            self._del_sub_prop('useLegacySql')
+
+        This is equivalent to using the ``_helper._del_sub_prop`` function::
+
+            _helper._del_sub_prop(
+                self._properties, ['query', 'useLegacySql'])
+
+        Arguments:
+            key (str):
+                 Key to remove in the ``self._properties[self._job_type]``
+                 dictionary.
+        """
+        _helpers._del_sub_prop(self._properties, [self._job_type, key])
+
     def to_api_repr(self):
         """Build an API representation of the job config.
 
@@ -1019,6 +1040,34 @@ class LoadJobConfig(_JobConfig):
         self._set_sub_prop('timePartitioning', api_repr)
 
     @property
+    def clustering_fields(self):
+        """Union[List[str], None]: Fields defining clustering for the table
+
+        (Defaults to :data:`None`).
+
+        Clustering fields are immutable after table creation.
+
+        .. note::
+
+           As of 2018-06-29, clustering fields cannot be set on a table
+           which does not also have time partioning defined.
+        """
+        prop = self._get_sub_prop('clustering')
+        if prop is not None:
+            return list(prop.get('fields', ()))
+
+    @clustering_fields.setter
+    def clustering_fields(self, value):
+        """Union[List[str], None]: Fields defining clustering for the table
+
+        (Defaults to :data:`None`).
+        """
+        if value is not None:
+            self._set_sub_prop('clustering', {'fields': value})
+        else:
+            self._del_sub_prop('clustering')
+
+    @property
     def schema_update_options(self):
         """List[google.cloud.bigquery.job.SchemaUpdateOption]: Specifies
         updates to the destination table schema to allow as a side effect of
@@ -1183,6 +1232,13 @@ class LoadJob(_AsyncJob):
         :attr:`google.cloud.bigquery.job.LoadJobConfig.time_partitioning`.
         """
         return self._configuration.time_partitioning
+
+    @property
+    def clustering_fields(self):
+        """See
+        :attr:`google.cloud.bigquery.job.LoadJobConfig.clustering_fields`.
+        """
+        return self._configuration.clustering_fields
 
     @property
     def schema_update_options(self):
@@ -2005,6 +2061,34 @@ class QueryJobConfig(_JobConfig):
         self._set_sub_prop('timePartitioning', api_repr)
 
     @property
+    def clustering_fields(self):
+        """Union[List[str], None]: Fields defining clustering for the table
+
+        (Defaults to :data:`None`).
+
+        Clustering fields are immutable after table creation.
+
+        .. note::
+
+           As of 2018-06-29, clustering fields cannot be set on a table
+           which does not also have time partioning defined.
+        """
+        prop = self._get_sub_prop('clustering')
+        if prop is not None:
+            return list(prop.get('fields', ()))
+
+    @clustering_fields.setter
+    def clustering_fields(self, value):
+        """Union[List[str], None]: Fields defining clustering for the table
+
+        (Defaults to :data:`None`).
+        """
+        if value is not None:
+            self._set_sub_prop('clustering', {'fields': value})
+        else:
+            self._del_sub_prop('clustering')
+
+    @property
     def schema_update_options(self):
         """List[google.cloud.bigquery.job.SchemaUpdateOption]: Specifies
         updates to the destination table schema to allow as a side effect of
@@ -2193,6 +2277,13 @@ class QueryJob(_AsyncJob):
         :attr:`google.cloud.bigquery.job.QueryJobConfig.time_partitioning`.
         """
         return self._configuration.time_partitioning
+
+    @property
+    def clustering_fields(self):
+        """See
+        :attr:`google.cloud.bigquery.job.QueryJobConfig.clustering_fields`.
+        """
+        return self._configuration.clustering_fields
 
     @property
     def schema_update_options(self):

--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -538,6 +538,36 @@ class Table(object):
         self._properties['timePartitioning']['expirationMs'] = str(value)
 
     @property
+    def clustering_fields(self):
+        """Union[List[str], None]: Fields defining clustering for the table
+
+        (Defaults to :data:`None`).
+
+        Clustering fields are immutable after table creation.
+
+        .. note::
+
+           As of 2018-06-29, clustering fields cannot be set on a table
+           which does not also have time partioning defined.
+        """
+        prop = self._properties.get('clustering')
+        if prop is not None:
+            return list(prop.get('fields', ()))
+
+    @clustering_fields.setter
+    def clustering_fields(self, value):
+        """Union[List[str], None]: Fields defining clustering for the table
+
+        (Defaults to :data:`None`).
+        """
+        if value is not None:
+            prop = self._properties.setdefault('clustering', {})
+            prop['fields'] = value
+        else:
+            if 'clustering' in self._properties:
+                del self._properties['clustering']
+
+    @property
     def description(self):
         """Union[str, None]: Description of the table (defaults to
         :data:`None`).

--- a/bigquery/tests/unit/test__helpers.py
+++ b/bigquery/tests/unit/test__helpers.py
@@ -860,6 +860,29 @@ class Test__set_sub_prop(unittest.TestCase):
         self.assertEqual(container, {'key1': {'key2': {'key3': 'after'}}})
 
 
+class Test__del_sub_prop(unittest.TestCase):
+
+    def _call_fut(self, container, keys):
+        from google.cloud.bigquery._helpers import _del_sub_prop
+
+        return _del_sub_prop(container, keys)
+
+    def test_w_single_key(self):
+        container = {'key1': 'value'}
+        self._call_fut(container, ['key1'])
+        self.assertEqual(container, {})
+
+    def test_w_empty_container_nested_keys(self):
+        container = {}
+        self._call_fut(container, ['key1', 'key2', 'key3'])
+        self.assertEqual(container, {'key1': {'key2': {}}})
+
+    def test_w_existing_value_nested_keys(self):
+        container = {'key1': {'key2': {'key3': 'value'}}}
+        self._call_fut(container, ['key1', 'key2', 'key3'])
+        self.assertEqual(container, {'key1': {'key2': {}}})
+
+
 class Test__int_or_none(unittest.TestCase):
 
     def _call_fut(self, value):

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -251,6 +251,15 @@ class TestLoadJobConfig(unittest.TestCase, _Base):
         config.time_partitioning = None
         self.assertIsNone(config.time_partitioning)
 
+    def test_clustering_fields(self):
+        fields = ['email', 'postal_code']
+        config = self._get_target_class()()
+        config.clustering_fields = fields
+        self.assertEqual(config.clustering_fields, fields)
+
+        config.clustering_fields = None
+        self.assertIsNone(config.clustering_fields)
+
     def test_api_repr(self):
         resource = self._make_resource()
         config = self._get_target_class().from_api_repr(resource)
@@ -455,6 +464,7 @@ class TestLoadJob(unittest.TestCase, _Base):
         self.assertIsNone(job.write_disposition)
         self.assertIsNone(job.destination_encryption_configuration)
         self.assertIsNone(job.time_partitioning)
+        self.assertIsNone(job.clustering_fields)
         self.assertIsNone(job.schema_update_options)
 
     def test_ctor_w_config(self):
@@ -1875,6 +1885,15 @@ class TestQueryJobConfig(unittest.TestCase, _Base):
         config.time_partitioning = None
         self.assertIsNone(config.time_partitioning)
 
+    def test_clustering_fields(self):
+        fields = ['email', 'postal_code']
+        config = self._get_target_class()()
+        config.clustering_fields = fields
+        self.assertEqual(config.clustering_fields, fields)
+
+        config.clustering_fields = None
+        self.assertIsNone(config.clustering_fields)
+
     def test_from_api_repr_empty(self):
         klass = self._get_target_class()
         config = klass.from_api_repr({})
@@ -2158,6 +2177,7 @@ class TestQueryJob(unittest.TestCase, _Base):
         self.assertIsNone(job.table_definitions)
         self.assertIsNone(job.destination_encryption_configuration)
         self.assertIsNone(job.time_partitioning)
+        self.assertIsNone(job.clustering_fields)
         self.assertIsNone(job.schema_update_options)
 
     def test_ctor_w_udf_resources(self):

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -398,6 +398,8 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertIsNone(table.external_data_configuration)
         self.assertEquals(table.labels, {})
         self.assertIsNone(table.encryption_configuration)
+        self.assertIsNone(table.time_partitioning)
+        self.assertIsNone(table.clustering_fields)
 
     def test_ctor_w_schema(self):
         from google.cloud.bigquery.table import SchemaField
@@ -863,6 +865,36 @@ class TestTable(unittest.TestCase, _SchemaBase):
             self.assertEqual(table.partitioning_type, 'DAY')
 
         assert warn_patch.called
+
+    def test_clustering_fields_setter_w_fields(self):
+        dataset = DatasetReference(self.PROJECT, self.DS_ID)
+        table_ref = dataset.table(self.TABLE_NAME)
+        table = self._make_one(table_ref)
+        fields = ['email', 'phone']
+
+        table.clustering_fields = fields
+        self.assertEqual(table.clustering_fields, fields)
+        self.assertEqual(table._properties['clustering'], {'fields': fields})
+
+    def test_clustering_fields_setter_w_none(self):
+        dataset = DatasetReference(self.PROJECT, self.DS_ID)
+        table_ref = dataset.table(self.TABLE_NAME)
+        table = self._make_one(table_ref)
+        fields = ['email', 'phone']
+
+        table._properties['clustering'] = {'fields': fields}
+        table.clustering_fields = None
+        self.assertEqual(table.clustering_fields, None)
+        self.assertFalse('clustering' in table._properties)
+
+    def test_clustering_fields_setter_w_none_noop(self):
+        dataset = DatasetReference(self.PROJECT, self.DS_ID)
+        table_ref = dataset.table(self.TABLE_NAME)
+        table = self._make_one(table_ref)
+
+        table.clustering_fields = None
+        self.assertEqual(table.clustering_fields, None)
+        self.assertFalse('clustering' in table._properties)
 
     def test_encryption_configuration_setter(self):
         from google.cloud.bigquery.table import EncryptionConfiguration


### PR DESCRIPTION
Add 'clustering_fields' support for load / query jobs. 

Include a system test creating a table w/ time partitioning and
clustering, including fetching the created table resource.

Previously reviewed in the private repository.  The feature is
scheduled to be in public beta 2018-07-19:  do not merge / release
until public beta is confirmed.