### PR TITLE
Firestore API: Fix return type name (unbalanced brackets) in pydoc.

### DIFF
--- a/firestore/google/cloud/firestore_v1beta1/document.py
+++ b/firestore/google/cloud/firestore_v1beta1/document.py
@@ -429,7 +429,7 @@ class DocumentReference(object):
             page_size (Optional[int]]): Iterator page size.
 
         Returns:
-            Sequence[~.firestore_v1beta1.collection.CollectionReference[:
+            Sequence[~.firestore_v1beta1.collection.CollectionReference]:
                 iterator of subcollections of the current document. If the
                 document does not exist at the time of `snapshot`, the
                 iterator will be empty


### PR DESCRIPTION
Currently the return type is specified as `Sequence[~.firestore_v1beta1.collection.CollectionReference[`. Changing to `Sequence[~.firestore_v1beta1.collection.CollectionReference]`. (Note the difference in the last symbol.)