### PR TITLE
Make 'Table.location' read-only.

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -591,19 +591,11 @@ class Table(object):
 
     @property
     def location(self):
-        """Union[str, None]: Location in which the table is hosted (defaults
-        to :data:`None`).
+        """Union[str, None]: Location in which the table is hosted
 
-        Raises:
-            ValueError: For invalid value types.
+        Defaults to :data:`None`.
         """
         return self._properties.get('location')
-
-    @location.setter
-    def location(self, value):
-        if not isinstance(value, six.string_types) and value is not None:
-            raise ValueError("Pass a string, or None")
-        self._properties['location'] = value
 
     @property
     def view_query(self):

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -1110,7 +1110,10 @@ class TestClient(unittest.TestCase):
                 'tableId': self.TABLE_ID
             },
             'schema': schema_resource,
-            'view': {'query': query, 'useLegacySql': True},
+            'view': {
+                'query': query,
+                'useLegacySql': True,
+            },
             'location': location,
             'expirationTime': _millis(exp_time)
         }
@@ -1118,31 +1121,34 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=self.PROJECT, credentials=creds)
         conn = client._connection = _make_connection(resource)
         table = Table(self.TABLE_REF, schema=schema)
-        table.location = location
         table.expires = exp_time
         table.view_query = query
         table.view_use_legacy_sql = True
-        updated_properties = ['schema', 'view_query', 'location',
-                              'expires', 'view_use_legacy_sql']
+        updated_properties = [
+            'schema', 'view_query', 'expires', 'view_use_legacy_sql']
 
         updated_table = client.update_table(table, updated_properties)
+
+        self.assertEqual(updated_table.schema, table.schema)
+        self.assertEqual(updated_table.view_query, table.view_query)
+        self.assertEqual(updated_table.expires, table.expires)
+        self.assertEqual(
+            updated_table.view_use_legacy_sql, table.view_use_legacy_sql)
+        self.assertEqual(updated_table.location, location)
 
         conn.api_request.assert_called_once_with(
             method='PATCH',
             path='/%s' % path,
             data={
-                'view': {'query': query, 'useLegacySql': True},
-                'location': location,
+                'view': {
+                    'query': query,
+                    'useLegacySql': True,
+                },
                 'expirationTime': str(_millis(exp_time)),
                 'schema': schema_resource,
             },
-            headers=None)
-        self.assertEqual(updated_table.schema, table.schema)
-        self.assertEqual(updated_table.view_query, table.view_query)
-        self.assertEqual(updated_table.location, table.location)
-        self.assertEqual(updated_table.expires, table.expires)
-        self.assertEqual(
-            updated_table.view_use_legacy_sql, table.view_use_legacy_sql)
+            headers=None,
+        )
 
     def test_update_table_w_schema_None(self):
         # Simulate deleting schema:  not sure if back-end will actually

--- a/bigquery/tests/unit/test_table.py
+++ b/bigquery/tests/unit/test_table.py
@@ -560,20 +560,6 @@ class TestTable(unittest.TestCase, _SchemaBase):
         table.friendly_name = 'FRIENDLY'
         self.assertEqual(table.friendly_name, 'FRIENDLY')
 
-    def test_location_setter_bad_value(self):
-        dataset = DatasetReference(self.PROJECT, self.DS_ID)
-        table_ref = dataset.table(self.TABLE_NAME)
-        table = self._make_one(table_ref)
-        with self.assertRaises(ValueError):
-            table.location = 12345
-
-    def test_location_setter(self):
-        dataset = DatasetReference(self.PROJECT, self.DS_ID)
-        table_ref = dataset.table(self.TABLE_NAME)
-        table = self._make_one(table_ref)
-        table.location = 'LOCATION'
-        self.assertEqual(table.location, 'LOCATION')
-
     def test_view_query_setter_bad_value(self):
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)


### PR DESCRIPTION
Documented as `[Output-only]` in the API reference.

Closes #5686.