### PR TITLE
Add 'Message.ack_id' property.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/subscriber/message.py
+++ b/pubsub/google/cloud/pubsub_v1/subscriber/message.py
@@ -164,6 +164,11 @@ class Message(object):
         """Return the size of the underlying message, in bytes."""
         return self._message.ByteSize()
 
+    @property
+    def ack_id(self):
+        """str: the ID used to ack the message."""
+        return self._ack_id
+
     def ack(self):
         """Acknowledge the given message.
 

--- a/pubsub/tests/unit/pubsub_v1/subscriber/test_message.py
+++ b/pubsub/tests/unit/pubsub_v1/subscriber/test_message.py
@@ -61,6 +61,17 @@ def test_data():
     assert msg.data == b'foo'
 
 
+def test_size():
+    msg = create_message(b'foo')
+    assert msg.size == 30  # payload + protobuf overhead
+
+
+def test_ack_id():
+    ack_id = 'MY-ACK-ID'
+    msg = create_message(b'foo', ack_id=ack_id)
+    assert msg.ack_id == ack_id
+
+
 def test_publish_time():
     msg = create_message(b'foo')
     assert msg.publish_time == PUBLISHED


### PR DESCRIPTION
Also, add explicit test for 'Message.size' property.

Closes #5691.