### PR TITLE
Update Spanner docs example

### DIFF
--- a/docs/spanner/snapshot-usage.rst
+++ b/docs/spanner/snapshot-usage.rst
@@ -24,7 +24,7 @@ reads as of a given timestamp:
 
     import datetime
     from pytz import UTC
-    TIMESTAMP = datetime.utcnow().replace(tzinfo=UTC)
+    TIMESTAMP = datetime.datetime.utcnow().replace(tzinfo=UTC)
     snapshot = database.snapshot(read_timestamp=TIMESTAMP)
 
 or as of a given duration in the past:


### PR DESCRIPTION
This should be datetime.datetime vs datetime, since the import has 'import datetime' vs 'from datetime import datetime'


(I think the `datetime.timedelta()` one is correct as-is, right)?