### PR TITLE
Fix typo in Client links

### DIFF
--- a/docs/spanner/usage.rst
+++ b/docs/spanner/usage.rst
@@ -74,10 +74,10 @@ Configuration
   Engine or Google Compute Engine the project will be detected automatically.
   (Setting this environment variable is not required, you may instead pass the
   ``project`` explicitly when constructing a
-  :class:`~google.cloud.storage.client.Client`).
+  :class:`~google.cloud.spanner.client.Client`).
 
 - After configuring your environment, create a
-  :class:`~google.cloud.storage.client.Client`
+  :class:`~google.cloud.spanner.client.Client`
 
   .. code::
 


### PR DESCRIPTION
References are to `google.cloud.storage.client.Client` instead of `google.cloud.spanner.client.Client`, which I believe is a typo.

In addition, the client self-links don't seem to work via https://googlecloudplatform.github.io, and seems like there are some differences in the side menu between
http://gcloud-python.readthedocs.io/en/latest/spanner/client-usage.html
and 
https://googlecloudplatform.github.io/google-cloud-python/latest/spanner/usage.html
?

Also, I don't see how to get to the main generated docs of the parameters for each method.