### PR TITLE
BIgtable: public API 'instance.labels' type to dictionary

### DIFF
--- a/bigtable/google/cloud/bigtable/cluster.py
+++ b/bigtable/google/cloud/bigtable/cluster.py
@@ -117,12 +117,9 @@ class Cluster(object):
             raise ValueError('Project ID on cluster does not match the '
                              'project ID on the client')
         cluster_id = match_cluster_name.group('cluster_id')
-        location_id = cluster_pb.location.split('/')[-1]
 
-        result = cls(cluster_id, instance, location_id=location_id,
-                     serve_nodes=cluster_pb.serve_nodes,
-                     default_storage_type=cluster_pb.default_storage_type,
-                     _state=cluster_pb.state)
+        result = cls(cluster_id, instance)
+        result._update_from_pb(cluster_pb)
         return result
 
     def _update_from_pb(self, cluster_pb):

--- a/bigtable/google/cloud/bigtable/instance.py
+++ b/bigtable/google/cloud/bigtable/instance.py
@@ -119,9 +119,8 @@ class Instance(object):
             raise ValueError('Project ID on instance does not match the '
                              'project ID on the client')
         instance_id = match.group('instance_id')
-
-        result = cls(instance_id, client, instance_pb.display_name,
-                     instance_pb.type, instance_pb.labels)
+        result = cls(instance_id, client)
+        result._update_from_pb(instance_pb)
         return result
 
     def _update_from_pb(self, instance_pb):
@@ -132,7 +131,7 @@ class Instance(object):
             raise ValueError('Instance protobuf does not contain display_name')
         self.display_name = instance_pb.display_name
         self.type_ = instance_pb.type
-        self.labels = instance_pb.labels
+        self.labels = dict(instance_pb.labels)
 
     @property
     def name(self):

--- a/bigtable/tests/system.py
+++ b/bigtable/tests/system.py
@@ -197,8 +197,7 @@ class TestInstanceAdminAPI(unittest.TestCase):
         self.assertEqual(instance, instance_alt)
         self.assertEqual(instance.display_name, instance_alt.display_name)
         self.assertEqual(instance.type_, instance_alt.type_)
-        self.assertIsInstance(instance_alt.labels, dict)
-        self.assertEqual(instance.labels, instance_alt.labels)
+        self.assertEqual(instance_alt.labels, LABELS)
 
     def test_cluster_exists(self):
         NONEXISTING_CLUSTER_ID = 'cluster-id'

--- a/bigtable/tests/system.py
+++ b/bigtable/tests/system.py
@@ -197,6 +197,7 @@ class TestInstanceAdminAPI(unittest.TestCase):
         self.assertEqual(instance, instance_alt)
         self.assertEqual(instance.display_name, instance_alt.display_name)
         self.assertEqual(instance.type_, instance_alt.type_)
+        self.assertIsInstance(instance_alt.labels, dict)
         self.assertEqual(instance.labels, instance_alt.labels)
 
     def test_cluster_exists(self):


### PR DESCRIPTION
Converting `instance.labels` public API to dictionary from protobuf `ScalarMapContainer`
Reroute to use `_update_from_pb` to set properties of instance and cluster in `list_instances` and `list_clusters`  methods.