### PR TITLE
Spanner: add support for session / pool labels

### DIFF
--- a/spanner/google/cloud/spanner_v1/database.py
+++ b/spanner/google/cloud/spanner_v1/database.py
@@ -272,13 +272,16 @@ class Database(object):
         metadata = _metadata_with_prefix(self.name)
         api.drop_database(self.name, metadata=metadata)
 
-    def session(self):
+    def session(self, labels=None):
         """Factory to create a session for this database.
+
+        :type labels: dict (str -> str) or None
+        :param labels: (Optional) user-assigned labels for the session.
 
         :rtype: :class:`~google.cloud.spanner_v1.session.Session`
         :returns: a session bound to this database.
         """
-        return Session(self)
+        return Session(self, labels=labels)
 
     def snapshot(self, **kw):
         """Return an object which wraps a snapshot.

--- a/spanner/google/cloud/spanner_v1/pool.py
+++ b/spanner/google/cloud/spanner_v1/pool.py
@@ -104,6 +104,8 @@ class AbstractSessionPool(object):
         :rtype: :class:`~google.cloud.spanner_v1.session.Session`
         :returns: new session instance.
         """
+        if self.labels:
+            return self._database.session(labels=self.labels)
         return self._database.session()
 
     def session(self, **kwargs):

--- a/spanner/google/cloud/spanner_v1/session.py
+++ b/spanner/google/cloud/spanner_v1/session.py
@@ -108,7 +108,14 @@ class Session(object):
             raise ValueError('Session ID already set by back-end')
         api = self._database.spanner_api
         metadata = _metadata_with_prefix(self._database.name)
-        session_pb = api.create_session(self._database.name, metadata=metadata)
+        kw = {}
+        if self._labels:
+            kw = {'session': {'labels': self._labels}}
+        session_pb = api.create_session(
+            self._database.name,
+            metadata=metadata,
+            **kw,
+        )
         self._session_id = session_pb.name.split('/')[-1]
 
     def exists(self):

--- a/spanner/google/cloud/spanner_v1/session.py
+++ b/spanner/google/cloud/spanner_v1/session.py
@@ -44,13 +44,19 @@ class Session(object):
 
     :type database: :class:`~google.cloud.spanner_v1.database.Database`
     :param database: The database to which the session is bound.
+
+    :type labels: dict (str -> str)
+    :param labels: (Optional) User-assigned labels for the session.
     """
 
     _session_id = None
     _transaction = None
 
-    def __init__(self, database):
+    def __init__(self, database, labels=None):
         self._database = database
+        if labels is None:
+            labels = {}
+        self._labels = labels
 
     def __lt__(self, other):
         return self._session_id < other._session_id
@@ -59,6 +65,15 @@ class Session(object):
     def session_id(self):
         """Read-only ID, set by the back-end during :meth:`create`."""
         return self._session_id
+
+    @property
+    def labels(self):
+        """User-assigned labels for the session.
+
+        :rtype: dict (str -> str)
+        :returns: the labels dict (empty if no labels were assigned.
+        """
+        return self._labels
 
     @property
     def name(self):

--- a/spanner/google/cloud/spanner_v1/session.py
+++ b/spanner/google/cloud/spanner_v1/session.py
@@ -114,7 +114,7 @@ class Session(object):
         session_pb = api.create_session(
             self._database.name,
             metadata=metadata,
-            **kw,
+            **kw
         )
         self._session_id = session_pb.name.split('/')[-1]
 

--- a/spanner/tests/system/test_system.py
+++ b/spanner/tests/system/test_system.py
@@ -239,7 +239,7 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
 
     @classmethod
     def setUpClass(cls):
-        pool = BurstyPool()
+        pool = BurstyPool(labels={'testcase': 'database_api'})
         cls._db = Config.INSTANCE.database(
             cls.DATABASE_NAME, ddl_statements=DDL_STATEMENTS, pool=pool)
         operation = cls._db.create()
@@ -264,7 +264,7 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
         self.assertTrue(self._db.name in database_names)
 
     def test_create_database(self):
-        pool = BurstyPool()
+        pool = BurstyPool(labels={'testcase': 'create_database'})
         temp_db_id = 'temp_db' + unique_resource_id('_')
         temp_db = Config.INSTANCE.database(temp_db_id, pool=pool)
         operation = temp_db.create()
@@ -311,7 +311,7 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
         'https://github.com/GoogleCloudPlatform/google-cloud-python/issues/'
         '5629'))
     def test_update_database_ddl(self):
-        pool = BurstyPool()
+        pool = BurstyPool(labels={'testcase': 'update_database_ddl'})
         temp_db_id = 'temp_db' + unique_resource_id('_')
         temp_db = Config.INSTANCE.database(temp_db_id, pool=pool)
         create_op = temp_db.create()
@@ -434,7 +434,7 @@ class TestSessionAPI(unittest.TestCase, _TestData):
 
     @classmethod
     def setUpClass(cls):
-        pool = BurstyPool()
+        pool = BurstyPool(labels={'testcase': 'session_api'})
         cls._db = Config.INSTANCE.database(
             cls.DATABASE_NAME, ddl_statements=DDL_STATEMENTS, pool=pool)
         operation = cls._db.create()
@@ -901,7 +901,7 @@ class TestSessionAPI(unittest.TestCase, _TestData):
         EXTRA_DDL = [
             'CREATE INDEX contacts_by_last_name ON contacts(last_name)',
         ]
-        pool = BurstyPool()
+        pool = BurstyPool(labels={'testcase': 'read_w_index'})
         temp_db = Config.INSTANCE.database(
             'test_read' + unique_resource_id('_'),
             ddl_statements=DDL_STATEMENTS + EXTRA_DDL,

--- a/spanner/tests/unit/test_database.py
+++ b/spanner/tests/unit/test_database.py
@@ -596,7 +596,7 @@ class TestDatabase(_BaseTest):
         self.assertEqual(
             metadata, [('google-cloud-resource-prefix', database.name)])
 
-    def test_session_factory(self):
+    def test_session_factory_defaults(self):
         from google.cloud.spanner_v1.session import Session
 
         client = _Client()
@@ -609,6 +609,23 @@ class TestDatabase(_BaseTest):
         self.assertTrue(isinstance(session, Session))
         self.assertIs(session.session_id, None)
         self.assertIs(session._database, database)
+        self.assertEqual(session.labels, {})
+
+    def test_session_factory_w_labels(self):
+        from google.cloud.spanner_v1.session import Session
+
+        client = _Client()
+        instance = _Instance(self.INSTANCE_NAME, client=client)
+        pool = _Pool()
+        labels = {'foo': 'bar'}
+        database = self._make_one(self.DATABASE_ID, instance, pool=pool)
+
+        session = database.session(labels=labels)
+
+        self.assertTrue(isinstance(session, Session))
+        self.assertIs(session.session_id, None)
+        self.assertIs(session._database, database)
+        self.assertEqual(session.labels, labels)
 
     def test_snapshot_defaults(self):
         from google.cloud.spanner_v1.database import SnapshotCheckout

--- a/spanner/tests/unit/test_pool.py
+++ b/spanner/tests/unit/test_pool.py
@@ -30,6 +30,13 @@ class TestAbstractSessionPool(unittest.TestCase):
     def test_ctor_defaults(self):
         pool = self._make_one()
         self.assertIsNone(pool._database)
+        self.assertEqual(pool.labels, {})
+
+    def test_ctor_explicit(self):
+        labels = {'foo': 'bar'}
+        pool = self._make_one(labels=labels)
+        self.assertIsNone(pool._database)
+        self.assertEqual(pool.labels, labels)
 
     def test_bind_abstract(self):
         pool = self._make_one()
@@ -98,13 +105,16 @@ class TestFixedSizePool(unittest.TestCase):
         self.assertEqual(pool.size, 10)
         self.assertEqual(pool.default_timeout, 10)
         self.assertTrue(pool._sessions.empty())
+        self.assertEqual(pool.labels, {})
 
     def test_ctor_explicit(self):
-        pool = self._make_one(size=4, default_timeout=30)
+        labels = {'foo': 'bar'}
+        pool = self._make_one(size=4, default_timeout=30, labels=labels)
         self.assertIsNone(pool._database)
         self.assertEqual(pool.size, 4)
         self.assertEqual(pool.default_timeout, 30)
         self.assertTrue(pool._sessions.empty())
+        self.assertEqual(pool.labels, labels)
 
     def test_bind(self):
         pool = self._make_one()
@@ -230,12 +240,15 @@ class TestBurstyPool(unittest.TestCase):
         self.assertIsNone(pool._database)
         self.assertEqual(pool.target_size, 10)
         self.assertTrue(pool._sessions.empty())
+        self.assertEqual(pool.labels, {})
 
     def test_ctor_explicit(self):
-        pool = self._make_one(target_size=4)
+        labels = {'foo': 'bar'}
+        pool = self._make_one(target_size=4, labels=labels)
         self.assertIsNone(pool._database)
         self.assertEqual(pool.target_size, 4)
         self.assertTrue(pool._sessions.empty())
+        self.assertEqual(pool.labels, labels)
 
     def test_get_empty(self):
         pool = self._make_one()
@@ -348,14 +361,18 @@ class TestPingingPool(unittest.TestCase):
         self.assertEqual(pool.default_timeout, 10)
         self.assertEqual(pool._delta.seconds, 3000)
         self.assertTrue(pool._sessions.empty())
+        self.assertEqual(pool.labels, {})
 
     def test_ctor_explicit(self):
-        pool = self._make_one(size=4, default_timeout=30, ping_interval=1800)
+        labels = {'foo': 'bar'}
+        pool = self._make_one(
+            size=4, default_timeout=30, ping_interval=1800, labels=labels)
         self.assertIsNone(pool._database)
         self.assertEqual(pool.size, 4)
         self.assertEqual(pool.default_timeout, 30)
         self.assertEqual(pool._delta.seconds, 1800)
         self.assertTrue(pool._sessions.empty())
+        self.assertEqual(pool.labels, labels)
 
     def test_bind(self):
         pool = self._make_one()
@@ -575,15 +592,19 @@ class TestTransactionPingingPool(unittest.TestCase):
         self.assertEqual(pool._delta.seconds, 3000)
         self.assertTrue(pool._sessions.empty())
         self.assertTrue(pool._pending_sessions.empty())
+        self.assertEqual(pool.labels, {})
 
     def test_ctor_explicit(self):
-        pool = self._make_one(size=4, default_timeout=30, ping_interval=1800)
+        labels = {'foo': 'bar'}
+        pool = self._make_one(
+            size=4, default_timeout=30, ping_interval=1800, labels=labels)
         self.assertIsNone(pool._database)
         self.assertEqual(pool.size, 4)
         self.assertEqual(pool.default_timeout, 30)
         self.assertEqual(pool._delta.seconds, 1800)
         self.assertTrue(pool._sessions.empty())
         self.assertTrue(pool._pending_sessions.empty())
+        self.assertEqual(pool.labels, labels)
 
     def test_bind(self):
         pool = self._make_one()

--- a/spanner/tests/unit/test_pool.py
+++ b/spanner/tests/unit/test_pool.py
@@ -53,6 +53,14 @@ class TestAbstractSessionPool(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             pool.clear()
 
+    def test__new_session(self):
+        pool = self._make_one()
+        database = pool._database = _Database('name')
+        sessions = [_Session(database)]
+        database._sessions.extend(sessions)
+        session = pool._new_session()
+        self.assertIsInstance(session, _Session)
+
     def test_session_wo_kwargs(self):
         from google.cloud.spanner_v1.pool import SessionCheckout
 

--- a/spanner/tests/unit/test_session.py
+++ b/spanner/tests/unit/test_session.py
@@ -44,7 +44,16 @@ class TestSession(unittest.TestCase):
     def _make_one(self, *args, **kwargs):
         return self._getTargetClass()(*args, **kwargs)
 
-    def _make_session_pb(self, name, labels=None):
+    @staticmethod
+    def _make_database(name=DATABASE_NAME):
+        from google.cloud.spanner_v1.database import Database
+
+        database = mock.create_autospec(Database, instance=True)
+        database.name = name
+        return database
+
+    @staticmethod
+    def _make_session_pb(name, labels=None):
         from google.cloud.spanner_v1.proto.spanner_pb2 import Session
 
         return Session(name=name, labels=labels)
@@ -55,14 +64,14 @@ class TestSession(unittest.TestCase):
         return mock.Mock(autospec=SpannerClient, instance=True)
 
     def test_constructor_wo_labels(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         self.assertIs(session.session_id, None)
         self.assertIs(session._database, database)
         self.assertEqual(session.labels, {})
 
     def test_constructor_w_labels(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         labels = {'foo': 'bar'}
         session = self._make_one(database, labels=labels)
         self.assertIs(session.session_id, None)
@@ -70,7 +79,7 @@ class TestSession(unittest.TestCase):
         self.assertEqual(session.labels, labels)
 
     def test___lt___(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         lhs = self._make_one(database)
         lhs._session_id = b'123'
         rhs = self._make_one(database)
@@ -78,20 +87,20 @@ class TestSession(unittest.TestCase):
         self.assertTrue(lhs < rhs)
 
     def test_name_property_wo_session_id(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
 
         with self.assertRaises(ValueError):
             (session.name)
 
     def test_name_property_w_session_id(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         session._session_id = self.SESSION_ID
         self.assertEqual(session.name, self.SESSION_NAME)
 
     def test_create_w_session_id(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         session._session_id = self.SESSION_ID
 
@@ -102,7 +111,7 @@ class TestSession(unittest.TestCase):
         session_pb = self._make_session_pb(self.SESSION_NAME)
         gax_api = self._make_spanner_api()
         gax_api.create_session.return_value = session_pb
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
 
@@ -111,7 +120,7 @@ class TestSession(unittest.TestCase):
         self.assertEqual(session.session_id, self.SESSION_ID)
 
         gax_api.create_session.assert_called_once_with(
-            self.DATABASE_NAME,
+            database.name,
             metadata=[('google-cloud-resource-prefix', database.name)],
         )
 
@@ -120,7 +129,7 @@ class TestSession(unittest.TestCase):
         session_pb = self._make_session_pb(self.SESSION_NAME, labels=labels)
         gax_api = self._make_spanner_api()
         gax_api.create_session.return_value = session_pb
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database, labels=labels)
 
@@ -129,7 +138,7 @@ class TestSession(unittest.TestCase):
         self.assertEqual(session.session_id, self.SESSION_ID)
 
         gax_api.create_session.assert_called_once_with(
-            self.DATABASE_NAME,
+            database.name,
             session={'labels': labels},
             metadata=[('google-cloud-resource-prefix', database.name)],
         )
@@ -139,7 +148,7 @@ class TestSession(unittest.TestCase):
 
         gax_api = self._make_spanner_api()
         gax_api.create_session.side_effect = Unknown('error')
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
 
@@ -147,7 +156,7 @@ class TestSession(unittest.TestCase):
             session.create()
 
     def test_exists_wo_session_id(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         self.assertFalse(session.exists())
 
@@ -155,7 +164,7 @@ class TestSession(unittest.TestCase):
         session_pb = self._make_session_pb(self.SESSION_NAME)
         gax_api = self._make_spanner_api()
         gax_api.get_session.return_value = session_pb
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
         session._session_id = self.SESSION_ID
@@ -172,7 +181,7 @@ class TestSession(unittest.TestCase):
 
         gax_api = self._make_spanner_api()
         gax_api.get_session.side_effect = NotFound('testing')
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
         session._session_id = self.SESSION_ID
@@ -189,7 +198,7 @@ class TestSession(unittest.TestCase):
 
         gax_api = self._make_spanner_api()
         gax_api.get_session.side_effect = Unknown('testing')
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
         session._session_id = self.SESSION_ID
@@ -203,7 +212,7 @@ class TestSession(unittest.TestCase):
         )
 
     def test_delete_wo_session_id(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
 
         with self.assertRaises(ValueError):
@@ -212,7 +221,7 @@ class TestSession(unittest.TestCase):
     def test_delete_hit(self):
         gax_api = self._make_spanner_api()
         gax_api.delete_session.return_value = None
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
         session._session_id = self.SESSION_ID
@@ -229,7 +238,7 @@ class TestSession(unittest.TestCase):
 
         gax_api = self._make_spanner_api()
         gax_api.delete_session.side_effect = NotFound('testing')
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
         session._session_id = self.SESSION_ID
@@ -247,7 +256,7 @@ class TestSession(unittest.TestCase):
 
         gax_api = self._make_spanner_api()
         gax_api.delete_session.side_effect = Unknown('testing')
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
         session._session_id = self.SESSION_ID
@@ -261,7 +270,7 @@ class TestSession(unittest.TestCase):
         )
 
     def test_snapshot_not_created(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
 
         with self.assertRaises(ValueError):
@@ -270,7 +279,7 @@ class TestSession(unittest.TestCase):
     def test_snapshot_created(self):
         from google.cloud.spanner_v1.snapshot import Snapshot
 
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         session._session_id = 'DEADBEEF'  # emulate 'session.create()'
 
@@ -284,7 +293,7 @@ class TestSession(unittest.TestCase):
     def test_snapshot_created_w_multi_use(self):
         from google.cloud.spanner_v1.snapshot import Snapshot
 
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         session._session_id = 'DEADBEEF'  # emulate 'session.create()'
 
@@ -302,15 +311,13 @@ class TestSession(unittest.TestCase):
         COLUMNS = ['email', 'first_name', 'last_name', 'age']
         KEYS = ['bharney@example.com', 'phred@example.com']
         KEYSET = KeySet(keys=KEYS)
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
 
         with self.assertRaises(ValueError):
             session.read(TABLE_NAME, COLUMNS, KEYSET)
 
     def test_read(self):
-        from google.cloud.spanner_v1 import session as MUT
-        from google.cloud._testing import _Monkey
         from google.cloud.spanner_v1.keyset import KeySet
 
         TABLE_NAME = 'citizens'
@@ -319,87 +326,81 @@ class TestSession(unittest.TestCase):
         KEYSET = KeySet(keys=KEYS)
         INDEX = 'email-address-index'
         LIMIT = 20
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         session._session_id = 'DEADBEEF'
 
-        _read_with = []
-        expected = object()
-
-        class _Snapshot(object):
-
-            def __init__(self, session, **kwargs):
-                self._session = session
-                self._kwargs = kwargs.copy()
-
-            def read(self, table, columns, keyset, index='', limit=0):
-                _read_with.append(
-                    (table, columns, keyset, index, limit))
-                return expected
-
-        with _Monkey(MUT, Snapshot=_Snapshot):
+        with mock.patch(
+                'google.cloud.spanner_v1.session.Snapshot') as snapshot:
             found = session.read(
                 TABLE_NAME, COLUMNS, KEYSET,
                 index=INDEX, limit=LIMIT)
 
-        self.assertIs(found, expected)
+        self.assertIs(found, snapshot().read.return_value)
 
-        self.assertEqual(len(_read_with), 1)
-        (table, columns, key_set, index, limit) = _read_with[0]
-
-        self.assertEqual(table, TABLE_NAME)
-        self.assertEqual(columns, COLUMNS)
-        self.assertEqual(key_set, KEYSET)
-        self.assertEqual(index, INDEX)
-        self.assertEqual(limit, LIMIT)
+        snapshot().read.assert_called_once_with(
+            TABLE_NAME,
+            COLUMNS,
+            KEYSET,
+            INDEX,
+            LIMIT,
+        )
 
     def test_execute_sql_not_created(self):
         SQL = 'SELECT first_name, age FROM citizens'
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
 
         with self.assertRaises(ValueError):
             session.execute_sql(SQL)
 
     def test_execute_sql_defaults(self):
-        from google.cloud.spanner_v1 import session as MUT
-        from google.cloud._testing import _Monkey
-
         SQL = 'SELECT first_name, age FROM citizens'
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         session._session_id = 'DEADBEEF'
 
-        _executed_sql_with = []
-        expected = object()
-
-        class _Snapshot(object):
-
-            def __init__(self, session, **kwargs):
-                self._session = session
-                self._kwargs = kwargs.copy()
-
-            def execute_sql(
-                    self, sql, params=None, param_types=None, query_mode=None):
-                _executed_sql_with.append(
-                    (sql, params, param_types, query_mode))
-                return expected
-
-        with _Monkey(MUT, Snapshot=_Snapshot):
+        with mock.patch(
+                'google.cloud.spanner_v1.session.Snapshot') as snapshot:
             found = session.execute_sql(SQL)
 
-        self.assertIs(found, expected)
+        self.assertIs(found, snapshot().execute_sql.return_value)
 
-        self.assertEqual(len(_executed_sql_with), 1)
-        sql, params, param_types, query_mode = _executed_sql_with[0]
+        snapshot().execute_sql.assert_called_once_with(
+            SQL,
+            None,
+            None,
+            None,
+        )
 
-        self.assertEqual(sql, SQL)
-        self.assertEqual(params, None)
-        self.assertEqual(param_types, None)
-        self.assertEqual(query_mode, None)
+    def test_execute_sql_explicit(self):
+        from google.protobuf.struct_pb2 import Struct, Value
+        from google.cloud.spanner_v1.proto.type_pb2 import STRING
+
+        SQL = 'SELECT first_name, age FROM citizens'
+        database = self._make_database()
+        session = self._make_one(database)
+        session._session_id = 'DEADBEEF'
+
+        params = Struct(fields={'foo': Value(string_value='bar')})
+        param_types = {'foo': STRING}
+
+        with mock.patch(
+                'google.cloud.spanner_v1.session.Snapshot') as snapshot:
+            found = session.execute_sql(
+                SQL, params, param_types, 'PLAN')
+
+        self.assertIs(found, snapshot().execute_sql.return_value)
+
+        snapshot().execute_sql.assert_called_once_with(
+            SQL,
+            params,
+            param_types,
+            'PLAN',
+        )
 
     def test_batch_not_created(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
 
         with self.assertRaises(ValueError):
@@ -408,7 +409,7 @@ class TestSession(unittest.TestCase):
     def test_batch_created(self):
         from google.cloud.spanner_v1.batch import Batch
 
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         session._session_id = 'DEADBEEF'
 
@@ -418,7 +419,7 @@ class TestSession(unittest.TestCase):
         self.assertIs(batch._session, session)
 
     def test_transaction_not_created(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
 
         with self.assertRaises(ValueError):
@@ -427,7 +428,7 @@ class TestSession(unittest.TestCase):
     def test_transaction_created(self):
         from google.cloud.spanner_v1.transaction import Transaction
 
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         session._session_id = 'DEADBEEF'
 
@@ -438,7 +439,7 @@ class TestSession(unittest.TestCase):
         self.assertIs(session._transaction, transaction)
 
     def test_transaction_w_existing_txn(self):
-        database = _Database(self.DATABASE_NAME)
+        database = self._make_database()
         session = self._make_one(database)
         session._session_id = 'DEADBEEF'
 
@@ -450,7 +451,7 @@ class TestSession(unittest.TestCase):
 
     def test_run_in_transaction_callback_raises_non_gax_error(self):
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
-            Transaction as TransactionPB)
+            Transaction as TransactionPB, TransactionOptions)
         from google.cloud.spanner_v1.transaction import Transaction
 
         TABLE_NAME = 'citizens'
@@ -461,14 +462,13 @@ class TestSession(unittest.TestCase):
         ]
         TRANSACTION_ID = b'FACEDACE'
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
-        gax_api = _SpannerApi(
-            _begin_transaction_response=transaction_pb,
-            _rollback_response=None,
-        )
-        database = _Database(self.DATABASE_NAME)
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.rollback.return_value = None
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
-        session._session_id = 'DEADBEEF'
+        session._session_id = self.SESSION_ID
 
         called_with = []
 
@@ -492,10 +492,24 @@ class TestSession(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertEqual(kw, {})
 
+        expected_options = TransactionOptions(
+            read_write=TransactionOptions.ReadWrite(),
+        )
+        gax_api.begin_transaction.assert_called_once_with(
+            self.SESSION_NAME,
+            expected_options,
+            metadata=[('google-cloud-resource-prefix', database.name)],
+        )
+        gax_api.rollback.assert_called_once_with(
+            self.SESSION_NAME,
+            TRANSACTION_ID,
+            metadata=[('google-cloud-resource-prefix', database.name)],
+        )
+
     def test_run_in_transaction_callback_raises_non_abort_rpc_error(self):
         from google.api_core.exceptions import Cancelled
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
-            Transaction as TransactionPB)
+            Transaction as TransactionPB, TransactionOptions)
         from google.cloud.spanner_v1.transaction import Transaction
 
         TABLE_NAME = 'citizens'
@@ -506,14 +520,13 @@ class TestSession(unittest.TestCase):
         ]
         TRANSACTION_ID = b'FACEDACE'
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
-        gax_api = _SpannerApi(
-            _begin_transaction_response=transaction_pb,
-            _rollback_response=None,
-        )
-        database = _Database(self.DATABASE_NAME)
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.rollback.return_value = None
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
-        session._session_id = 'DEADBEEF'
+        session._session_id = self.SESSION_ID
 
         called_with = []
 
@@ -534,11 +547,21 @@ class TestSession(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertEqual(kw, {})
 
+        expected_options = TransactionOptions(
+            read_write=TransactionOptions.ReadWrite(),
+        )
+        gax_api.begin_transaction.assert_called_once_with(
+            self.SESSION_NAME,
+            expected_options,
+            metadata=[('google-cloud-resource-prefix', database.name)],
+        )
+        gax_api.rollback.assert_not_called()
+
     def test_run_in_transaction_w_args_w_kwargs_wo_abort(self):
         import datetime
         from google.cloud.spanner_v1.proto.spanner_pb2 import CommitResponse
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
-            Transaction as TransactionPB)
+            Transaction as TransactionPB, TransactionOptions)
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.transaction import Transaction
@@ -554,14 +577,13 @@ class TestSession(unittest.TestCase):
         now = datetime.datetime.utcnow().replace(tzinfo=UTC)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
-        gax_api = _SpannerApi(
-            _begin_transaction_response=transaction_pb,
-            _commit_response=response,
-        )
-        database = _Database(self.DATABASE_NAME)
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.commit.return_value = response
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
-        session._session_id = 'DEADBEEF'
+        session._session_id = self.SESSION_ID
 
         called_with = []
 
@@ -581,6 +603,21 @@ class TestSession(unittest.TestCase):
         self.assertEqual(args, ('abc',))
         self.assertEqual(kw, {'some_arg': 'def'})
 
+        expected_options = TransactionOptions(
+            read_write=TransactionOptions.ReadWrite(),
+        )
+        gax_api.begin_transaction.assert_called_once_with(
+            self.SESSION_NAME,
+            expected_options,
+            metadata=[('google-cloud-resource-prefix', database.name)],
+        )
+        gax_api.commit.assert_called_once_with(
+            self.SESSION_NAME,
+            txn._mutations,
+            transaction_id=TRANSACTION_ID,
+            metadata=[('google-cloud-resource-prefix', database.name)],
+        )
+
     def test_run_in_transaction_w_commit_error(self):
         from google.api_core.exceptions import Unknown
         from google.cloud.spanner_v1.transaction import Transaction
@@ -591,14 +628,15 @@ class TestSession(unittest.TestCase):
             ['phred@exammple.com', 'Phred', 'Phlyntstone', 32],
             ['bharney@example.com', 'Bharney', 'Rhubble', 31],
         ]
-        gax_api = _SpannerApi(
-            _commit_error=True)
-        database = _Database(self.DATABASE_NAME)
+        TRANSACTION_ID = b'FACEDACE'
+        gax_api = self._make_spanner_api()
+        gax_api.commit.side_effect = Unknown('error')
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
-        session._session_id = 'DEADBEEF'
+        session._session_id = self.SESSION_ID
         begun_txn = session._transaction = Transaction(session)
-        begun_txn._transaction_id = b'FACEDACE'
+        begun_txn._transaction_id = TRANSACTION_ID
 
         assert session._transaction._transaction_id
 
@@ -619,11 +657,20 @@ class TestSession(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertEqual(kw, {})
 
+        gax_api.begin_transaction.assert_not_called()
+        gax_api.commit.assert_called_once_with(
+            self.SESSION_NAME,
+            txn._mutations,
+            transaction_id=TRANSACTION_ID,
+            metadata=[('google-cloud-resource-prefix', database.name)],
+        )
+
     def test_run_in_transaction_w_abort_no_retry_metadata(self):
         import datetime
+        from google.api_core.exceptions import Aborted
         from google.cloud.spanner_v1.proto.spanner_pb2 import CommitResponse
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
-            Transaction as TransactionPB)
+            Transaction as TransactionPB, TransactionOptions)
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.transaction import Transaction
@@ -638,16 +685,15 @@ class TestSession(unittest.TestCase):
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
         now = datetime.datetime.utcnow().replace(tzinfo=UTC)
         now_pb = _datetime_to_pb_timestamp(now)
+        aborted = _make_rpc_error(Aborted, trailing_metadata=[])
         response = CommitResponse(commit_timestamp=now_pb)
-        gax_api = _SpannerApi(
-            _begin_transaction_response=transaction_pb,
-            _commit_abort_count=1,
-            _commit_response=response,
-        )
-        database = _Database(self.DATABASE_NAME)
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.commit.side_effect = [aborted, response]
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
-        session._session_id = 'DEADBEEF'
+        session._session_id = self.SESSION_ID
 
         called_with = []
 
@@ -666,16 +712,36 @@ class TestSession(unittest.TestCase):
             self.assertEqual(args, ('abc',))
             self.assertEqual(kw, {'some_arg': 'def'})
 
+        expected_options = TransactionOptions(
+            read_write=TransactionOptions.ReadWrite(),
+        )
+        self.assertEqual(
+            gax_api.begin_transaction.call_args_list,
+            [mock.call(
+                self.SESSION_NAME,
+                expected_options,
+                metadata=[('google-cloud-resource-prefix', database.name)],
+            )] * 2)
+        self.assertEqual(
+            gax_api.commit.call_args_list,
+            [mock.call(
+                self.SESSION_NAME,
+                txn._mutations,
+                transaction_id=TRANSACTION_ID,
+                metadata=[('google-cloud-resource-prefix', database.name)],
+            )] * 2)
+
     def test_run_in_transaction_w_abort_w_retry_metadata(self):
         import datetime
+        from google.api_core.exceptions import Aborted
+        from google.protobuf.duration_pb2 import Duration
+        from google.rpc.error_details_pb2 import RetryInfo
         from google.cloud.spanner_v1.proto.spanner_pb2 import CommitResponse
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
-            Transaction as TransactionPB)
+            Transaction as TransactionPB, TransactionOptions)
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.transaction import Transaction
-        from google.cloud.spanner_v1 import session as MUT
-        from google.cloud._testing import _Monkey
 
         TABLE_NAME = 'citizens'
         COLUMNS = ['email', 'first_name', 'last_name', 'age']
@@ -686,21 +752,28 @@ class TestSession(unittest.TestCase):
         TRANSACTION_ID = b'FACEDACE'
         RETRY_SECONDS = 12
         RETRY_NANOS = 3456
+        retry_info = RetryInfo(
+            retry_delay=Duration(
+                seconds=RETRY_SECONDS,
+                nanos=RETRY_NANOS))
+        trailing_metadata = [
+            ('google.rpc.retryinfo-bin', retry_info.SerializeToString()),
+        ]
+        aborted = _make_rpc_error(
+            Aborted,
+            trailing_metadata=trailing_metadata,
+        )
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
         now = datetime.datetime.utcnow().replace(tzinfo=UTC)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
-        gax_api = _SpannerApi(
-            _begin_transaction_response=transaction_pb,
-            _commit_abort_count=1,
-            _commit_abort_retry_seconds=RETRY_SECONDS,
-            _commit_abort_retry_nanos=RETRY_NANOS,
-            _commit_response=response,
-        )
-        database = _Database(self.DATABASE_NAME)
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.commit.side_effect = [aborted, response]
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
-        session._session_id = 'DEADBEEF'
+        session._session_id = self.SESSION_ID
 
         called_with = []
 
@@ -708,14 +781,12 @@ class TestSession(unittest.TestCase):
             called_with.append((txn, args, kw))
             txn.insert(TABLE_NAME, COLUMNS, VALUES)
 
-        time_module = _FauxTimeModule()
-
-        with _Monkey(MUT, time=time_module):
+        with mock.patch('time.sleep') as sleep_mock:
             session.run_in_transaction(unit_of_work, 'abc', some_arg='def')
 
-        self.assertEqual(time_module._slept,
-                         RETRY_SECONDS + RETRY_NANOS / 1.0e9)
+        sleep_mock.assert_called_once_with(RETRY_SECONDS + RETRY_NANOS / 1.0e9)
         self.assertEqual(len(called_with), 2)
+
         for index, (txn, args, kw) in enumerate(called_with):
             self.assertIsInstance(txn, Transaction)
             if index == 1:
@@ -725,17 +796,36 @@ class TestSession(unittest.TestCase):
             self.assertEqual(args, ('abc',))
             self.assertEqual(kw, {'some_arg': 'def'})
 
+        expected_options = TransactionOptions(
+            read_write=TransactionOptions.ReadWrite(),
+        )
+        self.assertEqual(
+            gax_api.begin_transaction.call_args_list,
+            [mock.call(
+                self.SESSION_NAME,
+                expected_options,
+                metadata=[('google-cloud-resource-prefix', database.name)],
+            )] * 2)
+        self.assertEqual(
+            gax_api.commit.call_args_list,
+            [mock.call(
+                self.SESSION_NAME,
+                txn._mutations,
+                transaction_id=TRANSACTION_ID,
+                metadata=[('google-cloud-resource-prefix', database.name)],
+            )] * 2)
+
     def test_run_in_transaction_w_callback_raises_abort_wo_metadata(self):
         import datetime
         from google.api_core.exceptions import Aborted
+        from google.protobuf.duration_pb2 import Duration
+        from google.rpc.error_details_pb2 import RetryInfo
         from google.cloud.spanner_v1.proto.spanner_pb2 import CommitResponse
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
-            Transaction as TransactionPB)
+            Transaction as TransactionPB, TransactionOptions)
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.transaction import Transaction
-        from google.cloud.spanner_v1 import session as MUT
-        from google.cloud._testing import _Monkey
 
         TABLE_NAME = 'citizens'
         COLUMNS = ['email', 'first_name', 'last_name', 'age']
@@ -750,33 +840,33 @@ class TestSession(unittest.TestCase):
         now = datetime.datetime.utcnow().replace(tzinfo=UTC)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
-        gax_api = _SpannerApi(
-            _begin_transaction_response=transaction_pb,
-            _commit_abort_retry_seconds=RETRY_SECONDS,
-            _commit_abort_retry_nanos=RETRY_NANOS,
-            _commit_response=response,
-        )
-        database = _Database(self.DATABASE_NAME)
+        retry_info = RetryInfo(
+            retry_delay=Duration(
+                seconds=RETRY_SECONDS,
+                nanos=RETRY_NANOS))
+        trailing_metadata = [
+            ('google.rpc.retryinfo-bin', retry_info.SerializeToString()),
+        ]
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.commit.side_effect = [response]
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
-        session._session_id = 'DEADBEEF'
+        session._session_id = self.SESSION_ID
 
         called_with = []
 
         def unit_of_work(txn, *args, **kw):
             called_with.append((txn, args, kw))
             if len(called_with) < 2:
-                raise _make_rpc_error(
-                    Aborted, gax_api._trailing_metadata())
+                raise _make_rpc_error(Aborted, trailing_metadata)
             txn.insert(TABLE_NAME, COLUMNS, VALUES)
 
-        time_module = _FauxTimeModule()
-
-        with _Monkey(MUT, time=time_module):
+        with mock.patch('time.sleep') as sleep_mock:
             session.run_in_transaction(unit_of_work)
 
-        self.assertEqual(time_module._slept,
-                         RETRY_SECONDS + RETRY_NANOS / 1.0e9)
+        sleep_mock.assert_called_once_with(RETRY_SECONDS + RETRY_NANOS / 1.0e9)
         self.assertEqual(len(called_with), 2)
         for index, (txn, args, kw) in enumerate(called_with):
             self.assertIsInstance(txn, Transaction)
@@ -787,16 +877,34 @@ class TestSession(unittest.TestCase):
             self.assertEqual(args, ())
             self.assertEqual(kw, {})
 
+        expected_options = TransactionOptions(
+            read_write=TransactionOptions.ReadWrite(),
+        )
+        self.assertEqual(
+            gax_api.begin_transaction.call_args_list,
+            [mock.call(
+                self.SESSION_NAME,
+                expected_options,
+                metadata=[('google-cloud-resource-prefix', database.name)],
+            )] * 2)
+        gax_api.commit.assert_called_once_with(
+            self.SESSION_NAME,
+            txn._mutations,
+            transaction_id=TRANSACTION_ID,
+            metadata=[('google-cloud-resource-prefix', database.name)],
+        )
+
     def test_run_in_transaction_w_abort_w_retry_metadata_deadline(self):
         import datetime
         from google.api_core.exceptions import Aborted
+        from google.protobuf.duration_pb2 import Duration
+        from google.rpc.error_details_pb2 import RetryInfo
         from google.cloud.spanner_v1.proto.spanner_pb2 import CommitResponse
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
-            Transaction as TransactionPB)
+            Transaction as TransactionPB, TransactionOptions)
+        from google.cloud.spanner_v1.transaction import Transaction
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
-        from google.cloud.spanner_v1 import session as MUT
-        from google.cloud._testing import _Monkey
 
         TABLE_NAME = 'citizens'
         COLUMNS = ['email', 'first_name', 'last_name', 'age']
@@ -811,17 +919,24 @@ class TestSession(unittest.TestCase):
         now = datetime.datetime.utcnow().replace(tzinfo=UTC)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
-        gax_api = _SpannerApi(
-            _begin_transaction_response=transaction_pb,
-            _commit_abort_count=1,
-            _commit_abort_retry_seconds=RETRY_SECONDS,
-            _commit_abort_retry_nanos=RETRY_NANOS,
-            _commit_response=response,
+        retry_info = RetryInfo(
+            retry_delay=Duration(
+                seconds=RETRY_SECONDS,
+                nanos=RETRY_NANOS))
+        trailing_metadata = [
+            ('google.rpc.retryinfo-bin', retry_info.SerializeToString()),
+        ]
+        aborted = _make_rpc_error(
+            Aborted,
+            trailing_metadata=trailing_metadata,
         )
-        database = _Database(self.DATABASE_NAME)
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.commit.side_effect = [aborted, response]
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
-        session._session_id = 'DEADBEEF'
+        session._session_id = self.SESSION_ID
 
         called_with = []
 
@@ -829,23 +944,44 @@ class TestSession(unittest.TestCase):
             called_with.append((txn, args, kw))
             txn.insert(TABLE_NAME, COLUMNS, VALUES)
 
-        time_module = _FauxTimeModule()
-        time_module._times = [1, 1.5]
+        # retry once w/ timeout_secs=1
+        def _time(_results=[1, 1.5]):
+            return _results.pop(0)
 
-        with _Monkey(MUT, time=time_module):
-            with self.assertRaises(Aborted):
-                session.run_in_transaction(
-                    unit_of_work, 'abc', timeout_secs=1)
+        with mock.patch('time.time', _time):
+            with mock.patch('time.sleep') as sleep_mock:
+                with self.assertRaises(Aborted):
+                    session.run_in_transaction(
+                        unit_of_work, 'abc', timeout_secs=1)
 
-        self.assertIsNone(time_module._slept)
+        sleep_mock.assert_not_called()
+
         self.assertEqual(len(called_with), 1)
+        txn, args, kw = called_with[0]
+        self.assertIsInstance(txn, Transaction)
+        self.assertIsNone(txn.committed)
+        self.assertEqual(args, ('abc',))
+        self.assertEqual(kw, {})
+
+        expected_options = TransactionOptions(
+            read_write=TransactionOptions.ReadWrite(),
+        )
+        gax_api.begin_transaction.assert_called_once_with(
+            self.SESSION_NAME,
+            expected_options,
+            metadata=[('google-cloud-resource-prefix', database.name)],
+        )
+        gax_api.commit.assert_called_once_with(
+            self.SESSION_NAME,
+            txn._mutations,
+            transaction_id=TRANSACTION_ID,
+            metadata=[('google-cloud-resource-prefix', database.name)],
+        )
 
     def test_run_in_transaction_w_timeout(self):
         from google.api_core.exceptions import Aborted
-        from google.cloud.spanner_v1 import session as MUT
-        from google.cloud._testing import _Monkey
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
-            Transaction as TransactionPB)
+            Transaction as TransactionPB, TransactionOptions)
         from google.cloud.spanner_v1.transaction import Transaction
 
         TABLE_NAME = 'citizens'
@@ -856,14 +992,17 @@ class TestSession(unittest.TestCase):
         ]
         TRANSACTION_ID = b'FACEDACE'
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
-        gax_api = _SpannerApi(
-            _begin_transaction_response=transaction_pb,
-            _commit_abort_count=1e6,
+        aborted = _make_rpc_error(
+            Aborted,
+            trailing_metadata=[],
         )
-        database = _Database(self.DATABASE_NAME)
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.commit.side_effect = aborted
+        database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
-        session._session_id = 'DEADBEEF'
+        session._session_id = self.SESSION_ID
 
         called_with = []
 
@@ -871,14 +1010,17 @@ class TestSession(unittest.TestCase):
             called_with.append((txn, args, kw))
             txn.insert(TABLE_NAME, COLUMNS, VALUES)
 
-        time_module = _FauxTimeModule()
-        time_module._times = [1, 1.5, 2.5]  # retry once w/ timeout_secs=1
+        # retry once w/ timeout_secs=1
+        def _time(_results=[1, 1.5, 2.5]):
+            return _results.pop(0)
 
-        with _Monkey(MUT, time=time_module):
-            with self.assertRaises(Aborted):
-                session.run_in_transaction(unit_of_work, timeout_secs=1)
+        with mock.patch('time.time', _time):
+            with mock.patch('time.sleep') as sleep_mock:
+                with self.assertRaises(Aborted):
+                    session.run_in_transaction(unit_of_work, timeout_secs=1)
 
-        self.assertEqual(time_module._slept, None)
+        sleep_mock.assert_not_called()
+
         self.assertEqual(len(called_with), 2)
         for txn, args, kw in called_with:
             self.assertIsInstance(txn, Transaction)
@@ -886,103 +1028,21 @@ class TestSession(unittest.TestCase):
             self.assertEqual(args, ())
             self.assertEqual(kw, {})
 
-
-class _Database(object):
-
-    def __init__(self, name):
-        self.name = name
-
-
-class _SpannerApi(object):
-
-    _commit_abort_count = 0
-    _commit_abort_retry_seconds = None
-    _commit_abort_retry_nanos = None
-    _commit_error = False
-    _rpc_error = None
-
-    def __init__(self, **kwargs):
-        self.__dict__.update(**kwargs)
-
-    def create_session(self, database, session=None, metadata=None):
-        if self._rpc_error is not None:
-            raise self._rpc_error
-
-        self._create_session_called_with = database, session, metadata
-        return self._create_session_response
-
-    def get_session(self, name, metadata=None):
-        from google.api_core.exceptions import NotFound
-
-        if self._rpc_error is not None:
-            raise self._rpc_error
-
-        self._get_session_called_with = name, metadata
-        try:
-            return self._get_session_response
-        except AttributeError:
-            raise NotFound('miss')
-
-    def delete_session(self, name, metadata=None):
-        from google.api_core.exceptions import NotFound
-
-        if self._rpc_error is not None:
-            raise self._rpc_error
-
-        self._delete_session_called_with = name, metadata
-        if not self._delete_session_ok:
-            raise NotFound('miss')
-
-    def begin_transaction(self, session, options_, metadata=None):
-        self._begun = (session, options_, metadata)
-        return self._begin_transaction_response
-
-    def _trailing_metadata(self):
-        from google.protobuf.duration_pb2 import Duration
-        from google.rpc.error_details_pb2 import RetryInfo
-
-        if self._commit_abort_retry_nanos is None:
-            return []
-
-        retry_info = RetryInfo(
-            retry_delay=Duration(
-                seconds=self._commit_abort_retry_seconds,
-                nanos=self._commit_abort_retry_nanos))
-        return [
-            ('google.rpc.retryinfo-bin', retry_info.SerializeToString()),
-        ]
-
-    def commit(self, session, mutations,
-               transaction_id='', single_use_transaction=None, metadata=None):
-        from google.api_core.exceptions import Unknown, Aborted
-
-        assert single_use_transaction is None
-        self._committed = (session, mutations, transaction_id, metadata)
-        if self._commit_error:
-            raise Unknown('error')
-        if self._commit_abort_count > 0:
-            self._commit_abort_count -= 1
-            raise _make_rpc_error(
-                Aborted, trailing_metadata=self._trailing_metadata())
-        return self._commit_response
-
-    def rollback(self, session, transaction_id, metadata=None):
-        self._rolled_back = (session, transaction_id, metadata)
-        return self._rollback_response
-
-
-class _FauxTimeModule(object):
-
-    _slept = None
-    _times = ()
-
-    def time(self):
-        import time
-
-        if len(self._times) > 0:
-            return self._times.pop(0)
-
-        return time.time()
-
-    def sleep(self, seconds):
-        self._slept = seconds
+        expected_options = TransactionOptions(
+            read_write=TransactionOptions.ReadWrite(),
+        )
+        self.assertEqual(
+            gax_api.begin_transaction.call_args_list,
+            [mock.call(
+                self.SESSION_NAME,
+                expected_options,
+                metadata=[('google-cloud-resource-prefix', database.name)],
+            )] * 2)
+        self.assertEqual(
+            gax_api.commit.call_args_list,
+            [mock.call(
+                self.SESSION_NAME,
+                txn._mutations,
+                transaction_id=TRANSACTION_ID,
+                metadata=[('google-cloud-resource-prefix', database.name)],
+            )] * 2)

--- a/spanner/tests/unit/test_session.py
+++ b/spanner/tests/unit/test_session.py
@@ -23,7 +23,7 @@ def _make_rpc_error(error_cls, trailing_metadata=None):
 
     grpc_error = mock.create_autospec(grpc.Call, instance=True)
     grpc_error.trailing_metadata.return_value = trailing_metadata
-    raise error_cls('error', errors=(grpc_error,))
+    return error_cls('error', errors=(grpc_error,))
 
 
 class TestSession(unittest.TestCase):

--- a/spanner/tests/unit/test_session.py
+++ b/spanner/tests/unit/test_session.py
@@ -44,11 +44,20 @@ class TestSession(unittest.TestCase):
     def _make_one(self, *args, **kwargs):
         return self._getTargetClass()(*args, **kwargs)
 
-    def test_constructor(self):
+    def test_constructor_wo_labels(self):
         database = _Database(self.DATABASE_NAME)
         session = self._make_one(database)
         self.assertIs(session.session_id, None)
         self.assertIs(session._database, database)
+        self.assertEqual(session.labels, {})
+
+    def test_constructor_w_labels(self):
+        database = _Database(self.DATABASE_NAME)
+        labels = {'foo': 'bar'}
+        session = self._make_one(database, labels=labels)
+        self.assertIs(session.session_id, None)
+        self.assertIs(session._database, database)
+        self.assertEqual(session.labels, labels)
 
     def test___lt___(self):
         database = _Database(self.DATABASE_NAME)


### PR DESCRIPTION
Labels are assigned to a pool at creation time, and then get propagated to the sessions created by the pool.