### PR TITLE
Bigtable optimize 'Table.exists' performance

### DIFF
--- a/bigtable/google/cloud/bigtable/enums.py
+++ b/bigtable/google/cloud/bigtable/enums.py
@@ -121,3 +121,31 @@ class RoutingPolicyType(object):
     """
     ANY = enums.RoutingPolicyType.ANY
     SINGLE = enums.RoutingPolicyType.SINGLE
+
+
+class Table(object):
+    class View(object):
+        """
+        Defines a view over a table's fields.
+
+        Attributes:
+          VIEW_UNSPECIFIED (int): Uses the default view for each method
+          as documented in its request.
+          NAME_ONLY (int): Only populates ``name``.
+          SCHEMA_VIEW (int): Only populates ``name`` and fields related
+          to the table's schema.
+          REPLICATION_VIEW (int): This is a private alpha release of
+          Cloud Bigtable replication. This feature is not currently available
+          to most Cloud Bigtable customers. This feature might be changed in
+          backward-incompatible ways and is not recommended for production use.
+          It is not subject to any SLA or deprecation policy.
+
+          Only populates ``name`` and fields related to the table's
+          replication state.
+          FULL (int): Populates all fields.
+        """
+        VIEW_UNSPECIFIED = enums.Table.View.VIEW_UNSPECIFIED
+        NAME_ONLY = enums.Table.View.NAME_ONLY
+        SCHEMA_VIEW = enums.Table.View.SCHEMA_VIEW
+        REPLICATION_VIEW = enums.Table.View.REPLICATION_VIEW
+        FULL = enums.Table.View.FULL

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -18,7 +18,6 @@
 from grpc import StatusCode
 
 from google.api_core.exceptions import RetryError
-from google.api_core.exceptions import NotFound
 from google.api_core.retry import if_exception_type
 from google.api_core.retry import Retry
 from google.cloud._helpers import _to_bytes
@@ -222,12 +221,10 @@ class Table(object):
         :returns: True if the table exists, else False.
         """
         table_client = self._instance._client.table_admin_client
-        try:
-            table_client.get_table(name=self.name)
-        except NotFound:
-            return False
-        else:
-            return True
+        for table_pb in table_client.list_tables(self._instance.name):
+            if self.name == table_pb.name:
+                return True
+        return False
 
     def delete(self):
         """Delete this table."""

--- a/bigtable/tests/system.py
+++ b/bigtable/tests/system.py
@@ -531,6 +531,15 @@ class TestTableAdminAPI(unittest.TestCase):
         tables = Config.INSTANCE.list_tables()
         self.assertEqual(tables, [self._table])
 
+    def test_exists(self):
+        temp_table_id = 'test-table_existence'
+        temp_table = Config.INSTANCE.table(temp_table_id)
+        self.assertFalse(temp_table.exists())
+        temp_table.create()
+        self.assertTrue(temp_table.exists())
+        temp_table.delete()
+        self.assertFalse(temp_table.exists())
+
     def test_create_table(self):
         temp_table_id = 'test-create-table'
         temp_table = Config.INSTANCE.table(temp_table_id)

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -309,7 +309,6 @@ class TestTable(unittest.TestCase):
             bigtable_table_admin_pb2 as table_messages_v1_pb2)
         from google.cloud.bigtable_admin_v2.gapic import (
             bigtable_instance_admin_client, bigtable_table_admin_client)
-        from google.api_core.exceptions import NotFound
 
         table_api = bigtable_table_admin_client.BigtableTableAdminClient(
             mock.Mock())
@@ -332,10 +331,7 @@ class TestTable(unittest.TestCase):
         client._instance_admin_client = instance_api
         bigtable_table_stub = (
             client._table_admin_client.bigtable_table_admin_stub)
-        bigtable_table_stub.ListTables.side_effect = [
-            response_pb,
-            NotFound('testing'),
-        ]
+        bigtable_table_stub.ListTables.side_effect = [response_pb]
 
         # Perform the method and check the result.
         table1 = instance.table(self.TABLE_ID)

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -331,7 +331,8 @@ class TestTable(unittest.TestCase):
         client._instance_admin_client = instance_api
         bigtable_table_stub = (
             client._table_admin_client.bigtable_table_admin_stub)
-        bigtable_table_stub.ListTables.side_effect = [response_pb]
+        bigtable_table_stub.ListTables.side_effect = [response_pb,
+                                                      response_pb]
 
         # Perform the method and check the result.
         table1 = instance.table(self.TABLE_ID)


### PR DESCRIPTION
1. Updated table.exists(), now using NAME_ONLY view in get_table() call.
2. Added system test around table.exists()