### PR TITLE
Remove synth fix for replacing iam_policy_pb2_grpc

### DIFF
--- a/kms/synth.py
+++ b/kms/synth.py
@@ -38,7 +38,3 @@ s.replace('setup.py',
           '(release_status = )(.*)$',
           f"\\1'{release_status}'")
 s.replace('setup.py', 'version = .*', f"version = '{client_library_version}'")
-
-# Wrong import name. Drop _grpc
-# https://github.com/googleapis/gapic-generator/issues/2160
-s.replace("**/*.py", "iam_policy_pb2_grpc", "iam_policy_pb2")


### PR DESCRIPTION
https://github.com/googleapis/gapic-generator/issues/2160 is fixed.

See https://github.com/GoogleCloudPlatform/google-cloud-python/pull/5754 for the regenerated kms with gapic-generator/master.

Thanks for filing!