### PR TITLE
Storage: Add 'Client.get_service_account_email'.

### DIFF
--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -151,6 +151,24 @@ class Client(ClientWithProject):
         """
         return self._batch_stack.top
 
+    def get_service_account_email(self, project=None):
+        """Get the email address of the project's GCS service account
+
+        :type project: str
+        :param project:
+            (Optional) Project ID to use for retreiving service account email.
+            Defaults to the client's project.
+
+        :rtype: str
+        :returns: service account email address
+        """
+        if project is None:
+            project = self.project
+        path = '/projects/%s/serviceAccount' % (project,)
+        api_response = self._base_connection.api_request(
+            method='GET', path=path)
+        return api_response['email_address']
+
     def bucket(self, bucket_name, user_project=None):
         """Factory constructor for bucket object.
 

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -156,8 +156,8 @@ class Client(ClientWithProject):
 
         :type project: str
         :param project:
-            (Optional) Project ID to use for retreiving service account email.
-            Defaults to the client's project.
+            (Optional) Project ID to use for retreiving GCS service account
+            email address.  Defaults to the client's project.
 
         :rtype: str
         :returns: service account email address

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -82,6 +82,15 @@ def tearDownModule():
     retry(Config.TEST_BUCKET.delete)(force=True)
 
 
+class TestClient(unittest.TestCase):
+
+    def test_get_service_account_email(self):
+        expected = '{}@gs-project-accounts.iam.gserviceaccount.com'.format(
+            Config.CLIENT.project)
+        self.assertEqual(
+            Config.CLIENT.get_service_account_email(), expected)
+
+
 class TestStorageBuckets(unittest.TestCase):
 
     def setUp(self):

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+import re
 import time
 import unittest
 
@@ -85,10 +86,20 @@ def tearDownModule():
 class TestClient(unittest.TestCase):
 
     def test_get_service_account_email(self):
-        expected = '{}@gs-project-accounts.iam.gserviceaccount.com'.format(
-            Config.CLIENT.project)
-        self.assertEqual(
-            Config.CLIENT.get_service_account_email(), expected)
+        domain = 'gs-project-accounts.iam.gserviceaccount.com'
+
+        email = Config.CLIENT.get_service_account_email()
+
+        new_style = re.compile(
+            r'service-(?P<projnum>[^@]+)@' + domain)
+        old_style = re.compile(
+            r'{}@{}'.format(Config.CLIENT.project, domain))
+        patterns = [new_style, old_style]
+        matches = [pattern.match(email) for pattern in patterns]
+
+        self.assertTrue(any(
+            match for match in matches if match is not None
+        ))
 
 
 class TestStorageBuckets(unittest.TestCase):

--- a/storage/tests/unit/test_client.py
+++ b/storage/tests/unit/test_client.py
@@ -173,6 +173,60 @@ class TestClient(unittest.TestCase):
         self.assertIs(client._connection, batch)
         self.assertIs(client.current_batch, batch)
 
+    def test_get_service_account_email_wo_project(self):
+        PROJECT = 'PROJECT'
+        CREDENTIALS = _make_credentials()
+        EMAIL = 'storage-user-123@example.com'
+        RESOURCE = {
+            'kind': 'storage#serviceAccount',
+            'email_address': EMAIL,
+        }
+
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+        http = _make_requests_session([
+            _make_json_response(RESOURCE)])
+        client._http_internal = http
+
+        service_account_email = client.get_service_account_email()
+
+        self.assertEqual(service_account_email, EMAIL)
+        URI = '/'.join([
+            client._connection.API_BASE_URL,
+            'storage',
+            client._connection.API_VERSION,
+            'projects/%s/serviceAccount' % (PROJECT,)
+        ])
+        http.request.assert_called_once_with(
+            method='GET', url=URI, data=None, headers=mock.ANY)
+
+    def test_get_service_account_email_w_project(self):
+        PROJECT = 'PROJECT'
+        OTHER_PROJECT = 'OTHER_PROJECT'
+        CREDENTIALS = _make_credentials()
+        EMAIL = 'storage-user-123@example.com'
+        RESOURCE = {
+            'kind': 'storage#serviceAccount',
+            'email_address': EMAIL,
+        }
+
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+        http = _make_requests_session([
+            _make_json_response(RESOURCE)])
+        client._http_internal = http
+
+        service_account_email = client.get_service_account_email(
+            project=OTHER_PROJECT)
+
+        self.assertEqual(service_account_email, EMAIL)
+        URI = '/'.join([
+            client._connection.API_BASE_URL,
+            'storage',
+            client._connection.API_VERSION,
+            'projects/%s/serviceAccount' % (OTHER_PROJECT,)
+        ])
+        http.request.assert_called_once_with(
+            method='GET', url=URI, data=None, headers=mock.ANY)
+
     def test_bucket(self):
         from google.cloud.storage.bucket import Bucket
 


### PR DESCRIPTION
Returns email address of service account of a given project, defaulting to the client's project.

Closes #5635.