### PR TITLE
Storage: elaborate docs for '{Bucket,Blob}.make_{public,private}'.

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -256,7 +256,10 @@ class Blob(_PropertyMixin):
 
     @property
     def public_url(self):
-        """The public URL for this blob's object.
+        """The public URL for this blob.
+
+        Use :meth:`make_public` to enable anonymous access via the returned
+        URL.
 
         :rtype: `string`
         :returns: The public URL for this blob.
@@ -1336,7 +1339,7 @@ class Blob(_PropertyMixin):
         return resp.get('permissions', [])
 
     def make_public(self, client=None):
-        """Make this blob public giving all users read access.
+        """Update blob's ACL, granting read access to anonymous users.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
@@ -1347,8 +1350,7 @@ class Blob(_PropertyMixin):
         self.acl.save(client=client)
 
     def make_private(self, client=None):
-        """Make this blob private by removing `allusers` read access.
-        Does not revoke access for anything other than the `allusers` group.
+        """Update blob's ACL, revoking read access for anonymous users.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -1303,7 +1303,9 @@ class Bucket(_PropertyMixin):
         :raises ValueError:
             If ``recursive`` is True, and the bucket contains more than 256
             blobs.  This is to prevent extremely long runtime of this
-            method.
+            method.  For such buckets, iterate over the blobs returned by
+            :meth:`Bucket.list_blobs` and call :meth:`Blob.make_public`
+            for each blob.
         """
         self.acl.all().grant_read()
         self.acl.save(client=client)
@@ -1322,10 +1324,11 @@ class Bucket(_PropertyMixin):
                 client=client))
             if len(blobs) > self._MAX_OBJECTS_FOR_ITERATION:
                 message = (
-                    'Refusing to make public recursively with more than '
-                    '%d objects. If you actually want to make every object '
-                    'in this bucket public, please do it on the objects '
-                    'yourself.'
+                    "Refusing to make public recursively with more than "
+                    "%d objects. If you actually want to make every object "
+                    "in this bucket public, iterate through the blobs "
+                    "returned by 'Bucket.list_blobs()' and call "
+                    "'make_public' on each one."
                 ) % (self._MAX_OBJECTS_FOR_ITERATION,)
                 raise ValueError(message)
 
@@ -1352,7 +1355,9 @@ class Bucket(_PropertyMixin):
         :raises ValueError:
             If ``recursive`` is True, and the bucket contains more than 256
             blobs.  This is to prevent extremely long runtime of this
-            method.
+            method.  For such buckets, iterate over the blobs returned by
+            :meth:`Bucket.list_blobs` and call :meth:`Blob.make_private`
+            for each blob.
         """
         self.acl.all().revoke_read()
         self.acl.save(client=client)
@@ -1373,8 +1378,9 @@ class Bucket(_PropertyMixin):
                 message = (
                     'Refusing to make private recursively with more than '
                     '%d objects. If you actually want to make every object '
-                    'in this bucket private, please do it on the objects '
-                    'yourself.'
+                    "in this bucket private, iterate through the blobs "
+                    "returned by 'Bucket.list_blobs()' and call "
+                    "'make_private' on each one."
                 ) % (self._MAX_OBJECTS_FOR_ITERATION,)
                 raise ValueError(message)
 

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -1285,11 +1285,7 @@ class Bucket(_PropertyMixin):
         return resp.get('permissions', [])
 
     def make_public(self, recursive=False, future=False, client=None):
-        """Make a bucket public.
-
-        If ``recursive=True`` and the bucket contains more than 256
-        objects / blobs this will cowardly refuse to make the objects public.
-        This is to prevent extremely long runtime of this method.
+        """Update bucket's ACL, granting read access to anonymous users.
 
         :type recursive: bool
         :param recursive: If True, this will make all blobs inside the bucket
@@ -1303,6 +1299,11 @@ class Bucket(_PropertyMixin):
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the current bucket.
+
+        :raises ValueError:
+            If ``recursive`` is True, and the bucket contains more than 256
+            blobs.  This is to prevent extremely long runtime of this
+            method.
         """
         self.acl.all().grant_read()
         self.acl.save(client=client)
@@ -1333,11 +1334,7 @@ class Bucket(_PropertyMixin):
                 blob.acl.save(client=client)
 
     def make_private(self, recursive=False, future=False, client=None):
-        """Undo the `make_public` method and make the bucket private.
-
-        If ``recursive=True`` and the bucket contains more than 256
-        objects / blobs this will cowardly refuse to make the objects private.
-        This is to prevent extremely long runtime of this method.
+        """Update bucket's ACL, revoking read access for anonymous users.
 
         :type recursive: bool
         :param recursive: If True, this will make all blobs inside the bucket
@@ -1351,6 +1348,11 @@ class Bucket(_PropertyMixin):
                       ``NoneType``
         :param client: Optional. The client to use.  If not passed, falls back
                        to the ``client`` stored on the current bucket.
+
+        :raises ValueError:
+            If ``recursive`` is True, and the bucket contains more than 256
+            blobs.  This is to prevent extremely long runtime of this
+            method.
         """
         self.acl.all().revoke_read()
         self.acl.save(client=client)

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -1304,7 +1304,8 @@ class Bucket(_PropertyMixin):
             If ``recursive`` is True, and the bucket contains more than 256
             blobs.  This is to prevent extremely long runtime of this
             method.  For such buckets, iterate over the blobs returned by
-            :meth:`Bucket.list_blobs` and call :meth:`Blob.make_public`
+            :meth:`list_blobs` and call
+            :meth:`~google.cloud.storage.blob.Blob.make_public`
             for each blob.
         """
         self.acl.all().grant_read()
@@ -1356,7 +1357,8 @@ class Bucket(_PropertyMixin):
             If ``recursive`` is True, and the bucket contains more than 256
             blobs.  This is to prevent extremely long runtime of this
             method.  For such buckets, iterate over the blobs returned by
-            :meth:`Bucket.list_blobs` and call :meth:`Blob.make_private`
+            :meth:`list_blobs` and call
+            :meth:`~google.cloud.storage.blob.Blob.make_private`
             for each blob.
         """
         self.acl.all().revoke_read()


### PR DESCRIPTION
Also note how to enable anonymous access to 'Blob.public_url'.

Closes #5457.