### PR TITLE
Move location specification to Bucket.create and deprecate location setter

### DIFF
--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -953,7 +953,7 @@ class Bucket(_PropertyMixin):
 
         See https://cloud.google.com/storage/docs/json_api/v1/buckets and
         https://cloud.google.com/storage/docs/bucket-locations
-        
+
         Returns ``None`` if the property has not been set before creation,
         or if the bucket's resource has not been loaded from the server.
         :rtype: str or ``NoneType``

--- a/storage/google/cloud/storage/client.py
+++ b/storage/google/cloud/storage/client.py
@@ -260,8 +260,8 @@ class Client(ClientWithProject):
         If the bucket already exists, will raise
         :class:`google.cloud.exceptions.Conflict`.
 
-        To set additional properties when creating a bucket such as
-        :attr:`~.Bucket.location`, use :meth:`~.Bucket.create`.
+        To set additional properties when creating a bucket, such as the
+        bucket location, use :meth:`~.Bucket.create`.
 
         :type bucket_name: str
         :param bucket_name: The bucket name to create.

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -308,6 +308,25 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(kw['query_params'], {'project': OTHER_PROJECT})
         self.assertEqual(kw['data'], DATA)
 
+    def test_create_w_explicit_location(self):
+        PROJECT = 'PROJECT'
+        BUCKET_NAME = 'bucket-name'
+        LOCATION = 'continent-northeast1'
+        DATA = {'location': LOCATION, 'name': BUCKET_NAME}
+        connection = _Connection(
+            DATA,
+            "{'location': 'continent-northeast1', 'name': 'bucket-name'}")
+        client = _Client(connection, project=PROJECT)
+        bucket = self._make_one(client, BUCKET_NAME)
+
+        bucket.create(location=LOCATION)
+
+        kw, = connection._requested
+        self.assertEqual(kw['method'], 'POST')
+        self.assertEqual(kw['path'], '/b')
+        self.assertEqual(kw['data'], DATA)
+        self.assertEqual(bucket.location, LOCATION)
+
     def test_create_hit(self):
         PROJECT = 'PROJECT'
         BUCKET_NAME = 'bucket-name'

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -311,11 +311,11 @@ class Test_Bucket(unittest.TestCase):
     def test_create_w_explicit_location(self):
         PROJECT = 'PROJECT'
         BUCKET_NAME = 'bucket-name'
-        LOCATION = 'continent-northeast1'
+        LOCATION = 'us-central1'
         DATA = {'location': LOCATION, 'name': BUCKET_NAME}
         connection = _Connection(
             DATA,
-            "{'location': 'continent-northeast1', 'name': 'bucket-name'}")
+            "{'location': 'us-central1', 'name': 'bucket-name'}")
         client = _Client(connection, project=PROJECT)
         bucket = self._make_one(client, BUCKET_NAME)
 


### PR DESCRIPTION
Addresses #5194 by labeling setting location deprecated. Support setting location on create method of bucket.