### PR TITLE
Bigtable: consolidating read_rows and yield_rows

### DIFF
--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -305,7 +305,6 @@ def _retry_read_rows_exception(exc):
                             exceptions.DeadlineExceeded))
 
 
-
 class PartialRowsData(object):
     """Convenience wrapper for consuming a ``ReadRows`` streaming response.
 

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -353,10 +353,6 @@ class PartialRowsData(object):
         self.request = request
         self.response_iterator = read_method(request)
 
-        # Fully-processed rows, keyed by `row_key`.  This is only populated
-        # if `consume_all` is called.  This is required for backwards
-        # compatibility.  Ideally, consume all should just return a method
-        # scoped variable, and not a member variable.
         self.rows = {}
 
     @property
@@ -392,6 +388,10 @@ class PartialRowsData(object):
 
     def consume_all(self, max_loops=None):
         """Consume the streamed responses until there are no more.
+
+        .. warning::
+           This method will be removed in future releases.  Please use this
+           class as a generator instead.
 
         :type max_loops: int
         :param max_loops: (Optional) Maximum number of times to try to consume

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -352,6 +352,11 @@ class PartialRowsData(object):
         self.read_method = read_method
         self.request = request
         self.response_iterator = read_method(request)
+
+        # Fully-processed rows, keyed by `row_key`.  This is only populated
+        # if `consume_all` is called.  This is required for backwards
+        # compatibility.  Ideally, consume all should just return a method
+        # scoped variable, and not a member variable.
         self.rows = {}
 
     @property

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -336,7 +336,7 @@ class Table(object):
                         row_ranges.
 
         :rtype: :class:`.PartialRowsData`
-        :returns: A :class:`.PartialRowsData` an iterable for consuming
+        :returns: A :class:`.PartialRowsData` a generator for consuming
                   the streamed results.
         """
         request_pb = _create_row_request(

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -348,9 +348,10 @@ class Table(object):
 
     def yield_rows(self, **kwargs):
         """Read rows from this table.
-        
-        NOTE: This method will be removed in future releases.  Please use
-        ``read_rows`` instead as a drop-in replacement.
+
+        .. warning::
+           This method will be removed in future releases.  Please use
+           ``read_rows`` instead.
 
         :type start_key: bytes
         :param start_key: (Optional) The beginning of a range of row keys to

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -336,7 +336,7 @@ class Table(object):
                         row_ranges.
 
         :rtype: :class:`.PartialRowsData`
-        :returns: A :class:`.PartialRowsData` convenience wrapper for consuming
+        :returns: A :class:`.PartialRowsData` an iterable for consuming
                   the streamed results.
         """
         request_pb = _create_row_request(
@@ -348,6 +348,9 @@ class Table(object):
 
     def yield_rows(self, **kwargs):
         """Read rows from this table.
+        
+        NOTE: This method will be removed in future releases.  Please use
+        ``read_rows`` instead as a drop-in replacement.
 
         :type start_key: bytes
         :param start_key: (Optional) The beginning of a range of row keys to

--- a/bigtable/tests/system.py
+++ b/bigtable/tests/system.py
@@ -877,7 +877,7 @@ class TestDataAPI(unittest.TestCase):
         read_rows = self._table.yield_rows(row_set=row_set)
 
         expected_row_keys = [b'row_key_1', b'row_key_3', b'row_key_4',
-                                 b'row_key_5', b'row_key_6']
+                             b'row_key_5', b'row_key_6']
         found_row_keys = [row.row_key for row in read_rows]
         self.assertEqual(found_row_keys, expected_row_keys)
 

--- a/bigtable/tests/system.py
+++ b/bigtable/tests/system.py
@@ -876,10 +876,10 @@ class TestDataAPI(unittest.TestCase):
 
         read_rows = self._table.yield_rows(row_set=row_set)
 
-        expected_row_keys = set([b'row_key_1', b'row_key_3', b'row_key_4',
-                                 b'row_key_5', b'row_key_6'])
-        found_row_keys = set([row.row_key for row in read_rows])
-        self.assertEqual(found_row_keys, set(expected_row_keys))
+        expected_row_keys = [b'row_key_1', b'row_key_3', b'row_key_4',
+                                 b'row_key_5', b'row_key_6']
+        found_row_keys = [row.row_key for row in read_rows]
+        self.assertEqual(found_row_keys, expected_row_keys)
 
     def test_read_large_cell_limit(self):
         row = self._table.row(ROW_KEY)

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -400,7 +400,6 @@ class TestPartialRowsData(unittest.TestCase):
         partial_rows_data.rows = value = object()
         self.assertIs(partial_rows_data.rows, value)
 
-
     def _make_client(self, *args, **kwargs):
         return self._get_target_client_class()(*args, **kwargs)
 

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -321,12 +321,23 @@ class _Client(object):
 
 
 class TestPartialRowsData(unittest.TestCase):
+    ROW_KEY = b'row-key'
+    FAMILY_NAME = u'family'
+    QUALIFIER = b'qualifier'
+    TIMESTAMP_MICROS = 100
+    VALUE = b'value'
 
     @staticmethod
     def _get_target_class():
         from google.cloud.bigtable.row_data import PartialRowsData
 
         return PartialRowsData
+
+    @staticmethod
+    def _get_target_client_class():
+        from google.cloud.bigtable.client import Client
+
+        return Client
 
     def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
@@ -337,8 +348,7 @@ class TestPartialRowsData(unittest.TestCase):
         request = object()
         partial_rows_data = self._make_one(client._data_stub.ReadRows,
                                            request)
-        self.assertIs(partial_rows_data._generator.request,
-                      request)
+        self.assertIs(partial_rows_data.request, request)
         self.assertEqual(partial_rows_data.rows, {})
 
     def test___eq__(self):
@@ -391,28 +401,6 @@ class TestPartialRowsData(unittest.TestCase):
         self.assertIs(partial_rows_data.rows, value)
 
 
-class TestYieldRowsData(unittest.TestCase):
-    ROW_KEY = b'row-key'
-    FAMILY_NAME = u'family'
-    QUALIFIER = b'qualifier'
-    TIMESTAMP_MICROS = 100
-    VALUE = b'value'
-
-    @staticmethod
-    def _get_target_class():
-        from google.cloud.bigtable.row_data import YieldRowsData
-
-        return YieldRowsData
-
-    def _make_one(self, *args, **kwargs):
-        return self._get_target_class()(*args, **kwargs)
-
-    @staticmethod
-    def _get_target_client_class():
-        from google.cloud.bigtable.client import Client
-
-        return Client
-
     def _make_client(self, *args, **kwargs):
         return self._get_target_client_class()(*args, **kwargs)
 
@@ -451,7 +439,7 @@ class TestYieldRowsData(unittest.TestCase):
             client._table_data_client.bigtable_stub.ReadRows, request)
         yrd._response_iterator = iterator
         yrd._last_scanned_row_key = ''
-        rows = [row for row in yrd.read_rows()]
+        rows = [row for row in yrd]
 
         result = rows[0]
         self.assertEqual(result.row_key, self.ROW_KEY)
@@ -696,15 +684,12 @@ class TestYieldRowsData(unittest.TestCase):
 
         yrd = self._make_one(client._data_stub.ReadRows, request)
 
-        rows = []
-        for row in yrd.read_rows():
-            rows.append(row)
-        result = rows[0]
+        result = self._consume_all(yrd)[0]
 
-        self.assertEqual(result.row_key, self.ROW_KEY)
+        self.assertEqual(result, self.ROW_KEY)
 
     def _consume_all(self, yrd):
-        return [row.row_key for row in yrd.read_rows()]
+        return [row.row_key for row in yrd]
 
 
 class Test_ReadRowsRequestManager(unittest.TestCase):

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -620,7 +620,7 @@ class TestTable(unittest.TestCase):
             'limit': limit,
             'end_inclusive': False,
             'app_profile_id': app_profile_id,
-            'row_set' : None
+            'row_set': None
         }
         self.assertEqual(mock_created, [(table.name, created_kwargs)])
 

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -619,7 +619,8 @@ class TestTable(unittest.TestCase):
             'filter_': filter_obj,
             'limit': limit,
             'end_inclusive': False,
-            'app_profile_id': app_profile_id
+            'app_profile_id': app_profile_id,
+            'row_set' : None
         }
         self.assertEqual(mock_created, [(table.name, created_kwargs)])
 


### PR DESCRIPTION
- Fold `YieldRowsData` functionality into `PartialRowsData`
- Using the name `__iter__()` instead of `read_rows()` so that `PartialRowsData` is now an iterable.
- `Table.yield_rows()` just calls `Table.read_rows()`, making `Table.yield_rows` obsolete, but required for backwards compatiblity.