### PR TITLE
Monitoring: test pandas under all supported Python versions

### DIFF
--- a/monitoring/nox.py
+++ b/monitoring/nox.py
@@ -37,7 +37,7 @@ def unit(session, py):
 
     # Install all test dependencies, then install this package in-place.
     session.install('pytest', 'mock')
-    session.install('-e', '.')
+    session.install('-e', '.[pandas]')
 
     # Run py.test against the unit tests.
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))

--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -76,6 +76,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Operating System :: OS Independent',
         'Topic :: Internet',
     ],


### PR DESCRIPTION
Declare full support for Python 3.7.

Closes #5293.