### PR TITLE
Nox: use inplace installs

### DIFF
--- a/bigquery/nox.py
+++ b/bigquery/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
 
     # Pyarrow does not support Python 3.7
     if session.interpreter == 'python3.7':
@@ -97,10 +98,10 @@ def system(session, py):
     # Use pre-release gRPC for system tests.
     session.install('--pre', 'grpcio')
 
-    # Install all test dependencies, then install this package into the
-    # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install(
+    # Install all test dependencies, then install local packages in place.
+    session.install('mock', 'pytest')
+    session.install('-e', *LOCAL_DEPS)
+    session.install('-e',
         os.path.join('..', 'storage'),
         os.path.join('..', 'test_utils'),
     )
@@ -136,10 +137,10 @@ def snippets(session, py):
     # Set the virtualenv dirname.
     session.virtualenv_dirname = 'snip-' + py
 
-    # Install all test dependencies, then install this package into the
-    # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install(
+    # Install all test dependencies, then install local packages in place.
+    session.install('mock', 'pytest')
+    session.install('-e', *LOCAL_DEPS)
+    session.install('-e',
         os.path.join('..', 'storage'),
         os.path.join('..', 'test_utils'),
     )

--- a/bigquery/nox.py
+++ b/bigquery/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
 
     # Pyarrow does not support Python 3.7
     if session.interpreter == 'python3.7':
@@ -100,11 +101,10 @@ def system(session, py):
 
     # Install all test dependencies, then install local packages in place.
     session.install('mock', 'pytest')
-    session.install('-e', *LOCAL_DEPS)
-    session.install('-e',
-        os.path.join('..', 'storage'),
-        os.path.join('..', 'test_utils'),
-    )
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', os.path.join('..', 'storage'))
+    session.install('-e', os.path.join('..', 'test_utils'))
     session.install('-e', '.[pandas]')
 
     # IPython does not support Python 2 after version 5.x
@@ -139,11 +139,10 @@ def snippets(session, py):
 
     # Install all test dependencies, then install local packages in place.
     session.install('mock', 'pytest')
-    session.install('-e', *LOCAL_DEPS)
-    session.install('-e',
-        os.path.join('..', 'storage'),
-        os.path.join('..', 'test_utils'),
-    )
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', os.path.join('..', 'storage'))
+    session.install('-e', os.path.join('..', 'test_utils'))
     session.install('-e', '.[pandas, pyarrow]')
 
     # Run py.test against the system tests.

--- a/bigtable/nox.py
+++ b/bigtable/nox.py
@@ -35,7 +35,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -88,7 +89,8 @@ def system(session, py):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install('mock', 'pytest')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '../test_utils/')
     session.install('-e', '.')
 

--- a/bigtable/nox.py
+++ b/bigtable/nox.py
@@ -33,8 +33,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -86,8 +87,9 @@ def system(session, py):
 
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install('../test_utils/')
+    session.install('mock', 'pytest')
+    session.install('-e', *LOCAL_DEPS)
+    session.install('-e', '../test_utils/')
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/container/nox.py
+++ b/container/nox.py
@@ -33,8 +33,9 @@ def default(session):
     Python corresponding to the ``nox`` binary on the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -83,8 +84,8 @@ def system(session, py):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install('mock', 'pytest')
-    session.install('../test_utils/')
-    session.install('.')
+    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    session.install('-e', '.')
 
     # Run py.test against the system tests.
     session.run('py.test', '--quiet', 'tests/system/')

--- a/container/nox.py
+++ b/container/nox.py
@@ -35,7 +35,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -84,7 +85,9 @@ def system(session, py):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install('mock', 'pytest')
-    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', '../test_utils/')
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/core/nox.py
+++ b/core/nox.py
@@ -39,7 +39,8 @@ def default(session):
         'pytest-cov',
         'grpcio >= 1.0.2',
     )
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/core/nox.py
+++ b/core/nox.py
@@ -32,14 +32,14 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
+    # Install all test dependencies, then install local packages in-place.
     session.install(
         'mock',
         'pytest',
         'pytest-cov',
         'grpcio >= 1.0.2',
-        *LOCAL_DEPS
     )
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/datastore/nox.py
+++ b/datastore/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -85,11 +86,10 @@ def system(session, py):
     # Use pre-release gRPC for system tests.
     session.install('--pre', 'grpcio')
 
-    # Install all test dependencies, then install this package into the
-    # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install('../test_utils/')
-    session.install('.')
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest')
+    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    session.install('-e', '.')
 
     # Run py.test against the system tests.
     session.run('py.test', '--quiet', 'tests/system', *session.posargs)
@@ -111,9 +111,9 @@ def doctests(session):
 
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
-    session.install('mock', 'pytest', 'sphinx', *LOCAL_DEPS)
-    session.install('../test_utils/')
-    session.install('.')
+    session.install('mock', 'pytest', 'sphinx')
+    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    session.install('-e', '.')
 
     # Run py.test against the system tests.
     session.run('py.test', '--quiet', 'tests/doctests.py')

--- a/datastore/nox.py
+++ b/datastore/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -88,7 +89,9 @@ def system(session, py):
 
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest')
-    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', '../test_utils/')
     session.install('-e', '.')
 
     # Run py.test against the system tests.
@@ -112,7 +115,9 @@ def doctests(session):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install('mock', 'pytest', 'sphinx')
-    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', '../test_utils/')
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/dns/nox.py
+++ b/dns/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/dns/nox.py
+++ b/dns/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -37,7 +37,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -114,7 +115,9 @@ def system(session, py):
 
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest')
-    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', '../test_utils/')
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/error_reporting/nox.py
+++ b/error_reporting/nox.py
@@ -35,8 +35,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -111,11 +112,10 @@ def system(session, py):
     # Use pre-release gRPC for system tests.
     session.install('--pre', 'grpcio')
 
-    # Install all test dependencies, then install this package into the
-    # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install('../test_utils/')
-    session.install('.')
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest')
+    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    session.install('-e', '.')
 
     # Run py.test against the system tests.
     session.run('py.test', '-vvv', 'tests/system', *session.posargs)

--- a/firestore/nox.py
+++ b/firestore/nox.py
@@ -35,8 +35,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -86,11 +87,10 @@ def system(session, py):
     # Use pre-release gRPC for system tests.
     session.install('--pre', 'grpcio')
 
-    # Install all test dependencies, then install this package into the
-    # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install(os.path.join('..', 'test_utils'))
-    session.install('.')
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest')
+    session.install('-e', os.path.join('..', 'test_utils'), *LOCAL_DEPS)
+    session.install('-e', '.')
 
     # Run py.test against the system tests.
     session.run(

--- a/firestore/nox.py
+++ b/firestore/nox.py
@@ -37,7 +37,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -89,7 +90,9 @@ def system(session, py):
 
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest')
-    session.install('-e', os.path.join('..', 'test_utils'), *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', os.path.join('..', 'test_utils'))
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/language/nox.py
+++ b/language/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -84,11 +85,10 @@ def system(session, py):
     # Use pre-release gRPC for system tests.
     session.install('--pre', 'grpcio')
 
-    # Install all test dependencies, then install this package into the
-    # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install('../storage/', '../test_utils/')
-    session.install('.')
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest')
+    session.install('-e', '../storage/', '../test_utils/', *LOCAL_DEPS)
+    session.install('-e', '.')
 
     # Run py.test against the system tests.
     session.run('py.test', '--quiet', 'tests/system/')

--- a/language/nox.py
+++ b/language/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -87,7 +88,10 @@ def system(session, py):
 
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest')
-    session.install('-e', '../storage/', '../test_utils/', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', '../storage/')
+    session.install('-e', '../test_utils/')
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/logging/nox.py
+++ b/logging/nox.py
@@ -52,7 +52,8 @@ def default(session, django_dep=('django',)):
         deps += django_dep
 
     session.install(*deps)
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -115,12 +116,16 @@ def system(session, py):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install('mock', 'pytest')
-    session.install('-e',
-        '../test_utils/',
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    systest_deps = [
         '../bigquery/',
         '../pubsub/',
         '../storage/',
-        *LOCAL_DEPS)
+        '../test_utils/',
+    ]
+    for systest_dep in systest_deps:
+        session.install('-e', systest_dep)
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/logging/nox.py
+++ b/logging/nox.py
@@ -51,8 +51,8 @@ def default(session, django_dep=('django',)):
     else:
         deps += django_dep
 
-    deps += LOCAL_DEPS
     session.install(*deps)
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -114,10 +114,14 @@ def system(session, py):
 
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install('../test_utils/', '../bigquery/', '../pubsub/',
-                    '../storage/')
-    session.install('.')
+    session.install('mock', 'pytest')
+    session.install('-e',
+        '../test_utils/',
+        '../bigquery/',
+        '../pubsub/',
+        '../storage/',
+        *LOCAL_DEPS)
+    session.install('-e', '.')
 
     # Run py.test against the system tests.
     session.run(

--- a/pubsub/nox.py
+++ b/pubsub/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -87,7 +88,9 @@ def system(session, py):
 
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest')
-    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', '../test_utils/')
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/pubsub/nox.py
+++ b/pubsub/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -84,11 +85,10 @@ def system(session, py):
     # Use pre-release gRPC for system tests.
     session.install('--pre', 'grpcio')
 
-    # Install all test dependencies, then install this package into the
-    # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install('../test_utils/')
-    session.install('.')
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest')
+    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    session.install('-e', '.')
 
     # Run py.test against the system tests.
     session.run(

--- a/redis/nox.py
+++ b/redis/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/redis/nox.py
+++ b/redis/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/resource_manager/nox.py
+++ b/resource_manager/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/resource_manager/nox.py
+++ b/resource_manager/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/spanner/nox.py
+++ b/spanner/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -89,10 +90,9 @@ def system_common(session):
     # Use pre-release gRPC for system tests.
     session.install('--pre', 'grpcio')
 
-    # Install all test dependencies, then install this package into the
-    # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install('../test_utils/')
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest')
+    session.install('-e', '../test_utils/', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/spanner/nox.py
+++ b/spanner/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -92,7 +93,9 @@ def system_common(session):
 
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest')
-    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', '../test_utils/')
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/storage/nox.py
+++ b/storage/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -88,11 +89,15 @@ def system(session, py):
 
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest')
-    session.install('-e',
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    systest_deps = [
         '../test_utils/',
         '../pubsub',
         '../kms',
-        *LOCAL_DEPS)
+    ]
+    for systest_dep in systest_deps:
+        session.install('-e', systest_dep)
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/storage/nox.py
+++ b/storage/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -85,12 +86,13 @@ def system(session, py):
     # Use pre-release gRPC for system tests.
     session.install('--pre', 'grpcio')
 
-    # Install all test dependencies, then install this package into the
-    # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install('../test_utils/')
-    session.install('../pubsub')
-    session.install('../kms')
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest')
+    session.install('-e',
+        '../test_utils/',
+        '../pubsub',
+        '../kms',
+        *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/trace/nox.py
+++ b/trace/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/trace/nox.py
+++ b/trace/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/translate/nox.py
+++ b/translate/nox.py
@@ -36,7 +36,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -82,7 +83,9 @@ def system(session, py):
 
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest')
-    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
+    session.install('-e', '../test_utils/')
     session.install('-e', '.')
 
     # Run py.test against the system tests.

--- a/translate/nox.py
+++ b/translate/nox.py
@@ -34,8 +34,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.
@@ -79,11 +80,10 @@ def system(session, py):
     # Use pre-release gRPC for system tests.
     session.install('--pre', 'grpcio')
 
-    # Install all test dependencies, then install this package into the
-    # virtualenv's dist-packages.
-    session.install('mock', 'pytest', *LOCAL_DEPS)
-    session.install('../test_utils/')
-    session.install('.')
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest')
+    session.install('-e', '../test_utils/', *LOCAL_DEPS)
+    session.install('-e', '.')
 
     # Run py.test against the system tests.
     session.run('py.test', '--quiet', 'tests/system.py')

--- a/websecurityscanner/google/cloud/websecurityscanner_v1alpha/types.py
+++ b/websecurityscanner/google/cloud/websecurityscanner_v1alpha/types.py
@@ -26,11 +26,11 @@ from google.cloud.websecurityscanner_v1alpha.proto import crawled_url_pb2
 from google.cloud.websecurityscanner_v1alpha.proto import finding_addon_pb2
 from google.cloud.websecurityscanner_v1alpha.proto import finding_pb2
 from google.cloud.websecurityscanner_v1alpha.proto import (
-    finding_type_stats_pb2 )
+    finding_type_stats_pb2)
 from google.cloud.websecurityscanner_v1alpha.proto import scan_config_pb2
 from google.cloud.websecurityscanner_v1alpha.proto import scan_run_pb2
 from google.cloud.websecurityscanner_v1alpha.proto import (
-    web_security_scanner_pb2 )
+    web_security_scanner_pb2)
 
 
 _shared_modules = [

--- a/websecurityscanner/nox.py
+++ b/websecurityscanner/nox.py
@@ -33,8 +33,9 @@ def default(session):
     Python corresponding to the ``nox`` binary the ``PATH`` can
     run the tests.
     """
-    # Install all test dependencies, then install this package in-place.
-    session.install('mock', 'pytest', 'pytest-cov', *LOCAL_DEPS)
+    # Install all test dependencies, then install local packages in-place.
+    session.install('mock', 'pytest', 'pytest-cov')
+    session.install('-e', *LOCAL_DEPS)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.

--- a/websecurityscanner/nox.py
+++ b/websecurityscanner/nox.py
@@ -35,7 +35,8 @@ def default(session):
     """
     # Install all test dependencies, then install local packages in-place.
     session.install('mock', 'pytest', 'pytest-cov')
-    session.install('-e', *LOCAL_DEPS)
+    for local_dep in LOCAL_DEPS:
+        session.install('-e', local_dep)
     session.install('-e', '.')
 
     # Run py.test against the unit tests.


### PR DESCRIPTION
The overall intent here is to use in-place installs for all local packages, to ease debugging using the "mainline" versions of the packages.