### PR TITLE
Avoid pulling entire result set into memory when constructing dataframe.

### DIFF
--- a/bigquery/google/cloud/bigquery/table.py
+++ b/bigquery/google/cloud/bigquery/table.py
@@ -1166,7 +1166,8 @@ class RowIterator(HTTPIterator):
             raise ValueError(_NO_PANDAS_ERROR)
 
         column_headers = [field.name for field in self.schema]
-        rows = [row.values() for row in iter(self)]
+        # Use generator, rather than pulling the whole rowset into memory.
+        rows = (row.values() for row in iter(self))
 
         return pandas.DataFrame(rows, columns=column_headers)
 


### PR DESCRIPTION
Closes #5859.