### PR TITLE
Fix non-admin client access to table data

### DIFF
--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -156,8 +156,6 @@ class Client(ClientWithProject):
         :returns: A BigtableClient object.
         """
         if self._table_data_client is None:
-            if not self._admin:
-                raise ValueError('Client is not an admin client.')
             self._table_data_client = (
                 bigtable_v2.BigtableClient(credentials=self._credentials,
                                            client_info=_CLIENT_INFO))

--- a/bigtable/google/cloud/bigtable/paths.py
+++ b/bigtable/google/cloud/bigtable/paths.py
@@ -1,0 +1,84 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for constructing paths used in the Bigtable API"""
+
+from google.api_core import path_template
+
+
+def project_path(project):
+    """Return a fully-qualified project string."""
+    return path_template.expand(
+        'projects/{project}',
+        project=project,
+    )
+
+
+def location_path(project, location):
+    """Return a fully-qualified location string."""
+    return path_template.expand(
+        'projects/{project}/locations/{location}',
+        project=project,
+        location=location,
+    )
+
+
+def instance_path(project, instance):
+    """Return a fully-qualified instance string."""
+    return path_template.expand(
+        'projects/{project}/instances/{instance}',
+        project=project,
+        instance=instance,
+    )
+
+
+def app_profile_path(project, instance, app_profile):
+    """Return a fully-qualified app_profile string."""
+    return path_template.expand(
+        'projects/{project}/instances/{instance}/appProfiles/{app_profile}',
+        project=project,
+        instance=instance,
+        app_profile=app_profile,
+    )
+
+
+def cluster_path(project, instance, cluster):
+    """Return a fully-qualified cluster string."""
+    return path_template.expand(
+        'projects/{project}/instances/{instance}/clusters/{cluster}',
+        project=project,
+        instance=instance,
+        cluster=cluster,
+    )
+
+
+def snapshot_path(project, instance, cluster, snapshot):
+    """Return a fully-qualified snapshot string."""
+    return path_template.expand(
+        'projects/{project}/instances/{instance}/clusters/{cluster}/'
+        'snapshots/{snapshot}',
+        project=project,
+        instance=instance,
+        cluster=cluster,
+        snapshot=snapshot,
+    )
+
+
+def table_path(project, instance, table):
+    """Return a fully-qualified table string."""
+    return path_template.expand(
+        'projects/{project}/instances/{instance}/tables/{table}',
+        project=project,
+        instance=instance,
+        table=table,
+    )

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -21,11 +21,13 @@ from google.api_core.exceptions import RetryError
 from google.api_core.exceptions import NotFound
 from google.api_core.retry import if_exception_type
 from google.api_core.retry import Retry
+
 from google.cloud._helpers import _to_bytes
 from google.cloud.bigtable.column_family import _gc_rule_from_pb
 from google.cloud.bigtable.column_family import ColumnFamily
 from google.cloud.bigtable.batcher import MutationsBatcher
 from google.cloud.bigtable.batcher import (FLUSH_COUNT, MAX_ROW_BYTES)
+from google.cloud.bigtable import paths
 from google.cloud.bigtable.row import AppendRow
 from google.cloud.bigtable.row import ConditionalRow
 from google.cloud.bigtable.row import DirectRow
@@ -122,8 +124,7 @@ class Table(object):
         """
         project = self._instance._client.project
         instance_id = self._instance.instance_id
-        table_client = self._instance._client.table_admin_client
-        return table_client.table_path(
+        return paths.table_path(
             project=project, instance=instance_id, table=self.table_id)
 
     def column_family(self, column_family_id, gc_rule=None):

--- a/bigtable/google/cloud/bigtable_admin_v2/gapic/bigtable_instance_admin_client.py
+++ b/bigtable/google/cloud/bigtable_admin_v2/gapic/bigtable_instance_admin_client.py
@@ -16,6 +16,12 @@
 import functools
 import pkg_resources
 
+from google.iam.v1 import iam_policy_pb2
+from google.iam.v1 import policy_pb2
+from google.longrunning import operations_pb2
+from google.protobuf import empty_pb2
+from google.protobuf import field_mask_pb2
+
 import google.api_core.gapic_v1.client_info
 import google.api_core.gapic_v1.config
 import google.api_core.gapic_v1.method
@@ -24,18 +30,15 @@ import google.api_core.grpc_helpers
 import google.api_core.operation
 import google.api_core.operations_v1
 import google.api_core.page_iterator
-import google.api_core.path_template
 
-from google.cloud.bigtable_admin_v2.gapic import bigtable_instance_admin_client_config
+from google.cloud.bigtable import paths
+from google.cloud.bigtable_admin_v2.gapic import (
+    bigtable_instance_admin_client_config)
 from google.cloud.bigtable_admin_v2.gapic import enums
 from google.cloud.bigtable_admin_v2.proto import bigtable_instance_admin_pb2
-from google.cloud.bigtable_admin_v2.proto import bigtable_instance_admin_pb2_grpc
+from google.cloud.bigtable_admin_v2.proto import (
+    bigtable_instance_admin_pb2_grpc)
 from google.cloud.bigtable_admin_v2.proto import instance_pb2
-from google.iam.v1 import iam_policy_pb2
-from google.iam.v1 import policy_pb2
-from google.longrunning import operations_pb2
-from google.protobuf import empty_pb2
-from google.protobuf import field_mask_pb2
 
 _GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
     'google-cloud-bigtable', ).version
@@ -69,51 +72,11 @@ class BigtableInstanceAdminClient(object):
     # method configuration in the client_config dictionary.
     _INTERFACE_NAME = 'google.bigtable.admin.v2.BigtableInstanceAdmin'
 
-    @classmethod
-    def project_path(cls, project):
-        """Return a fully-qualified project string."""
-        return google.api_core.path_template.expand(
-            'projects/{project}',
-            project=project,
-        )
-
-    @classmethod
-    def instance_path(cls, project, instance):
-        """Return a fully-qualified instance string."""
-        return google.api_core.path_template.expand(
-            'projects/{project}/instances/{instance}',
-            project=project,
-            instance=instance,
-        )
-
-    @classmethod
-    def app_profile_path(cls, project, instance, app_profile):
-        """Return a fully-qualified app_profile string."""
-        return google.api_core.path_template.expand(
-            'projects/{project}/instances/{instance}/appProfiles/{app_profile}',
-            project=project,
-            instance=instance,
-            app_profile=app_profile,
-        )
-
-    @classmethod
-    def cluster_path(cls, project, instance, cluster):
-        """Return a fully-qualified cluster string."""
-        return google.api_core.path_template.expand(
-            'projects/{project}/instances/{instance}/clusters/{cluster}',
-            project=project,
-            instance=instance,
-            cluster=cluster,
-        )
-
-    @classmethod
-    def location_path(cls, project, location):
-        """Return a fully-qualified location string."""
-        return google.api_core.path_template.expand(
-            'projects/{project}/locations/{location}',
-            project=project,
-            location=location,
-        )
+    project_path = staticmethod(paths.project_path)
+    instance_path = staticmethod(paths.instance_path)
+    app_profile_path = staticmethod(paths.app_profile_path)
+    cluster_path = staticmethod(paths.cluster_path)
+    location_path = staticmethod(paths.location_path)
 
     def __init__(self,
                  channel=None,

--- a/bigtable/google/cloud/bigtable_admin_v2/gapic/bigtable_table_admin_client.py
+++ b/bigtable/google/cloud/bigtable_admin_v2/gapic/bigtable_table_admin_client.py
@@ -16,6 +16,13 @@
 import functools
 import pkg_resources
 
+from google.iam.v1 import iam_policy_pb2
+from google.iam.v1 import policy_pb2
+from google.longrunning import operations_pb2
+from google.protobuf import duration_pb2
+from google.protobuf import empty_pb2
+from google.protobuf import field_mask_pb2
+
 import google.api_core.gapic_v1.client_info
 import google.api_core.gapic_v1.config
 import google.api_core.gapic_v1.method
@@ -27,20 +34,17 @@ import google.api_core.page_iterator
 import google.api_core.path_template
 import google.api_core.protobuf_helpers
 
-from google.cloud.bigtable_admin_v2.gapic import bigtable_table_admin_client_config
+from google.cloud.bigtable import paths
+from google.cloud.bigtable_admin_v2.gapic import (
+    bigtable_table_admin_client_config)
 from google.cloud.bigtable_admin_v2.gapic import enums
 from google.cloud.bigtable_admin_v2.proto import bigtable_instance_admin_pb2
-from google.cloud.bigtable_admin_v2.proto import bigtable_instance_admin_pb2_grpc
+from google.cloud.bigtable_admin_v2.proto import (
+    bigtable_instance_admin_pb2_grpc)
 from google.cloud.bigtable_admin_v2.proto import bigtable_table_admin_pb2
 from google.cloud.bigtable_admin_v2.proto import bigtable_table_admin_pb2_grpc
 from google.cloud.bigtable_admin_v2.proto import instance_pb2
 from google.cloud.bigtable_admin_v2.proto import table_pb2
-from google.iam.v1 import iam_policy_pb2
-from google.iam.v1 import policy_pb2
-from google.longrunning import operations_pb2
-from google.protobuf import duration_pb2
-from google.protobuf import empty_pb2
-from google.protobuf import field_mask_pb2
 
 _GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
     'google-cloud-bigtable', ).version
@@ -76,45 +80,10 @@ class BigtableTableAdminClient(object):
     # method configuration in the client_config dictionary.
     _INTERFACE_NAME = 'google.bigtable.admin.v2.BigtableTableAdmin'
 
-    @classmethod
-    def instance_path(cls, project, instance):
-        """Return a fully-qualified instance string."""
-        return google.api_core.path_template.expand(
-            'projects/{project}/instances/{instance}',
-            project=project,
-            instance=instance,
-        )
-
-    @classmethod
-    def cluster_path(cls, project, instance, cluster):
-        """Return a fully-qualified cluster string."""
-        return google.api_core.path_template.expand(
-            'projects/{project}/instances/{instance}/clusters/{cluster}',
-            project=project,
-            instance=instance,
-            cluster=cluster,
-        )
-
-    @classmethod
-    def snapshot_path(cls, project, instance, cluster, snapshot):
-        """Return a fully-qualified snapshot string."""
-        return google.api_core.path_template.expand(
-            'projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}',
-            project=project,
-            instance=instance,
-            cluster=cluster,
-            snapshot=snapshot,
-        )
-
-    @classmethod
-    def table_path(cls, project, instance, table):
-        """Return a fully-qualified table string."""
-        return google.api_core.path_template.expand(
-            'projects/{project}/instances/{instance}/tables/{table}',
-            project=project,
-            instance=instance,
-            table=table,
-        )
+    instance_path = staticmethod(paths.instance_path)
+    cluster_path = staticmethod(paths.cluster_path)
+    snapshot_path = staticmethod(paths.snapshot_path)
+    table_path = staticmethod(paths.table_path)
 
     def __init__(self,
                  channel=None,

--- a/bigtable/tests/system.py
+++ b/bigtable/tests/system.py
@@ -1013,3 +1013,9 @@ class TestDataAPI(unittest.TestCase):
         self.assertEqual(cell3_new.timestamp, cell3.timestamp)
         self.assertEqual(cell3.labels, [])
         self.assertEqual(cell3_new.labels, [label2])
+
+    def test_access_with_non_admin_client(self):
+        client = Client(admin=False)
+        instance = client.instance(INSTANCE_ID)
+        table = instance.table(self._table.table_id)
+        self.assertIsNone(table.read_row('nonesuch'))

--- a/bigtable/tests/unit/test_client.py
+++ b/bigtable/tests/unit/test_client.py
@@ -125,46 +125,74 @@ class TestClient(unittest.TestCase):
         self.assertEqual(instance.labels, labels)
         self.assertIs(instance._client, client)
 
-    def test_admin_client_w_value_error(self):
+    def test_table_data_client_not_initialized(self):
+        from google.cloud.bigtable_v2 import BigtableClient
+
+        credentials = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=credentials)
+
+        table_data_client = client.table_data_client
+        self.assertIsInstance(table_data_client, BigtableClient)
+        self.assertIs(client._table_data_client, table_data_client)
+
+    def test_table_data_client_initialized(self):
+        credentials = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=credentials,
+                                admin=True)
+
+        already = client._table_data_client = object()
+        self.assertIs(client.table_data_client, already)
+
+    def test_table_admin_client_not_initialized_no_admin_flag(self):
         credentials = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=credentials)
 
         with self.assertRaises(ValueError):
             client.table_admin_client()
 
-        with self.assertRaises(ValueError):
-            client.instance_admin_client()
+    def test_table_admin_client_not_initialized_w_admin_flag(self):
+        from google.cloud.bigtable_admin_v2 import BigtableTableAdminClient
 
-    def test_table_data_client(self):
+        credentials = _make_credentials()
+        client = self._make_one(
+            project=self.PROJECT, credentials=credentials, admin=True)
+
+        table_admin_client = client.table_admin_client
+        self.assertIsInstance(table_admin_client, BigtableTableAdminClient)
+
+    def test_table_admin_client_initialized(self):
         credentials = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=credentials,
                                 admin=True)
 
-        table_data_client = client.table_data_client
-        self.assertEqual(client._table_data_client, table_data_client)
+        already = client._table_admin_client = object()
+        self.assertIs(client.table_admin_client, already)
 
-        client._table_data_client = object()
-        table_data_client = client.table_data_client
-        self.assertEqual(client.table_data_client, table_data_client)
-
-    def test_table_admin_client(self):
-        credentials = _make_credentials()
-        client = self._make_one(project=self.PROJECT, credentials=credentials,
-                                admin=True)
-
-        table_admin_client = client.table_admin_client
-        self.assertEqual(client._table_admin_client, table_admin_client)
-
-        client._table_admin_client = object()
-        table_admin_client = client.table_admin_client
-        self.assertEqual(client._table_admin_client, table_admin_client)
-
-    def test_table_data_client_w_value_error(self):
+    def test_instance_admin_client_not_initialized_no_admin_flag(self):
         credentials = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=credentials)
 
         with self.assertRaises(ValueError):
-            client.table_data_client()
+            client.instance_admin_client()
+
+    def test_instance_admin_client_not_initialized_w_admin_flag(self):
+        from google.cloud.bigtable_admin_v2 import BigtableInstanceAdminClient
+
+        credentials = _make_credentials()
+        client = self._make_one(
+            project=self.PROJECT, credentials=credentials, admin=True)
+
+        instance_admin_client = client.instance_admin_client
+        self.assertIsInstance(
+            instance_admin_client, BigtableInstanceAdminClient)
+
+    def test_instance_admin_client_initialized(self):
+        credentials = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=credentials,
+                                admin=True)
+
+        already = client._instance_admin_client = object()
+        self.assertIs(client.instance_admin_client, already)
 
     def test_list_instances(self):
         from google.cloud.bigtable_admin_v2.proto import (

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -791,8 +791,6 @@ class TestTable(unittest.TestCase):
         client._table_admin_client = table_api
         instance = client.instance(instance_id=self.INSTANCE_ID)
         table = self._make_one(self.TABLE_ID, instance)
-        table.name.return_value = client._table_data_client.table_path(
-            self.PROJECT_ID,  self.INSTANCE_ID, self.TABLE_ID)
 
         expected_result = None  # truncate() has no return value.
         with mock.patch('google.cloud.bigtable.table.Table.name',


### PR DESCRIPTION
- Remove spurious check for the admin flag in `Client.table_data_client`:  that flag is supposed to cover only access the the *admin* clients.
- Move path generation logic from admin client classmethods to a new module, 'google.cloud.bigtable.paths`:  leave staticmethod wrappers behind in admin clients.

Closes #5874.