### PR TITLE
Storage: add lifecycle rules helpers to bucket

### DIFF
--- a/docs/storage/snippets.py
+++ b/docs/storage/snippets.py
@@ -186,6 +186,27 @@ def get_bucket(client, to_delete):
 
 
 @snippet
+def add_lifecycle_delete_rule(client, to_delete):
+    # [START add_lifecycle_delete_rule]
+    bucket = client.get_bucket('my-bucket')
+    bucket.add_lifecycle_rule_delete(age=2)
+    bucket.patch()
+    # [END add_lifecycle_delete_rule]
+    to_delete.append(bucket)
+
+
+@snippet
+def add_lifecycle_set_storage_class_rule(client, to_delete):
+    # [START add_lifecycle_set_storage_class_rule]
+    bucket = client.get_bucket('my-bucket')
+    bucket.add_lifecycle_rule_set_storage_class(
+        'COLD_LINE', matches_storage_class=['NEARLINE'])
+    bucket.patch()
+    # [END add_lifecycle_set_storage_class_rule]
+    to_delete.append(bucket)
+
+
+@snippet
 def lookup_bucket(client, to_delete):
     from google.cloud.storage.bucket import Bucket
     # [START lookup_bucket]

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -119,7 +119,8 @@ class LifecycleRuleConditions(dict):
                     rule action to versioned items with at least one newer
                     version.
 
-    :type matches_storage_class: str, one of :attr:`Bucket._STORAGE_CLASSES`.
+    :type matches_storage_class: list(str), one or more of
+                                 :attr:`Bucket._STORAGE_CLASSES`.
     :param matches_storage_class: (optional) apply rule action to items which
                                   whose storage class matches this value.
 

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -1118,6 +1118,43 @@ class Bucket(_PropertyMixin):
         rules = [dict(rule) for rule in rules]  # Convert helpers if needed
         self._patch_property('lifecycle', {'rule': rules})
 
+    def clear_lifecyle_rules(self):
+        """Set lifestyle rules configured for this bucket.
+
+        See https://cloud.google.com/storage/docs/lifecycle and
+             https://cloud.google.com/storage/docs/json_api/v1/buckets
+        """
+        self.lifecycle_rules = []
+
+    def add_lifecycle_delete_rule(self, **kw):
+        """Add a "delete" rule to lifestyle rules configured for this bucket.
+
+        See https://cloud.google.com/storage/docs/lifecycle and
+             https://cloud.google.com/storage/docs/json_api/v1/buckets
+
+        :type kw: dict
+        :params kw: arguments passed to :class:`LifecycleRuleConditions`.
+        """
+        rules = list(self.lifecycle_rules)
+        rules.append(LifecycleRuleDelete(**kw))
+        self.lifecycle_rules = rules
+
+    def add_lifecycle_set_storage_class_rule(self, storage_class, **kw):
+        """Add a "delete" rule to lifestyle rules configured for this bucket.
+
+        See https://cloud.google.com/storage/docs/lifecycle and
+             https://cloud.google.com/storage/docs/json_api/v1/buckets
+
+        :type storage_class: str, one of :attr:`_STORAGE_CLASSES`.
+        :param storage_class: new storage class to assign to matching items.
+
+        :type kw: dict
+        :params kw: arguments passed to :class:`LifecycleRuleConditions`.
+        """
+        rules = list(self.lifecycle_rules)
+        rules.append(LifecycleRuleSetStorageClass(storage_class, **kw))
+        self.lifecycle_rules = rules
+
     _location = _scalar_property('location')
 
     @property

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -198,6 +198,27 @@ class LifecycleRuleDeleteItem(dict):
         super(LifecycleRuleDeleteItem, self).__init__(rule)
 
 
+class LifecycleRuleSetItemStorageClass(dict):
+    """Map a lifecycle rule upating storage class of matching items.
+
+    :type storage_class: str, one of :attr:`Bucket._STORAGE_CLASSES`.
+    :param storage_class: new storage class to assign to matching items.
+
+    :type kw: dict
+    :params kw: arguments passed to :class:`LifecycleRuleConditions`.
+    """
+    def __init__(self, storage_class, **kw):
+        conditions = LifecycleRuleConditions(**kw)
+        rule = {
+            'action': {
+                'type': 'SetStorageClass',
+                'storageClass': storage_class,
+            },
+            'condition': dict(conditions),
+        }
+        super(LifecycleRuleSetItemStorageClass, self).__init__(rule)
+
+
 class Bucket(_PropertyMixin):
     """A class representing a Bucket on Cloud Storage.
 

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -181,6 +181,23 @@ class LifecycleRuleConditions(dict):
         return self.get('numNewerVersions')
 
 
+class LifecycleRuleDeleteItem(dict):
+    """Map a lifecycle rule deleting matching items.
+
+    :type kw: dict
+    :params kw: arguments passed to :class:`LifecycleRuleConditions`.
+    """
+    def __init__(self, **kw):
+        conditions = LifecycleRuleConditions(**kw)
+        rule = {
+            'action': {
+                'type': 'Delete',
+            },
+            'condition': dict(conditions),
+        }
+        super(LifecycleRuleDeleteItem, self).__init__(rule)
+
+
 class Bucket(_PropertyMixin):
     """A class representing a Bucket on Cloud Storage.
 

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -130,7 +130,8 @@ class LifecycleRuleConditions(dict):
     :raises ValueError: if no arguments are passed.
     """
     def __init__(self, age=None, created_before=None, is_live=None,
-                 matches_storage_class=None, number_of_newer_versions=None):
+                 matches_storage_class=None, number_of_newer_versions=None,
+                 _factory=False):
         conditions = {}
 
         if age is not None:
@@ -148,10 +149,24 @@ class LifecycleRuleConditions(dict):
         if number_of_newer_versions is not None:
             conditions['numNewerVersions'] = number_of_newer_versions
 
-        if not conditions:
+        if not _factory and not conditions:
             raise ValueError("Supply at least one condition")
 
         super(LifecycleRuleConditions, self).__init__(conditions)
+
+    @classmethod
+    def from_api_repr(cls, resource):
+        """Factory:  construct instance from resource.
+
+        :type resource: dict
+        :param resource: mapping as returned from API call.
+
+        :rtype: :class:`LifecycleRuleConditions`
+        :returns: Instance created from resource.
+        """
+        instance = cls(_factory=True)
+        instance.update(resource)
+        return instance
 
     @property
     def age(self):
@@ -197,6 +212,20 @@ class LifecycleRuleDeleteItem(dict):
         }
         super(LifecycleRuleDeleteItem, self).__init__(rule)
 
+    @classmethod
+    def from_api_repr(cls, resource):
+        """Factory:  construct instance from resource.
+
+        :type resource: dict
+        :param resource: mapping as returned from API call.
+
+        :rtype: :class:`LifecycleRuleDeleteItem`
+        :returns: Instance created from resource.
+        """
+        instance = cls(_factory=True)
+        instance.update(resource)
+        return instance
+
 
 class LifecycleRuleSetItemStorageClass(dict):
     """Map a lifecycle rule upating storage class of matching items.
@@ -217,6 +246,21 @@ class LifecycleRuleSetItemStorageClass(dict):
             'condition': dict(conditions),
         }
         super(LifecycleRuleSetItemStorageClass, self).__init__(rule)
+
+    @classmethod
+    def from_api_repr(cls, resource):
+        """Factory:  construct instance from resource.
+
+        :type resource: dict
+        :param resource: mapping as returned from API call.
+
+        :rtype: :class:`LifecycleRuleDeleteItem`
+        :returns: Instance created from resource.
+        """
+        action = resource['action']
+        instance = cls(action['storageClass'], _factory=True)
+        instance.update(resource)
+        return instance
 
 
 class Bucket(_PropertyMixin):

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -1132,6 +1132,10 @@ class Bucket(_PropertyMixin):
         See https://cloud.google.com/storage/docs/lifecycle and
              https://cloud.google.com/storage/docs/json_api/v1/buckets
 
+        .. literalinclude:: snippets.py
+          :start-after: [START add_lifecycle_delete_rule]
+          :end-before: [END add_lifecycle_delete_rule]
+
         :type kw: dict
         :params kw: arguments passed to :class:`LifecycleRuleConditions`.
         """
@@ -1144,6 +1148,10 @@ class Bucket(_PropertyMixin):
 
         See https://cloud.google.com/storage/docs/lifecycle and
              https://cloud.google.com/storage/docs/json_api/v1/buckets
+
+        .. literalinclude:: snippets.py
+          :start-after: [START add_lifecycle_set_storage_class_rule]
+          :end-before: [END add_lifecycle_set_storage_class_rule]
 
         :type storage_class: str, one of :attr:`_STORAGE_CLASSES`.
         :param storage_class: new storage class to assign to matching items.

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -197,7 +197,7 @@ class LifecycleRuleConditions(dict):
         return self.get('numNewerVersions')
 
 
-class LifecycleRuleDeleteItem(dict):
+class LifecycleRuleDelete(dict):
     """Map a lifecycle rule deleting matching items.
 
     :type kw: dict
@@ -211,7 +211,7 @@ class LifecycleRuleDeleteItem(dict):
             },
             'condition': dict(conditions),
         }
-        super(LifecycleRuleDeleteItem, self).__init__(rule)
+        super(LifecycleRuleDelete, self).__init__(rule)
 
     @classmethod
     def from_api_repr(cls, resource):
@@ -220,7 +220,7 @@ class LifecycleRuleDeleteItem(dict):
         :type resource: dict
         :param resource: mapping as returned from API call.
 
-        :rtype: :class:`LifecycleRuleDeleteItem`
+        :rtype: :class:`LifecycleRuleDelete`
         :returns: Instance created from resource.
         """
         instance = cls(_factory=True)
@@ -228,7 +228,7 @@ class LifecycleRuleDeleteItem(dict):
         return instance
 
 
-class LifecycleRuleSetItemStorageClass(dict):
+class LifecycleRuleSetStorageClass(dict):
     """Map a lifecycle rule upating storage class of matching items.
 
     :type storage_class: str, one of :attr:`Bucket._STORAGE_CLASSES`.
@@ -246,7 +246,7 @@ class LifecycleRuleSetItemStorageClass(dict):
             },
             'condition': dict(conditions),
         }
-        super(LifecycleRuleSetItemStorageClass, self).__init__(rule)
+        super(LifecycleRuleSetStorageClass, self).__init__(rule)
 
     @classmethod
     def from_api_repr(cls, resource):
@@ -255,7 +255,7 @@ class LifecycleRuleSetItemStorageClass(dict):
         :type resource: dict
         :param resource: mapping as returned from API call.
 
-        :rtype: :class:`LifecycleRuleDeleteItem`
+        :rtype: :class:`LifecycleRuleDelete`
         :returns: Instance created from resource.
         """
         action = resource['action']
@@ -1099,9 +1099,9 @@ class Bucket(_PropertyMixin):
         for rule in info.get('rule', ()):
             action_type = rule['action']['type']
             if action_type == 'Delete':
-                yield LifecycleRuleDeleteItem.from_api_repr(rule)
+                yield LifecycleRuleDelete.from_api_repr(rule)
             elif action_type == 'SetStorageClass':
-                yield LifecycleRuleSetItemStorageClass.from_api_repr(rule)
+                yield LifecycleRuleSetStorageClass.from_api_repr(rule)
             else:
                 raise ValueError("Unknown lifecycle rule: {}".format(rule))
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -24,8 +24,8 @@ import six
 from google.cloud import exceptions
 from google.cloud import storage
 from google.cloud.storage._helpers import _base64_md5hash
-from google.cloud.storage.bucket import LifecycleRuleDeleteItem
-from google.cloud.storage.bucket import LifecycleRuleSetItemStorageClass
+from google.cloud.storage.bucket import LifecycleRuleDelete
+from google.cloud.storage.bucket import LifecycleRuleSetStorageClass
 from google.cloud import kms
 
 from test_utils.retry import RetryErrors
@@ -129,8 +129,8 @@ class TestStorageBuckets(unittest.TestCase):
                           Config.CLIENT.get_bucket, new_bucket_name)
         bucket = Config.CLIENT.bucket(new_bucket_name)
         rules = bucket.lifecycle_rules = [
-            LifecycleRuleDeleteItem(age=42),
-            LifecycleRuleSetItemStorageClass(
+            LifecycleRuleDelete(age=42),
+            LifecycleRuleSetStorageClass(
                 'COLDLINE', is_live=False, matches_storage_class=['NEARLINE']),
         ]
 

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -24,6 +24,8 @@ import six
 from google.cloud import exceptions
 from google.cloud import storage
 from google.cloud.storage._helpers import _base64_md5hash
+from google.cloud.storage.bucket import LifecycleRuleDeleteItem
+from google.cloud.storage.bucket import LifecycleRuleSetItemStorageClass
 from google.cloud import kms
 
 from test_utils.retry import RetryErrors
@@ -120,6 +122,23 @@ class TestStorageBuckets(unittest.TestCase):
         created = retry_429(Config.CLIENT.create_bucket)(new_bucket_name)
         self.case_buckets_to_delete.append(new_bucket_name)
         self.assertEqual(created.name, new_bucket_name)
+
+    def test_create_bucket_w_lifecycle_rules(self):
+        new_bucket_name = 'w-lifcycle-rules' + unique_resource_id('-')
+        self.assertRaises(exceptions.NotFound,
+                          Config.CLIENT.get_bucket, new_bucket_name)
+        bucket = Config.CLIENT.bucket(new_bucket_name)
+        rules = bucket.lifecycle_rules = [
+            LifecycleRuleDeleteItem(age=42),
+            LifecycleRuleSetItemStorageClass(
+                'COLDLINE', is_live=False, matches_storage_class='NEARLINE'),
+        ]
+
+        retry_429(bucket.create)()
+
+        self.case_buckets_to_delete.append(new_bucket_name)
+        self.assertEqual(bucket.name, new_bucket_name)
+        self.assertEqual(list(bucket.lifecycle_rules), rules)
 
     def test_list_buckets(self):
         buckets_to_create = [

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -131,7 +131,7 @@ class TestStorageBuckets(unittest.TestCase):
         rules = bucket.lifecycle_rules = [
             LifecycleRuleDeleteItem(age=42),
             LifecycleRuleSetItemStorageClass(
-                'COLDLINE', is_live=False, matches_storage_class='NEARLINE'),
+                'COLDLINE', is_live=False, matches_storage_class=['NEARLINE']),
         ]
 
         retry_429(bucket.create)()

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -134,7 +134,7 @@ class TestStorageBuckets(unittest.TestCase):
                 'COLDLINE', is_live=False, matches_storage_class=['NEARLINE']),
         ]
 
-        retry_429(bucket.create)()
+        retry_429(bucket.create)(location='us')
 
         self.case_buckets_to_delete.append(new_bucket_name)
         self.assertEqual(bucket.name, new_bucket_name)

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -107,12 +107,12 @@ class Test_LifecycleRuleConditions(unittest.TestCase):
         self.assertEqual(conditions.number_of_newer_versions, 3)
 
 
-class Test_LifecycleRuleDeleteItem(unittest.TestCase):
+class Test_LifecycleRuleDelete(unittest.TestCase):
 
     @staticmethod
     def _get_target_class():
-        from google.cloud.storage.bucket import LifecycleRuleDeleteItem
-        return LifecycleRuleDeleteItem
+        from google.cloud.storage.bucket import LifecycleRuleDelete
+        return LifecycleRuleDelete
 
     def _make_one(self, **kw):
         return self._get_target_class()(**kw)
@@ -153,13 +153,13 @@ class Test_LifecycleRuleDeleteItem(unittest.TestCase):
         self.assertEqual(dict(rule), resource)
 
 
-class Test_LifecycleRuleSetItemStorageClass(unittest.TestCase):
+class Test_LifecycleRuleSetStorageClass(unittest.TestCase):
 
     @staticmethod
     def _get_target_class():
         from google.cloud.storage.bucket import (
-            LifecycleRuleSetItemStorageClass)
-        return LifecycleRuleSetItemStorageClass
+            LifecycleRuleSetStorageClass)
+        return LifecycleRuleSetStorageClass
 
     def _make_one(self, **kw):
         return self._get_target_class()(**kw)
@@ -1121,7 +1121,7 @@ class Test_Bucket(unittest.TestCase):
 
     def test_lifecycle_rules_getter(self):
         from google.cloud.storage.bucket import (
-            LifecycleRuleDeleteItem, LifecycleRuleSetItemStorageClass)
+            LifecycleRuleDelete, LifecycleRuleSetStorageClass)
 
         NAME = 'name'
         DELETE_RULE = {
@@ -1148,11 +1148,11 @@ class Test_Bucket(unittest.TestCase):
         found = list(bucket.lifecycle_rules)
 
         delete_rule = found[0]
-        self.assertIsInstance(delete_rule, LifecycleRuleDeleteItem)
+        self.assertIsInstance(delete_rule, LifecycleRuleDelete)
         self.assertEqual(dict(delete_rule), DELETE_RULE)
 
         ssc_rule = found[1]
-        self.assertIsInstance(ssc_rule, LifecycleRuleSetItemStorageClass)
+        self.assertIsInstance(ssc_rule, LifecycleRuleSetStorageClass)
         self.assertEqual(dict(ssc_rule), SSC_RULE)
 
     def test_lifecycle_rules_setter_w_dicts(self):
@@ -1186,7 +1186,7 @@ class Test_Bucket(unittest.TestCase):
 
     def test_lifecycle_rules_setter_w_helpers(self):
         from google.cloud.storage.bucket import (
-            LifecycleRuleDeleteItem, LifecycleRuleSetItemStorageClass)
+            LifecycleRuleDelete, LifecycleRuleSetStorageClass)
 
         NAME = 'name'
         DELETE_RULE = {
@@ -1211,8 +1211,8 @@ class Test_Bucket(unittest.TestCase):
         self.assertEqual(list(bucket.lifecycle_rules), [])
 
         bucket.lifecycle_rules = [
-            LifecycleRuleDeleteItem(age=42),
-            LifecycleRuleSetItemStorageClass('NEARLINE', is_live=False),
+            LifecycleRuleDelete(age=42),
+            LifecycleRuleSetStorageClass('NEARLINE', is_live=False),
         ]
 
         self.assertEqual(

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -31,6 +31,62 @@ def _create_signing_credentials():
     return credentials
 
 
+class Test_LifecycleRuleConditions(unittest.TestCase):
+
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.storage.bucket import LifecycleRuleConditions
+        return LifecycleRuleConditions
+
+    def _make_one(self, **kw):
+        return self._get_target_class()(**kw)
+
+    def test_ctor_wo_conditions(self):
+        with self.assertRaises(ValueError):
+            self._make_one()
+
+    def test_ctor_w_age_and_matches_storage_class(self):
+        conditions = self._make_one(age=10, matches_storage_class='REGIONAL')
+        expected = {
+            'age': 10,
+            'matchesStorageClass': 'REGIONAL',
+        }
+        self.assertEqual( dict(conditions), expected)
+        self.assertEqual(conditions.age, 10)
+        self.assertIsNone(conditions.created_before)
+        self.assertIsNone(conditions.is_live)
+        self.assertEqual(conditions.matches_storage_class, 'REGIONAL')
+        self.assertIsNone(conditions.number_of_newer_versions)
+
+    def test_ctor_w_created_before_and_is_live(self):
+        import datetime
+
+        before = datetime.date(2018, 8, 1)
+        conditions = self._make_one(created_before=before, is_live=False)
+        expected = {
+            'createdBefore': '2018-08-01',
+            'isLive': False,
+        }
+        self.assertEqual(dict(conditions), expected)
+        self.assertIsNone(conditions.age)
+        self.assertEqual(conditions.created_before, before)
+        self.assertEqual(conditions.is_live, False)
+        self.assertIsNone(conditions.matches_storage_class)
+        self.assertIsNone(conditions.number_of_newer_versions)
+
+    def test_ctor_w_number_of_newer_versions(self):
+        conditions = self._make_one(number_of_newer_versions=3)
+        expected = {
+            'numNewerVersions': 3,
+        }
+        self.assertEqual(dict(conditions), expected)
+        self.assertIsNone(conditions.age)
+        self.assertIsNone(conditions.created_before)
+        self.assertIsNone(conditions.is_live)
+        self.assertIsNone(conditions.matches_storage_class)
+        self.assertEqual(conditions.number_of_newer_versions, 3)
+
+
 class Test_Bucket(unittest.TestCase):
 
     @staticmethod

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -115,6 +115,37 @@ class Test_LifecycleRuleDeleteItem(unittest.TestCase):
         self.assertEqual(dict(rule), expected)
 
 
+class Test_LifecycleRuleSetItemStorageClass(unittest.TestCase):
+
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.storage.bucket import (
+            LifecycleRuleSetItemStorageClass)
+        return LifecycleRuleSetItemStorageClass
+
+    def _make_one(self, **kw):
+        return self._get_target_class()(**kw)
+
+    def test_ctor_wo_conditions(self):
+        with self.assertRaises(ValueError):
+            self._make_one(storage_class='REGIONAL')
+
+    def test_ctor_w_condition(self):
+        rule = self._make_one(
+            storage_class='NEARLINE', age=10, matches_storage_class='REGIONAL')
+        expected = {
+            'action': {
+                'type': 'SetStorageClass',
+                'storageClass': 'NEARLINE',
+            },
+            'condition': {
+                'age': 10,
+                'matchesStorageClass': 'REGIONAL',
+            }
+        }
+        self.assertEqual(dict(rule), expected)
+
+
 class Test_Bucket(unittest.TestCase):
 
     @staticmethod

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -86,6 +86,25 @@ class Test_LifecycleRuleConditions(unittest.TestCase):
         self.assertIsNone(conditions.matches_storage_class)
         self.assertEqual(conditions.number_of_newer_versions, 3)
 
+    def test_from_api_repr(self):
+        import datetime
+
+        before = datetime.date(2018, 8, 1)
+        klass = self._get_target_class()
+        resource = {
+            'age': 10,
+            'createdBefore': '2018-08-01',
+            'isLive': True,
+            'matchesStorageClass': 'REGIONAL',
+            'numNewerVersions': 3,
+        }
+        conditions = klass.from_api_repr(resource)
+        self.assertEqual(conditions.age, 10)
+        self.assertEqual(conditions.created_before, before)
+        self.assertEqual(conditions.is_live, True)
+        self.assertEqual(conditions.matches_storage_class, 'REGIONAL')
+        self.assertEqual(conditions.number_of_newer_versions, 3)
+
 
 class Test_LifecycleRuleDeleteItem(unittest.TestCase):
 
@@ -113,6 +132,24 @@ class Test_LifecycleRuleDeleteItem(unittest.TestCase):
             }
         }
         self.assertEqual(dict(rule), expected)
+
+    def test_from_api_repr(self):
+        klass = self._get_target_class()
+        conditions = {
+            'age': 10,
+            'createdBefore': '2018-08-01',
+            'isLive': True,
+            'matchesStorageClass': 'REGIONAL',
+            'numNewerVersions': 3,
+        }
+        resource = {
+            'action': {
+                'type': 'Delete',
+            },
+            'condition': conditions,
+        }
+        rule = klass.from_api_repr(resource)
+        self.assertEqual(dict(rule), resource)
 
 
 class Test_LifecycleRuleSetItemStorageClass(unittest.TestCase):
@@ -144,6 +181,25 @@ class Test_LifecycleRuleSetItemStorageClass(unittest.TestCase):
             }
         }
         self.assertEqual(dict(rule), expected)
+
+    def test_from_api_repr(self):
+        klass = self._get_target_class()
+        conditions = {
+            'age': 10,
+            'createdBefore': '2018-08-01',
+            'isLive': True,
+            'matchesStorageClass': 'REGIONAL',
+            'numNewerVersions': 3,
+        }
+        resource = {
+            'action': {
+                'type': 'SetStorageClass',
+                'storageClass': 'NEARLINE',
+            },
+            'condition': conditions,
+        }
+        rule = klass.from_api_repr(resource)
+        self.assertEqual(dict(rule), resource)
 
 
 class Test_Bucket(unittest.TestCase):

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -51,7 +51,7 @@ class Test_LifecycleRuleConditions(unittest.TestCase):
             'age': 10,
             'matchesStorageClass': 'REGIONAL',
         }
-        self.assertEqual( dict(conditions), expected)
+        self.assertEqual(dict(conditions), expected)
         self.assertEqual(conditions.age, 10)
         self.assertIsNone(conditions.created_before)
         self.assertIsNone(conditions.is_live)
@@ -85,6 +85,34 @@ class Test_LifecycleRuleConditions(unittest.TestCase):
         self.assertIsNone(conditions.is_live)
         self.assertIsNone(conditions.matches_storage_class)
         self.assertEqual(conditions.number_of_newer_versions, 3)
+
+
+class Test_LifecycleRuleDeleteItem(unittest.TestCase):
+
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.storage.bucket import LifecycleRuleDeleteItem
+        return LifecycleRuleDeleteItem
+
+    def _make_one(self, **kw):
+        return self._get_target_class()(**kw)
+
+    def test_ctor_wo_conditions(self):
+        with self.assertRaises(ValueError):
+            self._make_one()
+
+    def test_ctor_w_condition(self):
+        rule = self._make_one(age=10, matches_storage_class='REGIONAL')
+        expected = {
+            'action': {
+                'type': 'Delete',
+            },
+            'condition': {
+                'age': 10,
+                'matchesStorageClass': 'REGIONAL',
+            }
+        }
+        self.assertEqual(dict(rule), expected)
 
 
 class Test_Bucket(unittest.TestCase):

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -1219,6 +1219,76 @@ class Test_Bucket(unittest.TestCase):
             [dict(rule) for rule in bucket.lifecycle_rules], rules)
         self.assertTrue('lifecycle' in bucket._changes)
 
+    def test_clear_lifecycle_rules(self):
+        NAME = 'name'
+        DELETE_RULE = {
+            'action': {
+                'type': 'Delete',
+            },
+            'condition': {
+                'age': 42,
+            },
+        }
+        SSC_RULE = {
+            'action': {
+                'type': 'SetStorageClass',
+                'storageClass': 'NEARLINE',
+            },
+            'condition': {
+                'isLive': False,
+            },
+        }
+        rules = [DELETE_RULE, SSC_RULE]
+        bucket = self._make_one(name=NAME)
+        bucket._properties['lifecycle'] = {'rule': rules}
+        self.assertEqual(list(bucket.lifecycle_rules), rules)
+
+        bucket.clear_lifecyle_rules()
+
+        self.assertEqual(list(bucket.lifecycle_rules), [])
+        self.assertTrue('lifecycle' in bucket._changes)
+
+    def test_add_lifecycle_delete_rule(self):
+        NAME = 'name'
+        DELETE_RULE = {
+            'action': {
+                'type': 'Delete',
+            },
+            'condition': {
+                'age': 42,
+            },
+        }
+        rules = [DELETE_RULE]
+        bucket = self._make_one(name=NAME)
+        self.assertEqual(list(bucket.lifecycle_rules), [])
+
+        bucket.add_lifecycle_delete_rule(age=42)
+
+        self.assertEqual(
+            [dict(rule) for rule in bucket.lifecycle_rules], rules)
+        self.assertTrue('lifecycle' in bucket._changes)
+
+    def test_add_lifecycle_set_storage_class_rule(self):
+        NAME = 'name'
+        SSC_RULE = {
+            'action': {
+                'type': 'SetStorageClass',
+                'storageClass': 'NEARLINE',
+            },
+            'condition': {
+                'isLive': False,
+            },
+        }
+        rules = [SSC_RULE]
+        bucket = self._make_one(name=NAME)
+        self.assertEqual(list(bucket.lifecycle_rules), [])
+
+        bucket.add_lifecycle_set_storage_class_rule('NEARLINE', is_live=False)
+
+        self.assertEqual(
+            [dict(rule) for rule in bucket.lifecycle_rules], rules)
+        self.assertTrue('lifecycle' in bucket._changes)
+
     def test_cors_getter(self):
         NAME = 'name'
         CORS_ENTRY = {

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -46,16 +46,17 @@ class Test_LifecycleRuleConditions(unittest.TestCase):
             self._make_one()
 
     def test_ctor_w_age_and_matches_storage_class(self):
-        conditions = self._make_one(age=10, matches_storage_class='REGIONAL')
+        conditions = self._make_one(
+            age=10, matches_storage_class=['REGIONAL'])
         expected = {
             'age': 10,
-            'matchesStorageClass': 'REGIONAL',
+            'matchesStorageClass': ['REGIONAL'],
         }
         self.assertEqual(dict(conditions), expected)
         self.assertEqual(conditions.age, 10)
         self.assertIsNone(conditions.created_before)
         self.assertIsNone(conditions.is_live)
-        self.assertEqual(conditions.matches_storage_class, 'REGIONAL')
+        self.assertEqual(conditions.matches_storage_class, ['REGIONAL'])
         self.assertIsNone(conditions.number_of_newer_versions)
 
     def test_ctor_w_created_before_and_is_live(self):
@@ -95,14 +96,14 @@ class Test_LifecycleRuleConditions(unittest.TestCase):
             'age': 10,
             'createdBefore': '2018-08-01',
             'isLive': True,
-            'matchesStorageClass': 'REGIONAL',
+            'matchesStorageClass': ['REGIONAL'],
             'numNewerVersions': 3,
         }
         conditions = klass.from_api_repr(resource)
         self.assertEqual(conditions.age, 10)
         self.assertEqual(conditions.created_before, before)
         self.assertEqual(conditions.is_live, True)
-        self.assertEqual(conditions.matches_storage_class, 'REGIONAL')
+        self.assertEqual(conditions.matches_storage_class, ['REGIONAL'])
         self.assertEqual(conditions.number_of_newer_versions, 3)
 
 
@@ -121,14 +122,14 @@ class Test_LifecycleRuleDeleteItem(unittest.TestCase):
             self._make_one()
 
     def test_ctor_w_condition(self):
-        rule = self._make_one(age=10, matches_storage_class='REGIONAL')
+        rule = self._make_one(age=10, matches_storage_class=['REGIONAL'])
         expected = {
             'action': {
                 'type': 'Delete',
             },
             'condition': {
                 'age': 10,
-                'matchesStorageClass': 'REGIONAL',
+                'matchesStorageClass': ['REGIONAL'],
             }
         }
         self.assertEqual(dict(rule), expected)
@@ -139,7 +140,7 @@ class Test_LifecycleRuleDeleteItem(unittest.TestCase):
             'age': 10,
             'createdBefore': '2018-08-01',
             'isLive': True,
-            'matchesStorageClass': 'REGIONAL',
+            'matchesStorageClass': ['REGIONAL'],
             'numNewerVersions': 3,
         }
         resource = {
@@ -169,7 +170,9 @@ class Test_LifecycleRuleSetItemStorageClass(unittest.TestCase):
 
     def test_ctor_w_condition(self):
         rule = self._make_one(
-            storage_class='NEARLINE', age=10, matches_storage_class='REGIONAL')
+            storage_class='NEARLINE',
+            age=10,
+            matches_storage_class=['REGIONAL'])
         expected = {
             'action': {
                 'type': 'SetStorageClass',
@@ -177,7 +180,7 @@ class Test_LifecycleRuleSetItemStorageClass(unittest.TestCase):
             },
             'condition': {
                 'age': 10,
-                'matchesStorageClass': 'REGIONAL',
+                'matchesStorageClass': ['REGIONAL'],
             }
         }
         self.assertEqual(dict(rule), expected)
@@ -188,7 +191,7 @@ class Test_LifecycleRuleSetItemStorageClass(unittest.TestCase):
             'age': 10,
             'createdBefore': '2018-08-01',
             'isLive': True,
-            'matchesStorageClass': 'REGIONAL',
+            'matchesStorageClass': ['REGIONAL'],
             'numNewerVersions': 3,
         }
         resource = {


### PR DESCRIPTION
@frankyn Note that the system test added in the last commit currently fails.  It is sending the POST body as

```python
{'lifecycle': {'rule': [{'action': {'type': 'Delete'},
                         'condition': {'age': 42}},
                        {'action': {'type': 'SetStorageClass'},
                         'condition': {'isLive': False,
                                       'matchesStorageClass': 'NEARLINE'},
                         'storageClass': 'COLDLINE'}]},
 'name': 'w-lifcycle-rules-1535755546278'}
```

and fails with a 400:

```python
{'error': {'code': 400,
           'errors': [{'domain': 'global',
                       'message': 'Invalid argument',
                       'reason': 'invalid'}],
           'message': 'Invalid argument'}}
```

I'd like help tracking down what is causing that error from the back-end's perspective.