### PR TITLE
Add span_id to LogEntry

### DIFF
--- a/logging/google/cloud/logging/entries.py
+++ b/logging/google/cloud/logging/entries.py
@@ -79,10 +79,14 @@ class _BaseEntry(object):
 
     :type trace: str
     :param trace: (optional) traceid to apply to the entry.
+
+    :type span_id: str
+    :param span_id: (optional) span_id within the trace for the log entry.
+                    Specify the trace parameter if span_id is set.
     """
     def __init__(self, payload, logger, insert_id=None, timestamp=None,
                  labels=None, severity=None, http_request=None, resource=None,
-                 trace=None):
+                 trace=None, span_id=None):
         self.payload = payload
         self.logger = logger
         self.insert_id = insert_id
@@ -92,6 +96,7 @@ class _BaseEntry(object):
         self.http_request = http_request
         self.resource = resource
         self.trace = trace
+        self.span_id = span_id
 
     @classmethod
     def from_api_repr(cls, resource, client, loggers=None):
@@ -129,6 +134,7 @@ class _BaseEntry(object):
         severity = resource.get('severity')
         http_request = resource.get('httpRequest')
         trace = resource.get('trace')
+        span_id = resource.get('spanId')
 
         monitored_resource_dict = resource.get('resource')
         monitored_resource = None
@@ -137,7 +143,7 @@ class _BaseEntry(object):
 
         return cls(payload, logger, insert_id=insert_id, timestamp=timestamp,
                    labels=labels, severity=severity, http_request=http_request,
-                   resource=monitored_resource, trace=trace)
+                   resource=monitored_resource, trace=trace, span_id=span_id)
 
 
 class TextEntry(_BaseEntry):
@@ -194,16 +200,20 @@ class ProtobufEntry(_BaseEntry):
 
     :type trace: str
     :param trace: (optional) traceid to apply to the entry.
+
+    :type span_id: str
+    :param span_id: (optional) span_id within the trace for the log entry.
+                    Specify the trace parameter if span_id is set.
     """
     _PAYLOAD_KEY = 'protoPayload'
 
     def __init__(self, payload, logger, insert_id=None, timestamp=None,
                  labels=None, severity=None, http_request=None, resource=None,
-                 trace=None):
+                 trace=None, span_id=None):
         super(ProtobufEntry, self).__init__(
             payload, logger, insert_id=insert_id, timestamp=timestamp,
             labels=labels, severity=severity, http_request=http_request,
-            resource=resource, trace=trace)
+            resource=resource, trace=trace, span_id=span_id)
         if isinstance(self.payload, any_pb2.Any):
             self.payload_pb = self.payload
             self.payload = None

--- a/logging/google/cloud/logging/logger.py
+++ b/logging/google/cloud/logging/logger.py
@@ -96,7 +96,8 @@ class Logger(object):
     def _make_entry_resource(self, text=None, info=None, message=None,
                              labels=None, insert_id=None, severity=None,
                              http_request=None, timestamp=None,
-                             resource=_GLOBAL_RESOURCE, trace=None):
+                             resource=_GLOBAL_RESOURCE, trace=None,
+                             span_id=None):
         """Return a log entry resource of the appropriate type.
 
         Helper for :meth:`log_text`, :meth:`log_struct`, and :meth:`log_proto`.
@@ -133,6 +134,10 @@ class Logger(object):
 
         :type trace: str
         :param trace: (optional) traceid to apply to the entry.
+
+        :type span_id: str
+        :param span_id: (optional) span_id within the trace for the log entry.
+                        Specify the trace parameter if span_id is set.
 
         :rtype: dict
         :returns: The JSON resource created.
@@ -178,11 +183,14 @@ class Logger(object):
         if trace is not None:
             entry['trace'] = trace
 
+        if span_id is not None:
+            entry['spanId'] = span_id
+
         return entry
 
     def log_text(self, text, client=None, labels=None, insert_id=None,
                  severity=None, http_request=None, timestamp=None,
-                 resource=_GLOBAL_RESOURCE, trace=None):
+                 resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
         """API call:  log a text message via a POST request
 
         See
@@ -218,17 +226,21 @@ class Logger(object):
 
         :type trace: str
         :param trace: (optional) traceid to apply to the entry.
+
+        :type span_id: str
+        :param span_id: (optional) span_id within the trace for the log entry.
+                        Specify the trace parameter if span_id is set.
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
             text=text, labels=labels, insert_id=insert_id, severity=severity,
             http_request=http_request, timestamp=timestamp, resource=resource,
-            trace=trace)
+            trace=trace, span_id=span_id)
         client.logging_api.write_entries([entry_resource])
 
     def log_struct(self, info, client=None, labels=None, insert_id=None,
                    severity=None, http_request=None, timestamp=None,
-                   resource=_GLOBAL_RESOURCE, trace=None):
+                   resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
         """API call:  log a structured message via a POST request
 
         See
@@ -264,17 +276,21 @@ class Logger(object):
 
         :type trace: str
         :param trace: (optional) traceid to apply to the entry.
+
+        :type span_id: str
+        :param span_id: (optional) span_id within the trace for the log entry.
+                        Specify the trace parameter if span_id is set.
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
             info=info, labels=labels, insert_id=insert_id, severity=severity,
             http_request=http_request, timestamp=timestamp, resource=resource,
-            trace=trace)
+            trace=trace, span_id=span_id)
         client.logging_api.write_entries([entry_resource])
 
     def log_proto(self, message, client=None, labels=None, insert_id=None,
                   severity=None, http_request=None, timestamp=None,
-                  resource=_GLOBAL_RESOURCE, trace=None):
+                  resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
         """API call:  log a protobuf message via a POST request
 
         See
@@ -310,12 +326,16 @@ class Logger(object):
 
         :type trace: str
         :param trace: (optional) traceid to apply to the entry.
+
+        :type span_id: str
+        :param span_id: (optional) span_id within the trace for the log entry.
+                        Specify the trace parameter if span_id is set.
         """
         client = self._require_client(client)
         entry_resource = self._make_entry_resource(
             message=message, labels=labels, insert_id=insert_id,
             severity=severity, http_request=http_request, timestamp=timestamp,
-            resource=resource, trace=trace)
+            resource=resource, trace=trace, span_id=span_id)
         client.logging_api.write_entries([entry_resource])
 
     def delete(self, client=None):
@@ -410,7 +430,7 @@ class Batch(object):
 
     def log_text(self, text, labels=None, insert_id=None, severity=None,
                  http_request=None, timestamp=None, resource=_GLOBAL_RESOURCE,
-                 trace=None):
+                 trace=None, span_id=None):
         """Add a text entry to be logged during :meth:`commit`.
 
         :type text: str
@@ -441,14 +461,18 @@ class Batch(object):
 
         :type trace: str
         :param trace: (optional) traceid to apply to the entry.
+
+        :type span_id: str
+        :param span_id: (optional) span_id within the trace for the log entry.
+                        Specify the trace parameter if span_id is set.
         """
         self.entries.append(
             ('text', text, labels, insert_id, severity, http_request,
-             timestamp, resource, trace))
+             timestamp, resource, trace, span_id))
 
     def log_struct(self, info, labels=None, insert_id=None, severity=None,
                    http_request=None, timestamp=None,
-                   resource=_GLOBAL_RESOURCE, trace=None):
+                   resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
         """Add a struct entry to be logged during :meth:`commit`.
 
         :type info: dict
@@ -479,14 +503,18 @@ class Batch(object):
 
         :type trace: str
         :param trace: (optional) traceid to apply to the entry.
+
+        :type span_id: str
+        :param span_id: (optional) span_id within the trace for the log entry.
+                        Specify the trace parameter if span_id is set.
         """
         self.entries.append(
             ('struct', info, labels, insert_id, severity, http_request,
-             timestamp, resource, trace))
+             timestamp, resource, trace, span_id))
 
     def log_proto(self, message, labels=None, insert_id=None, severity=None,
                   http_request=None, timestamp=None,
-                  resource=_GLOBAL_RESOURCE, trace=None):
+                  resource=_GLOBAL_RESOURCE, trace=None, span_id=None):
         """Add a protobuf entry to be logged during :meth:`commit`.
 
         :type message: protobuf message
@@ -517,10 +545,14 @@ class Batch(object):
 
         :type trace: str
         :param trace: (optional) traceid to apply to the entry.
+
+        :type span_id: str
+        :param span_id: (optional) span_id within the trace for the log entry.
+                        Specify the trace parameter if span_id is set.
         """
         self.entries.append(
             ('proto', message, labels, insert_id, severity, http_request,
-             timestamp, resource, trace))
+             timestamp, resource, trace, span_id))
 
     def commit(self, client=None):
         """Send saved log entries as a single API call.
@@ -544,7 +576,7 @@ class Batch(object):
 
         entries = []
         for (entry_type, entry, labels, iid, severity, http_req,
-             timestamp, resource, trace) in self.entries:
+             timestamp, resource, trace, span_id) in self.entries:
             if entry_type == 'text':
                 info = {'textPayload': entry}
             elif entry_type == 'struct':
@@ -573,6 +605,8 @@ class Batch(object):
                 info['timestamp'] = _datetime_to_rfc3339(timestamp)
             if trace is not None:
                 info['trace'] = trace
+            if span_id is not None:
+                info['spanId'] = span_id
             entries.append(info)
 
         client.logging_api.write_entries(entries, **kwargs)

--- a/logging/tests/unit/test_entries.py
+++ b/logging/tests/unit/test_entries.py
@@ -69,6 +69,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertIsNone(entry.http_request)
         self.assertIsNone(entry.resource)
         self.assertIsNone(entry.trace)
+        self.assertIsNone(entry.span_id)
 
     def test_ctor_explicit(self):
         import datetime
@@ -89,6 +90,7 @@ class Test_BaseEntry(unittest.TestCase):
         }
         resource = Resource(type='global', labels={})
         TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
 
         logger = _Logger(self.LOGGER_NAME, self.PROJECT)
         entry = self._make_one(PAYLOAD, logger,
@@ -98,7 +100,8 @@ class Test_BaseEntry(unittest.TestCase):
                                severity=SEVERITY,
                                http_request=REQUEST,
                                resource=resource,
-                               trace=TRACE)
+                               trace=TRACE,
+                               span_id=SPANID)
         self.assertEqual(entry.payload, PAYLOAD)
         self.assertIs(entry.logger, logger)
         self.assertEqual(entry.insert_id, IID)
@@ -110,6 +113,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertEqual(entry.http_request['status'], STATUS)
         self.assertEqual(entry.resource, resource)
         self.assertEqual(entry.trace, TRACE)
+        self.assertEqual(entry.span_id, SPANID)
 
     def test_from_api_repr_missing_data_no_loggers(self):
         client = _Client(self.PROJECT)
@@ -127,6 +131,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertIsNone(entry.severity)
         self.assertIsNone(entry.http_request)
         self.assertIsNone(entry.trace)
+        self.assertIsNone(entry.span_id)
         logger = entry.logger
         self.assertIsInstance(logger, _Logger)
         self.assertIs(logger.client, client)
@@ -160,6 +165,7 @@ class Test_BaseEntry(unittest.TestCase):
         )
         STATUS = '500'
         TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
         API_REPR = {
             'dummyPayload': PAYLOAD,
             'logName': LOG_NAME,
@@ -173,7 +179,8 @@ class Test_BaseEntry(unittest.TestCase):
                 'status': STATUS,
             },
             'resource': RESOURCE._to_dict(),
-            'trace': TRACE
+            'trace': TRACE,
+            'spanId': SPANID
         }
         loggers = {}
         entry = klass.from_api_repr(API_REPR, client, loggers=loggers)
@@ -192,6 +199,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertEqual(loggers, {LOG_NAME: logger})
         self.assertEqual(entry.resource, RESOURCE)
         self.assertEqual(entry.trace, TRACE)
+        self.assertEqual(entry.span_id, SPANID)
 
     def test_from_api_repr_w_loggers_w_logger_match(self):
         from datetime import datetime
@@ -205,13 +213,15 @@ class Test_BaseEntry(unittest.TestCase):
         LOG_NAME = 'projects/%s/logs/%s' % (self.PROJECT, self.LOGGER_NAME)
         LABELS = {'foo': 'bar', 'baz': 'qux'}
         TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
         API_REPR = {
             'dummyPayload': PAYLOAD,
             'logName': LOG_NAME,
             'insertId': IID,
             'timestamp': TIMESTAMP,
             'labels': LABELS,
-            'trace': TRACE
+            'trace': TRACE,
+            'spanId': SPANID
         }
         LOGGER = object()
         loggers = {LOG_NAME: LOGGER}
@@ -222,6 +232,7 @@ class Test_BaseEntry(unittest.TestCase):
         self.assertEqual(entry.timestamp, NOW)
         self.assertEqual(entry.labels, LABELS)
         self.assertEqual(entry.trace, TRACE)
+        self.assertEqual(entry.span_id, SPANID)
         self.assertIs(entry.logger, LOGGER)
 
 
@@ -251,6 +262,7 @@ class TestProtobufEntry(unittest.TestCase):
         self.assertIsNone(pb_entry.severity)
         self.assertIsNone(pb_entry.http_request)
         self.assertIsNone(pb_entry.trace)
+        self.assertIsNone(pb_entry.span_id)
 
     def test_constructor_with_any(self):
         from google.protobuf.any_pb2 import Any
@@ -266,6 +278,7 @@ class TestProtobufEntry(unittest.TestCase):
         self.assertIsNone(pb_entry.severity)
         self.assertIsNone(pb_entry.http_request)
         self.assertIsNone(pb_entry.trace)
+        self.assertIsNone(pb_entry.span_id)
 
     def test_parse_message(self):
         import json

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -859,7 +859,7 @@ class TestBatch(unittest.TestCase):
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         batch = self._make_one(logger, client)
         batch.entries.append(('bogus', 'BOGUS', None, None, None, None, None,
-                              None, None))
+                              None, None, None))
         with self.assertRaises(ValueError):
             batch.commit()
 

--- a/logging/tests/unit/test_logger.py
+++ b/logging/tests/unit/test_logger.py
@@ -178,6 +178,29 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
 
+    def test_log_text_w_span(self):
+
+        TEXT = 'TEXT'
+        SPANID = '000000000000004a'
+        ENTRIES = [{
+            'logName': 'projects/%s/logs/%s' % (
+                self.PROJECT, self.LOGGER_NAME),
+            'textPayload': TEXT,
+            'resource': {
+                'type': 'global',
+                'labels': {},
+            },
+            'spanId': SPANID
+        }]
+        client = _Client(self.PROJECT)
+        api = client.logging_api = _DummyLoggingAPI()
+        logger = self._make_one(self.LOGGER_NAME, client=client)
+
+        logger.log_text(TEXT, span_id=SPANID)
+
+        self.assertEqual(api._write_entries_called_with,
+                         (ENTRIES, None, None, None))
+
     def test_log_text_w_unicode_explicit_client_labels_severity_httpreq(self):
         TEXT = u'TEXT'
         DEFAULT_LABELS = {'foo': 'spam'}
@@ -188,6 +211,7 @@ class TestLogger(unittest.TestCase):
         URI = 'https://api.example.com/endpoint'
         STATUS = '500'
         TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
         REQUEST = {
             'requestMethod': METHOD,
             'requestUrl': URI,
@@ -205,7 +229,8 @@ class TestLogger(unittest.TestCase):
             'insertId': IID,
             'severity': SEVERITY,
             'httpRequest': REQUEST,
-            'trace': TRACE
+            'trace': TRACE,
+            'spanId': SPANID
         }]
         client1 = _Client(self.PROJECT)
         client2 = _Client(self.PROJECT)
@@ -215,7 +240,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_text(TEXT, client=client2, labels=LABELS,
                         insert_id=IID, severity=SEVERITY, http_request=REQUEST,
-                        trace=TRACE)
+                        trace=TRACE, span_id=SPANID)
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -273,6 +298,7 @@ class TestLogger(unittest.TestCase):
         URI = 'https://api.example.com/endpoint'
         STATUS = '500'
         TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
         REQUEST = {
             'requestMethod': METHOD,
             'requestUrl': URI,
@@ -290,7 +316,8 @@ class TestLogger(unittest.TestCase):
             'insertId': IID,
             'severity': SEVERITY,
             'httpRequest': REQUEST,
-            'trace': TRACE
+            'trace': TRACE,
+            'spanId': SPANID
         }]
         client1 = _Client(self.PROJECT)
         client2 = _Client(self.PROJECT)
@@ -300,7 +327,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_struct(STRUCT, client=client2, labels=LABELS,
                           insert_id=IID, severity=SEVERITY,
-                          http_request=REQUEST, trace=TRACE)
+                          http_request=REQUEST, trace=TRACE, span_id=SPANID)
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -348,6 +375,29 @@ class TestLogger(unittest.TestCase):
         logger = self._make_one(self.LOGGER_NAME, client=client)
 
         logger.log_struct(STRUCT, trace=TRACE)
+
+        self.assertEqual(api._write_entries_called_with,
+                         (ENTRIES, None, None, None))
+
+    def test_log_struct_w_span(self):
+
+        STRUCT = {'message': 'MESSAGE', 'weather': 'cloudy'}
+        SPANID = '000000000000004a'
+        ENTRIES = [{
+            'logName': 'projects/%s/logs/%s' % (
+                self.PROJECT, self.LOGGER_NAME),
+            'jsonPayload': STRUCT,
+            'resource': {
+                'type': 'global',
+                'labels': {},
+            },
+            'spanId': SPANID
+        }]
+        client = _Client(self.PROJECT)
+        api = client.logging_api = _DummyLoggingAPI()
+        logger = self._make_one(self.LOGGER_NAME, client=client)
+
+        logger.log_struct(STRUCT, span_id=SPANID)
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -418,6 +468,7 @@ class TestLogger(unittest.TestCase):
         URI = 'https://api.example.com/endpoint'
         STATUS = '500'
         TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
         REQUEST = {
             'requestMethod': METHOD,
             'requestUrl': URI,
@@ -435,7 +486,8 @@ class TestLogger(unittest.TestCase):
             'insertId': IID,
             'severity': SEVERITY,
             'httpRequest': REQUEST,
-            'trace': TRACE
+            'trace': TRACE,
+            'spanId': SPANID
         }]
         client1 = _Client(self.PROJECT)
         client2 = _Client(self.PROJECT)
@@ -445,7 +497,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_proto(message, client=client2, labels=LABELS,
                          insert_id=IID, severity=SEVERITY,
-                         http_request=REQUEST, trace=TRACE)
+                         http_request=REQUEST, trace=TRACE, span_id=SPANID)
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -501,6 +553,33 @@ class TestLogger(unittest.TestCase):
         logger = self._make_one(self.LOGGER_NAME, client=client)
 
         logger.log_proto(message, trace=TRACE)
+
+        self.assertEqual(api._write_entries_called_with,
+                         (ENTRIES, None, None, None))
+
+    def test_log_proto_w_span(self):
+        import json
+        from google.protobuf.json_format import MessageToJson
+        from google.protobuf.struct_pb2 import Struct
+        from google.protobuf.struct_pb2 import Value
+
+        message = Struct(fields={'foo': Value(bool_value=True)})
+        SPANID = '000000000000004a'
+        ENTRIES = [{
+            'logName': 'projects/%s/logs/%s' % (
+                self.PROJECT, self.LOGGER_NAME),
+            'protoPayload': json.loads(MessageToJson(message)),
+            'resource': {
+                'type': 'global',
+                'labels': {},
+            },
+            'spanId': SPANID
+        }]
+        client = _Client(self.PROJECT)
+        api = client.logging_api = _DummyLoggingAPI()
+        logger = self._make_one(self.LOGGER_NAME, client=client)
+
+        logger.log_proto(message, span_id=SPANID)
 
         self.assertEqual(api._write_entries_called_with,
                          (ENTRIES, None, None, None))
@@ -630,7 +709,7 @@ class TestBatch(unittest.TestCase):
         batch.log_text(TEXT)
         self.assertEqual(batch.entries,
                          [('text', TEXT, None, None, None, None, None,
-                           _GLOBAL_RESOURCE, None)])
+                           _GLOBAL_RESOURCE, None, None)])
 
     def test_log_text_explicit(self):
         import datetime
@@ -657,17 +736,18 @@ class TestBatch(unittest.TestCase):
             }
         )
         TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
 
         client = _Client(project=self.PROJECT, connection=_make_credentials())
         logger = _Logger()
         batch = self._make_one(logger, client=client)
         batch.log_text(TEXT, labels=LABELS, insert_id=IID, severity=SEVERITY,
                        http_request=REQUEST, timestamp=TIMESTAMP,
-                       resource=RESOURCE, trace=TRACE)
+                       resource=RESOURCE, trace=TRACE, span_id=SPANID)
         self.assertEqual(
             batch.entries,
             [('text', TEXT, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP,
-              RESOURCE, TRACE)])
+              RESOURCE, TRACE, SPANID)])
 
     def test_log_struct_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
@@ -679,7 +759,7 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(
             batch.entries,
             [('struct', STRUCT, None, None, None, None, None,
-              _GLOBAL_RESOURCE, None)])
+              _GLOBAL_RESOURCE, None, None)])
 
     def test_log_struct_explicit(self):
         import datetime
@@ -693,6 +773,7 @@ class TestBatch(unittest.TestCase):
         URI = 'https://api.example.com/endpoint'
         STATUS = '500'
         TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
         REQUEST = {
             'requestMethod': METHOD,
             'requestUrl': URI,
@@ -712,11 +793,12 @@ class TestBatch(unittest.TestCase):
         batch = self._make_one(logger, client=client)
         batch.log_struct(STRUCT, labels=LABELS, insert_id=IID,
                          severity=SEVERITY, http_request=REQUEST,
-                         timestamp=TIMESTAMP, resource=RESOURCE, trace=TRACE)
+                         timestamp=TIMESTAMP, resource=RESOURCE, trace=TRACE,
+                         span_id=SPANID)
         self.assertEqual(
             batch.entries,
             [('struct', STRUCT, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP,
-              RESOURCE, TRACE)])
+              RESOURCE, TRACE, SPANID)])
 
     def test_log_proto_defaults(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
@@ -730,7 +812,7 @@ class TestBatch(unittest.TestCase):
         batch.log_proto(message)
         self.assertEqual(batch.entries,
                          [('proto', message, None, None, None, None, None,
-                           _GLOBAL_RESOURCE, None)])
+                           _GLOBAL_RESOURCE, None, None)])
 
     def test_log_proto_explicit(self):
         import datetime
@@ -746,6 +828,7 @@ class TestBatch(unittest.TestCase):
         URI = 'https://api.example.com/endpoint'
         STATUS = '500'
         TRACE = '12345678-1234-5678-1234-567812345678'
+        SPANID = '000000000000004a'
         REQUEST = {
             'requestMethod': METHOD,
             'requestUrl': URI,
@@ -764,11 +847,12 @@ class TestBatch(unittest.TestCase):
         batch = self._make_one(logger, client=client)
         batch.log_proto(message, labels=LABELS, insert_id=IID,
                         severity=SEVERITY, http_request=REQUEST,
-                        timestamp=TIMESTAMP, resource=RESOURCE, trace=TRACE)
+                        timestamp=TIMESTAMP, resource=RESOURCE, trace=TRACE,
+                        span_id=SPANID)
         self.assertEqual(
             batch.entries,
             [('proto', message, LABELS, IID, SEVERITY, REQUEST, TIMESTAMP,
-              RESOURCE, TRACE)])
+              RESOURCE, TRACE, SPANID)])
 
     def test_commit_w_invalid_entry_type(self):
         logger = _Logger()
@@ -828,17 +912,23 @@ class TestBatch(unittest.TestCase):
         TRACE1 = '12345678-1234-5678-1234-567812345678'
         TRACE2 = '12345678-1234-5678-1234-567812345679'
         TRACE3 = '12345678-1234-5678-1234-567812345670'
+        SPANID1 = '000000000000004a'
+        SPANID2 = '000000000000004b'
+        SPANID3 = '000000000000004c'
         ENTRIES = [
             {'textPayload': TEXT, 'insertId': IID1,
              'timestamp': _datetime_to_rfc3339(TIMESTAMP1),
-             'resource': _GLOBAL_RESOURCE._to_dict(), 'trace': TRACE1},
+             'resource': _GLOBAL_RESOURCE._to_dict(), 'trace': TRACE1,
+             'spanId': SPANID1},
             {'jsonPayload': STRUCT, 'insertId': IID2,
              'timestamp': _datetime_to_rfc3339(TIMESTAMP2),
-             'resource': _GLOBAL_RESOURCE._to_dict(), 'trace': TRACE2},
+             'resource': _GLOBAL_RESOURCE._to_dict(), 'trace': TRACE2,
+             'spanId': SPANID2},
             {'protoPayload': json.loads(MessageToJson(message)),
              'insertId': IID3,
              'timestamp': _datetime_to_rfc3339(TIMESTAMP3),
-             'resource': _GLOBAL_RESOURCE._to_dict(), 'trace': TRACE3},
+             'resource': _GLOBAL_RESOURCE._to_dict(), 'trace': TRACE3,
+             'spanId': SPANID3},
         ]
         client = _Client(project=self.PROJECT)
         api = client.logging_api = _DummyLoggingAPI()
@@ -846,11 +936,11 @@ class TestBatch(unittest.TestCase):
         batch = self._make_one(logger, client=client)
 
         batch.log_text(TEXT, insert_id=IID1, timestamp=TIMESTAMP1,
-                       trace=TRACE1)
+                       trace=TRACE1, span_id=SPANID1)
         batch.log_struct(STRUCT, insert_id=IID2, timestamp=TIMESTAMP2,
-                         trace=TRACE2)
+                         trace=TRACE2, span_id=SPANID2)
         batch.log_proto(message, insert_id=IID3, timestamp=TIMESTAMP3,
-                        trace=TRACE3)
+                        trace=TRACE3, span_id=SPANID3)
         batch.commit()
 
         self.assertEqual(list(batch.entries), [])
@@ -977,11 +1067,11 @@ class TestBatch(unittest.TestCase):
         logger = _Logger()
         UNSENT = [
             ('text', TEXT, None, IID, None, None, TIMESTAMP,
-             _GLOBAL_RESOURCE, None),
+             _GLOBAL_RESOURCE, None, None),
             ('struct', STRUCT, None, None, SEVERITY, None, None,
-             _GLOBAL_RESOURCE, None),
+             _GLOBAL_RESOURCE, None, None),
             ('proto', message, LABELS, None, None, REQUEST, None,
-             _GLOBAL_RESOURCE, None),
+             _GLOBAL_RESOURCE, None, None),
         ]
         batch = self._make_one(logger, client=client)
 


### PR DESCRIPTION
Add `span_id` to `LogEntry`

Note `trace` should get specified if `span_id` is set.  The logging API does not currently return an error and while the final displayed log line does have a `span_id`, its not too useful.  Instead of client-side validation, CloudLogging would return exception later (i'll file internal FR for that)

ref:
 - https://github.com/GoogleCloudPlatform/google-cloud-python/issues/5505