### PR TITLE
Bigtable: fix non admin client access (minimal version)

### DIFF
--- a/bigtable/google/cloud/bigtable/client.py
+++ b/bigtable/google/cloud/bigtable/client.py
@@ -156,8 +156,6 @@ class Client(ClientWithProject):
         :returns: A BigtableClient object.
         """
         if self._table_data_client is None:
-            if not self._admin:
-                raise ValueError('Client is not an admin client.')
             self._table_data_client = (
                 bigtable_v2.BigtableClient(credentials=self._credentials,
                                            client_info=_CLIENT_INFO))

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -123,7 +123,7 @@ class Table(object):
         """
         project = self._instance._client.project
         instance_id = self._instance.instance_id
-        table_client = self._instance._client.table_admin_client
+        table_client = self._instance._client.table_data_client
         return table_client.table_path(
             project=project, instance=instance_id, table=self.table_id)
 

--- a/bigtable/tests/system.py
+++ b/bigtable/tests/system.py
@@ -1013,3 +1013,9 @@ class TestDataAPI(unittest.TestCase):
         self.assertEqual(cell3_new.timestamp, cell3.timestamp)
         self.assertEqual(cell3.labels, [])
         self.assertEqual(cell3_new.labels, [label2])
+
+    def test_access_with_non_admin_client(self):
+        client = Client(admin=False)
+        instance = client.instance(INSTANCE_ID)
+        table = instance.table(self._table.table_id)
+        self.assertIsNone(table.read_row('nonesuch'))

--- a/bigtable/tests/unit/test_client.py
+++ b/bigtable/tests/unit/test_client.py
@@ -125,46 +125,74 @@ class TestClient(unittest.TestCase):
         self.assertEqual(instance.labels, labels)
         self.assertIs(instance._client, client)
 
-    def test_admin_client_w_value_error(self):
+    def test_table_data_client_not_initialized(self):
+        from google.cloud.bigtable_v2 import BigtableClient
+
+        credentials = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=credentials)
+
+        table_data_client = client.table_data_client
+        self.assertIsInstance(table_data_client, BigtableClient)
+        self.assertIs(client._table_data_client, table_data_client)
+
+    def test_table_data_client_initialized(self):
+        credentials = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=credentials,
+                                admin=True)
+
+        already = client._table_data_client = object()
+        self.assertIs(client.table_data_client, already)
+
+    def test_table_admin_client_not_initialized_no_admin_flag(self):
         credentials = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=credentials)
 
         with self.assertRaises(ValueError):
             client.table_admin_client()
 
-        with self.assertRaises(ValueError):
-            client.instance_admin_client()
+    def test_table_admin_client_not_initialized_w_admin_flag(self):
+        from google.cloud.bigtable_admin_v2 import BigtableTableAdminClient
 
-    def test_table_data_client(self):
+        credentials = _make_credentials()
+        client = self._make_one(
+            project=self.PROJECT, credentials=credentials, admin=True)
+
+        table_admin_client = client.table_admin_client
+        self.assertIsInstance(table_admin_client, BigtableTableAdminClient)
+
+    def test_table_admin_client_initialized(self):
         credentials = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=credentials,
                                 admin=True)
 
-        table_data_client = client.table_data_client
-        self.assertEqual(client._table_data_client, table_data_client)
+        already = client._table_admin_client = object()
+        self.assertIs(client.table_admin_client, already)
 
-        client._table_data_client = object()
-        table_data_client = client.table_data_client
-        self.assertEqual(client.table_data_client, table_data_client)
-
-    def test_table_admin_client(self):
-        credentials = _make_credentials()
-        client = self._make_one(project=self.PROJECT, credentials=credentials,
-                                admin=True)
-
-        table_admin_client = client.table_admin_client
-        self.assertEqual(client._table_admin_client, table_admin_client)
-
-        client._table_admin_client = object()
-        table_admin_client = client.table_admin_client
-        self.assertEqual(client._table_admin_client, table_admin_client)
-
-    def test_table_data_client_w_value_error(self):
+    def test_instance_admin_client_not_initialized_no_admin_flag(self):
         credentials = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=credentials)
 
         with self.assertRaises(ValueError):
-            client.table_data_client()
+            client.instance_admin_client()
+
+    def test_instance_admin_client_not_initialized_w_admin_flag(self):
+        from google.cloud.bigtable_admin_v2 import BigtableInstanceAdminClient
+
+        credentials = _make_credentials()
+        client = self._make_one(
+            project=self.PROJECT, credentials=credentials, admin=True)
+
+        instance_admin_client = client.instance_admin_client
+        self.assertIsInstance(
+            instance_admin_client, BigtableInstanceAdminClient)
+
+    def test_instance_admin_client_initialized(self):
+        credentials = _make_credentials()
+        client = self._make_one(project=self.PROJECT, credentials=credentials,
+                                admin=True)
+
+        already = client._instance_admin_client = object()
+        self.assertIs(client.instance_admin_client, already)
 
     def test_list_instances(self):
         from google.cloud.bigtable_admin_v2.proto import (

--- a/bigtable/tests/unit/test_table.py
+++ b/bigtable/tests/unit/test_table.py
@@ -156,15 +156,25 @@ class TestTable(unittest.TestCase):
     def _make_client(self, *args, **kwargs):
         return self._get_target_client_class()(*args, **kwargs)
 
-    def test_constructor(self):
+    def test_constructor_w_admin(self):
         credentials = _make_credentials()
-        client = self._make_client(project='project-id',
+        client = self._make_client(project=self.PROJECT_ID,
                                    credentials=credentials, admin=True)
-        table_id = 'table-id'
         instance = client.instance(instance_id=self.INSTANCE_ID)
         table = self._make_one(self.TABLE_ID, instance)
-        self.assertEqual(table.table_id, table_id)
+        self.assertEqual(table.table_id, self.TABLE_ID)
         self.assertIs(table._instance._client, client)
+        self.assertEqual(table.name, self.TABLE_NAME)
+
+    def test_constructor_wo_admin(self):
+        credentials = _make_credentials()
+        client = self._make_client(project=self.PROJECT_ID,
+                                   credentials=credentials, admin=False)
+        instance = client.instance(instance_id=self.INSTANCE_ID)
+        table = self._make_one(self.TABLE_ID, instance)
+        self.assertEqual(table.table_id, self.TABLE_ID)
+        self.assertIs(table._instance._client, client)
+        self.assertEqual(table.name, self.TABLE_NAME)
 
     def test_row_factory_direct(self):
         from google.cloud.bigtable.row import DirectRow
@@ -804,8 +814,6 @@ class TestTable(unittest.TestCase):
         client._table_admin_client = table_api
         instance = client.instance(instance_id=self.INSTANCE_ID)
         table = self._make_one(self.TABLE_ID, instance)
-        table.name.return_value = client._table_data_client.table_path(
-            self.PROJECT_ID,  self.INSTANCE_ID, self.TABLE_ID)
 
         expected_result = None  # truncate() has no return value.
         with mock.patch('google.cloud.bigtable.table.Table.name',


### PR DESCRIPTION
- Remove spurious check for the `admin` flag in `Client.table_data_client`: that flag is supposed to cover only access the the admin clients.
- Use the `table_data_client` to generate table_name path.
- Add a system test exercising non-admin access to table data.

Supersedes #5875.
Closes #5874.