### PR TITLE
Storage: Add 'stacklevel=2' to deprecation warnings.

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -1026,7 +1026,8 @@ class Blob(_PropertyMixin):
         .. _lifecycle: https://cloud.google.com/storage/docs/lifecycle
         """
         if num_retries is not None:
-            warnings.warn(_NUM_RETRIES_MESSAGE, DeprecationWarning)
+            warnings.warn(
+                _NUM_RETRIES_MESSAGE, DeprecationWarning, stacklevel=2)
 
         _maybe_rewind(file_obj, rewind=rewind)
         predefined_acl = ACL.validate_predefined(predefined_acl)

--- a/storage/google/cloud/storage/bucket.py
+++ b/storage/google/cloud/storage/bucket.py
@@ -40,6 +40,12 @@ from google.cloud.storage.notification import BucketNotification
 from google.cloud.storage.notification import NONE_PAYLOAD_FORMAT
 
 
+_LOCATION_SETTER_MESSAGE = (
+    "Assignment to 'Bucket.location' is deprecated, as it is only "
+    "valid before the bucket is created. Instead, pass the location "
+    "to `Bucket.create`.")
+
+
 def _blobs_page_start(iterator, page, response):
     """Grab prefixes after a :class:`~google.cloud.iterator.Page` started.
 
@@ -976,10 +982,7 @@ class Bucket(_PropertyMixin):
             to `Bucket.create`.
         """
         warnings.warn(
-            "Assignment to 'Bucket.location' is deprecated, as it is only "
-            "valid before the bucket is created. Instead, pass the location "
-            "to `Bucket.create`.",
-            DeprecationWarning)
+            _LOCATION_SETTER_MESSAGE, DeprecationWarning, stacklevel=2)
         self._location = value
 
     def get_logging(self):

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -1654,7 +1654,9 @@ class Test_Blob(unittest.TestCase):
 
         self._upload_from_file_helper(num_retries=20)
         mock_warn.assert_called_once_with(
-            blob_module._NUM_RETRIES_MESSAGE, DeprecationWarning)
+            blob_module._NUM_RETRIES_MESSAGE,
+            DeprecationWarning,
+            stacklevel=2)
 
     def test_upload_from_file_with_rewind(self):
         stream = self._upload_from_file_helper(rewind=True)

--- a/storage/tests/unit/test_bucket.py
+++ b/storage/tests/unit/test_bucket.py
@@ -373,12 +373,11 @@ class Test_Bucket(unittest.TestCase):
         bucket = self._make_one(client=client, name=BUCKET_NAME)
         bucket.cors = CORS
         bucket.lifecycle_rules = LIFECYCLE_RULES
-        bucket.location = LOCATION
         bucket.storage_class = STORAGE_CLASS
         bucket.versioning_enabled = True
         bucket.requester_pays = True
         bucket.labels = LABELS
-        bucket.create()
+        bucket.create(location=LOCATION)
 
         kw, = connection._requested
         self.assertEqual(kw['method'], 'POST')
@@ -920,13 +919,20 @@ class Test_Bucket(unittest.TestCase):
         bucket = self._make_one(name=NAME, properties=before)
         self.assertEqual(bucket.location, 'AS')
 
-    def test_location_setter(self):
+    @mock.patch('warnings.warn')
+    def test_location_setter(self, mock_warn):
+        from google.cloud.storage import bucket as bucket_module
+
         NAME = 'name'
         bucket = self._make_one(name=NAME)
         self.assertIsNone(bucket.location)
         bucket.location = 'AS'
         self.assertEqual(bucket.location, 'AS')
         self.assertTrue('location' in bucket._changes)
+        mock_warn.assert_called_once_with(
+            bucket_module._LOCATION_SETTER_MESSAGE,
+            DeprecationWarning,
+            stacklevel=2)
 
     def test_lifecycle_rules_getter(self):
         NAME = 'name'


### PR DESCRIPTION
Add test assertion for warning from 'Bucket.location' setter.