### PR TITLE
Change 'BatchSettings.max_bytes' default.

### DIFF
--- a/pubsub/google/cloud/pubsub_v1/types.py
+++ b/pubsub/google/cloud/pubsub_v1/types.py
@@ -40,7 +40,7 @@ BatchSettings = collections.namedtuple(
     ['max_bytes', 'max_latency', 'max_messages'],
 )
 BatchSettings.__new__.__defaults__ = (
-    1024 * 1024 * 10,  # max_bytes: 10 MB
+    1000 * 1000 * 10,  # max_bytes: documented "10 MB", enforced 10000000
     0.05,              # max_latency: 0.05 seconds
     1000,              # max_messages: 1,000
 )

--- a/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
+++ b/pubsub/tests/unit/pubsub_v1/publisher/test_publisher_client.py
@@ -31,7 +31,7 @@ def test_init():
     # A plain client should have an `api` (the underlying GAPIC) and a
     # batch settings object, which should have the defaults.
     assert isinstance(client.api, publisher_client.PublisherClient)
-    assert client.batch_settings.max_bytes == 10 * (2 ** 20)
+    assert client.batch_settings.max_bytes == 10 * 1000 * 1000
     assert client.batch_settings.max_latency == 0.05
     assert client.batch_settings.max_messages == 1000
 


### PR DESCRIPTION
It is documented as '10MB', but enforced as 10000000 bytes.

Closes #5898.