### PR TITLE
Add trace and span_id to logging async API

### DIFF
--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -229,7 +229,7 @@ class _Worker(object):
                 'Failed to send %d pending logs.' % (self._queue.qsize(),),
                 file=sys.stderr)
 
-    def enqueue(self, record, message, resource=None, labels=None):
+    def enqueue(self, record, message, resource=None, labels=None, trace=None, span_id=None):
         """Queues a log entry to be written by the background thread.
 
         :type record: :class:`logging.LogRecord`
@@ -244,6 +244,13 @@ class _Worker(object):
 
         :type labels: dict
         :param labels: (Optional) Mapping of labels for the entry.
+
+        :type trace: str
+        :param trace: (optional) traceid to apply to the logging entry.
+
+        :type span_id: str
+        :param span_id: (optional) span_id within the trace for the log entry.
+                        Specify the trace parameter if span_id is set.
         """
         self._queue.put_nowait({
             'info': {
@@ -253,6 +260,8 @@ class _Worker(object):
             'severity': record.levelname,
             'resource': resource,
             'labels': labels,
+            'trace': trace,
+            'span_id': span_id,
         })
 
     def flush(self):
@@ -296,7 +305,7 @@ class BackgroundThreadTransport(Transport):
                               max_latency=max_latency)
         self.worker.start()
 
-    def send(self, record, message, resource=None, labels=None):
+    def send(self, record, message, resource=None, labels=None, trace=None, span_id=None):
         """Overrides Transport.send().
 
         :type record: :class:`logging.LogRecord`
@@ -311,8 +320,15 @@ class BackgroundThreadTransport(Transport):
 
         :type labels: dict
         :param labels: (Optional) Mapping of labels for the entry.
+
+        :type trace: str
+        :param trace: (optional) traceid to apply to the logging entry.
+
+        :type span_id: str
+        :param span_id: (optional) span_id within the trace for the log entry.
+                        Specify the trace parameter if span_id is set.
         """
-        self.worker.enqueue(record, message, resource=resource, labels=labels)
+        self.worker.enqueue(record, message, resource=resource, labels=labels, trace=trace, span_id=span_id)
 
     def flush(self):
         """Submit any pending log records."""

--- a/logging/google/cloud/logging/handlers/transports/background_thread.py
+++ b/logging/google/cloud/logging/handlers/transports/background_thread.py
@@ -229,7 +229,8 @@ class _Worker(object):
                 'Failed to send %d pending logs.' % (self._queue.qsize(),),
                 file=sys.stderr)
 
-    def enqueue(self, record, message, resource=None, labels=None, trace=None, span_id=None):
+    def enqueue(self, record, message, resource=None, labels=None,
+                trace=None, span_id=None):
         """Queues a log entry to be written by the background thread.
 
         :type record: :class:`logging.LogRecord`
@@ -305,7 +306,8 @@ class BackgroundThreadTransport(Transport):
                               max_latency=max_latency)
         self.worker.start()
 
-    def send(self, record, message, resource=None, labels=None, trace=None, span_id=None):
+    def send(self, record, message, resource=None, labels=None,
+             trace=None, span_id=None):
         """Overrides Transport.send().
 
         :type record: :class:`logging.LogRecord`
@@ -328,7 +330,8 @@ class BackgroundThreadTransport(Transport):
         :param span_id: (optional) span_id within the trace for the log entry.
                         Specify the trace parameter if span_id is set.
         """
-        self.worker.enqueue(record, message, resource=resource, labels=labels, trace=trace, span_id=span_id)
+        self.worker.enqueue(record, message, resource=resource, labels=labels,
+                            trace=trace, span_id=span_id)
 
     def flush(self):
         """Submit any pending log records."""

--- a/logging/google/cloud/logging/handlers/transports/base.py
+++ b/logging/google/cloud/logging/handlers/transports/base.py
@@ -22,7 +22,8 @@ class Transport(object):
     client and name object, and must override :meth:`send`.
     """
 
-    def send(self, record, message, resource=None, labels=None):
+    def send(self, record, message, resource=None, labels=None,
+             trace=None, span_id=None):
         """Transport send to be implemented by subclasses.
 
         :type record: :class:`logging.LogRecord`

--- a/logging/google/cloud/logging/handlers/transports/sync.py
+++ b/logging/google/cloud/logging/handlers/transports/sync.py
@@ -29,7 +29,8 @@ class SyncTransport(Transport):
     def __init__(self, client, name):
         self.logger = client.logger(name)
 
-    def send(self, record, message, resource=None, labels=None):
+    def send(self, record, message, resource=None, labels=None,
+             trace=None, span_id=None):
         """Overrides transport.send().
 
         :type record: :class:`logging.LogRecord`
@@ -49,4 +50,6 @@ class SyncTransport(Transport):
         self.logger.log_struct(info,
                                severity=record.levelname,
                                resource=resource,
-                               labels=labels)
+                               labels=labels,
+                               trace=trace,
+                               span_id=span_id)

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -105,7 +105,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             python_logger_name, logging.INFO,
             None, None, message, None, None)
 
-        transport.send(record, message, _GLOBAL_RESOURCE, span_id=record.span_id)
+        transport.send(record, message, _GLOBAL_RESOURCE, span_id=span_id)
 
         transport.worker.enqueue.assert_called_once_with(
             record, message, _GLOBAL_RESOURCE, None,

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -64,7 +64,49 @@ class TestBackgroundThreadHandler(unittest.TestCase):
         transport.send(record, message, _GLOBAL_RESOURCE, None)
 
         transport.worker.enqueue.assert_called_once_with(
-            record, message, _GLOBAL_RESOURCE, None)
+            record, message, _GLOBAL_RESOURCE, None, None, None)
+
+    def test_trace_send(self):
+        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+
+        client = _Client(self.PROJECT)
+        name = 'python_logger'
+
+        transport, _ = self._make_one(client, name)
+
+        python_logger_name = 'mylogger'
+        message = 'hello world'
+        trace = 'the-project/trace/longlogTraceid'
+
+        record = logging.LogRecord(
+            python_logger_name, logging.INFO,
+            None, None, message, trace, None)
+
+        transport.send(record, message, _GLOBAL_RESOURCE, None)
+
+        transport.worker.enqueue.assert_called_once_with(
+            record, message, _GLOBAL_RESOURCE, None, trace, None)
+
+    def test_span_send(self):
+        from google.cloud.logging.logger import _GLOBAL_RESOURCE
+
+        client = _Client(self.PROJECT)
+        name = 'python_logger'
+
+        transport, _ = self._make_one(client, name)
+
+        python_logger_name = 'mylogger'
+        message = 'hello world'
+        span_id = 'the-project/trace/longlogTraceid/span/123456789012abbacdac'
+
+        record = logging.LogRecord(
+            python_logger_name, logging.INFO,
+            None, None, message, None, span_id)
+
+        transport.send(record, message, _GLOBAL_RESOURCE, None)
+
+        transport.worker.enqueue.assert_called_once_with(
+            record, message, _GLOBAL_RESOURCE, None, None, span_id)
 
     def test_flush(self):
         client = _Client(self.PROJECT)

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -64,7 +64,8 @@ class TestBackgroundThreadHandler(unittest.TestCase):
         transport.send(record, message, _GLOBAL_RESOURCE)
 
         transport.worker.enqueue.assert_called_once_with(
-            record, message, _GLOBAL_RESOURCE, None, trace=None, span_id=None)
+            record, message, _GLOBAL_RESOURCE, None,
+            trace=None, span_id=None)
 
     def test_trace_send(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
@@ -85,7 +86,8 @@ class TestBackgroundThreadHandler(unittest.TestCase):
         transport.send(record, message, _GLOBAL_RESOURCE, None)
 
         transport.worker.enqueue.assert_called_once_with(
-            record, message, _GLOBAL_RESOURCE, None, trace=trace, span_id=None)
+            record, message, _GLOBAL_RESOURCE, None,
+            trace=trace, span_id=None)
 
     def test_span_send(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
@@ -106,7 +108,8 @@ class TestBackgroundThreadHandler(unittest.TestCase):
         transport.send(record, message, _GLOBAL_RESOURCE, span_id=record.span_id)
 
         transport.worker.enqueue.assert_called_once_with(
-            record, message, _GLOBAL_RESOURCE, trace=None, span_id=span_id)
+            record, message, _GLOBAL_RESOURCE, None,
+            trace=None, span_id=span_id)
 
     def test_flush(self):
         client = _Client(self.PROJECT)

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -433,7 +433,8 @@ class _Batch(object):
         assert resource is None
         resource = _GLOBAL_RESOURCE
 
-        self.log_struct_called_with = (info, severity, resource, labels, trace, span_id)
+        self.log_struct_called_with = (info, severity, resource, labels,
+                                       trace, span_id)
         self.entries.append(info)
 
     def commit(self):

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -426,13 +426,14 @@ class _Batch(object):
         self.commit_count = None
 
     def log_struct(
-            self, info, severity=logging.INFO, resource=None, labels=None):
+            self, info, severity=logging.INFO, resource=None, labels=None,
+            trace=None, span_id=None):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
 
         assert resource is None
         resource = _GLOBAL_RESOURCE
 
-        self.log_struct_called_with = (info, severity, resource, labels)
+        self.log_struct_called_with = (info, severity, resource, labels, trace, span_id)
         self.entries.append(info)
 
     def commit(self):

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -59,7 +59,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
 
         record = logging.LogRecord(
             python_logger_name, logging.INFO,
-            None, None, message)
+            None, None, message, None, None)
 
         transport.send(record, message, _GLOBAL_RESOURCE)
 
@@ -80,7 +80,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
 
         record = logging.LogRecord(
             python_logger_name, logging.INFO,
-            None, None, message)
+            None, None, message, None, None)
 
         transport.send(record, message, _GLOBAL_RESOURCE, None)
 
@@ -101,7 +101,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
 
         record = logging.LogRecord(
             python_logger_name, logging.INFO,
-            None, None, message)
+            None, None, message, None, None)
 
         transport.send(record, message, _GLOBAL_RESOURCE, span_id=record.span_id)
 

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -59,12 +59,12 @@ class TestBackgroundThreadHandler(unittest.TestCase):
 
         record = logging.LogRecord(
             python_logger_name, logging.INFO,
-            None, None, message, None, None)
+            None, None, message)
 
-        transport.send(record, message, _GLOBAL_RESOURCE, None)
+        transport.send(record, message, _GLOBAL_RESOURCE)
 
         transport.worker.enqueue.assert_called_once_with(
-            record, message, _GLOBAL_RESOURCE, None, None, None)
+            record, message, _GLOBAL_RESOURCE, None, trace=None, span_id=None)
 
     def test_trace_send(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
@@ -80,12 +80,12 @@ class TestBackgroundThreadHandler(unittest.TestCase):
 
         record = logging.LogRecord(
             python_logger_name, logging.INFO,
-            None, None, message, trace, None)
+            None, None, message)
 
         transport.send(record, message, _GLOBAL_RESOURCE, None)
 
         transport.worker.enqueue.assert_called_once_with(
-            record, message, _GLOBAL_RESOURCE, None, trace, None)
+            record, message, _GLOBAL_RESOURCE, None, trace=trace, span_id=None)
 
     def test_span_send(self):
         from google.cloud.logging.logger import _GLOBAL_RESOURCE
@@ -101,12 +101,12 @@ class TestBackgroundThreadHandler(unittest.TestCase):
 
         record = logging.LogRecord(
             python_logger_name, logging.INFO,
-            None, None, message, None, span_id)
+            None, None, message)
 
-        transport.send(record, message, _GLOBAL_RESOURCE, None)
+        transport.send(record, message, _GLOBAL_RESOURCE, span_id=record.span_id)
 
         transport.worker.enqueue.assert_called_once_with(
-            record, message, _GLOBAL_RESOURCE, None, None, span_id)
+            record, message, _GLOBAL_RESOURCE, trace=None, span_id=span_id)
 
     def test_flush(self):
         client = _Client(self.PROJECT)

--- a/logging/tests/unit/handlers/transports/test_background_thread.py
+++ b/logging/tests/unit/handlers/transports/test_background_thread.py
@@ -83,7 +83,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             python_logger_name, logging.INFO,
             None, None, message, None, None)
 
-        transport.send(record, message, _GLOBAL_RESOURCE, None)
+        transport.send(record, message, _GLOBAL_RESOURCE, trace=trace)
 
         transport.worker.enqueue.assert_called_once_with(
             record, message, _GLOBAL_RESOURCE, None,

--- a/logging/tests/unit/handlers/transports/test_sync.py
+++ b/logging/tests/unit/handlers/transports/test_sync.py
@@ -52,7 +52,8 @@ class TestSyncHandler(unittest.TestCase):
             'message': message,
             'python_logger': python_logger_name,
         }
-        EXPECTED_SENT = (EXPECTED_STRUCT, 'INFO', _GLOBAL_RESOURCE, None)
+        EXPECTED_SENT = (EXPECTED_STRUCT, 'INFO', _GLOBAL_RESOURCE, None,
+                         None, None)
         self.assertEqual(
             transport.logger.log_struct_called_with, EXPECTED_SENT)
 
@@ -65,7 +66,7 @@ class _Logger(object):
 
     def log_struct(self, message, severity=None,
                    resource=_GLOBAL_RESOURCE, labels=None,
-            trace=None, span_id=None):
+                   trace=None, span_id=None):
         self.log_struct_called_with = (message, severity, resource, labels, trace, span_id)
 
 

--- a/logging/tests/unit/handlers/transports/test_sync.py
+++ b/logging/tests/unit/handlers/transports/test_sync.py
@@ -67,7 +67,8 @@ class _Logger(object):
     def log_struct(self, message, severity=None,
                    resource=_GLOBAL_RESOURCE, labels=None,
                    trace=None, span_id=None):
-        self.log_struct_called_with = (message, severity, resource, labels, trace, span_id)
+        self.log_struct_called_with = (message, severity, resource, labels,
+                                       trace, span_id)
 
 
 class _Client(object):

--- a/logging/tests/unit/handlers/transports/test_sync.py
+++ b/logging/tests/unit/handlers/transports/test_sync.py
@@ -64,8 +64,9 @@ class _Logger(object):
         self.name = name
 
     def log_struct(self, message, severity=None,
-                   resource=_GLOBAL_RESOURCE, labels=None):
-        self.log_struct_called_with = (message, severity, resource, labels)
+                   resource=_GLOBAL_RESOURCE, labels=None,
+            trace=None, span_id=None):
+        self.log_struct_called_with = (message, severity, resource, labels, trace, span_id)
 
 
 class _Client(object):


### PR DESCRIPTION
Follow up to #5885 and #5878. Add function parameters on the logging async API to allow API logging with trace and span_id in a non-blocking way.