### PR TITLE
Drop separate testing for grpcio-gcp.

### DIFF
--- a/spanner/nox.py
+++ b/spanner/nox.py
@@ -70,23 +70,6 @@ def unit(session, py):
     default(session)
 
 
-@nox.session
-@nox.parametrize('py', ['2.7', '3.6'])
-def unit_grpc_gcp(session, py):
-    """Run the unit test suite with grpcio-gcp installed."""
-
-    # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python{}'.format(py)
-
-    # Set the virtualenv dirname.
-    session.virtualenv_dirname = 'unit-grpc-gcp-' + py
-
-    # Install grpcio-gcp
-    session.install('grpcio-gcp')
-
-    default(session)
-
-
 def system_common(session):
     # Use pre-release gRPC for system tests.
     session.install('--pre', 'grpcio')


### PR DESCRIPTION
We made it an unconditional dependency in #5904.

See #5925.