### PR TITLE
Retry '502 Bad Gateway' errors by default.

### DIFF
--- a/bigquery/google/cloud/bigquery/retry.py
+++ b/bigquery/google/cloud/bigquery/retry.py
@@ -20,6 +20,7 @@ _RETRYABLE_REASONS = frozenset([
     'backendError',
     'rateLimitExceeded',
     'internalError',
+    'badGateway',
 ])
 
 

--- a/bigquery/tests/unit/test_retry.py
+++ b/bigquery/tests/unit/test_retry.py
@@ -51,3 +51,8 @@ class Test_should_retry(unittest.TestCase):
         exc = mock.Mock(
             errors=[{'reason': 'internalError'}], spec=['errors'])
         self.assertTrue(self._call_fut(exc))
+
+    def test_w_badGateway(self):
+        exc = mock.Mock(
+            errors=[{'reason': 'badGateway'}], spec=['errors'])
+        self.assertTrue(self._call_fut(exc))


### PR DESCRIPTION
Closes #5918.