### PR TITLE
Bigtable: refactoring read_rows infrastructure

### DIFF
--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -483,7 +483,6 @@ class PartialRowsData(object):
             self._copy_from_previous(self._cell)
             self._validate_cell_data_new_cell()
         else:
-            self._validate_cell_data_cell_in_progress(chunk)
             self._cell.append_value(chunk.value)
 
     def _validate_cell_data_new_cell(self):
@@ -495,19 +494,6 @@ class PartialRowsData(object):
 
         prev = self._previous_cell
         if prev and prev.row_key != cell.row_key:
-            raise InvalidChunk()
-
-    def _validate_cell_data_cell_in_progress(self, chunk):
-        if (chunk.row_key and
-                chunk.row_key != self._cell.row_key):
-            raise InvalidChunk()
-
-        if (chunk.HasField('family_name') and
-                chunk.family_name.value != self._cell.family_name):
-            raise InvalidChunk()
-
-        if (chunk.HasField('qualifier') and
-                chunk.qualifier.value != self._cell.qualifier):
             raise InvalidChunk()
 
     def _validate_chunk_reset_row(self, chunk):

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -321,17 +321,15 @@ class PartialRowsData(object):
                     expected exceptions during iteration.
     """
 
-    START = 'Start'  # No responses yet processed.
     NEW_ROW = 'New row'  # No cells yet complete for row
     ROW_IN_PROGRESS = 'Row in progress'  # Some cells complete for row
     CELL_IN_PROGRESS = 'Cell in progress'  # Incomplete cell for row
 
-    STATE_START = 0
     STATE_NEW_ROW = 1
     STATE_ROW_IN_PROGRESS = 2
     STATE_CELL_IN_PROGRESS = 3
 
-    read_states = {STATE_START: START, STATE_NEW_ROW: NEW_ROW,
+    read_states = {STATE_NEW_ROW: NEW_ROW,
                    STATE_ROW_IN_PROGRESS: ROW_IN_PROGRESS,
                    STATE_CELL_IN_PROGRESS: CELL_IN_PROGRESS}
 
@@ -354,6 +352,7 @@ class PartialRowsData(object):
         self.response_iterator = read_method(request)
 
         self.rows = {}
+        self._state = self.STATE_NEW_ROW
 
     @property
     def state(self):
@@ -364,23 +363,6 @@ class PartialRowsData(object):
                    processing.
         """
         return self.read_states[self._state]
-
-    @property
-    def _state(self):
-        """State machine state.
-        :rtype: int
-        :returns:  id of state corresponding to currrent row / chunk
-                   processing.
-        """
-        if self._previous_cell is not None:
-            return self.STATE_ROW_IN_PROGRESS
-        if self.last_scanned_row_key is None:
-            return self.STATE_START
-        if self._row is None:
-            return self.STATE_NEW_ROW
-        if self._cell is not None:
-            return self.STATE_CELL_IN_PROGRESS
-        return self.STATE_NEW_ROW  # row added, no chunk yet processed
 
     def cancel(self):
         """Cancels the iterator, closing the stream."""
@@ -428,7 +410,7 @@ class PartialRowsData(object):
         return retry_(self._read_next, on_error=self._on_error)()
 
     def __iter__(self):
-        """Consume the ``ReadRowsResponse's`` from the stream.
+        """Consume the ``ReadRowsResponse``s from the stream.
         Read the rows and yield each to the reader
 
         Parse the response and its chunks into a new/existing row in
@@ -440,86 +422,91 @@ class PartialRowsData(object):
             except StopIteration:
                 break
 
-            self._counter += 1
-
-            if self.last_scanned_row_key is None:  # first response
-                if response.last_scanned_row_key:
-                    raise InvalidReadRowsResponse()
-
-            self.last_scanned_row_key = response.last_scanned_row_key
-
-            row = self._row
-            cell = self._cell
-
             for chunk in response.chunks:
-
-                if chunk.reset_row:
-                    self._validate_chunk_reset_row(chunk)
-                    row = self._row = None
-                    cell = self._cell = self._previous_cell = None
-                    continue
-
-                if cell is None:
-                    qualifier = chunk.qualifier.value
-                    if qualifier == b'' and not chunk.HasField('qualifier'):
-                        qualifier = None
-
-                    cell = PartialCellData(
-                        chunk.row_key,
-                        chunk.family_name.value,
-                        qualifier,
-                        chunk.timestamp_micros,
-                        chunk.labels,
-                        chunk.value)
-                    self._validate_cell_data(cell)
-                    self._cell = cell
-                    self._copy_from_previous(cell)
-                else:
-                    cell.append_value(chunk.value)
-
-                if row is None:
-                    row = self._row = PartialRowData(cell.row_key)
-
+                self._process_chunk(chunk)
                 if chunk.commit_row:
-                    if chunk.value_size > 0:
-                        raise InvalidChunk()
+                   self.last_scanned_row_key = self._previous_row.row_key
+                   self._counter += 1
+                   yield self._previous_row
 
-                    self._save_current_cell()
+            if (response.last_scanned_row_key and
+                response.last_scanned_row_key > self.last_scanned_row_key):
+                self.last_scanned_row_key = response.last_scanned_row_key
 
-                    yield self._row
+    def _process_chunk(self, chunk):
+        if chunk.reset_row:
+            self._validate_chunk_reset_row(chunk)
+            self._row = None
+            self._cell = self._previous_cell = None
+            self._state = self.STATE_NEW_ROW
+            return
 
-                    self.last_scanned_row_key = self._row.row_key
-                    self._row, self._previous_row = None, self._row
-                    self._previous_cell = None
-                    row = cell = None
-                    continue
+        self._update_cell(chunk)
 
-                if chunk.value_size == 0:
-                    self._save_current_cell()
-                    cell = None
+        if self._row is None:
+            if (self._previous_row is not None and
+                self._cell.row_key <= self._previous_row.row_key):
+                raise InvalidChunk()
+            self._row = PartialRowData(self._cell.row_key)
 
-    def _validate_cell_data(self, cell):
-        if self._state == self.STATE_ROW_IN_PROGRESS:
-            self._validate_cell_data_row_in_progress(cell)
-        if self._state == self.STATE_NEW_ROW:
-            self._validate_cell_data_new_row(cell)
-        if self._state == self.STATE_CELL_IN_PROGRESS:
-            self._copy_from_current(cell)
+        if chunk.value_size == 0:
+            self._state = self.STATE_ROW_IN_PROGRESS
+            self._save_current_cell()
+        else:
+            self._state = self.STATE_CELL_IN_PROGRESS
 
-    def _validate_cell_data_new_row(self, cell):
-        if (not cell.row_key or
-                not cell.family_name or
-                cell.qualifier is None):
+        if chunk.commit_row:
+            if chunk.value_size > 0:
+                raise InvalidChunk()
+
+            self._previous_row = self._row
+            self._row = None
+            self._previous_cell = None
+            self._state = self.STATE_NEW_ROW
+
+    def _update_cell(self, chunk):
+        if self._cell is None:
+            qualifier = None
+            if chunk.HasField('qualifier'):
+                qualifier = chunk.qualifier.value
+            family = None
+            if chunk.HasField('family_name'):
+                family = chunk.family_name.value
+
+            self._cell = PartialCellData(
+                chunk.row_key,
+                family,
+                qualifier,
+                chunk.timestamp_micros,
+                chunk.labels,
+                chunk.value)
+            self._copy_from_previous(self._cell)
+            self._validate_cell_data_new_cell()
+        else:
+            self._validate_cell_data_cell_in_progress(chunk)
+            self._cell.append_value(chunk.value)
+
+    def _validate_cell_data_new_cell(self):
+        if (not self._cell.row_key or
+            not self._cell.family_name or
+            self._cell.qualifier is None):
             raise InvalidChunk()
 
-        if (self._previous_row is not None and
-                cell.row_key <= self._previous_row.row_key):
+        if (self._previous_cell and 
+            self._previous_cell.row_key != self._cell.row_key):
             raise InvalidChunk()
 
-    def _validate_cell_data_row_in_progress(self, cell):
-        if ((cell.row_key and
-             cell.row_key != self._row.row_key) or
-                (cell.family_name and cell.qualifier is None)):
+    def _validate_cell_data_cell_in_progress(self, chunk):
+        if (chunk.row_key and
+            chunk.row_key != self._cell.row_key):
+            raise InvalidChunk()
+
+        if (chunk.HasField('family_name') and
+            chunk.family_name.value != self._cell.family_name):
+            raise InvalidChunk()
+
+        if (chunk.HasField('qualifier') and
+            chunk.qualifier.value != self._cell.qualifier):
             raise InvalidChunk()
 
     def _validate_chunk_reset_row(self, chunk):
@@ -534,6 +521,7 @@ class PartialRowsData(object):
         _raise_if(chunk.labels)
         _raise_if(chunk.value_size)
         _raise_if(chunk.value)
+        _raise_if(chunk.commit_row)
 
     def _save_current_cell(self):
         """Helper for :meth:`consume_next`."""
@@ -544,32 +532,17 @@ class PartialRowsData(object):
         qualified.append(complete)
         self._cell, self._previous_cell = None, cell
 
-    def _copy_from_current(self, cell):
-        current = self._cell
-        if current is not None:
-            if not cell.row_key:
-                cell.row_key = current.row_key
-            if not cell.family_name:
-                cell.family_name = current.family_name
-                # NOTE: ``cell.qualifier`` **can** be empty string.
-            if cell.qualifier is None:
-                cell.qualifier = current.qualifier
-            if not cell.timestamp_micros:
-                cell.timestamp_micros = current.timestamp_micros
-            if not cell.labels:
-                cell.labels.extend(current.labels)
-
     def _copy_from_previous(self, cell):
         """Helper for :meth:`consume_next`."""
         previous = self._previous_cell
         if previous is not None:
             if not cell.row_key:
                 cell.row_key = previous.row_key
-            if not cell.family_name:
-                cell.family_name = previous.family_name
-            # NOTE: ``cell.qualifier`` **can** be empty string.
-            if cell.qualifier is None:
-                cell.qualifier = previous.qualifier
+                if not cell.family_name:
+                    cell.family_name = previous.family_name
+                    NOTE: ``cell.qualifier`` **can** be empty string.
+                    if cell.qualifier is None:
+                        cell.qualifier = previous.qualifier
 
 
 class _ReadRowsRequestManager(object):

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -430,8 +430,7 @@ class PartialRowsData(object):
                     yield self._previous_row
 
             resp_last_key = response.last_scanned_row_key
-            if (resp_last_key and
-                   resp_last_key > self.last_scanned_row_key):
+            if resp_last_key and resp_last_key > self.last_scanned_row_key:
                 self.last_scanned_row_key = resp_last_key
 
     def _process_chunk(self, chunk):
@@ -495,7 +494,7 @@ class PartialRowsData(object):
             raise InvalidChunk()
 
         prev = self._previous_cell
-        if (prev and prev.row_key != cell.row_key:
+        if prev and prev.row_key != cell.row_key:
             raise InvalidChunk()
 
     def _validate_cell_data_cell_in_progress(self, chunk):

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -431,7 +431,7 @@ class PartialRowsData(object):
 
             resp_last_key = response.last_scanned_row_key
             if (resp_last_key and
-                resp_last_key > self.last_scanned_row_key):
+                   resp_last_key > self.last_scanned_row_key):
                 self.last_scanned_row_key = resp_last_key
 
     def _process_chunk(self, chunk):
@@ -446,7 +446,7 @@ class PartialRowsData(object):
 
         if self._row is None:
             if (self._previous_row is not None and
-                self._cell.row_key <= self._previous_row.row_key):
+                    self._cell.row_key <= self._previous_row.row_key):
                 raise InvalidChunk()
             self._row = PartialRowData(self._cell.row_key)
 
@@ -488,26 +488,27 @@ class PartialRowsData(object):
             self._cell.append_value(chunk.value)
 
     def _validate_cell_data_new_cell(self):
-        if (not self._cell.row_key or
-            not self._cell.family_name or
-            self._cell.qualifier is None):
+        cell = self._cell
+        if (not cell.row_key or
+                not cell.family_name or
+                cell.qualifier is None):
             raise InvalidChunk()
 
-        if (self._previous_cell and 
-            self._previous_cell.row_key != self._cell.row_key):
+        prev = self._previous_cell
+        if (prev and prev.row_key != cell.row_key:
             raise InvalidChunk()
 
     def _validate_cell_data_cell_in_progress(self, chunk):
         if (chunk.row_key and
-            chunk.row_key != self._cell.row_key):
+                chunk.row_key != self._cell.row_key):
             raise InvalidChunk()
 
         if (chunk.HasField('family_name') and
-            chunk.family_name.value != self._cell.family_name):
+                chunk.family_name.value != self._cell.family_name):
             raise InvalidChunk()
 
         if (chunk.HasField('qualifier') and
-            chunk.qualifier.value != self._cell.qualifier):
+                chunk.qualifier.value != self._cell.qualifier):
             raise InvalidChunk()
 
     def _validate_chunk_reset_row(self, chunk):

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -425,13 +425,14 @@ class PartialRowsData(object):
             for chunk in response.chunks:
                 self._process_chunk(chunk)
                 if chunk.commit_row:
-                   self.last_scanned_row_key = self._previous_row.row_key
-                   self._counter += 1
-                   yield self._previous_row
+                    self.last_scanned_row_key = self._previous_row.row_key
+                    self._counter += 1
+                    yield self._previous_row
 
-            if (response.last_scanned_row_key and
-                response.last_scanned_row_key > self.last_scanned_row_key):
-                self.last_scanned_row_key = response.last_scanned_row_key
+            resp_last_key = response.last_scanned_row_key
+            if (resp_last_key and
+                resp_last_key > self.last_scanned_row_key):
+                self.last_scanned_row_key = resp_last_key
 
     def _process_chunk(self, chunk):
         if chunk.reset_row:
@@ -540,7 +541,7 @@ class PartialRowsData(object):
                 cell.row_key = previous.row_key
                 if not cell.family_name:
                     cell.family_name = previous.family_name
-                    NOTE: ``cell.qualifier`` **can** be empty string.
+                    # NOTE: ``cell.qualifier`` **can** be empty string.
                     if cell.qualifier is None:
                         cell.qualifier = previous.qualifier
 

--- a/bigtable/google/cloud/bigtable/table.py
+++ b/bigtable/google/cloud/bigtable/table.py
@@ -308,7 +308,7 @@ class Table(object):
             request_pb)
 
         rows_data.consume_all()
-        if rows_data.state not in (rows_data.NEW_ROW, rows_data.START):
+        if rows_data.state != rows_data.NEW_ROW:
             raise ValueError('The row remains partial / is not committed.')
 
         if len(rows_data.rows) == 0:

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -444,8 +444,6 @@ class TestPartialRowsData(unittest.TestCase):
         result = rows[0]
         self.assertEqual(result.row_key, self.ROW_KEY)
         self.assertEqual(yrd._counter, 1)
-
-        yrd._row = object()
         self.assertEqual(yrd.state, yrd.NEW_ROW)
 
     def test_multiple_chunks(self):
@@ -485,13 +483,7 @@ class TestPartialRowsData(unittest.TestCase):
         result = rows[0]
         self.assertEqual(result.row_key, self.ROW_KEY)
         self.assertEqual(yrd._counter, 1)
-
-        yrd._row = object()
         self.assertEqual(yrd.state, yrd.NEW_ROW)
-
-    def test_multiple_chunks(self):
-        from google.cloud.bigtable_v2.gapic import bigtable_client
-
 
     def test_cancel(self):
         client = _Client()


### PR DESCRIPTION
This work is on behalf of understanding the issues behind issue #5876 where InvalidChunk is thrown due to row keys being processed out of order.
About this PR
- introducing `PartialRowsData._process_chunk` to break up logic in `__iter__`, and allow for additional testability.  `__iter__` is responsible to get chunks, call `_process_chunk`, and manage `last_scanned_row_key`.
- removed `_copy_from_current`
- _state is now explicitly set
- fixed a bug in `PartialRowsData.counter` which was counting chunks instead of rows.  This counter is used in reconstructing requests for "smart retries" that update the request on transient exceptions