### PR TITLE
Bigtable: smart retry logic to cover errors in 'read_rows()' and 'read_rows(rows_limit)' requests

### DIFF
--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -630,7 +630,8 @@ class _ReadRowsRequestManager(object):
 
         for row_range in self.message.rows.row_ranges:
             # if current end_key (open or closed) is set, return its value,
-            # if not, set to empty string ('')
+            # if not, set to empty string ('').
+            # NOTE: Empty string in end_key means "end of table"
             end_key = self._end_key_set(row_range)
             # if end_key is already read, skip to the next row_range
             if(end_key and self._key_already_read(end_key)):
@@ -638,6 +639,7 @@ class _ReadRowsRequestManager(object):
 
             # if current start_key (open or closed) is set, return its value,
             # if not, then set to empty string ('')
+            # NOTE: Empty string in start_key means "beginning of table"
             start_key = self._start_key_set(row_range)
 
             # if start_key was already read or doesn't exist,
@@ -657,11 +659,13 @@ class _ReadRowsRequestManager(object):
         """ Helper for :meth:`_filter_row_ranges`"""
         return key <= self.last_scanned_key
 
-    def _start_key_set(self, row_range):
+    @staticmethod
+    def _start_key_set(row_range):
         """ Helper for :meth:`_filter_row_ranges`"""
         return row_range.start_key_open or row_range.start_key_closed
 
-    def _end_key_set(self, row_range):
+    @staticmethod
+    def _end_key_set(row_range):
         """ Helper for :meth:`_filter_row_ranges`"""
         return row_range.end_key_open or row_range.end_key_closed
 

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -406,15 +406,16 @@ class PartialRowsData(object):
         req_manager = _ReadRowsRequestManager(self.request,
                                               self.last_scanned_row_key,
                                               self._counter)
-        self.request = req_manager.build_updated_request()
+        return req_manager.build_updated_request()
 
     def _on_error(self, exc):
         """Helper for :meth:`__iter__`."""
         # restart the read scan from AFTER the last successfully read row
+        retry_request = self.request
         if self.last_scanned_row_key:
-            self._create_retry_request()
+            retry_request = self._create_retry_request()
 
-        self.response_iterator = self.read_method(self.request)
+        self.response_iterator = self.read_method(retry_request)
 
     def _read_next(self):
         """Helper for :meth:`__iter__`."""

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -604,15 +604,18 @@ class _ReadRowsRequestManager(object):
             r_kwargs['rows_limit'] = max(1, self.message.rows_limit -
                                          self.rows_read_so_far)
 
-        row_keys = self._filter_rows_keys()
-        row_ranges = self._filter_row_ranges()
-        r_kwargs['rows'] = data_v2_pb2.RowSet(row_keys=row_keys,
-                                              row_ranges=row_ranges)
+        # if neither RowSet.row_keys nor RowSet.row_ranges currently exist,
+        # add row_range that starts with last_scanned_key as start_key_open
+        # to request only rows that have not been returned yet
         if not self.message.HasField('rows'):
             row_range = data_v2_pb2.RowRange(
                 start_key_open=self.last_scanned_key)
             r_kwargs['rows'] = data_v2_pb2.RowSet(row_ranges=[row_range])
-
+        else:
+            row_keys = self._filter_rows_keys()
+            row_ranges = self._filter_row_ranges()
+            r_kwargs['rows'] = data_v2_pb2.RowSet(row_keys=row_keys,
+                                                  row_ranges=row_ranges)
         return data_messages_v2_pb2.ReadRowsRequest(**r_kwargs)
 
     def _filter_rows_keys(self):
@@ -625,28 +628,41 @@ class _ReadRowsRequestManager(object):
         new_row_ranges = []
 
         for row_range in self.message.rows.row_ranges:
-            if((row_range.end_key_open and
-                self._key_already_read(row_range.end_key_open)) or
-                (row_range.end_key_closed and
-                 self._key_already_read(row_range.end_key_closed))):
-                    continue
+            # if current end_key (open or closed) is set, return its value,
+            # if not, set to empty string ('')
+            end_key = self._end_key_set(row_range)
+            # if end_key is already read, skip to the next row_range
+            if(end_key and self._key_already_read(end_key)):
+                continue
 
-            if ((row_range.start_key_open and
-                self._key_already_read(row_range.start_key_open)) or
-                (row_range.start_key_closed and
-                 self._key_already_read(row_range.start_key_closed))):
-                row_range.start_key_closed = _to_bytes("")
-                row_range.start_key_open = self.last_scanned_key
+            # if current start_key (open or closed) is set, return its value,
+            # if not, then set to empty string ('')
+            start_key = self._start_key_set(row_range)
 
-                new_row_ranges.append(row_range)
-            else:
-                new_row_ranges.append(row_range)
+            # if start_key was already read or doesn't exist,
+            # create a row_range with last_scanned_key as start_key_open
+            # to be passed to retry request
+            retry_row_range = row_range
+            if(self._key_already_read(start_key)):
+                retry_row_range = copy.deepcopy(row_range)
+                retry_row_range.start_key_closed = _to_bytes("")
+                retry_row_range.start_key_open = self.last_scanned_key
+
+            new_row_ranges.append(retry_row_range)
 
         return new_row_ranges
 
     def _key_already_read(self, key):
         """ Helper for :meth:`_filter_row_ranges`"""
         return key <= self.last_scanned_key
+
+    def _start_key_set(self, row_range):
+        """ Helper for :meth:`_filter_row_ranges`"""
+        return row_range.start_key_open or row_range.start_key_closed
+
+    def _end_key_set(self, row_range):
+        """ Helper for :meth:`_filter_row_ranges`"""
+        return row_range.end_key_open or row_range.end_key_closed
 
 
 def _raise_if(predicate, *args):

--- a/bigtable/google/cloud/bigtable/row_data.py
+++ b/bigtable/google/cloud/bigtable/row_data.py
@@ -608,6 +608,10 @@ class _ReadRowsRequestManager(object):
         row_ranges = self._filter_row_ranges()
         r_kwargs['rows'] = data_v2_pb2.RowSet(row_keys=row_keys,
                                               row_ranges=row_ranges)
+        if not self.message.HasField('rows'):
+            row_range = data_v2_pb2.RowRange(
+                start_key_open=self.last_scanned_key)
+            r_kwargs['rows'] = data_v2_pb2.RowSet(row_ranges=[row_range])
 
         return data_messages_v2_pb2.ReadRowsRequest(**r_kwargs)
 

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -795,7 +795,7 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
                                               end_key_open=b"row_key49")
         exp_row_ranges = [exp_row_range1, exp_row_range2, exp_row_range3]
 
-        self.assertEqual(row_ranges, exp_row_ranges)
+        self.assertEqual(exp_row_ranges, row_ranges)
 
     def test_build_updated_request(self):
         from google.cloud.bigtable.row_filters import RowSampleFilter
@@ -815,6 +815,54 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
                                              rows_limit=6)
         expected_result_row_range = RowRange(last_scanned_key, b"row_key29",
                                              False)
+        expected_result.rows.row_ranges.add(**expected_result_row_range.
+                                            get_range_kwargs())
+
+        self.assertEqual(expected_result, result)
+
+    def test_build_updated_request_no_start_key(self):
+        from google.cloud.bigtable.row_filters import RowSampleFilter
+        row_filter = RowSampleFilter(0.33)
+        last_scanned_key = b"row_key25"
+        request = _ReadRowsRequestPB(filter=row_filter.to_pb(),
+                                     rows_limit=8,
+                                     table_name=self.table_name)
+        row_range = RowRange(end_key=b"row_key29")
+        request.rows.row_ranges.add(**row_range.get_range_kwargs())
+
+        request_manager = self._make_one(request, last_scanned_key, 2)
+
+        result = request_manager.build_updated_request()
+
+        expected_result = _ReadRowsRequestPB(table_name=self.table_name,
+                                             filter=row_filter.to_pb(),
+                                             rows_limit=6)
+        expected_result_row_range = RowRange(last_scanned_key, b"row_key29",
+                                             False)
+        expected_result.rows.row_ranges.add(**expected_result_row_range.
+                                            get_range_kwargs())
+
+        self.assertEqual(expected_result, result)
+
+    def test_build_updated_request_no_end_key(self):
+        from google.cloud.bigtable.row_filters import RowSampleFilter
+        row_filter = RowSampleFilter(0.33)
+        last_scanned_key = b"row_key25"
+        request = _ReadRowsRequestPB(filter=row_filter.to_pb(),
+                                     rows_limit=8,
+                                     table_name=self.table_name)
+        row_range = RowRange(start_key=b"row_key20")
+        request.rows.row_ranges.add(**row_range.get_range_kwargs())
+
+        request_manager = self._make_one(request, last_scanned_key, 2)
+
+        result = request_manager.build_updated_request()
+
+        expected_result = _ReadRowsRequestPB(table_name=self.table_name,
+                                             filter=row_filter.to_pb(),
+                                             rows_limit=6)
+        expected_result_row_range = RowRange(last_scanned_key,
+                                             start_inclusive=False)
         expected_result.rows.row_ranges.add(**expected_result_row_range.
                                             get_range_kwargs())
 

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -813,10 +813,10 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
         expected_result = _ReadRowsRequestPB(table_name=self.table_name,
                                              filter=row_filter.to_pb(),
                                              rows_limit=6)
-        expected_result_row_range = RowRange(last_scanned_key, b"row_key29",
-                                             False)
-        expected_result.rows.row_ranges.add(**expected_result_row_range.
-                                            get_range_kwargs())
+        expected_result.rows.row_ranges.add(
+            start_key_open=last_scanned_key,
+            end_key_open=self.row_range1.end_key
+        )
 
         self.assertEqual(expected_result, result)
 
@@ -827,8 +827,7 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
         request = _ReadRowsRequestPB(filter=row_filter.to_pb(),
                                      rows_limit=8,
                                      table_name=self.table_name)
-        row_range = RowRange(end_key=b"row_key29")
-        request.rows.row_ranges.add(**row_range.get_range_kwargs())
+        request.rows.row_ranges.add(end_key_open=b"row_key29")
 
         request_manager = self._make_one(request, last_scanned_key, 2)
 
@@ -837,10 +836,8 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
         expected_result = _ReadRowsRequestPB(table_name=self.table_name,
                                              filter=row_filter.to_pb(),
                                              rows_limit=6)
-        expected_result_row_range = RowRange(last_scanned_key, b"row_key29",
-                                             False)
-        expected_result.rows.row_ranges.add(**expected_result_row_range.
-                                            get_range_kwargs())
+        expected_result.rows.row_ranges.add(start_key_open=last_scanned_key,
+                                            end_key_open=b"row_key29")
 
         self.assertEqual(expected_result, result)
 
@@ -851,8 +848,7 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
         request = _ReadRowsRequestPB(filter=row_filter.to_pb(),
                                      rows_limit=8,
                                      table_name=self.table_name)
-        row_range = RowRange(start_key=b"row_key20")
-        request.rows.row_ranges.add(**row_range.get_range_kwargs())
+        request.rows.row_ranges.add(start_key_closed=b"row_key20")
 
         request_manager = self._make_one(request, last_scanned_key, 2)
 
@@ -861,10 +857,7 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
         expected_result = _ReadRowsRequestPB(table_name=self.table_name,
                                              filter=row_filter.to_pb(),
                                              rows_limit=6)
-        expected_result_row_range = RowRange(last_scanned_key,
-                                             start_inclusive=False)
-        expected_result.rows.row_ranges.add(**expected_result_row_range.
-                                            get_range_kwargs())
+        expected_result.rows.row_ranges.add(start_key_open=last_scanned_key)
 
         self.assertEqual(expected_result, result)
 
@@ -891,7 +884,7 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
 
         self.assertEqual(expected_result, result)
 
-    def test_buil_updated_request_rows_limit(self):
+    def test_build_updated_request_rows_limit(self):
         last_scanned_key = b"row_key14"
 
         request = _ReadRowsRequestPB(table_name=self.table_name, rows_limit=10)
@@ -901,13 +894,10 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
         expected_result = _ReadRowsRequestPB(table_name=self.table_name,
                                              filter={},
                                              rows_limit=8)
-        expected_result_row_range = RowRange(start_key=last_scanned_key,
-                                             start_inclusive=False)
-        expected_result.rows.row_ranges.add(**expected_result_row_range.
-                                            get_range_kwargs())
+        expected_result.rows.row_ranges.add(start_key_open=last_scanned_key)
         self.assertEqual(expected_result, result)
 
-    def test_buil_updated_request_plain(self):
+    def test_build_updated_request_plain(self):
         last_scanned_key = b"row_key14"
 
         request = _ReadRowsRequestPB(table_name=self.table_name)
@@ -916,10 +906,7 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
         result = request_manager.build_updated_request()
         expected_result = _ReadRowsRequestPB(table_name=self.table_name,
                                              filter={})
-        expected_result_row_range = RowRange(start_key=last_scanned_key,
-                                             start_inclusive=False)
-        expected_result.rows.row_ranges.add(**expected_result_row_range.
-                                            get_range_kwargs())
+        expected_result.rows.row_ranges.add(start_key_open=last_scanned_key)
         self.assertEqual(expected_result, result)
 
     def test__key_already_read(self):

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -800,7 +800,7 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
     def test_build_updated_request(self):
         from google.cloud.bigtable.row_filters import RowSampleFilter
         row_filter = RowSampleFilter(0.33)
-        last_scanned_key = b"row_key14"
+        last_scanned_key = b"row_key25"
         request = _ReadRowsRequestPB(filter=row_filter.to_pb(),
                                      rows_limit=8,
                                      table_name=self.table_name)
@@ -813,9 +813,65 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
         expected_result = _ReadRowsRequestPB(table_name=self.table_name,
                                              filter=row_filter.to_pb(),
                                              rows_limit=6)
-        expected_result.rows.row_ranges.add(**self.row_range1.
+        expected_result_row_range = RowRange(last_scanned_key, b"row_key29",
+                                             False)
+        expected_result.rows.row_ranges.add(**expected_result_row_range.
                                             get_range_kwargs())
 
+        self.assertEqual(expected_result, result)
+
+    def test_build_updated_request_rows(self):
+        from google.cloud.bigtable.row_filters import RowSampleFilter
+        row_filter = RowSampleFilter(0.33)
+        last_scanned_key = b"row_key4"
+        request = _ReadRowsRequestPB(filter=row_filter.to_pb(),
+                                     rows_limit=5,
+                                     table_name=self.table_name)
+        request.rows.row_keys.extend([b'row_key1', b'row_key2',
+                                      b'row_key4', b'row_key5',
+                                      b'row_key7', b'row_key9'])
+
+        request_manager = self._make_one(request, last_scanned_key, 3)
+
+        result = request_manager.build_updated_request()
+
+        expected_result = _ReadRowsRequestPB(table_name=self.table_name,
+                                             filter=row_filter.to_pb(),
+                                             rows_limit=2)
+        expected_result.rows.row_keys.extend([b'row_key5', b'row_key7',
+                                              b'row_key9'])
+
+        self.assertEqual(expected_result, result)
+
+    def test_buil_updated_request_rows_limit(self):
+        last_scanned_key = b"row_key14"
+
+        request = _ReadRowsRequestPB(table_name=self.table_name, rows_limit=10)
+        request_manager = self._make_one(request, last_scanned_key, 2)
+
+        result = request_manager.build_updated_request()
+        expected_result = _ReadRowsRequestPB(table_name=self.table_name,
+                                             filter={},
+                                             rows_limit=8)
+        expected_result_row_range = RowRange(start_key=last_scanned_key,
+                                             start_inclusive=False)
+        expected_result.rows.row_ranges.add(**expected_result_row_range.
+                                            get_range_kwargs())
+        self.assertEqual(expected_result, result)
+
+    def test_buil_updated_request_plain(self):
+        last_scanned_key = b"row_key14"
+
+        request = _ReadRowsRequestPB(table_name=self.table_name)
+        request_manager = self._make_one(request, last_scanned_key, 2)
+
+        result = request_manager.build_updated_request()
+        expected_result = _ReadRowsRequestPB(table_name=self.table_name,
+                                             filter={})
+        expected_result_row_range = RowRange(start_key=last_scanned_key,
+                                             start_inclusive=False)
+        expected_result.rows.row_ranges.add(**expected_result_row_range.
+                                            get_range_kwargs())
         self.assertEqual(expected_result, result)
 
     def test__key_already_read(self):

--- a/bigtable/tests/unit/test_row_data.py
+++ b/bigtable/tests/unit/test_row_data.py
@@ -820,6 +820,18 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
 
         self.assertEqual(expected_result, result)
 
+    def test_build_updated_request_full_table(self):
+        last_scanned_key = b"row_key14"
+
+        request = _ReadRowsRequestPB(table_name=self.table_name)
+        request_manager = self._make_one(request, last_scanned_key, 2)
+
+        result = request_manager.build_updated_request()
+        expected_result = _ReadRowsRequestPB(table_name=self.table_name,
+                                             filter={})
+        expected_result.rows.row_ranges.add(start_key_open=last_scanned_key)
+        self.assertEqual(expected_result, result)
+
     def test_build_updated_request_no_start_key(self):
         from google.cloud.bigtable.row_filters import RowSampleFilter
         row_filter = RowSampleFilter(0.33)
@@ -894,18 +906,6 @@ class Test_ReadRowsRequestManager(unittest.TestCase):
         expected_result = _ReadRowsRequestPB(table_name=self.table_name,
                                              filter={},
                                              rows_limit=8)
-        expected_result.rows.row_ranges.add(start_key_open=last_scanned_key)
-        self.assertEqual(expected_result, result)
-
-    def test_build_updated_request_plain(self):
-        last_scanned_key = b"row_key14"
-
-        request = _ReadRowsRequestPB(table_name=self.table_name)
-        request_manager = self._make_one(request, last_scanned_key, 2)
-
-        result = request_manager.build_updated_request()
-        expected_result = _ReadRowsRequestPB(table_name=self.table_name,
-                                             filter={})
         expected_result.rows.row_ranges.add(start_key_open=last_scanned_key)
         self.assertEqual(expected_result, result)
 


### PR DESCRIPTION
Attempt to fix #5876 
Added logic to create a `RowRange(start_key_open=last_scanned_key)` if `current_request.rows` is empty.
This will cover `table.read_rows()` and `table.read_rows(rows_limit)` requests.