### PR TITLE
Translate: restore detailed usage docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -331,7 +331,6 @@ static_html_pages = [
     'logging/usage.html',
     'spanner/usage.html',
     'storage/client.html',
-    'translate/usage.html',
 ]
 
 def copy_static_html_pages(app, docname):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -327,8 +327,6 @@ intersphinx_mapping = {
 static_html_pages = [
     'datastore.usage.html',
     'bigquery/usage.html',
-    'language/usage.html',
-    'logging/usage.html',
     'spanner/usage.html',
     'storage/client.html',
 ]

--- a/language/docs/usage.html
+++ b/language/docs/usage.html
@@ -1,8 +1,0 @@
-<html>
-<head>
- <meta http-equiv="refresh" content="1; url=./index.html:" />
- <script>
-   window.location.href = "./index.html"
- </script>
-</head>
-</html>

--- a/logging/docs/usage.html
+++ b/logging/docs/usage.html
@@ -1,8 +1,0 @@
-<html>
-<head>
- <meta http-equiv="refresh" content="1; url=./index.html:" />
- <script>
-   window.location.href = "./index.html"
- </script>
-</head>
-</html>

--- a/translate/docs/usage.html
+++ b/translate/docs/usage.html
@@ -1,8 +1,0 @@
-<html>
-<head>
- <meta http-equiv="refresh" content="1; url=./index.html:" />
- <script>
-   window.location.href = "./index.html"
- </script>
-</head>
-</html>


### PR DESCRIPTION
Redirect file is not needed for 'translate'.

See #5996.