### PR TITLE
Docs: debug broken docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -334,8 +334,8 @@ static_html_pages = [
     'spanner/usage.html',
 ]
 
-def copy_static_html_pages(app, docname):
-    if app.builder.name == 'html':
+def copy_static_html_pages(app, exception):
+    if exception is None and app.builder.name == 'html':
         for static_html_page in static_html_pages:
             target_path = app.outdir + '/' + static_html_page
             src_path = app.srcdir + '/' + static_html_page

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,10 @@ import os
 import pkg_resources
 import shutil
 
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -325,7 +329,7 @@ intersphinx_mapping = {
 # See: https://tech.signavio.com/2017/managing-sphinx-redirects
 # HTML pages to be copied from source to target
 static_html_pages = [
-    'datastore.usage.html',
+    'datastore/usage.html',
     'bigquery/usage.html',
     'spanner/usage.html',
 ]
@@ -335,8 +339,10 @@ def copy_static_html_pages(app, docname):
         for static_html_page in static_html_pages:
             target_path = app.outdir + '/' + static_html_page
             src_path = app.srcdir + '/' + static_html_page
-        if os.path.isfile(src_path):
-            shutil.copyfile(src_path, target_path)
+            if os.path.isfile(src_path):
+                logger.info(
+                    'Copying static html: %s -> %s', src_path, target_path)
+                shutil.copyfile(src_path, target_path)
 
 def setup(app):
     app.connect('build-finished', copy_static_html_pages)

--- a/test_utils/scripts/update_docs.sh
+++ b/test_utils/scripts/update_docs.sh
@@ -25,7 +25,15 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 function build_docs {
     rm -rf docs/_build/
     rm -rf docs/bigquery/generated
-    sphinx-build -W -b html -d docs/_build/doctrees docs/ docs/_build/html/
+    # -W -> warnings as errors
+    # -T -> show full traceback on exception
+    # -N -> no color
+    sphinx-build \
+        -W -T -N \
+        -b html \
+        -d docs/_build/doctrees \
+        docs/ \
+        docs/_build/html/
     return $?
 }
 


### PR DESCRIPTION
- Run docs build during nox w/ better debug output (the colorized mode tends to hide some info).
- Fix loop boundary bug in copying static HTML files.
- Log each static HTML file copied.