### PR TITLE
Populate the jobReference from the API response.

### DIFF
--- a/bigquery/google/cloud/bigquery/job.py
+++ b/bigquery/google/cloud/bigquery/job.py
@@ -3038,4 +3038,3 @@ class UnknownJob(_AsyncJob):
         resource['jobReference'] = job_ref_properties
         job._properties = resource
         return job
-

--- a/bigquery/tests/system.py
+++ b/bigquery/tests/system.py
@@ -666,7 +666,7 @@ class TestBigQuery(unittest.TestCase):
             client.get_job(job_id, location='US')
 
         load_job_us = client.get_job(job_id)
-        load_job_us._job_ref._properties['location'] = 'US'
+        load_job_us._properties['jobReference']['location'] = 'US'
         self.assertFalse(load_job_us.exists())
         with self.assertRaises(NotFound):
             load_job_us.reload()

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -2740,6 +2740,41 @@ class TestClient(unittest.TestCase):
             data=resource,
         )
 
+    def test_query_detect_location(self):
+        from google.cloud.bigquery.job import QueryJob
+
+        query = 'select count(*) from persons'
+        resource_location = 'EU'
+        resource = {
+            'jobReference': {
+                'projectId': self.PROJECT,
+                # Location not set in request, but present in the response.
+                'location': resource_location,
+                'jobId': 'some-random-id',
+            },
+            'configuration': {
+                'query': {
+                    'query': query,
+                    'useLegacySql': False,
+                },
+            },
+        }
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(project=self.PROJECT, credentials=creds,
+                                _http=http)
+        conn = client._connection = _make_connection(resource)
+
+        job = client.query(query)
+
+        self.assertEqual(job.location, resource_location)
+
+        # Check that request did not contain a location.
+        conn.api_request.assert_called_once()
+        _, req = conn.api_request.call_args
+        sent = req['data']
+        self.assertIsNone(sent['jobReference'].get('location'))
+
     def test_query_w_udf_resources(self):
         from google.cloud.bigquery.job import QueryJob
         from google.cloud.bigquery.job import QueryJobConfig

--- a/bigquery/tests/unit/test_client.py
+++ b/bigquery/tests/unit/test_client.py
@@ -2741,8 +2741,6 @@ class TestClient(unittest.TestCase):
         )
 
     def test_query_detect_location(self):
-        from google.cloud.bigquery.job import QueryJob
-
         query = 'select count(*) from persons'
         resource_location = 'EU'
         resource = {

--- a/bigquery/tests/unit/test_job.py
+++ b/bigquery/tests/unit/test_job.py
@@ -156,7 +156,15 @@ class Test_AsyncJob(unittest.TestCase):
         self.assertEqual(job.project, self.PROJECT)
         self.assertIsNone(job.location)
         self.assertIs(job._client, client)
-        self.assertEqual(job._properties, {})
+        self.assertEqual(
+            job._properties,
+            {
+                'jobReference': {
+                    'projectId': self.PROJECT,
+                    'jobId': self.JOB_ID,
+                },
+            }
+        )
         self.assertIsInstance(job._completion_lock, type(threading.Lock()))
         self.assertEqual(
             job.path,
@@ -174,7 +182,16 @@ class Test_AsyncJob(unittest.TestCase):
         self.assertEqual(job.project, self.PROJECT)
         self.assertEqual(job.location, self.LOCATION)
         self.assertIs(job._client, client)
-        self.assertEqual(job._properties, {})
+        self.assertEqual(
+            job._properties,
+            {
+                'jobReference': {
+                    'projectId': self.PROJECT,
+                    'location': self.LOCATION,
+                    'jobId': self.JOB_ID,
+                },
+            }
+        )
         self.assertFalse(job._result_set)
         self.assertIsInstance(job._completion_lock, type(threading.Lock()))
         self.assertEqual(
@@ -359,6 +376,7 @@ class Test_AsyncJob(unittest.TestCase):
         job._copy_configuration_properties = mock.Mock()
         job._set_future_result = mock.Mock()
         job._properties = {
+            'jobReference': job._properties['jobReference'],
             'foo': 'bar',
         }
         return job
@@ -577,7 +595,7 @@ class Test_AsyncJob(unittest.TestCase):
         from google.cloud.bigquery.retry import DEFAULT_RETRY
 
         job = self._set_properties_job()
-        job._job_ref._properties['location'] = self.LOCATION
+        job._properties['jobReference']['location'] = self.LOCATION
         call_api = job._client._call_api = mock.Mock()
         call_api.side_effect = NotFound('testing')
 
@@ -636,7 +654,7 @@ class Test_AsyncJob(unittest.TestCase):
             }
         }
         job = self._set_properties_job()
-        job._job_ref._properties['location'] = self.LOCATION
+        job._properties['jobReference']['location'] = self.LOCATION
         call_api = job._client._call_api = mock.Mock()
         call_api.return_value = resource
 
@@ -693,7 +711,7 @@ class Test_AsyncJob(unittest.TestCase):
         }
         response = {'job': resource}
         job = self._set_properties_job()
-        job._job_ref._properties['location'] = self.LOCATION
+        job._properties['jobReference']['location'] = self.LOCATION
         connection = job._client._connection = _make_connection(response)
 
         self.assertTrue(job.cancel())


### PR DESCRIPTION
Before this change, the location field was not populated after
inititial construction. This is a problem when no location is
provided but it has been auto-detected based on the resources
referenced in the job (such as via the tables referenced in a
query).