### PR TITLE
Resource Manager: 'v1' API is not forward compatible.

### DIFF
--- a/resource_manager/google/cloud/resource_manager/_http.py
+++ b/resource_manager/google/cloud/resource_manager/_http.py
@@ -33,7 +33,7 @@ class Connection(_http.JSONConnection):
     API_BASE_URL = 'https://cloudresourcemanager.googleapis.com'
     """The base of the API call URL."""
 
-    API_VERSION = 'v1'
+    API_VERSION = 'v1beta1'
     """The version of the API, used in building the API call's URL."""
 
     API_URL_TEMPLATE = '{api_base_url}/{api_version}{path}'


### PR DESCRIPTION
Reverts #6041.

We need to review more deeply. Per @enriquejosepadilla's testing, the changes in the API from `v1beta1` -> `v1` are breaking for us.