### PR TITLE
Storage: ensure that 'method' for 'Blob.generate_signed_url' is uppercase.

### DIFF
--- a/storage/google/cloud/storage/blob.py
+++ b/storage/google/cloud/storage/blob.py
@@ -345,9 +345,11 @@ class Blob(_PropertyMixin):
             credentials = client._credentials
 
         return generate_signed_url(
-            credentials, resource=resource,
+            credentials,
+            resource=resource,
             api_access_endpoint=_API_ACCESS_ENDPOINT,
-            expiration=expiration, method=method,
+            expiration=expiration,
+            method=method.upper(),
             content_type=content_type,
             response_type=response_type,
             response_disposition=response_disposition,

--- a/storage/tests/system.py
+++ b/storage/tests/system.py
@@ -727,6 +727,16 @@ class TestStorageSignURLs(TestStorageFiles):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, self.LOCAL_FILE)
 
+    def test_create_signed_read_url_lowercase_method(self):
+        blob = self.bucket.blob('LogoToSign.jpg')
+        expiration = int(time.time() + 10)
+        signed_url = blob.generate_signed_url(expiration, method='get',
+                                              client=Config.CLIENT)
+
+        response = requests.get(signed_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, self.LOCAL_FILE)
+
     def test_create_signed_read_url_w_non_ascii_name(self):
         blob = self.bucket.blob(u'Caf\xe9.txt')
         payload = b'Test signed URL for blob w/ non-ASCII name'

--- a/storage/tests/unit/test_blob.py
+++ b/storage/tests/unit/test_blob.py
@@ -383,6 +383,36 @@ class Test_Blob(unittest.TestCase):
         credentials = object()
         self._basic_generate_signed_url_helper(credentials=credentials)
 
+    def test_generate_signed_url_lowercase_method(self):
+        BLOB_NAME = 'blob-name'
+        EXPIRATION = '2014-10-16T20:34:37.000Z'
+        connection = _Connection()
+        client = _Client(connection)
+        bucket = _Bucket(client)
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
+        URI = (u'http://example.com/abucket/a-blob-name?Signature=DEADBEEF'
+               u'&Expiration=2014-10-16T20:34:37.000Z')
+
+        SIGNER = _Signer()
+        with mock.patch('google.cloud.storage.blob.generate_signed_url',
+                        new=SIGNER):
+            signed_url = blob.generate_signed_url(EXPIRATION, method='get')
+            self.assertEqual(signed_url, URI)
+
+        PATH = '/name/%s' % (BLOB_NAME,)
+        EXPECTED_ARGS = (_Connection.credentials,)
+        EXPECTED_KWARGS = {
+            'api_access_endpoint': 'https://storage.googleapis.com',
+            'expiration': EXPIRATION,
+            'method': 'GET',
+            'resource': PATH,
+            'content_type': None,
+            'response_type': None,
+            'response_disposition': None,
+            'generation': None,
+        }
+        self.assertEqual(SIGNER._signed, [(EXPECTED_ARGS, EXPECTED_KWARGS)])
+
     def test_generate_signed_url_non_ascii(self):
         BLOB_NAME = u'\u0410\u043a\u043a\u043e\u0440\u0434\u044b.txt'
         EXPIRATION = '2014-10-16T20:34:37.000Z'


### PR DESCRIPTION
Closes #6107.