### PR TITLE
Add kokoro for translate, remove translate from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,12 +173,6 @@ jobs:
               nox -f trace/nox.py
             fi
       - run:
-          name: Run tests - google.cloud.translate
-          command: |
-            if [[ -n $(grep -x translate ~/target_packages) ]]; then
-              nox -f translate/nox.py
-            fi
-      - run:
           name: Make sure google-cloud setup.py is valid
           command: |
             nox -s lint_setup_py

--- a/.kokoro/continuous/translate.cfg
+++ b/.kokoro/continuous/translate.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "PACKAGE"
+    value: "translate"
+}

--- a/.kokoro/presubmit/translate.cfg
+++ b/.kokoro/presubmit/translate.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "PACKAGE"
+    value: "translate"
+}

--- a/translate/README.rst
+++ b/translate/README.rst
@@ -109,3 +109,4 @@ Example Usage
          'detectedSourceLanguage': 'pl',
          'input': 'koszula',
      }
+REMOVE ME!

--- a/translate/README.rst
+++ b/translate/README.rst
@@ -109,4 +109,3 @@ Example Usage
          'detectedSourceLanguage': 'pl',
          'input': 'koszula',
      }
-REMOVE ME!


### PR DESCRIPTION
These Kokoro jobs have configs in google3 and GitHub and should build successfully:
* API Core
* Video Intelligence
* Vision

These Kokoro jobs do not have configs in GitHub yet and will fail:
* Speech
* Storage
* Trace
* Translate