### PR TITLE
Add type-checking via pytype to api_core.

### DIFF
--- a/api_core/nox.py
+++ b/api_core/nox.py
@@ -15,7 +15,8 @@
 from __future__ import absolute_import
 import os
 
-import nox
+# https://github.com/google/importlab/issues/25
+import nox  # pytype: disable=import-error
 
 
 @nox.session

--- a/api_core/nox.py
+++ b/api_core/nox.py
@@ -112,15 +112,14 @@ def lint_setup_py(session):
 # No 2.7 due to https://github.com/google/importlab/issues/26.
 # No 3.7 because pytype supports up to 3.6 only.
 @nox.session
-@nox.parametrize('py', ['3.5', '3.6'])
-def pytype(session, py):
+def pytype(session):
   """Run type-checking."""
-  session.interpreter = 'python{}'.format(py)
+  session.interpreter = 'python3.6'
   session.install('.',
                   'grpcio >= 1.8.2',
                   'grpcio-gcp >= 0.2.2',
                   'pytype >= 2018.9.26')
-  session.run('pytype', '-V{}'.format(py))
+  session.run('pytype')
 
 
 @nox.session

--- a/api_core/nox.py
+++ b/api_core/nox.py
@@ -109,6 +109,20 @@ def lint_setup_py(session):
         'python', 'setup.py', 'check', '--restructuredtext', '--strict')
 
 
+# No 2.7 due to https://github.com/google/importlab/issues/26.
+# No 3.7 because pytype supports up to 3.6 only.
+@nox.session
+@nox.parametrize('py', ['3.5', '3.6'])
+def pytype(session, py):
+  """Run type-checking."""
+  session.interpreter = 'python{}'.format(py)
+  session.install('.',
+                  'grpcio >= 1.8.2',
+                  'grpcio-gcp >= 0.2.2',
+                  'pytype >= 2018.9.26')
+  session.run('pytype', '-V{}'.format(py))
+
+
 @nox.session
 def cover(session):
     """Run the final coverage report.

--- a/api_core/setup.cfg
+++ b/api_core/setup.cfg
@@ -1,2 +1,8 @@
 [bdist_wheel]
 universal = 1
+
+[pytype]
+inputs =
+    .
+exclude =
+    tests/

--- a/api_core/setup.cfg
+++ b/api_core/setup.cfg
@@ -2,6 +2,7 @@
 universal = 1
 
 [pytype]
+python_version = 3.6
 inputs =
     .
 exclude =


### PR DESCRIPTION
Type-checks all of api_core outside of tests with [pytype](https://github.com/google/pytype).
* Adds pytype options to setup.cfg so the code can be type-checked with `pytype -V{major.minor}`.
* Runs `pytype -V3.5` and `pytype -V3.6` under nox.
Manually tested by pip-installing `pytype` and `nox-automation` in a Python 3.6 virtualenv.

@theacodes cc-ing you on this PR as you requested