### PR TITLE
Logging: support request-correlated logging in App Engine standard python37 runtime

### DIFF
--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -50,7 +50,7 @@ _APPENGINE_FLEXIBLE_ENV_VM = 'GAE_APPENGINE_HOSTNAME'
 """Environment variable set in App Engine when vm:true is set."""
 
 _APPENGINE_INSTANCE_ID = 'GAE_INSTANCE'
-"""Environment variable set in App Engine standard and flexible environments."""
+"""Environment variable set in App Engine standard and flexible environment."""
 
 _GKE_CLUSTER_NAME = 'instance/attributes/cluster-name'
 """Attribute in metadata server when in GKE environment."""

--- a/logging/google/cloud/logging/client.py
+++ b/logging/google/cloud/logging/client.py
@@ -49,8 +49,8 @@ _USE_GRPC = _HAVE_GRPC and not _DISABLE_GRPC
 _APPENGINE_FLEXIBLE_ENV_VM = 'GAE_APPENGINE_HOSTNAME'
 """Environment variable set in App Engine when vm:true is set."""
 
-_APPENGINE_FLEXIBLE_ENV_FLEX = 'GAE_INSTANCE'
-"""Environment variable set in App Engine when env:flex is set."""
+_APPENGINE_INSTANCE_ID = 'GAE_INSTANCE'
+"""Environment variable set in App Engine standard and flexible environments."""
 
 _GKE_CLUSTER_NAME = 'instance/attributes/cluster-name'
 """Attribute in metadata server when in GKE environment."""
@@ -301,7 +301,7 @@ class Client(ClientWithProject):
         gke_cluster_name = retrieve_metadata_server(_GKE_CLUSTER_NAME)
 
         if (_APPENGINE_FLEXIBLE_ENV_VM in os.environ or
-                _APPENGINE_FLEXIBLE_ENV_FLEX in os.environ):
+                _APPENGINE_INSTANCE_ID in os.environ):
             return AppEngineHandler(self)
         elif gke_cluster_name is not None:
             return ContainerEngineHandler()

--- a/logging/google/cloud/logging/handlers/app_engine.py
+++ b/logging/google/cloud/logging/handlers/app_engine.py
@@ -57,6 +57,8 @@ class AppEngineHandler(logging.StreamHandler):
         self.transport = transport(client, name)
         self.project_id = os.environ.get(_GAE_PROJECT_ENV_FLEX,
                                          os.environ.get(_GAE_PROJECT_ENV_STANDARD, ''))
+        self.module_id = os.environ.get(_GAE_SERVICE_ENV, '')
+        self.version_id = os.environ.get(_GAE_VERSION_ENV, '')
         self.resource = self.get_gae_resource()
 
     def get_gae_resource(self):
@@ -69,8 +71,8 @@ class AppEngineHandler(logging.StreamHandler):
             type='gae_app',
             labels={
                 'project_id': self.project_id,
-                'module_id': os.environ.get(_GAE_SERVICE_ENV, ''),
-                'version_id': os.environ.get(_GAE_VERSION_ENV, ''),
+                'module_id': self.module_id,
+                'version_id': self.version_id,
             },
         )
         return gae_resource

--- a/logging/google/cloud/logging/handlers/app_engine.py
+++ b/logging/google/cloud/logging/handlers/app_engine.py
@@ -55,8 +55,9 @@ class AppEngineHandler(logging.StreamHandler):
         self.name = name
         self.client = client
         self.transport = transport(client, name)
-        self.project_id = os.environ.get(_GAE_PROJECT_ENV_FLEX,
-                                         os.environ.get(_GAE_PROJECT_ENV_STANDARD, ''))
+        self.project_id = os.environ.get(
+            _GAE_PROJECT_ENV_FLEX,
+            os.environ.get(_GAE_PROJECT_ENV_STANDARD, ''))
         self.module_id = os.environ.get(_GAE_SERVICE_ENV, '')
         self.version_id = os.environ.get(_GAE_VERSION_ENV, '')
         self.resource = self.get_gae_resource()
@@ -106,7 +107,8 @@ class AppEngineHandler(logging.StreamHandler):
         """
         message = super(AppEngineHandler, self).format(record)
         gae_labels = self.get_gae_labels()
-        trace_id = ('projects/%s/traces/%s' % (self.project_id, gae_labels[_TRACE_ID_LABEL])
+        trace_id = ('projects/%s/traces/%s' % (self.project_id,
+                                               gae_labels[_TRACE_ID_LABEL])
                     if _TRACE_ID_LABEL in gae_labels
                     else None)
         self.transport.send(

--- a/logging/tests/unit/handlers/test_app_engine.py
+++ b/logging/tests/unit/handlers/test_app_engine.py
@@ -30,15 +30,18 @@ class TestAppEngineHandler(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
-        from google.cloud.logging.handlers.app_engine import _GAE_PROJECT_ENV_STANDARD
+        from google.cloud.logging.handlers.app_engine import (
+            _GAE_PROJECT_ENV_STANDARD)
         from google.cloud.logging.handlers.app_engine import _GAE_SERVICE_ENV
         from google.cloud.logging.handlers.app_engine import _GAE_VERSION_ENV
 
         client = mock.Mock(project=self.PROJECT, spec=['project'])
 
-        with mock.patch('os.environ', new={_GAE_PROJECT_ENV_STANDARD: 'test_project',
-                                           _GAE_SERVICE_ENV: 'test_service',
-                                           _GAE_VERSION_ENV: 'test_version'}):
+        with mock.patch('os.environ', new={
+            _GAE_PROJECT_ENV_STANDARD: 'test_project',
+            _GAE_SERVICE_ENV: 'test_service',
+            _GAE_VERSION_ENV: 'test_version',
+        }):
             handler = self._make_one(client, transport=_Transport)
         self.assertIs(handler.client, client)
         self.assertEqual(handler.resource.type, 'gae_app')

--- a/logging/tests/unit/handlers/test_app_engine.py
+++ b/logging/tests/unit/handlers/test_app_engine.py
@@ -30,13 +30,13 @@ class TestAppEngineHandler(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_constructor(self):
-        from google.cloud.logging.handlers.app_engine import _GAE_PROJECT_ENV
+        from google.cloud.logging.handlers.app_engine import _GAE_PROJECT_ENV_STANDARD
         from google.cloud.logging.handlers.app_engine import _GAE_SERVICE_ENV
         from google.cloud.logging.handlers.app_engine import _GAE_VERSION_ENV
 
         client = mock.Mock(project=self.PROJECT, spec=['project'])
 
-        with mock.patch('os.environ', new={_GAE_PROJECT_ENV: 'test_project',
+        with mock.patch('os.environ', new={_GAE_PROJECT_ENV_STANDARD: 'test_project',
                                            _GAE_SERVICE_ENV: 'test_service',
                                            _GAE_VERSION_ENV: 'test_version'}):
             handler = self._make_one(client, transport=_Transport)
@@ -51,6 +51,7 @@ class TestAppEngineHandler(unittest.TestCase):
         handler = self._make_one(client, transport=_Transport)
         gae_resource = handler.get_gae_resource()
         gae_labels = handler.get_gae_labels()
+        trace = None
         logname = 'app'
         message = 'hello world'
         record = logging.LogRecord(logname, logging, None, None, message,
@@ -61,7 +62,7 @@ class TestAppEngineHandler(unittest.TestCase):
         self.assertEqual(handler.transport.name, logname)
         self.assertEqual(
             handler.transport.send_called_with,
-            (record, message, gae_resource, gae_labels))
+            (record, message, gae_resource, gae_labels, trace))
 
     def _get_gae_labels_helper(self, trace_id):
         get_trace_patch = mock.patch(
@@ -98,5 +99,5 @@ class _Transport(object):
         self.client = client
         self.name = name
 
-    def send(self, record, message, resource, labels):
-        self.send_called_with = (record, message, resource, labels)
+    def send(self, record, message, resource, labels, trace):
+        self.send_called_with = (record, message, resource, labels, trace)


### PR DESCRIPTION
The python37 runtime provides the GOOGLE_CLOUD_PROJECT environment variable instead of GCLOUD_PROJECT, and for log messages to be correlated with the request in StackDriver, their 'trace' value has to be passed as a top level member of the log record rather than as an appengine.googleapis.com/trace_id label.